### PR TITLE
#457: Add Basic Histogram Example

### DIFF
--- a/altair/vegalite/v2/examples/histogram.py
+++ b/altair/vegalite/v2/examples/histogram.py
@@ -1,0 +1,18 @@
+"""
+Histogram
+-----------------
+This example shows how to make a basic histogram, based on the vega-lite docs
+https://vega.github.io/vega-lite/examples/histogram.html
+"""
+import altair as alt
+
+movies = alt.load_dataset('movies')
+
+chart = alt.Chart(movies).mark_bar().encode(
+    x=alt.X("IMDB_Rating",
+            type='quantitative',
+            bin=alt.BinTransform(
+                maxbins=10,
+            )),
+    y='count(*):Q',
+)


### PR DESCRIPTION
Implements https://vega.github.io/vega-lite/examples/histogram.html .

The primary change compared to Altair 1.3 seems to be that the `Bin` class was renamed `BinTransform`. ( https://altair-viz.github.io/gallery/histogram.html ) . 

I'm not sure if there is a practical difference is between using `:Q` as a suffix, vs explicitly setting `type='quantitative'`. However I felt the second option was more explicit, and so I went with that instead.