### PR TITLE
Check field names

### DIFF
--- a/altair/v1/__init__.py
+++ b/altair/v1/__init__.py
@@ -42,6 +42,7 @@ from .api import (
     RangeFilter,
     OneOfFilter,
     MaxRowsExceeded,
+    FieldError,
     enable_mime_rendering,
     disable_mime_rendering
 )

--- a/altair/v1/api.py
+++ b/altair/v1/api.py
@@ -579,7 +579,8 @@ class TopLevelMixin(object):
                                 "Missing field/column name for channel: {}".format(channel_name)
                             )
                         else:
-                            encoded_columns.add(field)
+                            if field != '*':
+                                encoded_columns.add(field)
             # Find columns in the data
             data_columns = set(self.data.columns.values)
             transform = self.transform

--- a/altair/v1/examples/tests/test_examples.py
+++ b/altair/v1/examples/tests/test_examples.py
@@ -19,7 +19,7 @@ def test_json_examples_round_trip(example):
     filename, json_dict = example
 
     v = Chart.from_dict(json_dict)
-    v_dict = v.to_dict()
+    v_dict = v.to_dict(validate_columns=True)
     if '$schema' not in json_dict:
         v_dict.pop('$schema')
     assert v_dict == json_dict
@@ -27,7 +27,7 @@ def test_json_examples_round_trip(example):
     # code generation discards empty function calls, and so we
     # filter these out before comparison
     v2 = eval(v.to_python())
-    v2_dict = v2.to_dict()
+    v2_dict = v2.to_dict(validate_columns=True)
     if '$schema' not in json_dict:
         v2_dict.pop('$schema')
     assert v2_dict == remove_empty_fields(json_dict)

--- a/altair/v1/tests/test_api.py
+++ b/altair/v1/tests/test_api.py
@@ -594,15 +594,23 @@ def test_validate_spec():
     # Make sure we catch channels with no field specified
     c = make_chart()
     c.encode(Color())
+    assert isinstance(c.to_dict(), dict)
+    assert isinstance(c.to_dict(validate_columns=False), dict)
     with pytest.raises(FieldError):
-        c.to_dict()
+        c.to_dict(validate_columns=True)
+    c.validate_columns = False
+    assert isinstance(c.to_dict(validate_columns=True), dict)
 
     # Make sure we catch encoded fields not in the data
     c = make_chart()
     c.encode(x='x', y='y', color='z')
     c.encode(color='z')
+    assert isinstance(c.to_dict(), dict)
+    assert isinstance(c.to_dict(validate_columns=False), dict)
     with pytest.raises(FieldError):
-        c.to_dict()
+        c.to_dict(validate_columns=True)
+    c.validate_columns = False
+    assert isinstance(c.to_dict(validate_columns=True), dict)
     
     # Make sure we can resolve computed fields
     c = make_chart()

--- a/altair/v1/tests/test_api.py
+++ b/altair/v1/tests/test_api.py
@@ -587,3 +587,9 @@ def test_enable_mime_rendering():
     enable_mime_rendering()
     disable_mime_rendering()
     disable_mime_rendering()
+
+    
+def test_validate_spec():
+    c = make_chart()
+
+    

--- a/altair/v1/tests/test_api.py
+++ b/altair/v1/tests/test_api.py
@@ -588,8 +588,27 @@ def test_enable_mime_rendering():
     disable_mime_rendering()
     disable_mime_rendering()
 
-    
-def test_validate_spec():
-    c = make_chart()
 
+def test_validate_spec():
+
+    # Make sure we catch channels with no field specified
+    c = make_chart()
+    c.encode(Color())
+    with pytest.raises(FieldError):
+        c.to_dict()
+
+    # Make sure we catch encoded fields not in the data
+    c = make_chart()
+    c.encode(x='x', y='y', color='z')
+    c.encode(color='z')
+    with pytest.raises(FieldError):
+        c.to_dict()
     
+    # Make sure we can resolve computed fields
+    c = make_chart()
+    c.encode(x='x', y='y', color='z')
+    c.encode(color='z')
+    c.transform_data(
+        calculate=[Formula('z', 'sin(((2*PI)*datum.x))')]
+    )
+    assert isinstance(c.to_dict(), dict)

--- a/altair/v1/tests/test_api.py
+++ b/altair/v1/tests/test_api.py
@@ -612,6 +612,10 @@ def test_validate_spec():
     c.validate_columns = False
     assert isinstance(c.to_dict(validate_columns=True), dict)
     
+    c = make_chart()
+    c.encode(x='x', y='count(*)')
+    assert isinstance(c.to_dict(validate_columns=True), dict)
+
     # Make sure we can resolve computed fields
     c = make_chart()
     c.encode(x='x', y='y', color='z')


### PR DESCRIPTION
This adds a new `_validate_spec` method to the `Chart` object that is called during the last phase of `_finalize` (after shortcuts and expressions have been processed). It catches channels with missing fields and fields that are not in the dataset. It should ignore URL based datasets. Tests are included.

My only concern is how this will function for facetted and layered charts. I fear it will have the same problems that PR #185 does. But it would be a huge usability improvement that would catch the most common sources of silent failures that Altair users see.

I won't merge this until we get a chance to discuss and review...

Fixes #388 