### PR TITLE
DOC: adjust handling of reserved names in code generation

### DIFF
--- a/altair/vega/v2/schema/core.py
+++ b/altair/vega/v2/schema/core.py
@@ -167,6 +167,11 @@ class mark(VegaSchema):
     
     properties : anyOf(Mapping(required=[enter]), Mapping(required=[update]))
     
+    
+    Dict-Only Attributes
+    --------------------
+    'from' : Mapping(required=[])
+    
     """
     _schema = {'$ref': '#/defs/mark'}
     _rootschema = Root._schema
@@ -559,6 +564,12 @@ class crossTransform(VegaSchema):
         data elements.
     output : Mapping(required=[])
         Rename the output data fields
+    
+    Dict-Only Attributes
+    --------------------
+    'with' : string
+        The name of the secondary data set to cross with the primary data. If unspecified, 
+        the primary data is crossed with itself.
     """
     _schema = {'$ref': '#/defs/crossTransform'}
     _rootschema = Root._schema
@@ -958,6 +969,11 @@ class lookupTransform(VegaSchema):
         The default value to use if a lookup match fails.
     onKey : oneOf(string, signal)
         The key field to lookup, or null for index-based lookup.
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : List(string)
+        The names of the fields in which to store looked-up values.
     """
     _schema = {'$ref': '#/defs/lookupTransform'}
     _rootschema = Root._schema

--- a/altair/vega/v3/schema/core.py
+++ b/altair/vega/v3/schema/core.py
@@ -876,6 +876,11 @@ class aggregateTransform(VegaSchema):
     
     signal : string
     
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal, None)), signal)
+    
     """
     _schema = {'$ref': '#/defs/aggregateTransform'}
     _rootschema = Root._schema
@@ -919,6 +924,11 @@ class binTransform(VegaSchema):
     step : anyOf(float, signal)
     
     steps : oneOf(List(anyOf(float, signal)), signal)
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
     
     """
     _schema = {'$ref': '#/defs/binTransform'}
@@ -973,6 +983,11 @@ class countpatternTransform(VegaSchema):
     
     stopwords : anyOf(string, signal)
     
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
+    
     """
     _schema = {'$ref': '#/defs/countpatternTransform'}
     _rootschema = Root._schema
@@ -995,6 +1010,11 @@ class crossTransform(VegaSchema):
     filter : exprString
     
     signal : string
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
     
     """
     _schema = {'$ref': '#/defs/crossTransform'}
@@ -1023,6 +1043,11 @@ class densityTransform(VegaSchema):
     signal : string
     
     steps : anyOf(float, signal)
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
     
     """
     _schema = {'$ref': '#/defs/densityTransform'}
@@ -1089,6 +1114,11 @@ class flattenTransform(VegaSchema):
     
     signal : string
     
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
+    
     """
     _schema = {'$ref': '#/defs/flattenTransform'}
     _rootschema = Root._schema
@@ -1109,6 +1139,11 @@ class foldTransform(VegaSchema):
     type : enum('fold')
     
     signal : string
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
     
     """
     _schema = {'$ref': '#/defs/foldTransform'}
@@ -1132,6 +1167,11 @@ class formulaTransform(VegaSchema):
     initonly : anyOf(boolean, signal)
     
     signal : string
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : anyOf(string, signal)
     
     """
     _schema = {'$ref': '#/defs/formulaTransform'}
@@ -1197,6 +1237,11 @@ class joinaggregateTransform(VegaSchema):
     
     signal : string
     
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal, None)), signal)
+    
     """
     _schema = {'$ref': '#/defs/joinaggregateTransform'}
     _rootschema = Root._schema
@@ -1225,6 +1270,13 @@ class lookupTransform(VegaSchema):
     signal : string
     
     values : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
+    
+    'from' : string
     
     """
     _schema = {'$ref': '#/defs/lookupTransform'}
@@ -1283,6 +1335,11 @@ class projectTransform(VegaSchema):
     fields : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
     
     signal : string
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal, None)), signal)
     
     """
     _schema = {'$ref': '#/defs/projectTransform'}
@@ -1369,6 +1426,11 @@ class windowTransform(VegaSchema):
     
     sort : compare
     
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal, None)), signal)
+    
     """
     _schema = {'$ref': '#/defs/windowTransform'}
     _rootschema = Root._schema
@@ -1391,6 +1453,11 @@ class identifierTransform(VegaSchema):
     type : enum('identifier')
     
     signal : string
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : anyOf(string, signal)
     
     """
     _schema = {'$ref': '#/defs/identifierTransform'}
@@ -1423,6 +1490,11 @@ class linkpathTransform(VegaSchema):
     
     targetY : oneOf(scaleField, paramField, expr)
     
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : anyOf(string, signal)
+    
     """
     _schema = {'$ref': '#/defs/linkpathTransform'}
     _rootschema = Root._schema
@@ -1453,6 +1525,11 @@ class pieTransform(VegaSchema):
     
     startAngle : anyOf(float, signal)
     
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
+    
     """
     _schema = {'$ref': '#/defs/pieTransform'}
     _rootschema = Root._schema
