### PR TITLE
added example from vega-lite: one dot per zipcode

### DIFF
--- a/altair/vegalite/v2/examples/one_dot_per_zipcode.py
+++ b/altair/vegalite/v2/examples/one_dot_per_zipcode.py
@@ -7,9 +7,6 @@ This example shows a geographical plot with one dot per zipcode.
 import altair as alt
 from vega_datasets import data
 
-states = alt.UrlData(data.us_10m.url,
-                     format=alt.TopoDataFormat(type='topojson',
-                                               feature='states'))
 zipcodes = data.zipcodes.url
 
 chart = alt.Chart(zipcodes).mark_circle(size = 3).encode(

--- a/altair/vegalite/v2/examples/one_dot_per_zipcode.py
+++ b/altair/vegalite/v2/examples/one_dot_per_zipcode.py
@@ -14,7 +14,7 @@ zipcodes = data.zipcodes.url
 
 # US states background
 background = alt.Chart(states).mark_geoshape(
-    fill='lightgray',
+    fill='white',
     stroke='white'
 ).properties(
     projection={'type': 'albersUsa'},
@@ -23,7 +23,7 @@ background = alt.Chart(states).mark_geoshape(
 )
 
 # Zip Codes labeled on background
-points = alt.Chart(zipcodes).mark_circle(size = 2).encode(
+points = alt.Chart(zipcodes).mark_circle(size = 3).encode(
     #alt.Text('city', type='nominal'),
     alt.X('longitude', type='longitude'),
     alt.Y('latitude', type='latitude'),

--- a/altair/vegalite/v2/examples/one_dot_per_zipcode.py
+++ b/altair/vegalite/v2/examples/one_dot_per_zipcode.py
@@ -12,23 +12,14 @@ states = alt.UrlData(data.us_10m.url,
                                                feature='states'))
 zipcodes = data.zipcodes.url
 
-# US states background
-background = alt.Chart(states).mark_geoshape(
-    fill='white',
-    stroke='white'
-).properties(
-    projection={'type': 'albersUsa'},
-    width=800,
-    height=500
-)
-
-# Zip Codes labeled on background
-points = alt.Chart(zipcodes).mark_circle(size = 3).encode(
+chart = alt.Chart(zipcodes).mark_circle(size = 3).encode(
     #alt.Text('city', type='nominal'),
     alt.X('longitude', type='longitude'),
     alt.Y('latitude', type='latitude'),
     color = 'digit:N'
-)
+).properties(
+    projection={'type': 'albersUsa'},
+    width=800,
+    height=500)
 
-points.transform = [{"calculate": "substring(datum.zip_code, 0, 1)", "as": "digit"}]
-chart = background + points
+chart.transform = [{"calculate": "substring(datum.zip_code, 0, 1)", "as": "digit"}]

--- a/altair/vegalite/v2/examples/one_dot_per_zipcode.py
+++ b/altair/vegalite/v2/examples/one_dot_per_zipcode.py
@@ -10,8 +10,7 @@ from vega_datasets import data
 states = alt.UrlData(data.us_10m.url,
                      format=alt.TopoDataFormat(type='topojson',
                                                feature='states'))
-zipcodes = data.zipcodes()
-zipcodes = zipcodes[5000:10000]
+zipcodes = data.zipcodes.url
 
 # US states background
 background = alt.Chart(states).mark_geoshape(
@@ -24,7 +23,7 @@ background = alt.Chart(states).mark_geoshape(
 )
 
 # Zip Codes labeled on background
-points = alt.Chart(zipcodes).mark_circle(size = 1).encode(
+points = alt.Chart(zipcodes).mark_circle(size = 2).encode(
     #alt.Text('city', type='nominal'),
     alt.X('longitude', type='longitude'),
     alt.Y('latitude', type='latitude'),

--- a/altair/vegalite/v2/examples/one_dot_per_zipcode.py
+++ b/altair/vegalite/v2/examples/one_dot_per_zipcode.py
@@ -1,0 +1,35 @@
+"""
+One Dot Per Zipcode
+-----------------------
+This example shows a geographical plot with one dot per zipcode.
+"""
+
+import altair as alt
+from vega_datasets import data
+
+states = alt.UrlData(data.us_10m.url,
+                     format=alt.TopoDataFormat(type='topojson',
+                                               feature='states'))
+zipcodes = data.zipcodes()
+zipcodes = zipcodes[5000:10000]
+
+# US states background
+background = alt.Chart(states).mark_geoshape(
+    fill='lightgray',
+    stroke='white'
+).properties(
+    projection={'type': 'albersUsa'},
+    width=800,
+    height=500
+)
+
+# Zip Codes labeled on background
+points = alt.Chart(zipcodes).mark_circle(size = 1).encode(
+    #alt.Text('city', type='nominal'),
+    alt.X('longitude', type='longitude'),
+    alt.Y('latitude', type='latitude'),
+    color = 'digit:N'
+)
+
+points.transform = [{"calculate": "substring(datum.zip_code, 0, 1)", "as": "digit"}]
+chart = background + points


### PR DESCRIPTION
Note,
I had to have the row in here:
zipcodes = zipcodes[5000:10000]

to limit the amount of data or I get the error:
MaxRowsError: The number of rows in your dataset is greater than the max of 5000

and searching in the repo I don't see a way to temporarily lift that restriction.