### PR TITLE
Fix traceback when displaying chart with invalid spec

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -5,6 +5,8 @@ import re
 import warnings
 import collections
 from copy import deepcopy
+import sys
+import traceback
 
 import six
 import pandas as pd
@@ -348,3 +350,18 @@ def write_file_or_filename(fp, content, mode='w'):
             f.write(content)
     else:
         fp.write(content)
+
+
+def display_traceback(in_ipython=True):
+    exc_info = sys.exc_info()
+
+    if in_ipython:
+        from IPython.core.getipython import get_ipython
+        ip = get_ipython()
+    else:
+        ip = None
+
+    if ip is not None:
+        ip.showtraceback(exc_info)
+    else:
+        traceback.print_exception(*exc_info)

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -319,7 +319,15 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
     def _repr_mimebundle_(self, include, exclude):
         """Return a MIME bundle for display in Jupyter frontends."""
-        return renderers.get()(self.to_dict())
+        # Catch errors explicitly to get around issues in Jupyter frontend
+        # see https://github.com/ipython/ipython/issues/11038
+        try:
+            dct = self.to_dict()
+        except Exception:
+            utils.display_traceback(in_ipython=True)
+            return {}
+        else:
+            return renderers.get()(dct)
 
     def repeat(self, row=Undefined, column=Undefined, **kwargs):
         """Return a RepeatChart built from the chart


### PR DESCRIPTION
This addresses #480, with a workaround of the issue in https://github.com/ipython/ipython/issues/11038

@ellisonbg – I'd appreciate your opinion on the approach I used here.

After this, the traceback in #480 looks like this:
```python
import altair as alt
alt.Chart()
```
```python-traceback
---------------------------------------------------------------------------
SchemaValidationError                     Traceback (most recent call last)
~/github/altair-viz/altair/altair/vegalite/v2/api.py in to_dict(self, *args, **kwargs)
    254         if dct is None:
    255             kwargs['validate'] = 'deep'
--> 256             dct = super(TopLevelMixin, copy).to_dict(*args, **kwargs)
    257 
    258         if is_top_level:

~/github/altair-viz/altair/altair/utils/schemapi.py in to_dict(self, validate, ignore, context)
    228                 self.validate(result)
    229             except jsonschema.ValidationError as err:
--> 230                 raise SchemaValidationError(self, err)
    231         return result
    232 

SchemaValidationError: Invalid specification

        altair.vegalite.v2.api.Chart, validating 'required'

        'mark' is a required property
        
```