### PR TITLE
API change: make chart methods return copies

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly
-# 2018-02-18 06:49:20
+# 2018-02-18 21:30:42
 import collections
 import json
 
@@ -54,7 +54,7 @@ class SchemaBase(object):
         """
         def _deep_copy(obj, ignore=()):
             if isinstance(obj, SchemaBase):
-                args = tuple(_deep_copy(args) for arg in obj._args)
+                args = tuple(_deep_copy(arg) for arg in obj._args)
                 kwds = {k: (_deep_copy(v, ignore=ignore)
                             if k not in ignore else v)
                         for k, v in obj._kwds.items()}
@@ -64,7 +64,7 @@ class SchemaBase(object):
             elif isinstance(obj, dict):
                 return {k: (_deep_copy(v, ignore=ignore)
                             if k not in ignore else v)
-                        for k, v in val.items()}
+                        for k, v in obj.items()}
             else:
                 return obj
         if deep:
@@ -143,7 +143,7 @@ class SchemaBase(object):
                               if k not in ignore})
         else:
             raise ValueError("{0} instance has both a value and properties : "
-                             "cannot serialize to dict")
+                             "cannot serialize to dict".format(self.__class__))
         if validate:
             self.validate(result)
         return result

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly
-# 2018-02-15 13:27:12
+# 2018-02-16 06:27:48
 import collections
 import json
 
@@ -40,16 +40,9 @@ class SchemaBase(object):
         object.__setattr__(self, '_args', args)
         object.__setattr__(self, '_kwds', kwds)
 
-    def copy(self, deep=False):
-        """Return a deep copy of the object"""
-        args = self._args
-        kwds = self._kwds
-
-        if deep:
-            import copy
-            args = copy.deepcopy(args)
-            kwds = copy.deepcopy(kwds)
-        return self.__class__(*args, **kwds)
+    def copy(self):
+        """Return a shallow copy of the object"""
+        return self.__class__(*self._args, **self._kwds)
 
     def __getattr__(self, item):
         # reminder: getattr is called after the normal lookups

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -250,11 +250,3 @@ class LayerChart(TopLevelMixin, core.TopLevelLayerSpec):
         super(LayerChart, self).__init__(layer=layer, **kwargs)
 
     # TODO: think about the most useful class API here
-
-
-class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
-    def __init__(self, spec, repeat, **kwargs):
-        super(RepeatChart, self).__init__(spec=spec, repeat=repeat, **kwargs)
-
-    # TODO: change channel classes to allow repeat values
-    # TODO: think about the most useful class API here

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -70,7 +70,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
 
     @use_signature(core.MarkDef)
     def mark_area(self, **kwargs):
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         if kwargs:
             copy.mark = core.MarkDef(type='area', **kwargs)
         else:
@@ -79,7 +79,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
 
     @use_signature(core.MarkDef)
     def mark_bar(self, **kwargs):
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         if kwargs:
             copy.mark = core.MarkDef(type='bar', **kwargs)
         else:
@@ -88,7 +88,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
 
     @use_signature(core.MarkDef)
     def mark_line(self, **kwargs):
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         if kwargs:
             copy.mark = core.MarkDef(type='line', **kwargs)
         else:
@@ -97,7 +97,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
 
     @use_signature(core.MarkDef)
     def mark_point(self, **kwargs):
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         if kwargs:
             copy.mark = core.MarkDef(type='point', **kwargs)
         else:
@@ -106,7 +106,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
 
     @use_signature(core.MarkDef)
     def mark_text(self, **kwargs):
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         if kwargs:
             copy.mark = core.MarkDef(type='text', **kwargs)
         else:
@@ -115,7 +115,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
 
     @use_signature(core.MarkDef)
     def mark_tick(self, **kwargs):
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         if kwargs:
             copy.mark = core.MarkDef(type='tick', **kwargs)
         else:
@@ -124,7 +124,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
 
     @use_signature(core.MarkDef)
     def mark_rect(self, **kwargs):
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         if kwargs:
             copy.mark = core.MarkDef(type='rect', **kwargs)
         else:
@@ -133,7 +133,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
 
     @use_signature(core.MarkDef)
     def mark_rule(self, **kwargs):
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         if kwargs:
             copy.mark = core.MarkDef(type='rule', **kwargs)
         else:
@@ -142,7 +142,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
 
     @use_signature(core.MarkDef)
     def mark_circle(self, **kwargs):
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         if kwargs:
             copy.mark = core.MarkDef(type='circle', **kwargs)
         else:
@@ -151,7 +151,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
 
     @use_signature(core.MarkDef)
     def mark_square(self, **kwargs):
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         if kwargs:
             copy.mark = core.MarkDef(type='square', **kwargs)
         else:
@@ -160,7 +160,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
 
     @use_signature(core.MarkDef)
     def mark_geoshape(self, **kwargs):
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         if kwargs:
             copy.mark = core.MarkDef(type='geoshape', **kwargs)
         else:
@@ -190,12 +190,12 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
                 # as part of the to_dict() call.
                 kwargs[prop] = cls.from_dict(field, validate=False)
         # TODO: update nested values rather than overwriting them
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         encoding = copy.encoding
         if encoding is Undefined:
             encoding = {}
         elif isinstance(encoding, dict):
-            encoding = encoding.copy()
+            pass
         else:
             encoding = {k: v for k, v in encoding._kwds.items()
                         if v is not Undefined}
@@ -217,7 +217,7 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
             encodings.append('x')
         if bind_y:
             encodings.append('y')
-        copy = self.copy()
+        copy = self.copy(deep=True, ignore=['data'])
         # TODO: don't overwrite previous selections?
         copy.selection = {name: {'bind': 'scales',
                                  'type': 'interval',

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -189,8 +189,9 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
                 # Don't validate now, because field will be computed
                 # as part of the to_dict() call.
                 kwargs[prop] = cls.from_dict(field, validate=False)
-        # TODO: update nested values rather than overwriting them
         copy = self.copy(deep=True, ignore=['data'])
+
+        # get a copy of the dict representation of the previous encoding
         encoding = copy.encoding
         if encoding is Undefined:
             encoding = {}
@@ -199,6 +200,8 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
         else:
             encoding = {k: v for k, v in encoding._kwds.items()
                         if v is not Undefined}
+
+        # update with the new encodings, and apply them to the copy
         encoding.update(kwargs)
         copy.encoding = core.EncodingWithFacet(**encoding)
         return copy

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -68,71 +68,104 @@ class Chart(TopLevelMixin, core.TopLevelFacetedUnitSpec):
         super(Chart, self).__init__(data=data, encoding=encoding, mark=mark,
                                     width=width, height=height, **kwargs)
 
-    @use_signature(core.MarkConfig)
-    def mark_area(self, *args, **kwargs):
-        self.mark = 'area'
-        self.configure_mark(*args, **kwargs)
-        return self
+    @use_signature(core.MarkDef)
+    def mark_area(self, **kwargs):
+        copy = self.copy()
+        if kwargs:
+            copy.mark = core.MarkDef(type='area', **kwargs)
+        else:
+            copy.mark = 'area'
+        return copy
 
-    @use_signature(core.MarkConfig)
-    def mark_bar(self, *args, **kwargs):
-        self.mark = 'bar'
-        self.configure_mark(*args, **kwargs)
-        return self
+    @use_signature(core.MarkDef)
+    def mark_bar(self, **kwargs):
+        copy = self.copy()
+        if kwargs:
+            copy.mark = core.MarkDef(type='bar', **kwargs)
+        else:
+            copy.mark = 'bar'
+        return copy
 
-    @use_signature(core.MarkConfig)
-    def mark_line(self, *args, **kwargs):
-        self.mark = 'line'
-        self.configure_mark(*args, **kwargs)
-        return self
+    @use_signature(core.MarkDef)
+    def mark_line(self, **kwargs):
+        copy = self.copy()
+        if kwargs:
+            copy.mark = core.MarkDef(type='line', **kwargs)
+        else:
+            copy.mark = 'line'
+        return copy
 
-    @use_signature(core.MarkConfig)
-    def mark_point(self, *args, **kwargs):
-        self.mark = 'point'
-        self.configure_mark(*args, **kwargs)
-        return self
+    @use_signature(core.MarkDef)
+    def mark_point(self, **kwargs):
+        copy = self.copy()
+        if kwargs:
+            copy.mark = core.MarkDef(type='point', **kwargs)
+        else:
+            copy.mark = 'point'
+        return copy
 
-    @use_signature(core.MarkConfig)
-    def mark_text(self, *args, **kwargs):
-        self.mark = 'text'
-        self.configure_mark(*args, **kwargs)
-        return self
+    @use_signature(core.MarkDef)
+    def mark_text(self, **kwargs):
+        copy = self.copy()
+        if kwargs:
+            copy.mark = core.MarkDef(type='text', **kwargs)
+        else:
+            copy.mark = 'text'
+        return copy
 
-    @use_signature(core.MarkConfig)
-    def mark_tick(self, *args, **kwargs):
-        self.mark = 'tick'
-        self.configure_mark(*args, **kwargs)
-        return self
+    @use_signature(core.MarkDef)
+    def mark_tick(self, **kwargs):
+        copy = self.copy()
+        if kwargs:
+            copy.mark = core.MarkDef(type='tick', **kwargs)
+        else:
+            copy.mark = 'tick'
+        return copy
 
-    @use_signature(core.MarkConfig)
-    def mark_rect(self, *args, **kwargs):
-        self.mark = 'rect'
-        self.configure_mark(*args, **kwargs)
-        return self
+    @use_signature(core.MarkDef)
+    def mark_rect(self, **kwargs):
+        copy = self.copy()
+        if kwargs:
+            copy.mark = core.MarkDef(type='rect', **kwargs)
+        else:
+            copy.mark = 'rect'
+        return copy
 
-    @use_signature(core.MarkConfig)
-    def mark_rule(self, *args, **kwargs):
-        self.mark = 'rule'
-        self.configure_mark(*args, **kwargs)
-        return self
+    @use_signature(core.MarkDef)
+    def mark_rule(self, **kwargs):
+        copy = self.copy()
+        if kwargs:
+            copy.mark = core.MarkDef(type='rule', **kwargs)
+        else:
+            copy.mark = 'rule'
+        return copy
 
-    @use_signature(core.MarkConfig)
-    def mark_circle(self, *args, **kwargs):
-        self.mark = 'circle'
-        self.configure_mark(*args, **kwargs)
-        return self
+    @use_signature(core.MarkDef)
+    def mark_circle(self, **kwargs):
+        copy = self.copy()
+        if kwargs:
+            copy.mark = core.MarkDef(type='circle', **kwargs)
+        else:
+            copy.mark = 'circle'
+        return copy
 
-    @use_signature(core.MarkConfig)
-    def mark_square(self, *args, **kwargs):
-        self.mark = 'square'
-        self.configure_mark(*args, **kwargs)
-        return self
+    @use_signature(core.MarkDef)
+    def mark_square(self, **kwargs):
+        copy = self.copy()
+        if kwargs:
+            copy.mark = core.MarkDef(type='square', **kwargs)
+        else:
+            copy.mark = 'square'
+        return copy
 
-    @use_signature(core.MarkConfig)
-    def mark_geoshape(self, *args, **kwargs):
-        self.mark = 'geoshape'
-        self.configure_mark(*args, **kwargs)
-        return self
+    @use_signature(core.MarkDef)
+    def mark_geoshape(self, **kwargs):
+        copy = self.copy()
+        if kwargs:
+            copy.mark = core.MarkDef(type='geoshape', **kwargs)
+        else:
+            copy.mark = 'geoshape'
+        return copy
 
     def configure_mark(self, *args, **kwargs):
         if args or kwargs:
@@ -204,10 +237,19 @@ class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
 
     # TODO: think about the most useful class API here
 
+
 class LayerChart(TopLevelMixin, core.TopLevelLayerSpec):
     def __init__(self, layer, **kwargs):
         # TODO: move common data to top level?
         # TODO: check for conflicting interaction
         super(LayerChart, self).__init__(layer=layer, **kwargs)
 
+    # TODO: think about the most useful class API here
+
+
+class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
+    def __init__(self, spec, repeat, **kwargs):
+        super(RepeatChart, self).__init__(spec=spec, repeat=repeat, **kwargs)
+
+    # TODO: change channel classes to allow repeat values
     # TODO: think about the most useful class API here

--- a/altair/vegalite/v2/schema/channels.py
+++ b/altair/vegalite/v2/schema/channels.py
@@ -1,5 +1,5 @@
 # The contents of this file are automatically generated
-# 2018-02-16 06:27:48
+# 2018-02-18 06:49:20
 
 from . import core
 from altair.utils.schemapi import Undefined

--- a/altair/vegalite/v2/schema/channels.py
+++ b/altair/vegalite/v2/schema/channels.py
@@ -1,5 +1,5 @@
 # The contents of this file are automatically generated
-# 2018-02-15 13:27:12
+# 2018-02-16 06:27:48
 
 from . import core
 from altair.utils.schemapi import Undefined

--- a/altair/vegalite/v2/schema/channels.py
+++ b/altair/vegalite/v2/schema/channels.py
@@ -1,5 +1,5 @@
 # The contents of this file are automatically generated
-# 2018-02-18 06:49:20
+# 2018-02-18 21:30:42
 
 from . import core
 from altair.utils.schemapi import Undefined

--- a/altair/vegalite/v2/schema/core.py
+++ b/altair/vegalite/v2/schema/core.py
@@ -1,5 +1,5 @@
 # The contents of this file are automatically generated
-# at time 2018-02-15 13:27:12
+# at time 2018-02-16 06:27:48
 
 from altair.utils.schemapi import SchemaBase, Undefined
 

--- a/altair/vegalite/v2/schema/core.py
+++ b/altair/vegalite/v2/schema/core.py
@@ -1,5 +1,5 @@
 # The contents of this file are automatically generated
-# at time 2018-02-18 06:49:20
+# at time 2018-02-18 21:30:42
 
 from altair.utils.schemapi import SchemaBase, Undefined
 

--- a/altair/vegalite/v2/schema/core.py
+++ b/altair/vegalite/v2/schema/core.py
@@ -1,5 +1,5 @@
 # The contents of this file are automatically generated
-# at time 2018-02-16 06:27:48
+# at time 2018-02-18 06:49:20
 
 from altair.utils.schemapi import SchemaBase, Undefined
 

--- a/tools/schemapi/decorator.py
+++ b/tools/schemapi/decorator.py
@@ -34,17 +34,18 @@ def schemaclass(*args, init_func=True, docstring=True, property_map=True):
             warnings.warn("class is not an instance of SchemaBase.")
 
         name = cls.__name__
-        schema = SchemaInfo(cls)
 
         if init_func and '__init__' not in cls.__dict__:
-            init_code = codegen.init_code(name, schema.schema)
+            init_code = codegen.init_code(name, schema=cls._schema,
+                                          rootschema=cls._rootschema)
             globals_ = {name: cls, 'Undefined': Undefined}
             locals_ = {}
             exec(init_code, globals_, locals_)
             setattr(cls, '__init__', locals_['__init__'])
 
         if docstring and not cls.__doc__:
-            setattr(cls, '__doc__', codegen.docstring(name, schema.schema))
+            setattr(cls, '__doc__', codegen.docstring(name, schema=cls._schema,
+                                                      rootschema=cls._rootschema))
         return cls
 
     if len(args) == 0:

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -37,9 +37,37 @@ class SchemaBase(object):
         object.__setattr__(self, '_args', args)
         object.__setattr__(self, '_kwds', kwds)
 
-    def copy(self):
-        """Return a shallow copy of the object"""
-        return self.__class__(*self._args, **self._kwds)
+    def copy(self, deep=True, ignore=()):
+        """Return a copy of the object
+
+        Parameters
+        ----------
+        deep : boolean, optional
+            if True (default) then return a deep copy of all dict, list, and
+            SchemaBase objects within the object structure
+        ignore : list, optional
+            A list of keys for which the contents should not be copied, but
+            only stored by reference.
+        """
+        def _deep_copy(obj, ignore=()):
+            if isinstance(obj, SchemaBase):
+                args = tuple(_deep_copy(args) for arg in obj._args)
+                kwds = {k: (_deep_copy(v, ignore=ignore)
+                            if k not in ignore else v)
+                        for k, v in obj._kwds.items()}
+                return obj.__class__(*args, **kwds)
+            elif isinstance(obj, list):
+                return [_deep_copy(v, ignore=ignore) for v in obj]
+            elif isinstance(obj, dict):
+                return {k: (_deep_copy(v, ignore=ignore)
+                            if k not in ignore else v)
+                        for k, v in val.items()}
+            else:
+                return obj
+        if deep:
+            return _deep_copy(self, ignore=ignore)
+        else:
+            return self.__class__(*self._args, **self._kwds)
 
     def __getattr__(self, item):
         # reminder: getattr is called after the normal lookups

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -37,16 +37,9 @@ class SchemaBase(object):
         object.__setattr__(self, '_args', args)
         object.__setattr__(self, '_kwds', kwds)
 
-    def copy(self, deep=False):
-        """Return a deep copy of the object"""
-        args = self._args
-        kwds = self._kwds
-
-        if deep:
-            import copy
-            args = copy.deepcopy(args)
-            kwds = copy.deepcopy(kwds)
-        return self.__class__(*args, **kwds)
+    def copy(self):
+        """Return a shallow copy of the object"""
+        return self.__class__(*self._args, **self._kwds)
 
     def __getattr__(self, item):
         # reminder: getattr is called after the normal lookups

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -51,7 +51,7 @@ class SchemaBase(object):
         """
         def _deep_copy(obj, ignore=()):
             if isinstance(obj, SchemaBase):
