### PR TITLE
DOC: makes Chart.to_html more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![build status](http://img.shields.io/travis/ellisonbg/altair/master.svg?style=flat)](https://travis-ci.org/ellisonbg/altair)
 
-Altair is a declarative statistical visualization library for Python. [Altair
-Documentation](altair/notebooks/01-Index.ipynb)
+Altair is a declarative statistical visualization library for Python.
+
+**[Documentation](altair/notebooks/01-Index.ipynb)**
 
 *Altair is developed by [Brian Granger](https://github.com/ellisonbg) and [Jake Vanderplas](https://github.com/jakevdp) in close collaboration with the [UW Interactive Data Lab](http://idl.cs.washington.edu/).*
 

--- a/altair/api.py
+++ b/altair/api.py
@@ -82,6 +82,8 @@ def use_signature(Obj):
 # Top-level Objects
 #*************************************************************************
 class TopLevelMixin(object):
+    def __dir__(self):
+        return public_funcs(self)
     def to_html(self, template=None, title=None, **kwargs):
         """Emit a stand-alone HTML document containing this chart.
 
@@ -222,19 +224,7 @@ class Chart(schema.ExtendedUnitSpec, TopLevelMixin):
         self.data = data
 
     def __dir__(self):
-        base = super(Chart, self).__dir__()
-        methods = [
-            'to_altair', 'display',
-            'configure', 'configure_axis', 'configure_cell',
-            'configure_legend', 'configure_mark', 'configure_scale',
-            'configure_facet_axis', 'configure_facet_cell',
-            'configure_facet_grid', 'configure_facet_scale',
-            'transform_data',
-            'mark_area', 'mark_bar', 'mark_line', 'mark_point', 'mark_rule',
-            'mark_text', 'mark_tick', 'mark_circle', 'mark_square',
-            'encode',
-        ]
-        return base+methods
+        return public_funcs(self)
 
     @use_signature(MarkConfig)
     def mark_area(self, *args, **kwargs):
@@ -340,17 +330,7 @@ class LayeredChart(schema.LayerSpec, TopLevelMixin):
         self.data = data
 
     def __dir__(self):
-        base = super(Chart, self).__dir__()
-        methods = [
-            'to_dict', 'from_dict', 'to_altair', 'display',
-            'configure', 'configure_axis', 'configure_cell',
-            'configure_legend', 'configure_mark', 'configure_scale',
-            'configure_facet_axis', 'configure_facet_cell',
-            'configure_facet_grid', 'configure_facet_scale',
-            'transform_data',
-            'set_layers',
-        ]
-        return base+methods
+        return public_funcs(self)
 
     def set_layers(self, *layers):
         self.layers = list(layers)
@@ -400,17 +380,7 @@ class FacetedChart(schema.FacetSpec, TopLevelMixin):
         self.data = data
 
     def __dir__(self):
-        base = super(Chart, self).__dir__()
-        methods = [
-            'to_dict', 'from_dict', 'to_altair', 'display',
-            'configure', 'configure_axis', 'configure_cell',
-            'configure_legend', 'configure_mark', 'configure_scale',
-            'configure_facet_axis', 'configure_facet_cell',
-            'configure_facet_grid', 'configure_facet_scale',
-            'transform_data',
-            'set_facet',
-        ]
-        return base + methods
+        return public_funcs(self)
 
     @use_signature(Facet)
     def set_facet(self, *args, **kwargs):
@@ -422,3 +392,8 @@ class FacetedChart(schema.FacetSpec, TopLevelMixin):
         if self.data is not None:
             kwargs['data'] = self.data
         super(FacetedChart, self)._finalize(**kwargs)
+
+
+def public_funcs(self):
+    # avoid recursion when calling from within class with type(self)
+    return [f for f in dir(type(self)) if f[0] != '_']

--- a/altair/api.py
+++ b/altair/api.py
@@ -82,8 +82,6 @@ def use_signature(Obj):
 # Top-level Objects
 #*************************************************************************
 class TopLevelMixin(object):
-    def __dir__(self):
-        return public_funcs(self)
     def to_html(self, template=None, title=None, **kwargs):
         """Emit a stand-alone HTML document containing this chart.
 
@@ -224,7 +222,7 @@ class Chart(schema.ExtendedUnitSpec, TopLevelMixin):
         self.data = data
 
     def __dir__(self):
-        return public_funcs(self)
+        return all_funcs(self, ignore_class=T.HasTraits())
 
     @use_signature(MarkConfig)
     def mark_area(self, *args, **kwargs):
@@ -330,7 +328,7 @@ class LayeredChart(schema.LayerSpec, TopLevelMixin):
         self.data = data
 
     def __dir__(self):
-        return public_funcs(self)
+        return all_funcs(self, ignore_class=T.HasTraits())
 
     def set_layers(self, *layers):
         self.layers = list(layers)
@@ -380,7 +378,7 @@ class FacetedChart(schema.FacetSpec, TopLevelMixin):
         self.data = data
 
     def __dir__(self):
-        return public_funcs(self)
+        return all_funcs(self, ignore_class=T.HasTraits())
 
     @use_signature(Facet)
     def set_facet(self, *args, **kwargs):
@@ -394,6 +392,6 @@ class FacetedChart(schema.FacetSpec, TopLevelMixin):
         super(FacetedChart, self)._finalize(**kwargs)
 
 
-def public_funcs(self):
+def all_funcs(self, ignore_class=None):
     # avoid recursion when calling from within class with type(self)
-    return [f for f in dir(type(self)) if f[0] != '_']
+    return [f for f in dir(type(self)) if f not in dir(type(ignore_class))]

--- a/altair/notebooks/01-Index.ipynb
+++ b/altair/notebooks/01-Index.ipynb
@@ -31,6 +31,46 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Introductory documentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- [Introduction to Altair](02-Introduction.ipynb)\n",
+    "- [Vega-Lite Documentation](https://vega.github.io/vega-lite/docs/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introductory Altair interactive examples\n",
+    "\n",
+    "A picture is worth a thousand words. Try out these\n",
+    "interactive examples to see the ease and beauty of Altair:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- [Scatter Charts](03-ScatterCharts.ipynb)\n",
+    "- [Bar Charts](04-BarCharts.ipynb)\n",
+    "- [Line Charts](05-LineCharts.ipynb)\n",
+    "- [Area Charts](06-AreaCharts.ipynb)\n",
+    "- [Layered Charts](07-LayeredCharts.ipynb)\n",
+    "- [Grouped Regression Charts](08-GroupedRegressionCharts.ipynb)\n",
+    "- [Cars Dataset](09-CarsDataset.ipynb)\n",
+    "- [Iris Pair Grid](10-IrisPairgrid.ipynb)\n",
+    "- [Heatmaps](11-Heatmaps.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Quick Altair example"
    ]
   },
@@ -420,10 +460,6 @@
    "toc_cell": false,
    "toc_section_display": "block",
    "toc_window_display": false
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.1.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is a simple 3-line function that uses `to_html` to write an Altair chart to an HTML file.
