### PR TITLE
added vega-lite example of falkensee

### DIFF
--- a/altair/vegalite/v2/examples/falkensee.py
+++ b/altair/vegalite/v2/examples/falkensee.py
@@ -80,4 +80,4 @@ recta = alt.Chart(source2).mark_rect().encode(
 
 
 
-chart = line + recta + point
+chart = recta + line + point

--- a/altair/vegalite/v2/examples/falkensee.py
+++ b/altair/vegalite/v2/examples/falkensee.py
@@ -1,0 +1,83 @@
+"""
+Falkensee
+-----------------------
+This example is a reproduction of the Falkanesee plot found in the vega-lite examples.
+"""
+
+import altair as alt
+
+source = [
+      {"year": "1875", "population": 1309},
+      {"year": "1890", "population": 1558},
+      {"year": "1910", "population": 4512},
+      {"year": "1925", "population": 8180},
+      {"year": "1933", "population": 15915},
+      {"year": "1939", "population": 24824},
+      {"year": "1946", "population": 28275},
+      {"year": "1950", "population": 29189},
+      {"year": "1964", "population": 29881},
+      {"year": "1971", "population": 26007},
+      {"year": "1981", "population": 24029},
+      {"year": "1985", "population": 23340},
+      {"year": "1989", "population": 22307},
+      {"year": "1990", "population": 22087},
+      {"year": "1991", "population": 22139},
+      {"year": "1992", "population": 22105},
+      {"year": "1993", "population": 22242},
+      {"year": "1994", "population": 22801},
+      {"year": "1995", "population": 24273},
+      {"year": "1996", "population": 25640},
+      {"year": "1997", "population": 27393},
+      {"year": "1998", "population": 29505},
+      {"year": "1999", "population": 32124},
+      {"year": "2000", "population": 33791},
+      {"year": "2001", "population": 35297},
+      {"year": "2002", "population": 36179},
+      {"year": "2003", "population": 36829},
+      {"year": "2004", "population": 37493},
+      {"year": "2005", "population": 38376},
+      {"year": "2006", "population": 39008},
+      {"year": "2007", "population": 39366},
+      {"year": "2008", "population": 39821},
+      {"year": "2009", "population": 40179},
+      {"year": "2010", "population": 40511},
+      {"year": "2011", "population": 40465},
+      {"year": "2012", "population": 40905},
+      {"year": "2013", "population": 41258},
+      {"year": "2014", "population": 41777}
+    ]
+
+source2 = [{
+            "start": "1933",
+            "end": "1945",
+            "event": "Nazi Rule"
+          },{
+            "start": "1948",
+            "end": "1989",
+            "event": "GDR (East Germany)"
+          }]
+
+          
+source = alt.pd.DataFrame(source)
+source2 = alt.pd.DataFrame(source2)
+
+
+line = alt.Chart(source).mark_line(color = '#333').encode(
+    x = alt.X('year:T', axis=alt.Axis(format='%Y')), 
+    y = 'population'
+).properties(width = 700, height = 400)
+
+point = alt.Chart(source).mark_point(color = '#333').encode(
+    x = alt.X('year:T', axis=alt.Axis(format='%Y')), 
+    y = 'population'
+)
+
+recta = alt.Chart(source2).mark_rect().encode(
+    x = 'start:T', 
+    x2 = 'end:T',
+    color = 'event:N'
+)
+
+
+
+chart = line + recta + point


### PR DESCRIPTION
This has one issue:
When building the final chart
chart = line + recta + point

recta should be in the first position so it does not cover up the lines and points, but if I put recta there errors will result.  line + point + recta work fine as well, just (at this point) can't have recta in first position where it needs to be for the visual composition to work.


The errors are: KeyError: 'population'

I am assuming vega-lite is expecting the full axis with the item in first position - or it is building components before they are loaded(since population is only in the line/points data and not recta's data)?

The vega-lite example is here:
https://vega.github.io/vega-lite/examples/layer_falkensee.html