### PR TITLE
add in vega-lite example of line layer rule

### DIFF
--- a/altair/vegalite/v2/examples/layer_line_color_rule.py
+++ b/altair/vegalite/v2/examples/layer_line_color_rule.py
@@ -18,6 +18,6 @@ line = alt.Chart(stocks).mark_line().encode(
 rule = alt.Chart(stocks).mark_rule().encode(
     y = alt.Y('average(price)', ),
     color='symbol'
-)
+).encode(size=alt.SizeValue(2))
 
 chart = (line + rule)

--- a/altair/vegalite/v2/examples/layer_line_color_rule.py
+++ b/altair/vegalite/v2/examples/layer_line_color_rule.py
@@ -13,12 +13,13 @@ line = alt.Chart(stocks).mark_line().encode(
     x = 'date', 
     y = 'price', 
     color = 'symbol'
-).properties(width=800,
-            title="Daily closing prices with their aggregate prices").interactive()
+).properties(width = 800,
+            title = "Daily closing prices with their aggregate prices").interactive()
 
 rule = alt.Chart(stocks).mark_rule().encode(
     y = alt.Y('average(price)', ),
-    color='symbol'
-).encode(size=alt.SizeValue(2))
+    color = 'symbol',
+    size = alt.SizeValue(2)
+)
 
 chart = (line + rule)

--- a/altair/vegalite/v2/examples/layer_line_color_rule.py
+++ b/altair/vegalite/v2/examples/layer_line_color_rule.py
@@ -13,7 +13,7 @@ line = alt.Chart(stocks).mark_line().encode(
     x = 'date', 
     y = 'price', 
     color = 'symbol'
-).interactive()
+).properties(width=800).interactive()
 
 rule = alt.Chart(stocks).mark_rule().encode(
     y = alt.Y('average(price)', ),

--- a/altair/vegalite/v2/examples/layer_line_color_rule.py
+++ b/altair/vegalite/v2/examples/layer_line_color_rule.py
@@ -13,7 +13,8 @@ line = alt.Chart(stocks).mark_line().encode(
     x = 'date', 
     y = 'price', 
     color = 'symbol'
-).properties(width=800).interactive()
+).properties(width=800,
+            title="Daily closing prices with their aggregate prices").interactive()
 
 rule = alt.Chart(stocks).mark_rule().encode(
     y = alt.Y('average(price)', ),

--- a/altair/vegalite/v2/examples/layer_line_color_rule.py
+++ b/altair/vegalite/v2/examples/layer_line_color_rule.py
@@ -1,0 +1,25 @@
+"""
+Multi Series Line Chart Layered With Rule Aggregate Lines
+-----------------------
+This example shows how to make a multi series line chart of the daily closing stock prices for AAPL, AMZN, GOOG, IBM, and MSFT between 2000 and 2010.
+"""
+
+import altair as alt
+from vega_datasets import data
+
+stocks = data.stocks()
+
+line = alt.Chart(stocks).mark_line().encode(
+    x = 'date', 
+    y = 'price', 
+    color = 'symbol'
+)
+
+rule = alt.Chart(stocks).mark_rule().encode(
+    y = alt.Y('average(price)', ),
+    color='symbol'
+)
+
+chart = (line + rule)
+#chart.config = {'rule': {'size': 20}}
+#chart.interactive()

--- a/altair/vegalite/v2/examples/layer_line_color_rule.py
+++ b/altair/vegalite/v2/examples/layer_line_color_rule.py
@@ -13,7 +13,7 @@ line = alt.Chart(stocks).mark_line().encode(
     x = 'date', 
     y = 'price', 
     color = 'symbol'
-)
+).interactive()
 
 rule = alt.Chart(stocks).mark_rule().encode(
     y = alt.Y('average(price)', ),
@@ -21,5 +21,3 @@ rule = alt.Chart(stocks).mark_rule().encode(
 )
 
 chart = (line + rule)
-#chart.config = {'rule': {'size': 20}}
-#chart.interactive()


### PR DESCRIPTION
Jake, if I notice things not working while building examples - please let me know if you would rather me file a github issue, or do a pull request of the example noting the difficulties.

I saw this example:
https://github.com/altair-viz/altair/blob/master/altair/vegalite/v2/examples/mutli_series_line.py
and then looked at the vega-lite example:
https://vega.github.io/editor/#/examples/vega-lite/layer_line_color_rule

I noticed that I could not get the .config to modify an attribute, in this case the line:
 chart.config = {'rule': {'size': 20}}
does not seem to be doing anything, so I commented it out for the moment.  I have looked in the vega-lite documentation and I seem to be using the correct terms so I am not sure what is causing it.

I know you showed me how .config can work in this example:
https://github.com/altair-viz/altair/blob/master/altair/vegalite/v2/examples/layered_chart_bar_mark.py

I can't get chart.interactive() to work on the layered plot.
If I un-comment that line I get:
AttributeError: 'super' object has no attribute '__getattr__'

If I only put rule.interactive() on rule I get zooming on the y axis only (undoubtedly because I am only calling y for the rule).
If I only put line.interactive() on line, it works fine.

Is the expectation to not but interactive() on the layered chart - and just do it on one of the component charts?

If that is the case then line.interactive() and add a comment for others.