### PR TITLE
ENH: wrap to_dict() tracebacks for more user-friendly errors

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -54,7 +54,7 @@ class SchemaValidationError(jsonschema.ValidationError):
                                                'patternProperties'))
         return """Invalid specification
 
-        validator {1!r} in {0}
+        {0}, validating {1!r}
 
         {2}
         """.format(schema_path, self.validator, self.message)

--- a/altair/vegalite/api.py
+++ b/altair/vegalite/api.py
@@ -1,1 +1,1 @@
-from .v1.api import *
+from .v2.api import *

--- a/altair/vegalite/schema.py
+++ b/altair/vegalite/schema.py
@@ -1,3 +1,3 @@
 """Altair schema wrappers"""
 
-from .v1.schema import *
+from .v2.schema import *

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -52,7 +52,7 @@ class SchemaValidationError(jsonschema.ValidationError):
                                                'patternProperties'))
         return """Invalid specification
 
-        validator {1!r} in {0}
+        {0}, validating {1!r}
 
         {2}
         """.format(schema_path, self.validator, self.message)

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -1,8 +1,10 @@
 import collections
 import contextlib
 import json
+import textwrap
 
 import jsonschema
+import six
 
 
 # If DEBUG_MODE is True, then schema objects are converted to dict and
@@ -32,6 +34,35 @@ def debug_mode(arg):
         yield
     finally:
         DEBUG_MODE = original
+
+
+class SchemaValidationError(jsonschema.ValidationError):
+    """A wrapper for jsonschema.ValidationError with friendlier traceback"""
+    def __init__(self, obj, err):
+        super(SchemaValidationError, self).__init__(**err._contents())
+        self.obj = obj
+
+    def __unicode__(self):
+        cls = self.obj.__class__
+        schema_path = ['{0}.{1}'.format(cls.__module__,cls.__name__)]
+        schema_path.extend(self.schema_path)
+        schema_path = ' ->'.join(val for val in schema_path[:-1]
+                                if val not in ('properties',
+                                               'additionalProperties',
+                                               'patternProperties'))
+        return """Invalid specification
+
+        validator {1!r} in {0}
+
+        {2}
+        """.format(schema_path, self.validator, self.message)
+
+    if six.PY3:
+        __str__ = __unicode__
+    else:
+        def __str__(self):
+            return unicode(self).encode("utf-8")
+
 
 
 class UndefinedType(object):
@@ -144,9 +175,11 @@ class SchemaBase(object):
 
         Parameters
         ----------
-        validate : boolean
+        validate : boolean or string
             If True (default), then validate the output dictionary
-            against the schema.
+            against the schema. If "deep" then recursively validate
+            all objects in the spec. This takes much more time, but
+            it results in friendlier tracebacks for large objects.
         ignore : list
             A list of keys to ignore. This will *not* passed to child to_dict
             function calls.
@@ -164,10 +197,11 @@ class SchemaBase(object):
         jsonschema.ValidationError :
             if validate=True and the dict does not conform to the schema
         """
-        # TODO: add validate='once' and validate='deep'
+        sub_validate = 'deep' if validate == 'deep' else False
+
         def _todict(val):
             if isinstance(val, SchemaBase):
-                return val.to_dict(validate=False, context=context)
+                return val.to_dict(validate=sub_validate, context=context)
             elif isinstance(val, list):
                 return [_todict(v) for v in val]
             elif isinstance(val, dict):
@@ -185,7 +219,10 @@ class SchemaBase(object):
             raise ValueError("{0} instance has both a value and properties : "
                              "cannot serialize to dict".format(self.__class__))
         if validate:
-            self.validate(result)
+            try:
+                self.validate(result)
+            except jsonschema.ValidationError as err:
+                raise SchemaValidationError(self, err)
         return result
 
     @classmethod


### PR DESCRIPTION
This does two things:

- adds a custom exception that wraps ``jsonschema.ValidationError`` and provides tracebacks that are more useful for Altair specifications

- adds a ``validate='deep'`` option that triggers any time there is a validation error on a top-level object.

The result is friendlier tracebacks; for example (compare to #480):

```python
import altair as alt
alt.Chart()

---------------------------------------------------------------------------
SchemaValidationError                     Traceback (most recent call last)
~/anaconda/envs/vega3/lib/python3.6/site-packages/IPython/core/formatters.py in __call__(self, obj, include, exclude)
    968 
    969             if method is not None:
--> 970                 return method(include=include, exclude=exclude)
    971             return None
    972         else:

~/github/altair-viz/altair/altair/vegalite/v2/api.py in _repr_mimebundle_(self, include, exclude)
    239     def _repr_mimebundle_(self, include, exclude):
    240         """Return a MIME bundle for display in Jupyter frontends."""
--> 241         return renderers.get()(self.to_dict())
    242 
    243     def repeat(self, row=Undefined, column=Undefined, **kwargs):

~/github/altair-viz/altair/altair/vegalite/v2/api.py in to_dict(self, *args, **kwargs)
    212         if dct is None:
    213             kwargs['validate'] = 'deep'
--> 214             dct = super(TopLevelMixin, copy).to_dict(*args, **kwargs)
    215 
    216         if is_top_level:

~/github/altair-viz/altair/altair/utils/schemapi.py in to_dict(self, validate, ignore, context)
    225                 self.validate(result)
    226             except jsonschema.ValidationError as err:
--> 227                 raise SchemaValidationError(self, err)
    228         return result
    229 

SchemaValidationError: Invalid specification

        altair.vegalite.v2.api.Chart, validating 'required'

        'mark' is a required property
```