### PR TITLE
Validate on instantiation

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -1,10 +1,40 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-03-01 10:48
+# 2018-03-01 12:54
 import collections
+import contextlib
 import json
 
 import jsonschema
+
+
+# If DEBUG_MODE is True, then schema objects are converted to dict and
+# validated at creation time. This slows things down, particularly for
+# larger specs, but leads to much more useful tracebacks for the user.
+# Individual schema classes can override this by setting the
+# class-level _class_is_valid_at_instantiation attribute to False
+DEBUG_MODE = True
+
+
+def enable_debug_mode():
+    global DEBUG_MODE
+    DEBUG_MODE = True
+
+
+def disable_debug_mode():
+    global DEBUG_MODE
+    DEBUG_MODE = True
+
+
+@contextlib.contextmanager
+def debug_mode(arg):
+    global DEBUG_MODE
+    original = DEBUG_MODE
+    DEBUG_MODE = arg
+    try:
+        yield
+    finally:
+        DEBUG_MODE = original
 
 
 class UndefinedType(object):
@@ -28,6 +58,7 @@ class SchemaBase(object):
     """
     _schema = {}
     _rootschema = None
+    _class_is_valid_at_instantiation = True
 
     def __init__(self, *args, **kwds):
         # Two valid options for initialization, which should be handled by
@@ -42,6 +73,9 @@ class SchemaBase(object):
         # use object.__setattr__ because we override setattr below.
         object.__setattr__(self, '_args', args)
         object.__setattr__(self, '_kwds', kwds)
+
+        if DEBUG_MODE and self._class_is_valid_at_instantiation:
+            dct = self.to_dict(validate=True)
 
     def copy(self, deep=True, ignore=()):
         """Return a copy of the object
@@ -61,7 +95,8 @@ class SchemaBase(object):
                 kwds = {k: (_deep_copy(v, ignore=ignore)
                             if k not in ignore else v)
                         for k, v in obj._kwds.items()}
-                return obj.__class__(*args, **kwds)
+                with debug_mode(False):
+                    return obj.__class__(*args, **kwds)
             elif isinstance(obj, list):
                 return [_deep_copy(v, ignore=ignore) for v in obj]
             elif isinstance(obj, dict):
@@ -73,7 +108,8 @@ class SchemaBase(object):
         if deep:
             return _deep_copy(self, ignore=ignore)
         else:
-            return self.__class__(*self._args, **self._kwds)
+            with debug_mode(False):
+                return self.__class__(*self._args, **self._kwds)
 
     def __getattr__(self, attr):
         # reminder: getattr is called after the normal lookups
