### PR TITLE
ENH: add RepeatChart & example

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-02-27 13:26
+# 2018-02-28 08:23
 import collections
 import json
 

--- a/altair/utils/tests/test_schemapi.py
+++ b/altair/utils/tests/test_schemapi.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-02-27 13:26
+# 2018-02-28 08:23
 import jsonschema
 import pytest
 

--- a/altair/vega/v2/schema/core.py
+++ b/altair/vega/v2/schema/core.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-02-27 13:26
+# 2018-02-28 08:23
 
 from altair.utils.schemapi import SchemaBase, Undefined
 

--- a/altair/vega/v3/schema/core.py
+++ b/altair/vega/v3/schema/core.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-02-27 13:26
+# 2018-02-28 08:23
 
 from altair.utils.schemapi import SchemaBase, Undefined
 

--- a/altair/vegalite/v1/schema/channels.py
+++ b/altair/vegalite/v1/schema/channels.py
@@ -1,7 +1,8 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-02-27 13:26
+# 2018-02-28 08:23
 
+import six
 from . import core
 from altair.utils.schemapi import Undefined
 from altair.utils import parse_shorthand, parse_shorthand_plus_data
@@ -48,14 +49,19 @@ class Row(core.PositionChannelDef):
                                   timeUnit=timeUnit, title=title, type=type,
                                   value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Row, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Row, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Column(core.PositionChannelDef):
@@ -99,14 +105,19 @@ class Column(core.PositionChannelDef):
                                      timeUnit=timeUnit, title=title, type=type,
                                      value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Column, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Column, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class X(core.PositionChannelDef):
