### PR TITLE
Added layered heatmap + text example

### DIFF
--- a/altair/vegalite/v2/examples/layered_heatmap_text.py
+++ b/altair/vegalite/v2/examples/layered_heatmap_text.py
@@ -17,12 +17,14 @@ heatmap = alt.Chart(cars).mark_rect().encode(
 )
 
 text = alt.Chart(cars).mark_text(
-    color = 'white',
-    baseline = 'middle'
+    baseline='middle'
 ).encode(
     alt.X('Cylinders:O'),
     alt.Y('Origin:O'),
-    alt.Text('count(*):Q')
+    alt.Text('count(*):Q'),
+    color=alt.condition("datum['count_*'] > 100",
+                        alt.ColorValue('black'),
+                        alt.ColorValue('white'))
 )
 
 chart = heatmap + text

--- a/altair/vegalite/v2/examples/layered_heatmap_text.py
+++ b/altair/vegalite/v2/examples/layered_heatmap_text.py
@@ -1,0 +1,28 @@
+"""
+Layering text over a heatmap
+----------------------------
+
+An example of a layered chart of text over a heatmap using the cars dataset.
+"""
+
+import altair as alt
+from vega_datasets import data
+
+cars = data.cars.url
+
+heatmap = alt.Chart(cars).mark_rect().encode(
+    alt.X('Cylinders:O', scale=alt.Scale(paddingInner=0)),
+    alt.Y('Origin:O', scale=alt.Scale(paddingInner=0)),
+    alt.Color('count(*):Q')
+)
+
+text = alt.Chart(cars).mark_text(
+    color = 'white',
+    baseline = 'middle'
+).encode(
+    alt.X('Cylinders:O'),
+    alt.Y('Origin:O'),
+    alt.Text('count(*):Q')
+)
+
+chart = heatmap + text


### PR DESCRIPTION
Tried to reproduce [this](https://vega.github.io/vega-lite/examples/layer_text_heatmap.html) plot from the vega docs. No idea how to do the final step, which is to change the text color of those rectangles with values greater than 100 to black.

![plot](https://user-images.githubusercontent.com/559360/36644034-f7bf3f94-1a5c-11e8-8cd4-59929f3380ca.png)
