### PR TITLE
ENH: add cleanup_data option in to_dict

### DIFF
--- a/altair/schema/baseobject.py
+++ b/altair/schema/baseobject.py
@@ -123,10 +123,12 @@ class BaseObject(T.HasTraits):
         from ..utils.visitors import FromDict
         return FromDict().clsvisit(cls, dct)
 
-    def to_dict(self, data=True):
+    def to_dict(self, data=True, cleanup_data=False):
         """Emit the JSON representation for this object as as dict."""
         from ..utils.visitors import ToDict
         self._finalize()
+        if cleanup_data and hasattr(self, '_cleanup_data'):
+            self._cleanup_data()
         return ToDict().visit(self, data)
 
     def _finalize(self, **kwargs):

--- a/altair/tests/test_api.py
+++ b/altair/tests/test_api.py
@@ -41,6 +41,17 @@ def test_encode_update():
     assert chart1.to_dict() == chart2.to_dict()
 
 
+def test_cleanup_data():
+    data = pd.DataFrame({'x': [1, 2, 3],
+                         'y': [4, 5, 6],
+                         'z': [7, 8, 9]})
+    chart = Chart(data).encode(x='x', y='y')
+    D = chart.to_dict(cleanup_data=True)
+    assert ('x' in chart.data.columns and
+            'y' in chart.data.columns and
+            'z' not in chart.data.columns)
+
+
 def test_configure_update():
     # Test that configure updates rather than overwrites
     chart1 = Chart().configure(MarkConfig(color='red'))\
@@ -348,7 +359,7 @@ def test_chart_add():
     data = pd.DataFrame({'x':np.random.rand(10), 'y':np.random.rand(10)})
     l1 = Chart(data).mark_line().encode(x='x', y='y')
     l2 = Chart(data).mark_point().encode(x='x', y='y')
-    
+
     chart = l1+l2
     chart2 = LayeredChart()
     chart2.set_layers(l1, l2)


### PR DESCRIPTION
This is a work-in-progress that addresses the suggestion in #183.

It's a bit difficult because of the hierarchical nature of the top-level objects (i.e. a `LayeredChart` might have data that is referenced by the charts that make up its layers)

This solution works, but it modifies the original object; I think it would be cleaner (from the user's perspective) to leave the object unchanged. But it's not immediately obvious to me that there's a clean way (on the implementation side) to make this happen.

One thing I still need to figure out is the column access pattern when there are multiple data fields available to a single chart.

Also, this still needs more tests to cover cleanup within layered and faceted charts.
