### PR TITLE
Deviation ellipses example

### DIFF
--- a/altair/vegalite/v2/examples/deviation_ellipses.py
+++ b/altair/vegalite/v2/examples/deviation_ellipses.py
@@ -1,0 +1,63 @@
+"""
+Deviation ellipse
+-----------------------
+This example shows bivariate deviation ellipses of petal length and width of three iris species.
+"""
+
+import numpy as np
+import pandas as pd
+from scipy.stats import f as ssf
+import altair as alt
+from vega_datasets import data
+
+iris = data.iris()
+
+def ellipse(X, level=0.95, method='deviation', npoints=100):
+    """
+    X: data, 2D numpy array with 2 columns
+    level: confidence level
+    method: either 'deviation' (swarning data) or 'error (swarning the mean)'
+    npoints: number of points describing the ellipse
+    """
+    cov_mat = np.cov(X.T)
+    dfd = X.shape[0]-1
+    dfn = 2
+    center = np.apply_along_axis(np.mean, arr=X, axis=0) # np.mean(X, axis=0)
+    if method == 'deviation':
+        radius = np.sqrt(2 * ssf.ppf(q=level, dfn=dfn, dfd=dfd))
+    elif method == 'error':
+        radius = np.sqrt(2 * ssf.ppf(q=level, dfn=dfn, dfd=dfd)) / np.sqrt(X.shape[0])
+    else:
+        raise ValueError("Method should be either 'deviation' or 'error'.")
+    angles = (np.arange(0,npoints+1)) * 2 * np.pi/npoints
+    circle = np.vstack((np.cos(angles), np.sin(angles))).T
+    ellipse = center + (radius * np.dot(circle, np.linalg.cholesky(cov_mat).T).T).T
+    return ellipse
+
+columns = ['petalLength', 'petalWidth']
+petal_ellipse = []
+for species in iris.species.unique():
+    ell_df = pd.DataFrame(ellipse(X=iris.loc[iris.species == species, columns].as_matrix()),
+                                      columns = columns)
+    ell_df['species'] = species
+    petal_ellipse.append(ell_df)
+
+petal_ellipse = pd.concat(petal_ellipse, axis=0).reset_index()
+
+chart_deviation = alt.Chart(petal_ellipse).mark_line().\
+    encode(
+        x=alt.X('petalLength', scale=alt.Scale(zero=False)),
+        y=alt.Y('petalWidth', scale=alt.Scale(zero=False)),
+        color='species',
+        order='index')
+# works only if chart_deviation is printed here
+# chart_deviation
+
+chart_points = alt.Chart(iris).mark_point().\
+    encode(
+        x=alt.X('petalLength', scale=alt.Scale(zero=False)),
+        y=alt.Y('petalWidth', scale=alt.Scale(zero=False)),
+        color='species')
+
+chart = chart_points + chart_deviation
+chart


### PR DESCRIPTION
This is an example showing bivariate deviation ellipses of petal length and width of three iris species. In Jupyter lab, it works only if chart_deviation is printed before printing chart_points + chart_deviation (error message below). A more complete example could include a pairs plot including petal and sepal dimensions, with ellipses. Is it feasible? 

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/bin/anaconda3/envs/altair-env/lib/python3.6/site-packages/pandas/core/indexes/base.py in get_loc(self, key, method, tolerance)
   2524             try:
-> 2525                 return self._engine.get_loc(key)
   2526             except KeyError:

pandas/_libs/index.pyx in pandas._libs.index.IndexEngine.get_loc()

pandas/_libs/index.pyx in pandas._libs.index.IndexEngine.get_loc()

pandas/_libs/hashtable_class_helper.pxi in pandas._libs.hashtable.PyObjectHashTable.get_item()

pandas/_libs/hashtable_class_helper.pxi in pandas._libs.hashtable.PyObjectHashTable.get_item()

KeyError: 'index'

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
~/bin/anaconda3/envs/altair-env/lib/python3.6/site-packages/IPython/core/formatters.py in __call__(self, obj, include, exclude)
    968 
    969             if method is not None:
--> 970                 return method(include=include, exclude=exclude)
    971             return None
    972         else:

~/Documents/GitHub/altair/altair/vegalite/v2/api.py in _repr_mimebundle_(self, include, exclude)
     56     def _repr_mimebundle_(self, include, exclude):
     57         """Return a MIME bundle for display in Jupyter frontends."""
