### PR TITLE
DOC: change website to ReadTheDocs theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -124,7 +124,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'haiku'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,7 +2,7 @@ Declarative Visualization in Python
 ===================================
 
 .. altair-minigallery::
-   :size: 6
+   :size: 5
    :width: 125px
    :shuffle:
    :seed: 0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 jinja2
 numpydoc
 pillow
+sphinx_rtd_theme

--- a/doc/sphinxext/altair_ext/altairplot.py
+++ b/doc/sphinxext/altair_ext/altairplot.py
@@ -81,7 +81,11 @@ VEGAEMBED_JS_URL_DEFAULT = "https://vega.github.io/vega-editor/vendor/vega-embed
 VGL_TEMPLATE = jinja2.Template("""
 <div id="{{ div_id }}">
 <script>
-  vg.embed("#{{ div_id }}", "{{ filename }}", function(error, result) {});
+  // embed when document is loaded, to ensure vega library is available
+  // this works on all modern browsers, except IE8 and older
+  document.addEventListener("DOMContentLoaded", function(event) {
+    vg.embed("#{{ div_id }}", "{{ filename }}", function(error, result) {});
+  });
 </script>
 </div>
 """)


### PR DESCRIPTION
These are the changes required to use the basic ReadTheDocs theme. Only one nontrivial thing in here: because the theme loads javascript at the bottom rather than the top of each page, we need to use a ``DOMContentLoaded`` listener to build the charts once the rest of the content is loaded.

This is supported by all modern browsers, but not by IE8 or before, which according to [this site](http://caniuse.com/#feat=domcontentloaded) only account for about 0.2% of web traffic.

Can we live with that?