### PR TITLE
Refactor savechart

### DIFF
--- a/altair/utils/__init__.py
+++ b/altair/utils/__init__.py
@@ -1,5 +1,3 @@
 from .core import *
 
 from .plugin_registry import PluginRegistry
-
-from .headless import save_spec

--- a/altair/utils/headless.py
+++ b/altair/utils/headless.py
@@ -83,9 +83,11 @@ EXTRACT_CODE = {
             .catch(function(err) { console.error(err); });
         """}
 
-def spec_to_image_mimebundle(spec, format, mode, driver_timeout=10,
-                             vegalite_version='2', vega_version='3',
-                             vegaembed_version='3'):
+def spec_to_image_mimebundle(spec, format, mode,
+                             vega_version,
+                             vegaembed_version,
+                             vegalite_version=None,
+                             driver_timeout=10):
     """Conver a vega/vega-lite specification to a PNG/EPS image
 
     Parameters
@@ -96,15 +98,15 @@ def spec_to_image_mimebundle(spec, format, mode, driver_timeout=10,
         the file format to be saved.
     mode : string {'vega' | 'vega-lite'}
         The rendering mode.
-    driver_timeout : int (optional)
-        the number of seconds to wait for page load before raising an
-        error (default: 10)
     vega_version : string
         For html output, the version of vega.js to use
     vegalite_version : string
         For html output, the version of vegalite.js to use
     vegaembed_version : string
         For html output, the version of vegaembed.js to use
+    driver_timeout : int (optional)
+        the number of seconds to wait for page load before raising an
+        error (default: 10)
 
     Returns
     -------
@@ -122,6 +124,9 @@ def spec_to_image_mimebundle(spec, format, mode, driver_timeout=10,
         raise NotImplementedError("format must be 'svg' and 'png'")
     if mode not in ['vega', 'vega-lite']:
         raise ValueError("mode must be 'vega' or 'vega-lite'")
+
+    if mode == 'vega-lite' and vegalite_version is None:
+        raise ValueError("must specify vega-lite version")
 
     if webdriver is None:
         raise ImportError("selenium package is required for saving chart as {0}".format(format))

--- a/altair/utils/headless.py
+++ b/altair/utils/headless.py
@@ -88,7 +88,7 @@ def spec_to_image_mimebundle(spec, format, mode,
                              vegaembed_version,
                              vegalite_version=None,
                              driver_timeout=10):
-    """Conver a vega/vega-lite specification to a PNG/EPS image
+    """Conver a vega/vega-lite specification to a PNG/SVG image
 
     Parameters
     ----------

--- a/altair/utils/headless.py
+++ b/altair/utils/headless.py
@@ -11,7 +11,6 @@ import tempfile
 import six
 
 from .core import write_file_or_filename
-from ._py3k_compat import urlopen, HTTPError, URLError
 
 try:
     from selenium import webdriver
@@ -24,30 +23,14 @@ except ImportError:
     ChromeOptions = None
 
 
-def connection_ok():
-    """Check web connection.
-    Returns True if web connection is OK, False otherwise.
-    """
-    try:
-        urlopen('http://vega.github.io', timeout=1)
-    except HTTPError:
-        # connection works, but there's an HTTP error
-        return True
-    except URLError:
-        # This is raised if there is no internet connection
-        return False
-    else:
-        return True
-
-
 HTML_TEMPLATE = """
 <!DOCTYPE html>
 <html>
 <head>
   <title>Embedding Vega-Lite</title>
-  <script src="https://cdn.jsdelivr.net/npm/vega@3.2"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vega-lite@2.3"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vega-embed@3.0.0"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega@{vega_version}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-lite@{vegalite_version}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-embed@{vegaembed_version}"></script>
 </head>
 <body>
   <div id="vis"></div>
@@ -100,25 +83,33 @@ EXTRACT_CODE = {
             .catch(function(err) { console.error(err); });
         """}
 
-def save_spec(spec, fp, mode=None, format=None, driver_timeout=10):
-    """Save a spec to file
+def spec_to_image_mimebundle(spec, format, mode, driver_timeout=10,
+                             vegalite_version='2', vega_version='3',
+                             vegaembed_version='3'):
+    """Conver a vega/vega-lite specification to a PNG/EPS image
 
     Parameters
     ----------
     spec : dict
         a dictionary representing a vega-lite plot spec
-    fp : string or file-like object
-        the filename or file object at which the result will be saved
-    mode : string or None
-        The rendering mode ('vega' or 'vega-lite'). If None, the mode will be
-        inferred from the $schema attribute of the spec, or will default to
-        'vega' if $schema is not in the spec.
-    format : string (optional)
-        the file format to be saved. If not specified, it will be inferred
-        from the extension of filename.
+    format : string {'png' | 'svg'}
+        the file format to be saved.
+    mode : string {'vega' | 'vega-lite'}
+        The rendering mode.
     driver_timeout : int (optional)
         the number of seconds to wait for page load before raising an
         error (default: 10)
+    vega_version : string
+        For html output, the version of vega.js to use
+    vegalite_version : string
+        For html output, the version of vegalite.js to use
+    vegaembed_version : string
+        For html output, the version of vegaembed.js to use
+
+    Returns
+    -------
+    output : dict
+        a mime-bundle representing the image
 
     Note
     ----
@@ -127,39 +118,33 @@ def save_spec(spec, fp, mode=None, format=None, driver_timeout=10):
     """
     # TODO: allow package versions to be specified
     # TODO: detect & use local Jupyter caches of JS packages?
-
-    if format is None and isinstance(fp, six.string_types):
-        format = fp.split('.')[-1]
-
     if format not in ['png', 'svg']:
-        raise NotImplementedError("save_spec only supports 'svg' and 'png'")
+        raise NotImplementedError("format must be 'svg' and 'png'")
+    if mode not in ['vega', 'vega-lite']:
+        raise ValueError("mode must be 'vega' or 'vega-lite'")
 
     if webdriver is None:
         raise ImportError("selenium package is required for saving chart as {0}".format(format))
     if ChromeOptions is None:
         raise ImportError("chromedriver is required for saving chart as {0}".format(format))
 
-    if mode is None:
-        if '$schema' in spec:
-            mode = spec['$schema'].split('/')[-2]
-        else:
-            mode = 'vega'
-    if mode not in ['vega', 'vega-lite']:
-        raise ValueError("mode must be 'vega' or 'vega-lite'")
+    html = HTML_TEMPLATE.format(vega_version=vega_version,
+                                vegalite_version=vegalite_version,
+                                vegaembed_version=vegaembed_version)
 
     try:
         chrome_options = ChromeOptions()
         chrome_options.add_argument("--headless")
         if os.geteuid() == 0:
             chrome_options.add_argument('--no-sandbox')
-            
+
         driver = webdriver.Chrome(chrome_options=chrome_options)
         driver.set_page_load_timeout(driver_timeout)
 
         try:
             fd, htmlfile = tempfile.mkstemp(suffix='.html', text=True)
             with open(htmlfile, 'w') as f:
-                f.write(HTML_TEMPLATE)
+                f.write(html)
             driver.get("file://" + htmlfile)
             online = driver.execute_script("return navigator.onLine")
             if not online:
@@ -172,8 +157,6 @@ def save_spec(spec, fp, mode=None, format=None, driver_timeout=10):
         driver.close()
 
     if format == 'png':
-        img_bytes = base64.decodebytes(render.split(',')[1].encode())
-        write_file_or_filename(fp, img_bytes, mode='wb')
-    else:
-        img_bytes = render.encode()
-        write_file_or_filename(fp, img_bytes, mode='wb')
+        return {'image/png': base64.decodebytes(render.split(',', 1)[1].encode())}
+    elif format == 'svg':
+        return {'image/svg+xml': render}

--- a/altair/utils/savechart.py
+++ b/altair/utils/savechart.py
@@ -3,7 +3,8 @@ import textwrap
 
 import six
 
-from .headless import save_spec, write_file_or_filename
+from .core import write_file_or_filename
+from .headless import spec_to_image_mimebundle
 
 
 HTML_TEMPLATE = {
@@ -46,7 +47,7 @@ HTML_TEMPLATE = {
 
 
 def savechart(chart, fp, format=None, mode=None,
-              vegalite_version=2, vega_version=3, vegaembed_version=3,
+              vegalite_version='2', vega_version='3', vegaembed_version='3',
               opt=None, json_kwds=None):
     """Save a chart to file in a variety of formats
 
@@ -101,8 +102,7 @@ def savechart(chart, fp, format=None, mode=None,
             mode = 'vega-lite'
 
     if mode not in ['vega', 'vega-lite']:
-        print(mode)
-        raise ValueError("mode must be 'vega' or 'vegalite', "
+        raise ValueError("mode must be 'vega' or 'vega-lite', "
                          "not '{0}'".format(mode))
 
     if format == 'json':
@@ -119,6 +119,13 @@ def savechart(chart, fp, format=None, mode=None,
                                     vegaembed_version=vegaembed_version)
         write_file_or_filename(fp, spec_html, mode='w')
     elif format in ['png', 'svg']:
-        save_spec(chart.to_dict(), fp, mode=mode, format=format)
+        mimebundle = spec_to_image_mimebundle(spec, format=format, mode=mode,
+                                              vega_version=vega_version,
+                                              vegalite_version=vegalite_version,
+                                              vegaembed_version=vegaembed_version)
+        if format == 'png':
+            write_file_or_filename(fp, mimebundle['image/png'], mode='wb')
+        else:
+            write_file_or_filename(fp, mimebundle['image/svg+xml'], mode='w')
     else:
         raise ValueError("unrecognized format: '{0}'".format(format))

--- a/altair/utils/savechart.py
+++ b/altair/utils/savechart.py
@@ -46,8 +46,8 @@ HTML_TEMPLATE = {
 """}
 
 
-def savechart(chart, fp, format=None, mode=None,
-              vegalite_version='2', vega_version='3', vegaembed_version='3',
+def savechart(chart, fp, vega_version, vegaembed_version,
+              format=None, mode=None, vegalite_version=None,
               opt=None, json_kwds=None):
     """Save a chart to file in a variety of formats
 
@@ -104,6 +104,9 @@ def savechart(chart, fp, format=None, mode=None,
     if mode not in ['vega', 'vega-lite']:
         raise ValueError("mode must be 'vega' or 'vega-lite', "
                          "not '{0}'".format(mode))
+
+    if mode == 'vega-lite' and vegalite_version is None:
+        raise ValueError("must specify vega-lite version")
 
     if format == 'json':
         json_spec = json.dumps(spec, **json_kwds)

--- a/altair/utils/savechart.py
+++ b/altair/utils/savechart.py
@@ -1,0 +1,124 @@
+import json
+import textwrap
+
+import six
+
+from .headless import save_spec, write_file_or_filename
+
+
+HTML_TEMPLATE = {
+'vega-lite': """
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://cdn.jsdelivr.net/npm/vega@{vega_version}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-lite@{vegalite_version}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-embed@{vegaembed_version}"></script>
+</head>
+<body>
+  <div id="vis"></div>
+  <script type="text/javascript">
+    var spec = {spec};
+    var opt = {embed_opt};
+    vegaEmbed("#vis", spec, opt);
+  </script>
+</body>
+</html>
+""",
+
+'vega': """
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://cdn.jsdelivr.net/npm/vega@{vega_version}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-embed@{vegaembed_version}"></script>
+</head>
+<body>
+  <div id="vis"></div>
+  <script type="text/javascript">
+    var spec = {spec};
+    var opt = {embed_opt};
+    vegaEmbed("#vis", spec, opt);
+  </script>
+</body>
+</html>
+"""}
+
+
+def savechart(chart, fp, format=None, mode=None,
+              vegalite_version=2, vega_version=3, vegaembed_version=3,
+              opt=None, json_kwds=None):
+    """Save a chart to file in a variety of formats
+
+    Supported formats are [json, html, png, svg]
+
+    Parameters
+    ----------
+    chart : alt.Chart
+        the chart instance to save
+    fp : string filename or file-like object
+        file in which to write the chart.
+    format : string (optional)
+        the format to write: one of ['json', 'html', 'png', 'eps'].
+        If not specified, the format will be determined from the filename.
+    mode : string (optional)
+        Either 'vega' or 'vegalite'. If not specified, then infer the mode from
+        the '$schema' property of the spec, or the ``opt`` dictionary.
+        If it's not specified in either of those places, then use 'vegalite'.
+    vega_version : string
+        For html output, the version of vega.js to use
+    vegalite_version : string
+        For html output, the version of vegalite.js to use
+    vegaembed_version : string
+        For html output, the version of vegaembed.js to use
+    opt : dict
+        The vegaEmbed options dictionary. Default is {}
+        (See https://github.com/vega/vega-embed for details)
+    json_kwds : dict
+        Additional keyword arguments are passed to the output method
+        associated with the specified format.
+    """
+    if json_kwds is None:
+        json_kwds = {}
+
+    if opt is None:
+        opt = {}
+
+    if format is None:
+        if isinstance(fp, six.string_types):
+            format = fp.split('.')[-1]
+        else:
+            raise ValueError("must specify file format: "
+                             "['png', 'eps', 'html', 'json']")
+    spec = chart.to_dict()
+
+    if mode is None:
+        if 'mode' in opt:
+            mode = opt['mode']
+        elif '$schema' in spec:
+            mode = spec['$schema'].split('/')[-2]
+        else:
+            mode = 'vega-lite'
+
+    if mode not in ['vega', 'vega-lite']:
+        print(mode)
+        raise ValueError("mode must be 'vega' or 'vegalite', "
+                         "not '{0}'".format(mode))
+
+    if format == 'json':
+        json_spec = json.dumps(spec, **json_kwds)
+        write_file_or_filename(fp, json_spec, mode='w')
+    elif format == 'html':
+        template = HTML_TEMPLATE[mode]
+        opt['mode'] = mode
+        json_spec = json.dumps(spec, **json_kwds)
+        spec_html = template.format(spec=json_spec,
+                                    embed_opt=json.dumps(opt),
+                                    vega_version=vega_version,
+                                    vegalite_version=vegalite_version,
+                                    vegaembed_version=vegaembed_version)
+        write_file_or_filename(fp, spec_html, mode='w')
+    elif format in ['png', 'svg']:
+        save_spec(chart.to_dict(), fp, mode=mode, format=format)
+    else:
+        raise ValueError("unrecognized format: '{0}'".format(format))

--- a/altair/vegalite/v1/api.py
+++ b/altair/vegalite/v1/api.py
@@ -7,14 +7,16 @@ import six
 
 import pandas as pd
 
-from .schema import core, channels, Undefined
+from .schema import core, channels, Undefined, SCHEMA_URL, SCHEMA_VERSION
 
 from .data import data_transformers, pipe
 from ... import utils
 from .display import renderers
 
 
-SCHEMA_URL = "https://vega.github.io/schema/vega-lite/v1.json"
+VEGALITE_VERSION = SCHEMA_VERSION.lstrip('v')
+VEGA_VERSION = '2'
+VEGAEMBED_VERSION = '3'
 
 
 def _get_channels_mapping():
@@ -110,29 +112,12 @@ class TopLevelMixin(object):
             Additional keyword arguments are passed to the output method
             associated with the specified format.
         """
-
-        if isinstance(fp, six.string_types):
-            format = fp.split('.')[-1]
-
-        if format is None:
-            raise ValueError("must specify file format: "
-                             "['png', 'eps', 'html', 'json']")
-        elif format == 'json':
-            utils.write_file_or_filename(fp, self.to_json(**kwargs), mode='w')
-        elif format == 'html':
-            from .html import HTML_TEMPLATE
-            opt = dict(renderer=kwargs.pop('renderer', 'canvas'),
-                       actions=kwargs.pop('actions', False))
-            if opt['renderer'] not in ('canvas', 'svg'):
-                raise ValueError("renderer must be 'canvas' or 'svg'")
-            spec_html = HTML_TEMPLATE.format(spec=self.to_json(**kwargs),
-                                             opt=json.dumps(opt))
-            utils.write_file_or_filename(fp, spec_html, mode='w')
-        elif format in ['png', 'svg']:
-            raise NotImplementedError("saving of v1 specs")
-            utils.save_spec(self.to_dict(), fp, format=format, **kwargs)
-        else:
-            raise ValueError("unrecognized format: '{0}'".format(format))
+        from ...utils.savechart import savechart
+        return savechart(self, fp=fp, format=format,
+                         vegalite_version=VEGALITE_VERSION,
+                         vega_version=VEGA_VERSION,
+                         vegaembed_version=VEGAEMBED_VERSION,
+                         **kwargs)
 
     # transform method
     @utils.use_signature(core.Transform)

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -5,14 +5,15 @@ import jsonschema
 import six
 import pandas as pd
 
-from .schema import core, channels, mixins, Undefined
+from .schema import core, channels, mixins, Undefined, SCHEMA_URL, SCHEMA_VERSION
 
 from .data import data_transformers, pipe
 from ... import utils, expr
 from .display import renderers
 
-
-SCHEMA_URL = "https://vega.github.io/schema/vega-lite/v2.json"
+VEGALITE_VERSION = SCHEMA_VERSION.lstrip('v')
+VEGA_VERSION = '3.2'
+VEGAEMBED_VERSION = '3.0'
 
 #------------------------------------------------------------------------
 # Data Utilities
@@ -31,7 +32,7 @@ def _prepare_data(data):
         warnings.warn("data of type {0} not recognized".format(type(data)))
         return data
 
-
+    
 #------------------------------------------------------------------------
 # Aliases & specializations
 Bin = core.BinParams
@@ -350,9 +351,9 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         """
         from ...utils.savechart import savechart
         return savechart(self, fp=fp, format=format,
-                         vegalite_version='2.3',
-                         vega_version='3.2',
-                         vegaembed_version='3.0',
+                         vegalite_version=VEGALITE_VERSION,
+                         vega_version=VEGA_VERSION,
+                         vegaembed_version=VEGAEMBED_VERSION,
                          **kwargs)
 
     # Layering and stacking

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -349,7 +349,11 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             associated with the specified format.
         """
         from ...utils.savechart import savechart
-        return savechart(self, fp=fp, format=format, **kwargs)
+        return savechart(self, fp=fp, format=format,
+                         vegalite_version='2.3',
+                         vega_version='3.2',
+                         vegaembed_version='3.0',
+                         **kwargs)
 
     # Layering and stacking
 

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -348,27 +348,8 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             Additional keyword arguments are passed to the output method
             associated with the specified format.
         """
-        if isinstance(fp, six.string_types):
-            format = fp.split('.')[-1]
-
-        if format is None:
-            raise ValueError("must specify file format: "
-                             "['png', 'eps', 'html', 'json']")
-        elif format == 'json':
-            utils.write_file_or_filename(fp, self.to_json(**kwargs), mode='w')
-        elif format == 'html':
-            from .html import HTML_TEMPLATE
-            opt = dict(renderer=kwargs.pop('renderer', 'canvas'),
-                       actions=kwargs.pop('actions', False))
-            if opt['renderer'] not in ('canvas', 'svg'):
-                raise ValueError("renderer must be 'canvas' or 'svg'")
-            spec_html = HTML_TEMPLATE.format(spec=self.to_json(**kwargs),
-                                             opt=json.dumps(opt))
-            utils.write_file_or_filename(fp, spec_html, mode='w')
-        elif format in ['png', 'svg']:
-            utils.save_spec(self.to_dict(), fp, format=format, **kwargs)
-        else:
-            raise ValueError("unrecognized format: '{0}'".format(format))
+        from ...utils.savechart import savechart
+        return savechart(self, fp=fp, format=format, **kwargs)
 
     # Layering and stacking
 

--- a/altair/vegalite/v2/tests/test_api.py
+++ b/altair/vegalite/v2/tests/test_api.py
@@ -9,9 +9,6 @@ import pytest
 import pandas as pd
 
 import altair.vegalite.v2 as alt
-from altair.utils.headless import connection_ok
-
-CONNECTION_OK = connection_ok()
 
 
 def test_chart_data_types():
@@ -128,7 +125,7 @@ def test_selection_to_dict():
 def test_savechart(format):
     from ..examples.bar import chart
 
-    if format in ['html', 'json']:
+    if format in ['html', 'json', 'svg']:
         out = io.StringIO()
         mode = 'r'
     else:


### PR DESCRIPTION
This PR refactors the ``savechart`` code:

- move the bulk of the code to ``altair/utils`` and make library versions configurable
- change the ``headless`` code to output a mimetype representation, and leave the file saving to ``savechart``

This will allow us to trivially create PNG and SVG renderers for use in the case of large datasets cc/@ellisonbg