### PR TITLE
Modify transform_lookup to take from_ argument

### DIFF
--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -418,6 +418,8 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
     @utils.use_signature(core.LookupTransform)
     def transform_lookup(self, from_=Undefined, **kwargs):
         if from_ is not Undefined:
+            if 'from' in kwargs:
+                raise ValueError("transform_lookup: both 'from_' and 'from' passed as arguments.")
             kwargs['from'] = from_
         return self._add_transform(core.LookupTransform(**kwargs))
 

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -416,8 +416,10 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         return self._add_transform(core.FilterTransform(**kwargs))
 
     @utils.use_signature(core.LookupTransform)
-    def transform_lookup(self, *args, **kwargs):
-        return self._add_transform(core.LookupTransform(*args, **kwargs))
+    def transform_lookup(self, from_=Undefined, **kwargs):
+        if from_ is not Undefined:
+            kwargs['from'] = from_
+        return self._add_transform(core.LookupTransform(**kwargs))
 
     @utils.use_signature(core.TimeUnitTransform)
     def transform_timeunit(self, *args, **kwargs):

--- a/altair/vegalite/v2/examples/choropleth.py
+++ b/altair/vegalite/v2/examples/choropleth.py
@@ -1,0 +1,23 @@
+"""
+Choropleth Map
+==============
+A choropleth map of unemployment rate per county in the US
+"""
+# category: geographic
+
+import altair as alt
+from vega_datasets import data
+
+unemp_data = alt.UrlData(data.unemployment.url)
+
+counties = alt.UrlData(data.us_10m.url,
+                     format=alt.TopoDataFormat(type='topojson',
+                                               feature='counties'))
+
+chart = alt.Chart(counties).mark_geoshape().properties(
+    projection={'type': 'albersUsa'},
+    width=500,
+    height=300
+).encode(
+    color='rate:Q'
+).transform_lookup(lookup='id', from_=alt.LookupData(unemp_data, 'id', ['rate']))


### PR DESCRIPTION
I modified the `transform_lookup` method to take a `from_` parameter. I also included an example of a choropleth map using the method. 

This is in response to #545 