### PR TITLE
added vega-lite example: mean overlay..bar line layered chart

### DIFF
--- a/altair/vegalite/v2/examples/mean_overlay_over_precipitiation_chart.py
+++ b/altair/vegalite/v2/examples/mean_overlay_over_precipitiation_chart.py
@@ -1,0 +1,21 @@
+
+"""
+Layered Bar Chart with Line as Mean
+-----------------------
+This example shows mean overlay over precipitation chart.
+"""
+
+import altair as alt
+from vega_datasets import data
+
+source = data.seattle_weather()
+
+bar = alt.Chart(source).mark_bar().encode(
+    x = alt.X('date:O', timeUnit = 'month'),
+    y = alt.Y('mean(precipitation):Q'))
+
+rule = alt.Chart(source).mark_rule(color = 'red',
+                                  size = 3).encode(
+    y = 'mean(precipitation)')
+    #size = alt.Size(value = 3))
+chart = bar + rule

--- a/altair/vegalite/v2/examples/mean_overlay_over_precipitiation_chart.py
+++ b/altair/vegalite/v2/examples/mean_overlay_over_precipitiation_chart.py
@@ -14,8 +14,7 @@ bar = alt.Chart(source).mark_bar().encode(
     x = alt.X('date:O', timeUnit = 'month'),
     y = alt.Y('mean(precipitation):Q'))
 
-rule = alt.Chart(source).mark_rule(color = 'red',
-                                  size = 3).encode(
-    y = 'mean(precipitation)')
-    #size = alt.Size(value = 3))
+rule = alt.Chart(source).mark_rule(color = 'red').encode(
+    y = 'mean(precipitation)',
+    size = alt.SizeValue(3))
 chart = bar + rule


### PR DESCRIPTION
This is working and looks like:
https://vega.github.io/vega-lite/examples/layer_precipitation_mean.html

But, I can't seem to specify a size.
Obviously size = alt.Size(value = 3)) won't work because it requires a field.
In this example there is no field - we are using a calculated average and so we just need to set a static size.

I tried this: mark_rule(color = 'red', size = 3)
Which does not throw an error - but it also does not do anything (changing it to any number even 300).