@@ -131,9 +167,9 @@ class SchemaBase(object):
         jsonschema.ValidationError :
             if validate=True and the dict does not conform to the schema
         """
+        # TODO: add validate='once' and validate='deep'
         def _todict(val):
             if isinstance(val, SchemaBase):
-                # only validate at the top level
                 return val.to_dict(validate=False, context=context)
             elif isinstance(val, list):
                 return [_todict(v) for v in val]

--- a/altair/utils/tests/test_schemapi.py
+++ b/altair/utils/tests/test_schemapi.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-03-01 10:48
+# 2018-03-01 12:54
 import jsonschema
 import pytest
 

--- a/altair/vega/v2/schema/core.py
+++ b/altair/vega/v2/schema/core.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-03-01 10:48
+# 2018-03-01 12:54
 
 from altair.utils.schemapi import SchemaBase, Undefined
 

--- a/altair/vega/v3/schema/core.py
+++ b/altair/vega/v3/schema/core.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-03-01 10:48
+# 2018-03-01 12:54
 
 from altair.utils.schemapi import SchemaBase, Undefined
 

--- a/altair/vegalite/v1/api.py
+++ b/altair/vegalite/v1/api.py
@@ -82,6 +82,8 @@ def _get_channels_mapping():
 #*************************************************************************
 
 class TopLevelMixin(object):
+    _class_is_valid_at_instantiation = False
+    
     def _prepare_data(self):
         if isinstance(self.data, (dict, core.Data)):
             pass

--- a/altair/vegalite/v1/schema/channels.py
+++ b/altair/vegalite/v1/schema/channels.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-03-01 10:48
+# 2018-03-01 12:54
 
 import six
 from . import core
@@ -41,6 +41,8 @@ class Row(core.PositionChannelDef):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, axis=Undefined, bin=Undefined,
                  scale=Undefined, sort=Undefined, timeUnit=Undefined,
                  title=Undefined, type=Undefined, value=Undefined, **kwds):
@@ -98,6 +100,8 @@ class Column(core.PositionChannelDef):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, axis=Undefined, bin=Undefined,
                  scale=Undefined, sort=Undefined, timeUnit=Undefined,
                  title=Undefined, type=Undefined, value=Undefined, **kwds):
@@ -155,6 +159,8 @@ class X(core.PositionChannelDef):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, axis=Undefined, bin=Undefined,
                  scale=Undefined, sort=Undefined, timeUnit=Undefined,
                  title=Undefined, type=Undefined, value=Undefined, **kwds):
@@ -211,6 +217,8 @@ class Y(core.PositionChannelDef):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, axis=Undefined, bin=Undefined,
                  scale=Undefined, sort=Undefined, timeUnit=Undefined,
                  title=Undefined, type=Undefined, value=Undefined, **kwds):
@@ -261,6 +269,8 @@ class X2(core.FieldDef):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, bin=Undefined,
                  timeUnit=Undefined, title=Undefined, type=Undefined,
                  value=Undefined, **kwds):
@@ -311,6 +321,8 @@ class Y2(core.FieldDef):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, bin=Undefined,
                  timeUnit=Undefined, title=Undefined, type=Undefined,
                  value=Undefined, **kwds):
@@ -367,6 +379,8 @@ class Color(core.ChannelDefWithLegend):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, bin=Undefined, legend=Undefined,
                  scale=Undefined, sort=Undefined, timeUnit=Undefined,
                  title=Undefined, type=Undefined, value=Undefined, **kwds):
@@ -424,6 +438,8 @@ class Opacity(core.ChannelDefWithLegend):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, bin=Undefined, legend=Undefined,
                  scale=Undefined, sort=Undefined, timeUnit=Undefined,
                  title=Undefined, type=Undefined, value=Undefined, **kwds):
@@ -481,6 +497,8 @@ class Size(core.ChannelDefWithLegend):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, bin=Undefined, legend=Undefined,
                  scale=Undefined, sort=Undefined, timeUnit=Undefined,
                  title=Undefined, type=Undefined, value=Undefined, **kwds):
@@ -538,6 +556,8 @@ class Shape(core.ChannelDefWithLegend):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, bin=Undefined, legend=Undefined,
                  scale=Undefined, sort=Undefined, timeUnit=Undefined,
                  title=Undefined, type=Undefined, value=Undefined, **kwds):
@@ -589,6 +609,8 @@ class Detail(core.FieldDef):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, bin=Undefined,
                  timeUnit=Undefined, title=Undefined, type=Undefined,
                  value=Undefined, **kwds):
@@ -639,6 +661,8 @@ class Text(core.FieldDef):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, bin=Undefined,
                  timeUnit=Undefined, title=Undefined, type=Undefined,
                  value=Undefined, **kwds):
@@ -689,6 +713,8 @@ class Label(core.FieldDef):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, bin=Undefined,
                  timeUnit=Undefined, title=Undefined, type=Undefined,
                  value=Undefined, **kwds):
@@ -741,6 +767,8 @@ class Path(core.OrderChannelDef):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, bin=Undefined, sort=Undefined,
                  timeUnit=Undefined, title=Undefined, type=Undefined,
                  value=Undefined, **kwds):
@@ -793,6 +821,8 @@ class Order(core.OrderChannelDef):
     title : string
         Title for axis or legend.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, aggregate=Undefined, bin=Undefined, sort=Undefined,
                  timeUnit=Undefined, title=Undefined, type=Undefined,
                  value=Undefined, **kwds):

--- a/altair/vegalite/v1/schema/core.py
+++ b/altair/vegalite/v1/schema/core.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-03-01 10:48
+# 2018-03-01 12:54
 
 from altair.utils.schemapi import SchemaBase, Undefined
 

--- a/altair/vegalite/v2/examples/histogram.py
+++ b/altair/vegalite/v2/examples/histogram.py
@@ -10,10 +10,6 @@ from vega_datasets import data
 movies = data.movies.url
 
 chart = alt.Chart(movies).mark_bar().encode(
-    x=alt.X("IMDB_Rating",
-            type='quantitative',
-            bin=alt.BinTransform(
-                maxbins=10,
-            )),
+    alt.X("IMDB_Rating:Q", bin=alt.BinParams(maxbins=10)),
     y='count(*):Q',
 )

--- a/altair/vegalite/v2/schema/channels.py
+++ b/altair/vegalite/v2/schema/channels.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-03-01 10:48
+# 2018-03-01 12:54
 
 import six
 from . import core
@@ -84,6 +84,8 @@ class Color(core.MarkPropFieldDefWithCondition):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  condition=Undefined, legend=Undefined, scale=Undefined,
                  sort=Undefined, timeUnit=Undefined, **kwds):
@@ -127,6 +129,24 @@ class ColorValue(core.MarkPropValueDefWithCondition):
     """
     def __init__(self, value, condition=Undefined, **kwds):
         super(ColorValue, self).__init__(value=value, condition=condition, **kwds)
