### PR TITLE
Require traitlets 4.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-traitlets>=4.1
+traitlets>=4.3.1
 ipython
 pandas
 vega>=0.4.4

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ AUTHOR_EMAIL        = "ellisonbg@gmail.com / jakevdp@cs.washington.edu"
 URL                 = 'http://altair-viz.github.io'
 DOWNLOAD_URL        = 'http://github.com/altair-viz/altair/'
 LICENSE             = 'BSD 3-clause'
-INSTALL_REQUIRES    = ['traitlets','ipython','pandas','vega>=0.4.4']
+INSTALL_REQUIRES    = ['traitlets>=4.3.1','ipython','pandas','vega>=0.4.4']
 
 
 import io


### PR DESCRIPTION
Traitlets 4.3 fixes the issues that you reported wrt Union trait types. Error messages should now make sense.