### PR TITLE
adding vega-lite example of layered plot with dual-axis

### DIFF
--- a/altair/vegalite/v2/examples/layered_plot_with_dual_axis.py
+++ b/altair/vegalite/v2/examples/layered_plot_with_dual_axis.py
@@ -22,5 +22,5 @@ line = alt.Chart(source).mark_line(color = 'red').encode(
     y = 'mean(temp_max)')
 
 
-chart = line + bar
+chart = bar + line
 chart.resolve = {'scale': {'y': 'independent'}}

--- a/altair/vegalite/v2/examples/layered_plot_with_dual_axis.py
+++ b/altair/vegalite/v2/examples/layered_plot_with_dual_axis.py
@@ -1,0 +1,25 @@
+"""
+Layered Plot with Dual-Axis
+-----------------------
+This example shows how to combine two plots and keep their axes.
+"""
+
+import altair as alt
+from vega_datasets import data
+
+source = data.seattle_weather()
+
+bar = alt.Chart(source).mark_bar().encode(
+    x = alt.X('date:O', axis = alt.Axis(format = '%b'), timeUnit = 'month',
+             scale = alt.Scale(zero=False)),
+    y = 'mean(precipitation)')
+
+
+line = alt.Chart(source).mark_line(color = 'red').encode(
+    x = alt.X('date:O', axis = alt.Axis(format = '%b'), timeUnit = 'month',
+             scale = alt.Scale(zero=False)),
+    #y = alt.Y('mean(temp_max)', resolveMode = 'independent'))
+    y = 'mean(temp_max)')
+
+
+chart = line + bar

--- a/altair/vegalite/v2/examples/layered_plot_with_dual_axis.py
+++ b/altair/vegalite/v2/examples/layered_plot_with_dual_axis.py
@@ -23,3 +23,4 @@ line = alt.Chart(source).mark_line(color = 'red').encode(
 
 
 chart = line + bar
+chart.resolve = {'scale': {'y': 'independent'}}


### PR DESCRIPTION
Here is one I have been struggling with.  In the vega-lite example:
https://vega.github.io/vega-lite/examples/layer_bar_dual_axis.html

It has this part:
"resolve": {"scale": {"y": "independent"}}
that sits at the same level as:
"$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "data": {"url": "data/seattle-weather.csv"},

I have toyed with ideas like:
y = alt.Y('mean(temp_max)', resolveMode = 'independent'))
also tried to put it in config, but I get errors every time.

I do note that I see resolvemode in here:
https://github.com/altair-viz/altair/blob/0fec41674f062c5e37d5af0b6b318702362f0115/altair/vegalite/v2/vega-lite-schema.json

So I am missing how to connect it up.

Note: the plot included works, it just overwrites the line's y axis with the bar's y axis, if you call out line or bar you will see each looks how they should.  Just combining them I am not seeing the place to add the resolvemode.