+
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                if 'data' in context:
+                    kwds = parse_shorthand_plus_data(condition['field'], context['data'])
+                else:
+                    kwds = parse_shorthand(condition['field'])
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(ColorValue, copy).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context)
 
 
 class Column(core.FacetFieldDef):
@@ -176,6 +196,8 @@ class Column(core.FacetFieldDef):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  header=Undefined, sort=Undefined, timeUnit=Undefined, **kwds):
         super(Column, self).__init__(field=field, type=type, aggregate=aggregate,
@@ -242,6 +264,8 @@ class Detail(core.FieldDef):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  timeUnit=Undefined, **kwds):
         super(Detail, self).__init__(field=field, type=type, aggregate=aggregate,
@@ -318,6 +342,8 @@ class Href(core.FieldDefWithCondition):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  condition=Undefined, timeUnit=Undefined, **kwds):
         super(Href, self).__init__(field=field, type=type, aggregate=aggregate,
@@ -358,6 +384,24 @@ class HrefValue(core.ValueDefWithCondition):
     """
     def __init__(self, value, condition=Undefined, **kwds):
         super(HrefValue, self).__init__(value=value, condition=condition, **kwds)
+
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                if 'data' in context:
+                    kwds = parse_shorthand_plus_data(condition['field'], context['data'])
+                else:
+                    kwds = parse_shorthand(condition['field'])
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(HrefValue, copy).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context)
 
 
 class Opacity(core.MarkPropFieldDefWithCondition):
@@ -436,6 +480,8 @@ class Opacity(core.MarkPropFieldDefWithCondition):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  condition=Undefined, legend=Undefined, scale=Undefined,
                  sort=Undefined, timeUnit=Undefined, **kwds):
@@ -479,6 +525,24 @@ class OpacityValue(core.MarkPropValueDefWithCondition):
     """
     def __init__(self, value, condition=Undefined, **kwds):
         super(OpacityValue, self).__init__(value=value, condition=condition, **kwds)
+
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                if 'data' in context:
+                    kwds = parse_shorthand_plus_data(condition['field'], context['data'])
+                else:
+                    kwds = parse_shorthand(condition['field'])
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(OpacityValue, copy).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context)
 
 
 class Order(core.OrderFieldDef):
