### PR TITLE
'mean(temp_range):Q' had a bug in Jupyter Notebook

### DIFF
--- a/doc/tutorials/exploring-weather.rst
+++ b/doc/tutorials/exploring-weather.rst
@@ -139,7 +139,7 @@ be calculated by the renderer.
 
     Chart(df).mark_line().encode(
         X('date:T', timeUnit='month'),
-        y='mean(temp_range):Q'
+        y='mean(temp_range)'
     )
 
 Of course, the same calculation could be done by using Pandas manipulations to


### PR DESCRIPTION
There was a bug on [Exploring Data: Seattle Weather](https://altair-viz.github.io/tutorials/exploring-weather.html) when we try the code in Jupyter Notebook:

```python
Chart(df).mark_line().encode(
    X('date:T', timeUnit='month'),
    y='mean(temp_range):Q'
).transform_data(
    calculate=[temp_range]
)
```
However, it was ok if we change `'mean(temp_range):Q'` to `'mean(temp_range)'`.

```python
Chart(df).mark_line().encode(
    X('date:T', timeUnit='month'),
    y='mean(temp_range)'
).transform_data(
    calculate=[temp_range]
)
```