### PR TITLE
DOC: correct case in GitHub

### DIFF
--- a/doc/documentation/datasets.rst
+++ b/doc/documentation/datasets.rst
@@ -3,7 +3,7 @@
 Altair Datasets
 ===============
 Altair includes a loader for a number of built-in datasets, available in the
-`vega-datasets`_ github repository.
+`vega-datasets`_ GitHub repository.
 These datasets are used throughout the documentation, and particularly in
 the :ref:`example-gallery`.
 

--- a/doc/documentation/displaying.rst
+++ b/doc/documentation/displaying.rst
@@ -187,7 +187,7 @@ interactions between Python packages and NodeJS packages remains a
 challenging area in general.
 If you have ideas on how to improve this aspect of Altair's user experience,
 please send comments or contributions via Altair's
-`Github Issue Tracker <https://github.com/altair-viz/altair/issues>`_.
+`GitHub Issue Tracker <https://github.com/altair-viz/altair/issues>`_.
 
 
 .. _NodeJS: https://nodejs.org/en/

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -25,7 +25,7 @@ packages using, e.g. ``conda update altair vega`` or
 ``pip install altair vega --update``.
 
 If this still doesn't work, please open an issue in the Altair's
-`Github Issue Tracker <https://github.com/altair-viz/altair/issues>`_,
+`GitHub Issue Tracker <https://github.com/altair-viz/altair/issues>`_,
 and we will do our best to help. In the meantime, other means of displaying Altair
 plots are listed in :ref:`displaying-plots`.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -64,7 +64,7 @@ Documentation
 
 Bug Reports & Questions
 -----------------------
-Altair is BSD-licensed and the source is available on `Github <http://github.com/altair-viz/altair>`_.
+Altair is BSD-licensed and the source is available on `GitHub <http://github.com/altair-viz/altair>`_.
 If any questions or issues come up as you use Altair, please get in touch via the `Issues <http://github.com/altair-viz/altair/issues>`_ tracker there.
 
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -37,7 +37,7 @@ within the Jupyter Notebook:
 
 Development Install
 -------------------
-The `Altair source repository`_ is available on github.
+The `Altair source repository`_ is available on GitHub.
 Once you have cloned the repository and installed all the above dependencies,
 run the following command from the root of the repository to install the
 master version of Altair:
@@ -47,7 +47,7 @@ master version of Altair:
     $ pip install -e .
 
 If you do not wish to clone the source repository, you can install the development
-version directly from github using:
+version directly from GitHub using:
 
 .. code-block:: bash
 


### PR DESCRIPTION
@ellisonbg I noticed this when we looked at the docs earlier today. I've gone through all the files in the `docs` directory. These are the only files that needed edits.