@@ -526,6 +590,8 @@ class Order(core.OrderFieldDef):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  sort=Undefined, timeUnit=Undefined, **kwds):
         super(Order, self).__init__(field=field, type=type, aggregate=aggregate,
@@ -594,6 +660,8 @@ class Row(core.FacetFieldDef):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  header=Undefined, sort=Undefined, timeUnit=Undefined, **kwds):
         super(Row, self).__init__(field=field, type=type, aggregate=aggregate,
@@ -692,6 +760,8 @@ class Shape(core.MarkPropFieldDefWithCondition):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  condition=Undefined, legend=Undefined, scale=Undefined,
                  sort=Undefined, timeUnit=Undefined, **kwds):
@@ -735,6 +805,24 @@ class ShapeValue(core.MarkPropValueDefWithCondition):
     """
     def __init__(self, value, condition=Undefined, **kwds):
         super(ShapeValue, self).__init__(value=value, condition=condition, **kwds)
+
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                if 'data' in context:
+                    kwds = parse_shorthand_plus_data(condition['field'], context['data'])
+                else:
+                    kwds = parse_shorthand(condition['field'])
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(ShapeValue, copy).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context)
 
 
 class Size(core.MarkPropFieldDefWithCondition):
@@ -813,6 +901,8 @@ class Size(core.MarkPropFieldDefWithCondition):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  condition=Undefined, legend=Undefined, scale=Undefined,
                  sort=Undefined, timeUnit=Undefined, **kwds):
@@ -855,6 +945,24 @@ class SizeValue(core.MarkPropValueDefWithCondition):
     """
     def __init__(self, value, condition=Undefined, **kwds):
         super(SizeValue, self).__init__(value=value, condition=condition, **kwds)
+
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                if 'data' in context:
+                    kwds = parse_shorthand_plus_data(condition['field'], context['data'])
+                else:
+                    kwds = parse_shorthand(condition['field'])
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(SizeValue, copy).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context)
 
 
 class Text(core.TextFieldDefWithCondition):
@@ -917,6 +1025,8 @@ class Text(core.TextFieldDefWithCondition):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  condition=Undefined, format=Undefined, timeUnit=Undefined, **kwds):
         super(Text, self).__init__(field=field, type=type, aggregate=aggregate,
@@ -958,6 +1068,24 @@ class TextValue(core.TextValueDefWithCondition):
     """
     def __init__(self, value, condition=Undefined, **kwds):
         super(TextValue, self).__init__(value=value, condition=condition, **kwds)
+
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                if 'data' in context:
+                    kwds = parse_shorthand_plus_data(condition['field'], context['data'])
+                else:
+                    kwds = parse_shorthand(condition['field'])
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(TextValue, copy).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context)
 
 
 class Tooltip(core.TextFieldDefWithCondition):
@@ -1020,6 +1148,8 @@ class Tooltip(core.TextFieldDefWithCondition):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  condition=Undefined, format=Undefined, timeUnit=Undefined, **kwds):
         super(Tooltip, self).__init__(field=field, type=type, aggregate=aggregate,
@@ -1061,6 +1191,24 @@ class TooltipValue(core.TextValueDefWithCondition):
     """
     def __init__(self, value, condition=Undefined, **kwds):
         super(TooltipValue, self).__init__(value=value, condition=condition, **kwds)
+
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                if 'data' in context:
+                    kwds = parse_shorthand_plus_data(condition['field'], context['data'])
+                else:
+                    kwds = parse_shorthand(condition['field'])
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(TooltipValue, copy).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context)
 
 
 class X(core.PositionFieldDef):
@@ -1148,6 +1296,8 @@ class X(core.PositionFieldDef):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, axis=Undefined,
                  bin=Undefined, scale=Undefined, sort=Undefined, stack=Undefined,
                  timeUnit=Undefined, **kwds):
