### PR TITLE
ENH: interactive widget to plot different columns (WIP)

### DIFF
--- a/altair/utils/__init__.py
+++ b/altair/utils/__init__.py
@@ -1,1 +1,2 @@
 from .core import *
+from .widget import interact_with

--- a/altair/utils/widget.py
+++ b/altair/utils/widget.py
@@ -1,0 +1,27 @@
+# from .. import altair
+import altair
+
+
+def interact_with(df):
+    from ipywidgets import interact, interactive, fixed
+    import ipywidgets as widgets
+
+    def plot(x=None, y=None, color=None, text=None,
+         mark='mark_point', shape=None, size=None):
+        if df is None:
+            raise ValueError('pandas.DataFrame needs to be passed in')
+        kwargs = {'x': x, 'y': y, 'color': color, 'text': text,
+                'shape': shape, 'size': size}
+        for key, value in list(kwargs.items()):
+            if value in {None, False, 'None'}:
+                del kwargs[key]
+
+        c = getattr(altair.Chart(df), mark)().encode(**kwargs)
+        return c
+
+    cols = [None] + list(df.columns)
+    marks = ['mark_' + f for f in ['line', 'point', 'bar', 'tick', 'text',
+                                   'square', 'rule', 'circle', 'area']]
+
+    return interact(plot, x=cols, y=cols, color=cols, shape=cols, size=cols,
+                    text=cols, mark=marks)


### PR DESCRIPTION
Adds `altair.utils.interact_with` that allows functionality to plot different columns:

![untitled-3](https://cloud.githubusercontent.com/assets/1320475/19794996/fd049b5a-9c9c-11e6-9700-85e3718195c8.gif)

This depends on ipywidgets.interact. I see there's some work on using the branch altair#widget (not my branch). In my implementation, I have dropdown menus for the type of mark (line, point, area, etc) and the different encodings (x, y, color, etc).

There's a ton of work to do still:

* tests, documentation
* support for different stats function (median, max, mean, etc)
* style dropdown menus
* ensure works for heat maps (for my use case this will require `applyColorToBackground`). This will likely require styling the drop downs.