### PR TITLE
#457: Add Box Plot (Max/Min Whiskers) Example

### DIFF
--- a/altair/vegalite/v2/examples/boxplot_max_min.py
+++ b/altair/vegalite/v2/examples/boxplot_max_min.py
@@ -1,0 +1,47 @@
+"""
+Box Plot with Min/Max Whiskers
+-----------------
+This example shows how to make a basic box plot using US Population
+data from 2000.
+
+https://vega.github.io/vega-lite/examples/box-plot_minmax_2D_vertical_normalized.html
+"""
+import altair as alt
+
+population = alt.load_dataset('population')
+
+# Define aggregate fields
+lower_box = 'q1(people)'
+lower_whisker = 'min(people)'
+upper_box = 'q3(people)'
+upper_whisker = 'max(people)'
+
+# Compose each layer individually
+lower_plot = alt.Chart(population).mark_rule().encode(
+    y=alt.Y(lower_whisker,
+            axis=alt.Axis(title="population")),
+    y2=lower_box,
+    x='age:O'
+)
+
+middle_plot = alt.Chart(population).mark_bar(size=5.0).encode(
+    y=lower_box,
+    y2=upper_box,
+    x='age:O'
+)
+
+upper_plot = alt.Chart(population).mark_rule().encode(
+    y=upper_whisker,
+    y2=upper_box,
+    x='age:O'
+)
+
+middle_tick = alt.Chart(population).mark_tick(color='white', size=5.0).encode(
+    y='median(people)',
+    x='age:O',
+)
+
+chart = alt.layer(lower_plot,
+                  middle_plot,
+                  upper_plot,
+                  middle_tick)


### PR DESCRIPTION
Implements https://vega.github.io/vega-lite/examples/box-plot_minmax_2D_vertical_normalized.html .

A few open questions on style:

- Wasn't sure if there's a way to carry over the "create calculated fields and give them names" concept from the vega-lite spec, so I can rewrite this if there's a more idiomatic way to do this.

- The `size` parameter passed into the `mark_rule` and `mark_tick` methods appears to have no effect, as in the rendered chart, the widths of those items stays constant

- The `style` parameter appears to have no effect either (for setting rule style to `boxWhisker`).