### PR TITLE
Proposing true division as vconcat

### DIFF
--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -45,7 +45,7 @@ class TopLevelMixin(object):
     def __add__(self, other):
         return LayerChart([self, other])
 
-    def __sub__(self, other):
+    def __truediv__(self, other):
         return VConcatChart([self, other])
 
     def __or__(self, other):


### PR DESCRIPTION
I was playing around a bit with the API and found the mapping of `or` to hconcat to be very intuitive:

```python
chart.mark_line() | chart.mark_point()
```

This syntax is easy to mix with the layering operator (`+`), and the mental model seems consistent. However, I found the mapping of subtraction (`-`) to vconcat confusing. The mental model that `+` and `|` establish is "spatial" in nature. The operator I was expecting to map onto vconcat was true division (`/`), mainly because in mathematical notation, division is quite literally written by putting one thing over another (spatial in nature). The other aspect of using `-` that was confusing is that it is the inverse of `+` (mathematically) - but that doesn't map well onto using them for layering and vconcat.

This PR proposes to change vconcat from `-` to `/`.

Thoughts? @jakevdp  @craigcitro @domoritz @kanitw