@@ -149,14 +160,19 @@ class X(core.PositionChannelDef):
                                 bin=bin, scale=scale, sort=sort, timeUnit=timeUnit,
                                 title=title, type=type, value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(X, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(X, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Y(core.PositionChannelDef):
@@ -199,14 +215,19 @@ class Y(core.PositionChannelDef):
                                 bin=bin, scale=scale, sort=sort, timeUnit=timeUnit,
                                 title=title, type=type, value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Y, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Y, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class X2(core.FieldDef):
@@ -243,14 +264,19 @@ class X2(core.FieldDef):
                                  timeUnit=timeUnit, title=title, type=type,
                                  value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(X2, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(X2, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Y2(core.FieldDef):
@@ -287,14 +313,19 @@ class Y2(core.FieldDef):
                                  timeUnit=timeUnit, title=title, type=type,
                                  value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Y2, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Y2, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Color(core.ChannelDefWithLegend):
@@ -338,14 +369,19 @@ class Color(core.ChannelDefWithLegend):
                                     timeUnit=timeUnit, title=title, type=type,
                                     value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Color, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Color, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Opacity(core.ChannelDefWithLegend):
@@ -389,14 +425,19 @@ class Opacity(core.ChannelDefWithLegend):
                                       timeUnit=timeUnit, title=title, type=type,
                                       value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Opacity, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Opacity, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Size(core.ChannelDefWithLegend):
@@ -440,14 +481,19 @@ class Size(core.ChannelDefWithLegend):
                                    timeUnit=timeUnit, title=title, type=type,
                                    value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Size, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Size, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Shape(core.ChannelDefWithLegend):
@@ -491,14 +537,19 @@ class Shape(core.ChannelDefWithLegend):
                                     timeUnit=timeUnit, title=title, type=type,
                                     value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Shape, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Shape, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Detail(core.FieldDef):
@@ -535,14 +586,19 @@ class Detail(core.FieldDef):
                                      timeUnit=timeUnit, title=title, type=type,
                                      value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Detail, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Detail, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Text(core.FieldDef):
@@ -579,14 +635,19 @@ class Text(core.FieldDef):
                                    timeUnit=timeUnit, title=title, type=type,
                                    value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Text, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Text, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Label(core.FieldDef):
@@ -623,14 +684,19 @@ class Label(core.FieldDef):
                                     timeUnit=timeUnit, title=title, type=type,
                                     value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Label, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Label, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Path(core.OrderChannelDef):
@@ -669,14 +735,19 @@ class Path(core.OrderChannelDef):
                                    sort=sort, timeUnit=timeUnit, title=title,
                                    type=type, value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Path, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Path, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Order(core.OrderChannelDef):
@@ -715,11 +786,16 @@ class Order(core.OrderChannelDef):
                                     sort=sort, timeUnit=timeUnit, title=title,
                                     type=type, value=value, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Order, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Order, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})

--- a/altair/vegalite/v1/schema/core.py
+++ b/altair/vegalite/v1/schema/core.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-02-27 13:26
+# 2018-02-28 08:23
 
 from altair.utils.schemapi import SchemaBase, Undefined
 

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -230,6 +230,7 @@ class Chart(TopLevelMixin, mixins.MarkMethodMixin, core.TopLevelFacetedUnitSpec)
 
         def wrap_in_channel_class(obj, prop):
             clsname = prop.title()
+
             if isinstance(obj, SchemaBase):
                 return obj
 
@@ -296,14 +297,10 @@ class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
         return copy
 
 
-def repeat_row():
-    """Tie a channel to the row within a RepeatChart"""
-    return core.RepeatRef(repeat='row')
-
-
-def repeat_column():
-    """Tie a channel to the column within a RepeatChart"""
-    return core.RepeatRef(repeat='column')
+def repeat(repeater):
+    """Tie a channel to the row or column within a repeated chart"""
+    assert repeater in ['row', 'column']
+    return core.RepeatRef(repeat=repeater)
 
 
 class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -204,9 +204,6 @@ class Chart(TopLevelMixin, mixins.MarkMethodMixin, core.TopLevelFacetedUnitSpec)
         super(Chart, self).__init__(data=data, encoding=encoding, mark=mark,
                                     width=width, height=height, **kwargs)
 
-
-    # TODO: add configure_* methods
-
     def encode(self, *args, **kwargs):
         # First convert args to kwargs by inferring the class from the argument
         if args:
@@ -283,6 +280,31 @@ class Chart(TopLevelMixin, mixins.MarkMethodMixin, core.TopLevelFacetedUnitSpec)
         for key, val in kwargs.items():
             setattr(copy, key, val)
         return copy
+
+
+class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
+    def __init__(self, spec=Undefined, data=Undefined, repeat=Undefined, **kwargs):
+        super(RepeatChart, self).__init__(spec=spec, data=data, repeat=repeat, **kwargs)
+
+    def set_repeat(self, row=None, column=None):
+        copy = self.copy()
+        if copy.repeat is Undefined:
+            copy.repeat = core.Repeat()
+        if row is not None:
+            copy.repeat.row = row
+        if column is not None:
+            copy.repeat.column = column
+        return copy
+
+
+def repeat_row():
+    """Tie a channel to the row within a RepeatChart"""
+    return core.RepeatRef(repeat='row')
+
+
+def repeat_column():
+    """Tie a channel to the column within a RepeatChart"""
+    return core.RepeatRef(repeat='column')
 
 
 class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -197,6 +197,16 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         """Return a MIME bundle for display in Jupyter frontends."""
         return renderers.get()(self.to_dict())
 
+    def repeat(self, row=Undefined, column=Undefined, **kwargs):
+        repeat = core.Repeat(row=row, column=column)
+        return RepeatChart(spec=self, repeat=repeat, **kwargs)
+
+    def properties(self, **kwargs):
+        copy = self.copy(deep=True, ignore=['data'])
+        for key, val in kwargs.items():
+            setattr(copy, key, val)
+        return copy
+
 
 class Chart(TopLevelMixin, mixins.MarkMethodMixin, core.TopLevelFacetedUnitSpec):
     def __init__(self, data=Undefined, encoding=Undefined, mark=Undefined,
@@ -275,25 +285,14 @@ class Chart(TopLevelMixin, mixins.MarkMethodMixin, core.TopLevelFacetedUnitSpec)
                                  'encodings': encodings}}
         return copy
 
-    def properties(self, **kwargs):
-        copy = self.copy(deep=True, ignore=['data'])
-        for key, val in kwargs.items():
-            setattr(copy, key, val)
-        return copy
-
 
 class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
     def __init__(self, spec=Undefined, data=Undefined, repeat=Undefined, **kwargs):
         super(RepeatChart, self).__init__(spec=spec, data=data, repeat=repeat, **kwargs)
 
-    def set_repeat(self, row=None, column=None):
+    def interactive(self):
         copy = self.copy()
-        if copy.repeat is Undefined:
-            copy.repeat = core.Repeat()
-        if row is not None:
-            copy.repeat.row = row
-        if column is not None:
-            copy.repeat.column = column
+        copy.spec = copy.spec.interactive()
         return copy
 
 

--- a/altair/vegalite/v2/examples/scatter_matrix.py
+++ b/altair/vegalite/v2/examples/scatter_matrix.py
@@ -9,8 +9,8 @@ import altair as alt
 from vega_datasets import data
 
 chart = alt.Chart(data.cars.url).mark_circle().encode(
-    alt.X(alt.repeat_column(), type='quantitative'),
-    alt.Y(alt.repeat_row(), type='quantitative'),
+    alt.X(alt.repeat("column"), type='quantitative'),
+    alt.Y(alt.repeat("row"), type='quantitative'),
     color='Origin:N'
 ).properties(
     width=250,

--- a/altair/vegalite/v2/examples/scatter_matrix.py
+++ b/altair/vegalite/v2/examples/scatter_matrix.py
@@ -15,9 +15,7 @@ chart = alt.Chart(data.cars.url).mark_circle().encode(
 ).properties(
     width=250,
     height=250
-).interactive()
-
-alt.RepeatChart(chart).set_repeat(
+).repeat(
     row=['Horsepower', 'Acceleration', 'Miles_per_Gallon'],
     column=['Miles_per_Gallon', 'Acceleration', 'Horsepower']
-)
+).interactive()

--- a/altair/vegalite/v2/examples/scatter_matrix.py
+++ b/altair/vegalite/v2/examples/scatter_matrix.py
@@ -1,0 +1,23 @@
+"""
+Scatter Matrix
+--------------
+An example of using a RepeatChart to construct a multi-panel scatter plot
+with linked panning and zooming.
+"""
+
+import altair as alt
+from vega_datasets import data
+
+chart = alt.Chart(data.cars.url).mark_circle().encode(
+    alt.X(alt.repeat_column(), type='quantitative'),
+    alt.Y(alt.repeat_row(), type='quantitative'),
+    color='Origin:N'
+).properties(
+    width=250,
+    height=250
+).interactive()
+
+alt.RepeatChart(chart).set_repeat(
+    row=['Horsepower', 'Acceleration', 'Miles_per_Gallon'],
+    column=['Miles_per_Gallon', 'Acceleration', 'Horsepower']
+)

--- a/altair/vegalite/v2/schema/channels.py
+++ b/altair/vegalite/v2/schema/channels.py
@@ -1,7 +1,8 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-02-27 13:26
+# 2018-02-28 08:23
 
+import six
 from . import core
 from altair.utils.schemapi import Undefined
 from altair.utils import parse_shorthand, parse_shorthand_plus_data
@@ -91,14 +92,19 @@ class Color(core.MarkPropFieldDefWithCondition):
                                     scale=scale, sort=sort, timeUnit=timeUnit,
                                     **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Color, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Color, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class ColorValue(core.MarkPropValueDefWithCondition):
@@ -175,14 +181,19 @@ class Column(core.FacetFieldDef):
                                      bin=bin, header=header, sort=sort,
                                      timeUnit=timeUnit, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Column, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Column, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Detail(core.FieldDef):
@@ -234,14 +245,19 @@ class Detail(core.FieldDef):
         super(Detail, self).__init__(field=field, type=type, aggregate=aggregate,
                                      bin=bin, timeUnit=timeUnit, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Detail, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Detail, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Href(core.FieldDefWithCondition):
@@ -305,14 +321,19 @@ class Href(core.FieldDefWithCondition):
                                    bin=bin, condition=condition, timeUnit=timeUnit,
                                    **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Href, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Href, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class HrefValue(core.ValueDefWithCondition):
@@ -419,14 +440,19 @@ class Opacity(core.MarkPropFieldDefWithCondition):
                                       scale=scale, sort=sort, timeUnit=timeUnit,
                                       **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Opacity, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Opacity, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class OpacityValue(core.MarkPropValueDefWithCondition):
@@ -500,14 +526,19 @@ class Order(core.OrderFieldDef):
         super(Order, self).__init__(field=field, type=type, aggregate=aggregate,
                                     bin=bin, sort=sort, timeUnit=timeUnit, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Order, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Order, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Row(core.FacetFieldDef):
@@ -563,14 +594,19 @@ class Row(core.FacetFieldDef):
                                   bin=bin, header=header, sort=sort,
                                   timeUnit=timeUnit, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Row, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Row, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Shape(core.MarkPropFieldDefWithCondition):
@@ -657,14 +693,19 @@ class Shape(core.MarkPropFieldDefWithCondition):
                                     scale=scale, sort=sort, timeUnit=timeUnit,
                                     **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Shape, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Shape, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class ShapeValue(core.MarkPropValueDefWithCondition):
@@ -771,14 +812,19 @@ class Size(core.MarkPropFieldDefWithCondition):
                                    bin=bin, condition=condition, legend=legend,
                                    scale=scale, sort=sort, timeUnit=timeUnit, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Size, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Size, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class SizeValue(core.MarkPropValueDefWithCondition):
@@ -868,14 +914,19 @@ class Text(core.TextFieldDefWithCondition):
                                    bin=bin, condition=condition, format=format,
                                    timeUnit=timeUnit, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Text, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Text, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class TextValue(core.TextValueDefWithCondition):
@@ -965,14 +1016,19 @@ class Tooltip(core.TextFieldDefWithCondition):
                                       bin=bin, condition=condition, format=format,
                                       timeUnit=timeUnit, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Tooltip, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Tooltip, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class TooltipValue(core.TextValueDefWithCondition):
@@ -1088,14 +1144,19 @@ class X(core.PositionFieldDef):
                                 axis=axis, bin=bin, scale=scale, sort=sort,
                                 stack=stack, timeUnit=timeUnit, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(X, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(X, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class XValue(core.ValueDef):
@@ -1161,14 +1222,19 @@ class X2(core.FieldDef):
         super(X2, self).__init__(field=field, type=type, aggregate=aggregate,
                                  bin=bin, timeUnit=timeUnit, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(X2, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(X2, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class X2Value(core.ValueDef):
@@ -1277,14 +1343,19 @@ class Y(core.PositionFieldDef):
                                 axis=axis, bin=bin, scale=scale, sort=sort,
                                 stack=stack, timeUnit=timeUnit, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Y, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Y, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class YValue(core.ValueDef):
@@ -1350,14 +1421,19 @@ class Y2(core.FieldDef):
         super(Y2, self).__init__(field=field, type=type, aggregate=aggregate,
                                  bin=bin, timeUnit=timeUnit, **kwds)
 
-    def to_dict(self, validate=True, ignore=[], context={}):
+    def to_dict(self, validate=True, ignore=(), context=None):
         type_ = getattr(self, 'type', Undefined)
-        if type_ is Undefined and 'data' in context:
+        if not isinstance(self.field, six.string_types):
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {}
+        elif type_ is Undefined and 'data' in context:
             kwds = parse_shorthand_plus_data(self.field, context['data'])
         else:
             kwds = parse_shorthand(self.field)
         self._kwds.update(kwds)
-        return super(Y2, self).to_dict(validate=validate, ignore=ignore, context=context)
+        return super(Y2, self).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context or {})
 
 
 class Y2Value(core.ValueDef):

--- a/altair/vegalite/v2/schema/core.py
+++ b/altair/vegalite/v2/schema/core.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-02-27 13:26
+# 2018-02-28 08:23
 
 from altair.utils.schemapi import SchemaBase, Undefined
 

--- a/altair/vegalite/v2/schema/mixins.py
+++ b/altair/vegalite/v2/schema/mixins.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-02-27 13:26
+# 2018-02-28 08:23
 from . import core
 from altair.utils import use_signature
 from altair.utils.schemapi import Undefined


### PR DESCRIPTION
This PR adds a ``RepeatChart`` which allows repeated specs. For example:

```python
import altair as alt
from vega_datasets import data

chart = alt.Chart(data.cars.url).mark_circle().encode(
    alt.X(alt.repeat_column(), type='quantitative'),
    alt.Y(alt.repeat_row(), type='quantitative'),
    color='Origin:N'
).properties(
    width=250,
    height=250
).interactive()

alt.RepeatChart(chart).set_repeat(
    row=['Horsepower', 'Acceleration', 'Miles_per_Gallon'],
    column=['Miles_per_Gallon', 'Acceleration', 'Horsepower']
)
```
![vega 1](https://user-images.githubusercontent.com/781659/36800495-89418f04-1c64-11e8-8c37-5c812ce6e973.png)

If you run this example live, you'll see that panning and zooming are linked across plots.

I'd initially thought we'd leave the repeat chart out of the top-level API, and instead focus on using Python-side loops to construct these kinds of specs. But in trying to duplicate some of the vega-lite examples, that proved to be very clunky.

I think the API I proposed here is still a bit awkward, and I'd be happy to hear any thoughts on how it might be improved cc/ @kanitw @domoritz @ellisonbg
