### PR TITLE
DOC: mention altair_widgets in documentation

### DIFF
--- a/doc/documentation/index.rst
+++ b/doc/documentation/index.rst
@@ -21,4 +21,5 @@ are discussed in the following
    transform
    config
    displaying
+   interactive
    datasets

--- a/doc/documentation/interactive.rst
+++ b/doc/documentation/interactive.rst
@@ -3,9 +3,9 @@
 Interactive visualization
 -------------------------
 
-Another package, `altair_widgets`_ provides interactive visualization of a
-DataFrame. It provides a widget that allows to choose the encodings for
-different columns:
+Another experimental package, `altair_widgets`_ provides interactive
+visualization of a DataFrame. It provides a widget that allows to choose
+the encodings for different columns:
 
 .. _altair_widgets: https://github.com/altair-viz/altair_widgets
 

--- a/doc/documentation/interactive.rst
+++ b/doc/documentation/interactive.rst
@@ -1,0 +1,22 @@
+.. _interactive-reference:
+
+Interactive visualization
+-------------------------
+
+Another package, `altair_widgets`_ provides interactive visualization of a
+DataFrame. It provides a widget that allows to choose the encodings for
+different columns:
+
+.. _altair_widgets: https://github.com/altair-viz/altair_widgets
+
+
+.. image:: images/cars-basic.gif
+    :width: 60%
+    :align: center
+
+It also supports different options for each encoding. Below, we show a subset
+of the advanced features:
+
+.. image:: images/cars-adv.gif
+    :width: 70%
+    :align: center


### PR DESCRIPTION
Mentions package `altair_widgets` in documentation and shows GIFs of examples.

I would add an example in the HTML but #306 is blocking tests.