### PR TITLE
added vega-lite example: grouped bar chart

### DIFF
--- a/altair/vegalite/v2/examples/grouped_bar_chart.py
+++ b/altair/vegalite/v2/examples/grouped_bar_chart.py
@@ -1,0 +1,21 @@
+"""
+Grouped Bar Chart
+-----------------------
+This example shows a population broken out by gender and age for a specific year.
+"""
+
+import altair as alt
+from vega_datasets import data
+
+source = data.population()
+
+chart = alt.Chart(source).mark_bar(stroke = 'transparent').encode(
+    x = alt.X('gender:N', scale = alt.Scale(rangeStep = 12), axis = alt.Axis(title = '')),
+    y = alt.Y('sum(people):Q', axis = alt.Axis(title = 'population', grid = False)),
+    color = alt.Color('gender:N', scale = alt.Scale(range = ["#EA98D2", "#659CCA"])),
+    column = 'age:O')
+
+chart.transform = [{"filter": "datum.year == 2000"},
+    {"calculate": "datum.sex == 2 ? 'Female' : 'Male'", "as": "gender"}]
+
+chart.config = {"view": {"stroke": "transparent"}, "axis": {"domainWidth": 1}}


### PR DESCRIPTION
Note, this uses a configuration line:
chart.config = {"view": {"stroke": "transparent"}, "axis": {"domainWidth": 1}}

Which is what was done in:
https://github.com/altair-viz/altair/pull/473/files

Jake, I did not know if you wanted this merged like you did the last one I just mentioned.  I am assuming that when these options show up in the api they will be here:
https://github.com/altair-viz/altair/blob/master/altair/vegalite/v2/api.py#L306
?

Asking as I am trying to dive a bit deeper and learn more.