---> 58         return renderers.get()(self.to_dict())
     59 
     60 

~/Documents/GitHub/altair/altair/vegalite/v2/api.py in to_dict(self, *args, **kwargs)
     39             context['data'] = original_data
     40         kwargs['context'] = context
---> 41         return super(TopLevelMixin, self).to_dict(*args, **kwargs)
     42 
     43     # Layering and stacking

~/Documents/GitHub/altair/altair/utils/schemapi.py in to_dict(self, validate, ignore, context)
    143             result = _todict(self._args[0])
    144         elif not self._args:
--> 145             result = _todict({k: v for k, v in self._kwds.items()
    146                               if k not in ignore})
    147         else:

~/Documents/GitHub/altair/altair/utils/schemapi.py in _todict(val)
    135                 return [_todict(v) for v in val]
    136             elif isinstance(val, dict):
--> 137                 return {k: _todict(v) for k, v in val.items()
    138                         if v is not Undefined}
    139             else:

~/Documents/GitHub/altair/altair/utils/schemapi.py in <dictcomp>(.0)
    136             elif isinstance(val, dict):
    137                 return {k: _todict(v) for k, v in val.items()
--> 138                         if v is not Undefined}
    139             else:
    140                 return val

~/Documents/GitHub/altair/altair/utils/schemapi.py in _todict(val)
    133                 return val.to_dict(validate=False, context=context)
    134             elif isinstance(val, list):
