### PR TITLE
MAINT: add helpful message for when charts don't render

### DIFF
--- a/altair/vega/v2/display.py
+++ b/altair/vega/v2/display.py
@@ -20,9 +20,18 @@ from ..display import SpecType, MimeBundleType, RendererType
 VEGA_MIME_TYPE = 'application/vnd.vega.v2+json'  # type: str
 
 # The entry point group that can be used by other packages to declare other
-# renderers that will be auto-detected. Explicit registration is also 
+# renderers that will be auto-detected. Explicit registration is also
 # allowed by the PluginRegistery API.
 ENTRY_POINT_GROUP = 'altair.vega.v2.renderer'  # type: str
+
+# The display message when rendering fails
+DEFAULT_DISPLAY = """\
+<Vega 2 object>
+
+If you see this message, it means the renderer has not been properly enabled
+for the frontend that you are using. For more information, see
+https://altair-viz.github.io/user_guide/display.html
+"""
 
 renderers = PluginRegistry[RendererType](entry_point_group=ENTRY_POINT_GROUP)
 
@@ -31,11 +40,11 @@ here = os.path.dirname(os.path.realpath(__file__))
 
 
 def default_renderer(spec):
-    return default_renderer_base(spec, VEGA_MIME_TYPE, '<Vega 2 object>')
+    return default_renderer_base(spec, VEGA_MIME_TYPE, DEFAULT_DISPLAY)
 
 
 def json_renderer(spec):
-    return json_renderer_base(spec, '<Vega 2 object>')
+    return json_renderer_base(spec, DEFAULT_DISPLAY)
 
 
 renderers.register('default', default_renderer)

--- a/altair/vega/v3/display.py
+++ b/altair/vega/v3/display.py
@@ -20,9 +20,18 @@ from ..display import SpecType, MimeBundleType, RendererType
 VEGA_MIME_TYPE = 'application/vnd.vega.v3+json'  # type: str
 
 # The entry point group that can be used by other packages to declare other
-# renderers that will be auto-detected. Explicit registration is also 
+# renderers that will be auto-detected. Explicit registration is also
 # allowed by the PluginRegistery API.
 ENTRY_POINT_GROUP = 'altair.vega.v3.renderer'  # type: str
+
+# The display message when rendering fails
+DEFAULT_DISPLAY = """\
+<Vega 3 object>
+
+If you see this message, it means the renderer has not been properly enabled
+for the frontend that you are using. For more information, see
+https://altair-viz.github.io/user_guide/display.html
+"""
 
 renderers = PluginRegistry[RendererType](entry_point_group=ENTRY_POINT_GROUP)
 
@@ -31,11 +40,11 @@ here = os.path.dirname(os.path.realpath(__file__))
 
 
 def default_renderer(spec):
-    return default_renderer_base(spec, VEGA_MIME_TYPE, '<Vega 3 object>')
+    return default_renderer_base(spec, VEGA_MIME_TYPE, DEFAULT_DISPLAY)
 
 
 def json_renderer(spec):
-    return json_renderer_base(spec, '<Vega 3 object>')
+    return json_renderer_base(spec, DEFAULT_DISPLAY)
 
 
 renderers.register('default', default_renderer)

--- a/altair/vegalite/v1/display.py
+++ b/altair/vegalite/v1/display.py
@@ -24,6 +24,15 @@ VEGALITE_MIME_TYPE = 'application/vnd.vegalite.v1+json'  # type: str
 # allowed by the PluginRegistery API.
 ENTRY_POINT_GROUP = 'altair.vegalite.v1.renderer'  # type: str
 
+# The display message when rendering fails
+DEFAULT_DISPLAY = """\
+<VegaLite 1 object>
+
+If you see this message, it means the renderer has not been properly enabled
+for the frontend that you are using. For more information, see
+https://altair-viz.github.io/user_guide/display.html
+"""
+
 renderers = PluginRegistry[RendererType](entry_point_group=ENTRY_POINT_GROUP)
 
 
@@ -31,11 +40,11 @@ here = os.path.dirname(os.path.realpath(__file__))
 
 
 def default_renderer(spec):
-    return default_renderer_base(spec, VEGALITE_MIME_TYPE, '<VegaLite 1 object>')
+    return default_renderer_base(spec, VEGALITE_MIME_TYPE, DEFAULT_DISPLAY)
 
 
 def json_renderer(spec):
-    return json_renderer_base(spec, '<VegaLite 1 object>')
+    return json_renderer_base(spec, DEFAULT_DISPLAY)
 
 
 renderers.register('default', default_renderer)

--- a/altair/vegalite/v2/display.py
+++ b/altair/vegalite/v2/display.py
@@ -23,6 +23,15 @@ VEGALITE_MIME_TYPE = 'application/vnd.vegalite.v2+json'  # type: str
 # allowed by the PluginRegistery API.
 ENTRY_POINT_GROUP = 'altair.vegalite.v2.renderer'  # type: str
 
+# The display message when rendering fails
+DEFAULT_DISPLAY = """\
+<VegaLite 2 object>
+
+If you see this message, it means the renderer has not been properly enabled
+for the frontend that you are using. For more information, see
+https://altair-viz.github.io/user_guide/display.html
+"""
+
 renderers = PluginRegistry[RendererType](entry_point_group=ENTRY_POINT_GROUP)
 
 
@@ -31,11 +40,11 @@ here = os.path.dirname(os.path.realpath(__file__))
 
 
 def default_renderer(spec):
-    return default_renderer_base(spec, VEGALITE_MIME_TYPE, '<VegaLite 2 object>')
+    return default_renderer_base(spec, VEGALITE_MIME_TYPE, DEFAULT_DISPLAY)
 
 
 def json_renderer(spec):
-    return json_renderer_base(spec, '<VegaLite 2 object>')
+    return json_renderer_base(spec, DEFAULT_DISPLAY)
 
 
 renderers.register('default', default_renderer)


### PR DESCRIPTION
cc/ @ellisonbg 

We've already had a couple questions from users who either forgot to run or didn't realize they had to run ``renderers.enable('notebook')`` to use Altair in the notebook.

This PR changes the default output for when rendering fails to a more helpful message with a link to the docs.

Please let me know if this looks OK – I'm not sure if there's anything I'm overlooking.