@@ -1481,6 +1558,11 @@ class stackTransform(VegaSchema):
     signal : string
     
     sort : compare
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
     
     """
     _schema = {'$ref': '#/defs/stackTransform'}
@@ -1574,6 +1656,11 @@ class geopathTransform(VegaSchema):
     
     signal : string
     
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : anyOf(string, signal)
+    
     """
     _schema = {'$ref': '#/defs/geopathTransform'}
     _rootschema = Root._schema
@@ -1598,6 +1685,11 @@ class geopointTransform(VegaSchema):
     type : enum('geopoint')
     
     signal : string
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
     
     """
     _schema = {'$ref': '#/defs/geopointTransform'}
@@ -1624,6 +1716,11 @@ class geoshapeTransform(VegaSchema):
     projection : string
     
     signal : string
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : anyOf(string, signal)
     
     """
     _schema = {'$ref': '#/defs/geoshapeTransform'}
@@ -1702,6 +1799,11 @@ class forceTransform(VegaSchema):
     
     velocityDecay : anyOf(float, signal)
     
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
+    
     """
     _schema = {'$ref': '#/defs/forceTransform'}
     _rootschema = Root._schema
@@ -1763,6 +1865,11 @@ class packTransform(VegaSchema):
     
     sort : compare
     
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
+    
     """
     _schema = {'$ref': '#/defs/packTransform'}
     _rootschema = Root._schema
@@ -1793,6 +1900,11 @@ class partitionTransform(VegaSchema):
     size : oneOf(List(anyOf(float, signal)), signal)
     
     sort : compare
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
     
     """
     _schema = {'$ref': '#/defs/partitionTransform'}
@@ -1848,6 +1960,11 @@ class treeTransform(VegaSchema):
     size : oneOf(List(anyOf(float, signal)), signal)
     
     sort : compare
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
     
     """
     _schema = {'$ref': '#/defs/treeTransform'}
@@ -1918,6 +2035,11 @@ class treemapTransform(VegaSchema):
     
     sort : compare
     
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
+    
     """
     _schema = {'$ref': '#/defs/treemapTransform'}
     _rootschema = Root._schema
@@ -1952,6 +2074,11 @@ class voronoiTransform(VegaSchema):
     signal : string
     
     size : oneOf(List(anyOf(float, signal)), signal)
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : anyOf(string, signal)
     
     """
     _schema = {'$ref': '#/defs/voronoiTransform'}
@@ -1993,6 +2120,11 @@ class wordcloudTransform(VegaSchema):
     spiral : anyOf(string, signal)
     
     text : oneOf(scaleField, paramField, expr)
+    
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : oneOf(List(anyOf(string, signal)), signal)
     
     """
     _schema = {'$ref': '#/defs/wordcloudTransform'}

--- a/altair/vegalite/v2/schema/core.py
+++ b/altair/vegalite/v2/schema/core.py
@@ -94,6 +94,11 @@ class AggregatedFieldDef(VegaLiteSchema):
         See the [full list of supported aggregation 
         operations](https://vega.github.io/vega-lite/docs/aggregate.html#ops) for more 
         information.
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : string
+        The output field names to use for each aggregated field.
     """
     _schema = {'$ref': '#/definitions/AggregatedFieldDef'}
     _rootschema = Root._schema
@@ -693,6 +698,11 @@ class BinTransform(VegaLiteSchema):
         parameters.
     field : string
         The data field to bin.
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : string
+        The output fields at which to write the start and end bin values.
     """
     _schema = {'$ref': '#/definitions/BinTransform'}
     _rootschema = Root._schema
@@ -745,6 +755,11 @@ class CalculateTransform(VegaLiteSchema):
     calculate : string
         A [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string. 
         Use the variable `datum` to refer to the current data object.
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : string
+        The field for storing the computed formula value.
     """
     _schema = {'$ref': '#/definitions/CalculateTransform'}
     _rootschema = Root._schema
@@ -3117,6 +3132,11 @@ class LogicalAndPredicate(VegaLiteSchema):
     
     Attributes
     ----------
+    
+    Dict-Only Attributes
+    --------------------
+    'and' : List(LogicalOperandPredicate)
+    
     """
     _schema = {'$ref': '#/definitions/LogicalAnd<Predicate>'}
     _rootschema = Root._schema
@@ -3132,6 +3152,11 @@ class SelectionAnd(VegaLiteSchema):
     
     Attributes
     ----------
+    
+    Dict-Only Attributes
+    --------------------
+    'and' : List(SelectionOperand)
+    
     """
     _schema = {'$ref': '#/definitions/SelectionAnd'}
     _rootschema = Root._schema
@@ -3147,6 +3172,11 @@ class LogicalNotPredicate(VegaLiteSchema):
     
     Attributes
     ----------