--> 135                 return [_todict(v) for v in val]
    136             elif isinstance(val, dict):
    137                 return {k: _todict(v) for k, v in val.items()

~/Documents/GitHub/altair/altair/utils/schemapi.py in <listcomp>(.0)
    133                 return val.to_dict(validate=False, context=context)
    134             elif isinstance(val, list):
--> 135                 return [_todict(v) for v in val]
    136             elif isinstance(val, dict):
    137                 return {k: _todict(v) for k, v in val.items()

~/Documents/GitHub/altair/altair/utils/schemapi.py in _todict(val)
    131             if isinstance(val, SchemaBase):
    132                 # only validate at the top level
--> 133                 return val.to_dict(validate=False, context=context)
    134             elif isinstance(val, list):
    135                 return [_todict(v) for v in val]

~/Documents/GitHub/altair/altair/vegalite/v2/api.py in to_dict(self, *args, **kwargs)
     39             context['data'] = original_data
     40         kwargs['context'] = context
---> 41         return super(TopLevelMixin, self).to_dict(*args, **kwargs)
     42 
     43     # Layering and stacking

~/Documents/GitHub/altair/altair/utils/schemapi.py in to_dict(self, validate, ignore, context)
    143             result = _todict(self._args[0])
    144         elif not self._args:
--> 145             result = _todict({k: v for k, v in self._kwds.items()
    146                               if k not in ignore})
    147         else:

~/Documents/GitHub/altair/altair/utils/schemapi.py in _todict(val)
    135                 return [_todict(v) for v in val]
    136             elif isinstance(val, dict):
--> 137                 return {k: _todict(v) for k, v in val.items()
    138                         if v is not Undefined}
    139             else:

~/Documents/GitHub/altair/altair/utils/schemapi.py in <dictcomp>(.0)
    136             elif isinstance(val, dict):
    137                 return {k: _todict(v) for k, v in val.items()
--> 138                         if v is not Undefined}
    139             else:
    140                 return val

~/Documents/GitHub/altair/altair/utils/schemapi.py in _todict(val)
    131             if isinstance(val, SchemaBase):
    132                 # only validate at the top level
--> 133                 return val.to_dict(validate=False, context=context)
    134             elif isinstance(val, list):
    135                 return [_todict(v) for v in val]

~/Documents/GitHub/altair/altair/utils/schemapi.py in to_dict(self, validate, ignore, context)
    143             result = _todict(self._args[0])
    144         elif not self._args:
--> 145             result = _todict({k: v for k, v in self._kwds.items()
    146                               if k not in ignore})
    147         else:

~/Documents/GitHub/altair/altair/utils/schemapi.py in _todict(val)
    135                 return [_todict(v) for v in val]
    136             elif isinstance(val, dict):
--> 137                 return {k: _todict(v) for k, v in val.items()
    138                         if v is not Undefined}
    139             else:

~/Documents/GitHub/altair/altair/utils/schemapi.py in <dictcomp>(.0)
    136             elif isinstance(val, dict):
    137                 return {k: _todict(v) for k, v in val.items()
--> 138                         if v is not Undefined}
    139             else:
    140                 return val

~/Documents/GitHub/altair/altair/utils/schemapi.py in _todict(val)
    131             if isinstance(val, SchemaBase):
    132                 # only validate at the top level
--> 133                 return val.to_dict(validate=False, context=context)
    134             elif isinstance(val, list):
    135                 return [_todict(v) for v in val]

~/Documents/GitHub/altair/altair/vegalite/v2/schema/channels.py in to_dict(self, validate, ignore, context)
    108         type_ = getattr(self, 'type', Undefined)
    109         if type_ is Undefined and 'data' in context:
--> 110             kwds = parse_shorthand_plus_data(self.field, context['data'])
    111         else:
    112             kwds = parse_shorthand(self.field)

~/Documents/GitHub/altair/altair/utils/core.py in parse_shorthand_plus_data(shorthand, data)
    248             raise ValueError("type must be specified unless data is provided "
    249                              "in the form of a dataframe.")
--> 250         col = data[attrs['field']]
    251         attrs['type'] = infer_vegalite_type(col)
    252     return attrs

~/bin/anaconda3/envs/altair-env/lib/python3.6/site-packages/pandas/core/frame.py in __getitem__(self, key)
   2137             return self._getitem_multilevel(key)
   2138         else:
-> 2139             return self._getitem_column(key)
   2140 
   2141     def _getitem_column(self, key):

~/bin/anaconda3/envs/altair-env/lib/python3.6/site-packages/pandas/core/frame.py in _getitem_column(self, key)
   2144         # get column
   2145         if self.columns.is_unique:
-> 2146             return self._get_item_cache(key)
   2147 
   2148         # duplicate columns & possible reduce dimensionality

~/bin/anaconda3/envs/altair-env/lib/python3.6/site-packages/pandas/core/generic.py in _get_item_cache(self, item)
   1840         res = cache.get(item)
   1841         if res is None:
-> 1842             values = self._data.get(item)
   1843             res = self._box_item_values(item, values)
   1844             cache[item] = res

~/bin/anaconda3/envs/altair-env/lib/python3.6/site-packages/pandas/core/internals.py in get(self, item, fastpath)
   3841 
   3842             if not isna(item):
-> 3843                 loc = self.items.get_loc(item)
   3844             else:
   3845                 indexer = np.arange(len(self.items))[isna(self.items)]

~/bin/anaconda3/envs/altair-env/lib/python3.6/site-packages/pandas/core/indexes/base.py in get_loc(self, key, method, tolerance)
   2525                 return self._engine.get_loc(key)
   2526             except KeyError:
-> 2527                 return self._engine.get_loc(self._maybe_cast_indexer(key))
   2528 
   2529         indexer = self.get_indexer([key], method=method, tolerance=tolerance)

pandas/_libs/index.pyx in pandas._libs.index.IndexEngine.get_loc()

pandas/_libs/index.pyx in pandas._libs.index.IndexEngine.get_loc()

pandas/_libs/hashtable_class_helper.pxi in pandas._libs.hashtable.PyObjectHashTable.get_item()

pandas/_libs/hashtable_class_helper.pxi in pandas._libs.hashtable.PyObjectHashTable.get_item()

KeyError: 'index'

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-14-850840d4c0a1> in <module>()
     60 
     61 chart = chart_points + chart_deviation
---> 62 chart

~/bin/anaconda3/envs/altair-env/lib/python3.6/site-packages/IPython/core/displayhook.py in __call__(self, result)
    255             self.start_displayhook()
    256             self.write_output_prompt()
--> 257             format_dict, md_dict = self.compute_format_data(result)
    258             self.update_user_ns(result)
    259             self.fill_exec_result(result)

~/bin/anaconda3/envs/altair-env/lib/python3.6/site-packages/IPython/core/displayhook.py in compute_format_data(self, result)
    149 
    150         """
--> 151         return self.shell.display_formatter.format(result)
    152 
    153     # This can be set to True by the write_output_prompt method in a subclass

~/bin/anaconda3/envs/altair-env/lib/python3.6/site-packages/IPython/core/formatters.py in format(self, obj, include, exclude)
    148             return {}, {}
    149 
--> 150         format_dict, md_dict = self.mimebundle_formatter(obj, include=include, exclude=exclude)
    151 
    152         if format_dict or md_dict:

TypeError: 'NoneType' object is not iterable
```