-                args = tuple(_deep_copy(args) for arg in obj._args)
+                args = tuple(_deep_copy(arg) for arg in obj._args)
                 kwds = {k: (_deep_copy(v, ignore=ignore)
                             if k not in ignore else v)
                         for k, v in obj._kwds.items()}
@@ -61,7 +61,7 @@ class SchemaBase(object):
             elif isinstance(obj, dict):
                 return {k: (_deep_copy(v, ignore=ignore)
                             if k not in ignore else v)
-                        for k, v in val.items()}
+                        for k, v in obj.items()}
             else:
                 return obj
         if deep:
@@ -140,7 +140,7 @@ class SchemaBase(object):
                               if k not in ignore})
         else:
             raise ValueError("{0} instance has both a value and properties : "
-                             "cannot serialize to dict")
+                             "cannot serialize to dict".format(self.__class__))
         if validate:
             self.validate(result)
         return result

--- a/tools/schemapi/tests/test_utils.py
+++ b/tools/schemapi/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..utils import resolve_references, get_valid_identifier
-from ..core import _FromDict
+from ..schemapi import _FromDict
 
 
 @pytest.fixture


### PR DESCRIPTION
With the stacking and layering available in VegaLite 2.0, I think it makes sense to have chart methods return copies of the chart rather than mutate the chart.

