### PR TITLE
correct default url for version 1 of vega-lite.js

### DIFF
--- a/altair/urls.py
+++ b/altair/urls.py
@@ -1,4 +1,4 @@
 D3_JS_URL = "https://d3js.org/d3.v3.min.js"
 VEGA_JS_URL = "https://vega.github.io/vega/releases/v2.6.5/vega.js"
-VEGALITE_JS_URL = "https://vega.github.io/vega-lite-1/vega-lite.js"
+VEGALITE_JS_URL = "https://vega.github.io/vega-lite-v1/vega-lite.js"
 VEGAEMBED_JS_URL = "https://vega.github.io/vega-editor/vendor/vega-embed.js"

--- a/altair/urls.py
+++ b/altair/urls.py
@@ -1,4 +1,4 @@
 D3_JS_URL = "https://d3js.org/d3.v3.min.js"
-VEGA_JS_URL = "https://vega.github.io/vega/releases/v2.6.5/vega.js"
-VEGALITE_JS_URL = "https://vega.github.io/vega-lite-v1/vega-lite.js"
-VEGAEMBED_JS_URL = "https://vega.github.io/vega-editor/vendor/vega-embed.js"
+VEGA_JS_URL = "https://cdnjs.cloudflare.com/ajax/libs/vega/2.6.5/vega.min.js"
+VEGALITE_JS_URL = "https://cdnjs.cloudflare.com/ajax/libs/vega-lite/1.3.1/vega-lite.min.js"
+VEGAEMBED_JS_URL = "https://cdnjs.cloudflare.com/ajax/libs/vega-embed/2.2.0/vega-embed.min.js"


### PR DESCRIPTION
The default url for vega-lite.js no longer seems to work which means it has be overwritten in chart.to_html() every time.