@@ -1183,6 +1333,24 @@ class XValue(core.ValueDef):
     """
     def __init__(self, value, **kwds):
         super(XValue, self).__init__(value=value, **kwds)
+
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                if 'data' in context:
+                    kwds = parse_shorthand_plus_data(condition['field'], context['data'])
+                else:
+                    kwds = parse_shorthand(condition['field'])
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(XValue, copy).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context)
 
 
 class X2(core.FieldDef):
@@ -1229,6 +1397,8 @@ class X2(core.FieldDef):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  timeUnit=Undefined, **kwds):
         super(X2, self).__init__(field=field, type=type, aggregate=aggregate,
@@ -1262,6 +1432,24 @@ class X2Value(core.ValueDef):
     """
     def __init__(self, value, **kwds):
         super(X2Value, self).__init__(value=value, **kwds)
+
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                if 'data' in context:
+                    kwds = parse_shorthand_plus_data(condition['field'], context['data'])
+                else:
+                    kwds = parse_shorthand(condition['field'])
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(X2Value, copy).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context)
 
 
 class Y(core.PositionFieldDef):
@@ -1349,6 +1537,8 @@ class Y(core.PositionFieldDef):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, axis=Undefined,
                  bin=Undefined, scale=Undefined, sort=Undefined, stack=Undefined,
                  timeUnit=Undefined, **kwds):
@@ -1384,6 +1574,24 @@ class YValue(core.ValueDef):
     """
     def __init__(self, value, **kwds):
         super(YValue, self).__init__(value=value, **kwds)
+
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                if 'data' in context:
+                    kwds = parse_shorthand_plus_data(condition['field'], context['data'])
+                else:
+                    kwds = parse_shorthand(condition['field'])
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(YValue, copy).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context)
 
 
 class Y2(core.FieldDef):
@@ -1430,6 +1638,8 @@ class Y2(core.FieldDef):
         projection](https://vega.github.io/vega-lite/docs/projection.html)
          is applied.
     """
