### PR TITLE
added binned scatterplot example from vega-lite

### DIFF
--- a/altair/vegalite/v2/examples/binned_scatterplot.py
+++ b/altair/vegalite/v2/examples/binned_scatterplot.py
@@ -14,4 +14,3 @@ chart = alt.Chart(source).mark_circle().encode(
     y = alt.Y('Rotten_Tomatoes_Rating',  bin = alt.BinParams(maxbins=10)),
     size = 'count(IMDB_Rating)'
 )  
-chart

--- a/altair/vegalite/v2/examples/binned_scatterplot.py
+++ b/altair/vegalite/v2/examples/binned_scatterplot.py
@@ -12,5 +12,5 @@ source = data.movies()
 chart = alt.Chart(source).mark_circle().encode(
     x = alt.X('IMDB_Rating',  bin = alt.BinParams(maxbins=10)),
     y = alt.Y('Rotten_Tomatoes_Rating',  bin = alt.BinParams(maxbins=10)),
-    size = 'count(IMDB_Rating)'
+    size = 'count(*):Q'
 )  

--- a/altair/vegalite/v2/examples/binned_scatterplot.py
+++ b/altair/vegalite/v2/examples/binned_scatterplot.py
@@ -1,0 +1,17 @@
+"""
+Binned Scatterplot
+-----------------
+This example shows how to make a binned scatterplot.
+"""
+
+import altair as alt
+from vega_datasets import data
+
+source = data.movies()
+
+chart = alt.Chart(source).mark_circle().encode(
+    x = alt.X('IMDB_Rating',  bin = alt.BinParams(maxbins=10)),
+    y = alt.Y('Rotten_Tomatoes_Rating',  bin = alt.BinParams(maxbins=10)),
+    size = 'count(IMDB_Rating)'
+)  
+chart


### PR DESCRIPTION
I will note that:
size = 'count(*)'
does not work and gives a keyerror of:
KeyError: '*'

I thought this was a capability that was here before.
But for this example I just set it to:
size = 'count(IMDB_Rating)'

And it works fine and matches the vega-lite example.