What this means is that with this PR in place, we could do things like this:

```python
chart = Chart(data).encode(x='x', y='y')
chart.mark_line() + chart.mark_point()
```
![vega 2](https://user-images.githubusercontent.com/781659/36314673-6caf5dc2-12ea-11e8-952f-5700a25661bc.png)
The result is a layered chart marked by both points and lines

similarly for faceting:
```python
chart = alt.Chart(data).mark_point().encode(y='y')
chart.encode(x='x1') | chart.encode(x='x2')
```
![vega 3](https://user-images.githubusercontent.com/781659/36314659-61621c16-12ea-11e8-888e-c8fa68b3d219.png)
The result is a two-panel side-by-side chart with a shared y-axis, but different encodings on the x axes. Previously this kind of layering and stacking would require much more boilerplate, or an explicit copy of the chart.

The pattern that will not work anymore after this change is code like this:
```python
chart = Chart(data)
chart.mark_line()
chart.encode(x='x', y='y')
```
Instead, you'd have to do
```python
chart = Chart(data)
chart = chart.mark_line()
chart = chart.encode(x='x', y='y')
```

But, to be clear, the standard chaining approach used in our examples will still work correctly after this change:

```python
Chart(data).mark_line().encode(
    x='x',
    y='y'
)
```

I think the advantages of this change far outweigh the disadvantages, but I wanted to get some second opinions before I push it. Any thoughts? cc @ellisonbg @craigcitro @domoritz @kanitw