### PR TITLE
Use HTTPS prefix in example URLs to fix CORS issue

### DIFF
--- a/altair/v1/examples/json/area.vl.json
+++ b/altair/v1/examples/json/area.vl.json
@@ -6,7 +6,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/unemployment-across-industries.json"
+        "url": "https://vega.github.io/vega-lite/data/unemployment-across-industries.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/area_vertical.vl.json
+++ b/altair/v1/examples/json/area_vertical.vl.json
@@ -5,7 +5,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "description": "Area chart showing weight of cars over time (vertical).",
     "encoding": {

--- a/altair/v1/examples/json/bar_1d.vl.json
+++ b/altair/v1/examples/json/bar_1d.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/bar_1d_bandsize_config.vl.json
+++ b/altair/v1/examples/json/bar_1d_bandsize_config.vl.json
@@ -5,7 +5,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/bar_aggregate.vl.json
+++ b/altair/v1/examples/json/bar_aggregate.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "description": "A bar chart showing the US population distribution of age groups in 2000.",
     "encoding": {

--- a/altair/v1/examples/json/bar_aggregate_size.vl.json
+++ b/altair/v1/examples/json/bar_aggregate_size.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "description": "A bar chart showing the US population distribution of age groups in 2000.",
     "encoding": {

--- a/altair/v1/examples/json/bar_aggregate_vertical.vl.json
+++ b/altair/v1/examples/json/bar_aggregate_vertical.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/bar_grouped.vl.json
+++ b/altair/v1/examples/json/bar_grouped.vl.json
@@ -7,7 +7,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/bar_grouped_horizontal.vl.json
+++ b/altair/v1/examples/json/bar_grouped_horizontal.vl.json
@@ -7,7 +7,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/bar_layered_transparent.vl.json
+++ b/altair/v1/examples/json/bar_layered_transparent.vl.json
@@ -6,7 +6,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "description": "A bar chart showing the US population distribution of age groups and gender in 2000.",
     "encoding": {

--- a/altair/v1/examples/json/bar_size_default.vl.json
+++ b/altair/v1/examples/json/bar_size_default.vl.json
@@ -6,7 +6,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/bar_size_explicit.vl.json
+++ b/altair/v1/examples/json/bar_size_explicit.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/bar_size_explicit_bad.vl.json
+++ b/altair/v1/examples/json/bar_size_explicit_bad.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/bar_size_fit.vl.json
+++ b/altair/v1/examples/json/bar_size_fit.vl.json
@@ -6,7 +6,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/bar_yearmonth.vl.json
+++ b/altair/v1/examples/json/bar_yearmonth.vl.json
@@ -3,7 +3,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/seattle-temps.csv"
+        "url": "https://vega.github.io/vega-lite/data/seattle-temps.csv"
     },
     "description": "Temperature in Seattle as a bar chart with yearmonth time unit.",
     "encoding": {

--- a/altair/v1/examples/json/box_plot.vl.json
+++ b/altair/v1/examples/json/box_plot.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "description": "A box plot showing mean, min, and max in the US population distribution of age groups in 2000.",
     "layers": [

--- a/altair/v1/examples/json/bubble_health_income.vl.json
+++ b/altair/v1/examples/json/bubble_health_income.vl.json
@@ -9,7 +9,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/gapminder-health-income.csv"
+        "url": "https://vega.github.io/vega-lite/data/gapminder-health-income.csv"
     },
     "description": "A bubble plot showing the correlation between health and income for 187 countries in the world (modified from an example in Lisa Charlotte Rost's blog post 'One Chart, Twelve Charting Libraries' --http://lisacharlotterost.github.io/2016/05/17/one-chart-code/).",
     "encoding": {

--- a/altair/v1/examples/json/circle.vl.json
+++ b/altair/v1/examples/json/circle.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/errorbar_aggregate.vl.json
+++ b/altair/v1/examples/json/errorbar_aggregate.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "description": "A error bar plot showing mean, min, and max in the US population distribution of age groups in 2000.",
     "layers": [

--- a/altair/v1/examples/json/errorbar_horizontal_aggregate.vl.json
+++ b/altair/v1/examples/json/errorbar_horizontal_aggregate.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "description": "A bar chart showing the US population distribution of age groups in 2000.",
     "layers": [

--- a/altair/v1/examples/json/github_punchcard.vl.json
+++ b/altair/v1/examples/json/github_punchcard.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/github.csv"
+        "url": "https://vega.github.io/vega-lite/data/github.csv"
     },
     "encoding": {
         "size": {

--- a/altair/v1/examples/json/histogram.vl.json
+++ b/altair/v1/examples/json/histogram.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/movies.json"
+        "url": "https://vega.github.io/vega-lite/data/movies.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/layer_histogram.vl.json
+++ b/altair/v1/examples/json/layer_histogram.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/flights-2k.json"
+        "url": "https://vega.github.io/vega-lite/data/flights-2k.json"
     },
     "layers": [
         {

--- a/altair/v1/examples/json/layer_line_color_rule.vl.json
+++ b/altair/v1/examples/json/layer_line_color_rule.vl.json
@@ -3,7 +3,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "layers": [
         {

--- a/altair/v1/examples/json/line.vl.json
+++ b/altair/v1/examples/json/line.vl.json
@@ -3,7 +3,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "description": "Google's stock price over time.",
     "encoding": {

--- a/altair/v1/examples/json/line_color.vl.json
+++ b/altair/v1/examples/json/line_color.vl.json
@@ -3,7 +3,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "description": "Stock prices of 5 Tech Companies Over Time.",
     "encoding": {

--- a/altair/v1/examples/json/line_detail.vl.json
+++ b/altair/v1/examples/json/line_detail.vl.json
@@ -3,7 +3,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "description": "Stock prices of 5 Tech Companies Over Time.",
     "encoding": {

--- a/altair/v1/examples/json/line_monotone.vl.json
+++ b/altair/v1/examples/json/line_monotone.vl.json
@@ -8,7 +8,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/line_month.vl.json
+++ b/altair/v1/examples/json/line_month.vl.json
@@ -8,7 +8,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/seattle-temps.csv"
+        "url": "https://vega.github.io/vega-lite/data/seattle-temps.csv"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/line_quarter.vl.json
+++ b/altair/v1/examples/json/line_quarter.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "description": "Stock price mean per quarter broken down by years.",
     "encoding": {

--- a/altair/v1/examples/json/line_quarter_legend.vl.json
+++ b/altair/v1/examples/json/line_quarter_legend.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "description": "Stock price average broken down by quarter.",
     "encoding": {

--- a/altair/v1/examples/json/line_slope.vl.json
+++ b/altair/v1/examples/json/line_slope.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/barley.json"
+        "url": "https://vega.github.io/vega-lite/data/barley.json"
     },
     "description": "Slope graph showing the change in yield for different barley sites. It shows the error in the year labels for the Morris site.",
     "encoding": {

--- a/altair/v1/examples/json/line_step.vl.json
+++ b/altair/v1/examples/json/line_step.vl.json
@@ -8,7 +8,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "description": "Google's stock price over time.",
     "encoding": {

--- a/altair/v1/examples/json/overlay_area_full.vl.json
+++ b/altair/v1/examples/json/overlay_area_full.vl.json
@@ -3,7 +3,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "description": "Google's stock price over time.",
     "layers": [

--- a/altair/v1/examples/json/overlay_area_short.vl.json
+++ b/altair/v1/examples/json/overlay_area_short.vl.json
@@ -8,7 +8,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "description": "Google's stock price over time.",
     "encoding": {

--- a/altair/v1/examples/json/overlay_line_full.vl.json
+++ b/altair/v1/examples/json/overlay_line_full.vl.json
@@ -3,7 +3,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "layers": [
         {

--- a/altair/v1/examples/json/overlay_line_short.vl.json
+++ b/altair/v1/examples/json/overlay_line_short.vl.json
@@ -8,7 +8,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "description": "Google's stock price over time.",
     "encoding": {

--- a/altair/v1/examples/json/point_1d.vl.json
+++ b/altair/v1/examples/json/point_1d.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/point_custom_time_domain_values.vl.json
+++ b/altair/v1/examples/json/point_custom_time_domain_values.vl.json
@@ -3,7 +3,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/stocks.csv"
+        "url": "https://vega.github.io/vega-lite/data/stocks.csv"
     },
     "description": "Google's stock price over time.",
     "encoding": {

--- a/altair/v1/examples/json/point_dot_timeunit_color.vl.json
+++ b/altair/v1/examples/json/point_dot_timeunit_color.vl.json
@@ -3,7 +3,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/seattle-temps.csv"
+        "url": "https://vega.github.io/vega-lite/data/seattle-temps.csv"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/point_filled.vl.json
+++ b/altair/v1/examples/json/point_filled.vl.json
@@ -5,7 +5,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/scatter.vl.json
+++ b/altair/v1/examples/json/scatter.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "description": "A scatterplot showing horsepower and miles per gallons for various cars.",
     "encoding": {

--- a/altair/v1/examples/json/scatter_aggregate_detail.vl.json
+++ b/altair/v1/examples/json/scatter_aggregate_detail.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "description": "A scatterplot showing average horsepower and displacement for cars from different origins.",
     "encoding": {

--- a/altair/v1/examples/json/scatter_binned.vl.json
+++ b/altair/v1/examples/json/scatter_binned.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/movies.json"
+        "url": "https://vega.github.io/vega-lite/data/movies.json"
     },
     "encoding": {
         "size": {

--- a/altair/v1/examples/json/scatter_binned_color.vl.json
+++ b/altair/v1/examples/json/scatter_binned_color.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "description": "A scatterplot showing horsepower and miles per gallons with binned acceleration on color.",
     "encoding": {

--- a/altair/v1/examples/json/scatter_binned_size.vl.json
+++ b/altair/v1/examples/json/scatter_binned_size.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "description": "A scatterplot showing horsepower and miles per gallons with binned acceleration on size.",
     "encoding": {

--- a/altair/v1/examples/json/scatter_bubble.vl.json
+++ b/altair/v1/examples/json/scatter_bubble.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "description": "A bubbleplot showing horsepower on x, miles per gallons on y, and binned acceleration on size.",
     "encoding": {

--- a/altair/v1/examples/json/scatter_color.vl.json
+++ b/altair/v1/examples/json/scatter_color.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/scatter_color_custom.vl.json
+++ b/altair/v1/examples/json/scatter_color_custom.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/scatter_color_order.vl.json
+++ b/altair/v1/examples/json/scatter_color_order.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/scatter_color_ordinal.vl.json
+++ b/altair/v1/examples/json/scatter_color_ordinal.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/scatter_color_ordinal_custom.vl.json
+++ b/altair/v1/examples/json/scatter_color_ordinal_custom.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/scatter_color_quantitative.vl.json
+++ b/altair/v1/examples/json/scatter_color_quantitative.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/scatter_color_shape_constant.vl.json
+++ b/altair/v1/examples/json/scatter_color_shape_constant.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/scatter_colored_with_shape.vl.json
+++ b/altair/v1/examples/json/scatter_colored_with_shape.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "description": "A scatterplot showing horsepower and miles per gallons.",
     "encoding": {

--- a/altair/v1/examples/json/scatter_connected.vl.json
+++ b/altair/v1/examples/json/scatter_connected.vl.json
@@ -5,7 +5,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/driving.json"
+        "url": "https://vega.github.io/vega-lite/data/driving.json"
     },
     "encoding": {
         "path": {

--- a/altair/v1/examples/json/scatter_opacity.vl.json
+++ b/altair/v1/examples/json/scatter_opacity.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "opacity": {

--- a/altair/v1/examples/json/scatter_shape_custom.vl.json
+++ b/altair/v1/examples/json/scatter_shape_custom.vl.json
@@ -5,7 +5,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "description": "A scatterplot with custom star shapes.",
     "encoding": {

--- a/altair/v1/examples/json/square.vl.json
+++ b/altair/v1/examples/json/square.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/stacked_area.vl.json
+++ b/altair/v1/examples/json/stacked_area.vl.json
@@ -6,7 +6,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/unemployment-across-industries.json"
+        "url": "https://vega.github.io/vega-lite/data/unemployment-across-industries.json"
     },
     "description": "Area chart showing weight of cars over time.",
     "encoding": {

--- a/altair/v1/examples/json/stacked_area_binned.vl.json
+++ b/altair/v1/examples/json/stacked_area_binned.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/stacked_area_normalize.vl.json
+++ b/altair/v1/examples/json/stacked_area_normalize.vl.json
@@ -9,7 +9,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/unemployment-across-industries.json"
+        "url": "https://vega.github.io/vega-lite/data/unemployment-across-industries.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/stacked_area_ordinal.vl.json
+++ b/altair/v1/examples/json/stacked_area_ordinal.vl.json
@@ -5,7 +5,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/stacked_area_stream.vl.json
+++ b/altair/v1/examples/json/stacked_area_stream.vl.json
@@ -9,7 +9,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/unemployment-across-industries.json"
+        "url": "https://vega.github.io/vega-lite/data/unemployment-across-industries.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/stacked_bar_1d.vl.json
+++ b/altair/v1/examples/json/stacked_bar_1d.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/stacked_bar_h.vl.json
+++ b/altair/v1/examples/json/stacked_bar_h.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/barley.json"
+        "url": "https://vega.github.io/vega-lite/data/barley.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/stacked_bar_h_order.vl.json
+++ b/altair/v1/examples/json/stacked_bar_h_order.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/barley.json"
+        "url": "https://vega.github.io/vega-lite/data/barley.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/stacked_bar_normalize.vl.json
+++ b/altair/v1/examples/json/stacked_bar_normalize.vl.json
@@ -5,7 +5,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/stacked_bar_population.vl.json
+++ b/altair/v1/examples/json/stacked_bar_population.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "description": "A bar chart showing the US population distribution of age groups and gender in 2000.",
     "encoding": {

--- a/altair/v1/examples/json/stacked_bar_size.vl.json
+++ b/altair/v1/examples/json/stacked_bar_size.vl.json
@@ -8,7 +8,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/seattle-weather.csv"
+        "url": "https://vega.github.io/vega-lite/data/seattle-weather.csv"
     },
     "encoding": {
         "size": {

--- a/altair/v1/examples/json/stacked_bar_sum_opacity.vl.json
+++ b/altair/v1/examples/json/stacked_bar_sum_opacity.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "description": "A bar chart showing the US population distribution of age groups and gender in 2000.",
     "encoding": {

--- a/altair/v1/examples/json/stacked_bar_v.vl.json
+++ b/altair/v1/examples/json/stacked_bar_v.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/barley.json"
+        "url": "https://vega.github.io/vega-lite/data/barley.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/stacked_bar_weather.vl.json
+++ b/altair/v1/examples/json/stacked_bar_weather.vl.json
@@ -3,7 +3,7 @@
         "format": {
             "type": "csv"
         },
-        "url": "http://vega.github.io/vega-lite/data/seattle-weather.csv"
+        "url": "https://vega.github.io/vega-lite/data/seattle-weather.csv"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/text_scatter_colored.vl.json
+++ b/altair/v1/examples/json/text_scatter_colored.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/text_table_heatmap.vl.json
+++ b/altair/v1/examples/json/text_table_heatmap.vl.json
@@ -5,7 +5,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "color": {

--- a/altair/v1/examples/json/tick_dot.vl.json
+++ b/altair/v1/examples/json/tick_dot.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/tick_dot_thickness.vl.json
+++ b/altair/v1/examples/json/tick_dot_thickness.vl.json
@@ -6,7 +6,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "x": {

--- a/altair/v1/examples/json/tick_strip.vl.json
+++ b/altair/v1/examples/json/tick_strip.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "description": "Shows the relationship between horsepower and the numbver of cylinders using tick marks.",
     "encoding": {

--- a/altair/v1/examples/json/trellis_anscombe.vl.json
+++ b/altair/v1/examples/json/trellis_anscombe.vl.json
@@ -5,7 +5,7 @@
         }
     },
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/anscombe.json"
+        "url": "https://vega.github.io/vega-lite/data/anscombe.json"
     },
     "description": "Anscombe's Quartet",
     "encoding": {

--- a/altair/v1/examples/json/trellis_bar.vl.json
+++ b/altair/v1/examples/json/trellis_bar.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/population.json"
+        "url": "https://vega.github.io/vega-lite/data/population.json"
     },
     "description": "A trellis bar chart showing the US population distribution of age groups and gender in 2000.",
     "encoding": {

--- a/altair/v1/examples/json/trellis_bar_histogram.vl.json
+++ b/altair/v1/examples/json/trellis_bar_histogram.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "row": {

--- a/altair/v1/examples/json/trellis_barley.vl.json
+++ b/altair/v1/examples/json/trellis_barley.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/barley.json"
+        "url": "https://vega.github.io/vega-lite/data/barley.json"
     },
     "description": "The Trellis display by Becker et al. helped establish small multiples as a \u201cpowerful mechanism for understanding interactions in studies of how a response depends on explanatory variables\u201d. Here we reproduce a trellis of Barley yields from the 1930s, complete with main-effects ordering to facilitate comparison.",
     "encoding": {

--- a/altair/v1/examples/json/trellis_row_column.vl.json
+++ b/altair/v1/examples/json/trellis_row_column.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "encoding": {
         "column": {

--- a/altair/v1/examples/json/trellis_scatter.vl.json
+++ b/altair/v1/examples/json/trellis_scatter.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/movies.json"
+        "url": "https://vega.github.io/vega-lite/data/movies.json"
     },
     "encoding": {
         "column": {

--- a/altair/v1/examples/json/trellis_scatter_binned_row.vl.json
+++ b/altair/v1/examples/json/trellis_scatter_binned_row.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/cars.json"
+        "url": "https://vega.github.io/vega-lite/data/cars.json"
     },
     "description": "A trellis scatterplot showing Horsepower and Miles per gallons, faceted by binned values of Acceleration.",
     "encoding": {

--- a/altair/v1/examples/json/trellis_stacked_bar.vl.json
+++ b/altair/v1/examples/json/trellis_stacked_bar.vl.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "url": "http://vega.github.io/vega-lite/data/barley.json"
+        "url": "https://vega.github.io/vega-lite/data/barley.json"
     },
     "encoding": {
         "color": {

--- a/tools/altair_tools/syncing.py
+++ b/tools/altair_tools/syncing.py
@@ -65,7 +65,7 @@ def sync_schema(vegalite_version,
 
 def sync_examples(vegalite_version,
                   destination=path_within_altair('examples', 'json'),
-                  data_url='http://vega.github.io/vega-lite/',
+                  data_url='https://vega.github.io/vega-lite/',
                   vegalite_path=VEGALITE_PATH, vegalite_url=VEGALITE_URL):
     """
     Clone the vega-lite repository, check-out the appropriate version, and

--- a/tools/sync_vegalite.py
+++ b/tools/sync_vegalite.py
@@ -90,7 +90,7 @@ def sync_schema(vegalite_version,
 
 def sync_examples(vegalite_repo,
                   destination=abspath('..', 'altair', 'examples', 'json'),
-                  data_url='http://vega.github.io/vega-lite/'):
+                  data_url='https://vega.github.io/vega-lite/'):
     source_dir = os.path.join(vegalite_repo, 'examples', 'specs')
     index_source = os.path.join(vegalite_repo, 'examples', 'vl-examples.json')
     print("Reading from {0}".format(source_dir))


### PR DESCRIPTION
Per issue #407, a few examples in the documentation have HTTP-prefixed URLs that result in CORS errors when using Altair in Jupyter Notebook. This commit updates the default URL prefix in the example-syncing functions to `https://`, which should resolve the CORS issue when the examples are synced and the docs are re-built.

@jakevdp, want to take a look at this when you get a chance?