### PR TITLE
#457: Add Basic Trellis Histogram Example

### DIFF
--- a/altair/vegalite/v2/examples/trellis_histogram.py
+++ b/altair/vegalite/v2/examples/trellis_histogram.py
@@ -1,0 +1,19 @@
+"""
+Trellis Histogram
+-----------------
+This example shows how to make a basic trellis histogram.
+https://vega.github.io/vega-lite/examples/trellis_bar_histogram.html
+"""
+import altair as alt
+
+cars = alt.load_dataset('cars')
+
+chart = alt.Chart(cars).mark_bar().encode(
+    x=alt.X("Horsepower",
+            type="quantitative",
+            bin=alt.BinTransform(
+                maxbins=15
+            )),
+    y='count(*):Q',
+    row='Origin'
+)


### PR DESCRIPTION
Implements the vega-lite example from

https://vega.github.io/vega-lite/examples/trellis_bar_histogram.html

Note that the row labels will show up on the right instead of on the left (as they are in the vega-lite online example).