+    
+    Dict-Only Attributes
+    --------------------
+    'not' : LogicalOperandPredicate
+    
     """
     _schema = {'$ref': '#/definitions/LogicalNot<Predicate>'}
     _rootschema = Root._schema
@@ -3162,6 +3192,11 @@ class SelectionNot(VegaLiteSchema):
     
     Attributes
     ----------
+    
+    Dict-Only Attributes
+    --------------------
+    'not' : SelectionOperand
+    
     """
     _schema = {'$ref': '#/definitions/SelectionNot'}
     _rootschema = Root._schema
@@ -3201,6 +3236,11 @@ class LogicalOrPredicate(VegaLiteSchema):
     
     Attributes
     ----------
+    
+    Dict-Only Attributes
+    --------------------
+    'or' : List(LogicalOperandPredicate)
+    
     """
     _schema = {'$ref': '#/definitions/LogicalOr<Predicate>'}
     _rootschema = Root._schema
@@ -3216,6 +3256,11 @@ class SelectionOr(VegaLiteSchema):
     
     Attributes
     ----------
+    
+    Dict-Only Attributes
+    --------------------
+    'or' : List(SelectionOperand)
+    
     """
     _schema = {'$ref': '#/definitions/SelectionOr'}
     _rootschema = Root._schema
@@ -3256,6 +3301,16 @@ class LookupTransform(VegaLiteSchema):
         Key in primary data source.
     default : string
         The default value to use if lookup fails.  __Default value:__ `null`
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : anyOf(string, List(string))
+        The field or fields for storing the computed formula value. If `from.fields` is 
+        specified, the transform will use the same names for `as`. If `from.fields` is not 
+        specified, `as` has to be a string and we put the whole object into the data under 
+        the specified name.
+    'from' : LookupData
+        Secondary data reference.
     """
     _schema = {'$ref': '#/definitions/LookupTransform'}
     _rootschema = Root._schema
@@ -5072,6 +5127,11 @@ class TimeUnitTransform(VegaLiteSchema):
         The data field to apply time unit.
     timeUnit : TimeUnit
         The timeUnit.
+    
+    Dict-Only Attributes
+    --------------------
+    'as' : string
+        The output field to write the timeUnit value.
     """
     _schema = {'$ref': '#/definitions/TimeUnitTransform'}
     _rootschema = Root._schema
@@ -5219,6 +5279,14 @@ class TopLevelLayerSpec(VegaLiteSchema):
         channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
         represents the width of a single view.  __See also:__ The documentation for [width 
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+    
+    Dict-Only Attributes
+    --------------------
+    '$schema' : string
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
+        you have a reason to change this, use 
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelLayerSpec'}
     _rootschema = Root._schema
@@ -5277,6 +5345,14 @@ class TopLevelHConcatSpec(VegaLiteSchema):
         Title for the plot.
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
+    
+    Dict-Only Attributes
+    --------------------
+    '$schema' : string
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
+        you have a reason to change this, use 
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelHConcatSpec'}
     _rootschema = Root._schema
@@ -5336,6 +5412,14 @@ class TopLevelRepeatSpec(VegaLiteSchema):
         Title for the plot.
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
+    
+    Dict-Only Attributes
+    --------------------
+    '$schema' : string
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
+        you have a reason to change this, use 
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelRepeatSpec'}
     _rootschema = Root._schema
@@ -5393,6 +5477,14 @@ class TopLevelVConcatSpec(VegaLiteSchema):
         Title for the plot.
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
+    
+    Dict-Only Attributes
+    --------------------
+    '$schema' : string
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
+        you have a reason to change this, use 
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelVConcatSpec'}
     _rootschema = Root._schema
@@ -5452,6 +5544,14 @@ class TopLevelFacetSpec(VegaLiteSchema):
         Title for the plot.
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
+    
+    Dict-Only Attributes
+    --------------------
+    '$schema' : string
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
+        you have a reason to change this, use 
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelFacetSpec'}
     _rootschema = Root._schema
@@ -5558,6 +5658,14 @@ class TopLevelFacetedUnitSpec(VegaLiteSchema):
         channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
         represents the width of a single view.  __See also:__ The documentation for [width 
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+    
+    Dict-Only Attributes
+    --------------------
+    '$schema' : string
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
+        you have a reason to change this, use 
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelFacetedUnitSpec'}
     _rootschema = Root._schema

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -264,7 +264,7 @@ def generate_vegalite_mark_mixin(schemafile, mark_enum='Mark',
                       rootschema=schema)
 
     # adapted from SchemaInfo.init_code
-    nonkeyword, required, kwds, additional = codegen._get_args(info)
+    nonkeyword, required, kwds, invalid_kwds, additional = codegen._get_args(info)
     required -= {'type'}
     kwds -= {'type'}
 
@@ -273,7 +273,7 @@ def generate_vegalite_mark_mixin(schemafile, mark_enum='Mark',
     dict_args = ['{0}={0}'.format(p)
                  for p in (sorted(required) + sorted(kwds))]
 
-    if additional:
+    if additional or invalid_kwds:
         def_args.append('**kwds')
         dict_args.append('**kwds')
 


### PR DESCRIPTION
Previously, reserved names were ignored in the docstring.

Now the docstring contains a ``Dict-only Attribute`` section that lists these.