### PR TITLE
Allow chromedriver to work under the root user

### DIFF
--- a/altair/utils/headless.py
+++ b/altair/utils/headless.py
@@ -150,6 +150,9 @@ def save_spec(spec, fp, mode=None, format=None, driver_timeout=10):
     try:
         chrome_options = ChromeOptions()
         chrome_options.add_argument("--headless")
+        if os.geteuid() == 0:
+            chrome_options.add_argument('--no-sandbox')
+            
         driver = webdriver.Chrome(chrome_options=chrome_options)
         driver.set_page_load_timeout(driver_timeout)
 


### PR DESCRIPTION
On systems running on root (typical for many docker/CI set ups) Chrome fails with:
```
[0320/133959.828643:ERROR:zygote_host_impl_linux.cc(90)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180
```

This option allows headless chrome to run in such cases.