+    _class_is_valid_at_instantiation = False
+
     def __init__(self, field, type=Undefined, aggregate=Undefined, bin=Undefined,
                  timeUnit=Undefined, **kwds):
         super(Y2, self).__init__(field=field, type=type, aggregate=aggregate,
@@ -1463,3 +1673,21 @@ class Y2Value(core.ValueDef):
     """
     def __init__(self, value, **kwds):
         super(Y2Value, self).__init__(value=value, **kwds)
+
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                if 'data' in context:
+                    kwds = parse_shorthand_plus_data(condition['field'], context['data'])
+                else:
+                    kwds = parse_shorthand(condition['field'])
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(Y2Value, copy).to_dict(validate=validate,
+                                                ignore=ignore,
+                                                context=context)

--- a/altair/vegalite/v2/schema/core.py
+++ b/altair/vegalite/v2/schema/core.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-03-01 10:48
+# 2018-03-01 12:54
 
 from altair.utils.schemapi import SchemaBase, Undefined
 

--- a/altair/vegalite/v2/schema/mixins.py
+++ b/altair/vegalite/v2/schema/mixins.py
@@ -1,6 +1,6 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
-# 2018-03-01 10:48
+# 2018-03-01 12:54
 from . import core
 from altair.utils import use_signature
 from altair.utils.schemapi import Undefined

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -115,6 +115,7 @@ def _get_args(info):
         kwds -= required
         nonkeyword = False
         additional = True
+        #additional = info.additionalProperties or info.patternProperties
     else:
         raise ValueError("Schema object not understood")
 


### PR DESCRIPTION
This PR adds code that validates Schema classes when they're instantiated, rather than only when they're converted to a dictionary. This significantly improves the user experience (see examples below)

The downsides of this change are:

- increased code complexity: much more is happening in ``SchemaBase`` to accomplish this, and to make certain this kind of validation is disabled in cases that it causes issues (for example, when you do something like ``encode(x='Origin')``, the encoding is not valid until you can add type information, which requires data that may not be available until the final serialization).
- chart creation is a bit slower, because lower-level parts of the chart are being repeatedly validated as the chart is built up. In practice, that's only really noticeable when building several dozen examples back-to-back.
- some approaches that may have previously worked (such as creating an empty object and then adding attributes sequentially) will now raise an error. e.g. you could not do
    ```python
    sel = alt.selection()
    sel.type = 'interval'
    ```
    because ``type`` is required by the schema at the time it's instantiated. I've disabled this validation check on all top-level objects ('Chart', 'LayeredChart', 'X', 'Color', etc.), and I think that covers 99% of the cases where people use this pattern.

I *think* those downsides are worth swallowing for the added usability of informative error messages. In case performance is critical, I added a ``DEBUG_MODE`` flag that can be set to False; when it is, the chart will only be validated once, after the final serialization is constructed.

## Previous behavior

Before this PR, if you make a mistake somewhere deep in the chart, this is the kind of traceback you get:

```python
import altair as alt
from vega_datasets import data

driving = data.driving.url

base = alt.Chart(driving).encode(
    x = alt.X('miles:Q', scale = alt.Scale(zero=False)), 
    y = alt.Y('gas:Q', scale = alt.Scale(zero='false')),
    order = 'year:Q'
)

chart = base.mark_line() + base.mark_point().interactive()

chart.to_dict()
```

```
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
<ipython-input-1-071b9cebc769> in <module>()
     13 chart = base.mark_line() + base.mark_point().interactive()
     14 
---> 15 chart.to_dict()

~/github/altair-viz/altair/altair/vegalite/v2/api.py in to_dict(self, *args, **kwargs)
    176         kwargs['context'] = context
    177 
--> 178         dct = super(TopLevelMixin, copy).to_dict(*args, **kwargs)
    179 
    180         if is_top_level:

~/github/altair-viz/altair/altair/utils/schemapi.py in to_dict(self, validate, ignore, context)
    153                              "cannot serialize to dict".format(self.__class__))
    154         if validate:
--> 155             self.validate(result)
    156         return result
    157 

~/github/altair-viz/altair/altair/utils/schemapi.py in validate(cls, instance, schema)
    192             schema = cls._schema
    193         resolver = jsonschema.RefResolver.from_schema(cls._rootschema or cls._schema)
--> 194         return jsonschema.validate(instance, schema, resolver=resolver)
    195 
    196     @classmethod

~/anaconda/envs/vega3/lib/python3.6/site-packages/jsonschema/validators.py in validate(instance, schema, cls, *args, **kwargs)
    539         cls = validator_for(schema)
    540     cls.check_schema(schema)
--> 541     cls(schema, *args, **kwargs).validate(instance)

~/anaconda/envs/vega3/lib/python3.6/site-packages/jsonschema/validators.py in validate(self, *args, **kwargs)
    128         def validate(self, *args, **kwargs):
    129             for error in self.iter_errors(*args, **kwargs):
--> 130                 raise error
    131 
    132         def is_type(self, instance, type):

ValidationError: {'mark': 'line', 'data': {'url': 'https://vega.github.io/vega-datasets/data/driving.json'}, 'encoding': {'order': {'type': 'quantitative', 'field': 'year'}, 'x': {'type': 'quantitative', 'field': 'miles', 'scale': {'zero': False}}, 'y': {'type': 'quantitative', 'field': 'gas', 'scale': {'zero': 'false'}}}} is not valid under any of the given schemas

Failed validating 'anyOf' in schema['properties']['layer']['items']:
    {'anyOf': [{'$ref': '#/definitions/LayerSpec'},
               {'$ref': '#/definitions/CompositeUnitSpec'}]}

On instance['layer'][0]:
    {'data': {'url': 'https://vega.github.io/vega-datasets/data/driving.json'},
     'encoding': {'order': {'field': 'year', 'type': 'quantitative'},
                  'x': {'field': 'miles',
                        'scale': {'zero': False},
                        'type': 'quantitative'},
                  'y': {'field': 'gas',
                        'scale': {'zero': 'false'},
                        'type': 'quantitative'}},
     'mark': 'line'}
```

Not much specific information about where the code went wrong... it basically spits out the entire chart serialization and tells you that it's invalid, and it's up to you to decipher why.

After this PR, the behavior looks like this:

```python
import altair as alt
from vega_datasets import data

driving = data.driving.url

base = alt.Chart(driving).encode(
    x = alt.X('miles:Q', scale = alt.Scale(zero=False)), 
    y = alt.Y('gas:Q', scale = alt.Scale(zero='false')),
    order = 'year:Q'
)

chart = base.mark_line() + base.mark_point().interactive()

chart.to_dict()
```

```
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
<ipython-input-1-3f4dc1ac6e49> in <module>()
      6 base = alt.Chart(driving).encode(
      7     x = alt.X('miles:Q', scale = alt.Scale(zero=False)),
----> 8     y = alt.Y('gas:Q', scale = alt.Scale(zero='false')),
      9     order = 'year:Q'
     10 )

~/github/altair-viz/altair/altair/vegalite/v2/schema/core.py in __init__(self, base, clamp, domain, exponent, interpolate, nice, padding, paddingInner, paddingOuter, range, rangeStep, round, scheme, type, zero, **kwds)
   4557                                     paddingOuter=paddingOuter, range=range,
   4558                                     rangeStep=rangeStep, round=round, scheme=scheme,
-> 4559                                     type=type, zero=zero, **kwds)
   4560 
   4561 

~/github/altair-viz/altair/altair/utils/schemapi.py in __init__(self, *args, **kwds)
     76 
     77         if DEBUG_MODE and self._class_is_valid_at_instantiation:
---> 78             dct = self.to_dict(validate=True)
     79 
     80     def copy(self, deep=True, ignore=()):

~/github/altair-viz/altair/altair/utils/schemapi.py in to_dict(self, validate, ignore, context)
    189                              "cannot serialize to dict".format(self.__class__))
    190         if validate:
--> 191             self.validate(result)
    192         return result
    193 

~/github/altair-viz/altair/altair/utils/schemapi.py in validate(cls, instance, schema)
    228             schema = cls._schema
    229         resolver = jsonschema.RefResolver.from_schema(cls._rootschema or cls._schema)
--> 230         return jsonschema.validate(instance, schema, resolver=resolver)
    231 
    232     @classmethod

~/anaconda/envs/vega3/lib/python3.6/site-packages/jsonschema/validators.py in validate(instance, schema, cls, *args, **kwargs)
    539         cls = validator_for(schema)
    540     cls.check_schema(schema)
--> 541     cls(schema, *args, **kwargs).validate(instance)

~/anaconda/envs/vega3/lib/python3.6/site-packages/jsonschema/validators.py in validate(self, *args, **kwargs)
    128         def validate(self, *args, **kwargs):
    129             for error in self.iter_errors(*args, **kwargs):
--> 130                 raise error
    131 
    132         def is_type(self, instance, type):

ValidationError: 'false' is not of type 'boolean'

Failed validating 'type' in schema['properties']['zero']:
    {'description': 'If `true`, ensures that a zero baseline value is '
                    'included in the scale domain.\n'
                    '\n'
                    '__Default value:__ `true` for x and y channels if the '
                    'quantitative field is not binned and no custom '
                    '`domain` is provided; `false` otherwise.\n'
                    '\n'
                    '__Note:__ Log, time, and utc scales do not support '
                    '`zero`.',
     'type': 'boolean'}

On instance['zero']:
    'false'
```

The error is raised **when the class is instantiated**, which means you have the Python code context to help you figure out where things went wrong.

