### PR TITLE
MAINT: use pkgutil rather than open() to access internal data files

### DIFF
--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pkgutil
 from typing import Callable, Dict, Union
 
 from jsonschema import validate
@@ -19,7 +20,7 @@ class Displayable(object):
     """A base display class for VegaLite v1/v2.
 
     This class takes a VegaLite v1/v2 spec and does the following:
-    
+
     1. Optionally validates the spec against a schema.
     2. Uses the RendererPlugin to grab a renderer and call it when the
        IPython/Jupyter display method (_repr_mimebundle_) is called.
@@ -31,17 +32,16 @@ class Displayable(object):
     """
 
     renderers = None
-    schema_path = ''
+    schema_path = ('altair', '')
 
     def __init__(self, spec, validate=False) -> None:
         self.spec = spec
         self.validate = validate
         self._validate()
-    
+
     def _validate(self) -> None:
         """Validate the spec against the schema."""
-        with open(self.schema_path) as f:
-            schema_dict = json.load(f)
+        schema_dict = json.loads(pkgutil.get_data(*self.schema_path))
         validate(self.spec, schema_dict)
 
     def _repr_mimebundle_(self, include, exclude):

--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -41,7 +41,7 @@ class Displayable(object):
 
     def _validate(self) -> None:
         """Validate the spec against the schema."""
-        schema_dict = json.loads(pkgutil.get_data(*self.schema_path))
+        schema_dict = json.loads(pkgutil.get_data(*self.schema_path).decode())
         validate(self.spec, schema_dict)
 
     def _repr_mimebundle_(self, include, exclude):

--- a/altair/vega/v2/display.py
+++ b/altair/vega/v2/display.py
@@ -57,7 +57,7 @@ class Vega(Displayable):
     """An IPython/Jupyter display class for rendering Vega 2."""
 
     renderers = renderers
-    schema_path = os.path.join(here, 'schema', 'vega-schema.json')
+    schema_path = (__name__, 'schema/vega-schema.json')
 
 
 def vega(spec: dict, validate=True):

--- a/altair/vega/v2/schema/core.py
+++ b/altair/vega/v2/schema/core.py
@@ -8,7 +8,7 @@ import json
 
 def load_schema():
     """Load the json schema associated with this module's functions"""
-    return json.loads(pkgutil.get_data(__name__, 'vega-schema.json'))
+    return json.loads(pkgutil.get_data(__name__, 'vega-schema.json').decode())
 
 
 class VegaSchema(SchemaBase):

--- a/altair/vega/v2/schema/core.py
+++ b/altair/vega/v2/schema/core.py
@@ -3,14 +3,12 @@
 
 from altair.utils.schemapi import SchemaBase, Undefined
 
-import os
+import pkgutil
 import json
 
 def load_schema():
     """Load the json schema associated with this module's functions"""
-    directory = os.path.dirname(__file__)
-    with open(os.path.join(directory, 'vega-schema.json'), encoding='utf8') as f:
-        return json.load(f)
+    return json.loads(pkgutil.get_data(__name__, 'vega-schema.json'))
 
 
 class VegaSchema(SchemaBase):

--- a/altair/vega/v3/display.py
+++ b/altair/vega/v3/display.py
@@ -57,7 +57,7 @@ class Vega(Displayable):
     """An IPython/Jupyter display class for rendering Vega 3."""
 
     renderers = renderers
-    schema_path = os.path.join(here, 'schema', 'vega-schema.json')
+    schema_path = (__name__, 'schema/vega-schema.json')
 
 
 def vega(spec: dict, validate=True):

--- a/altair/vega/v3/schema/core.py
+++ b/altair/vega/v3/schema/core.py
@@ -8,7 +8,7 @@ import json
 
 def load_schema():
     """Load the json schema associated with this module's functions"""
-    return json.loads(pkgutil.get_data(__name__, 'vega-schema.json'))
+    return json.loads(pkgutil.get_data(__name__, 'vega-schema.json').decode())
 
 
 class VegaSchema(SchemaBase):

--- a/altair/vega/v3/schema/core.py
+++ b/altair/vega/v3/schema/core.py
@@ -3,14 +3,12 @@
 
 from altair.utils.schemapi import SchemaBase, Undefined
 
-import os
+import pkgutil
 import json
 
 def load_schema():
     """Load the json schema associated with this module's functions"""
-    directory = os.path.dirname(__file__)
-    with open(os.path.join(directory, 'vega-schema.json'), encoding='utf8') as f:
-        return json.load(f)
+    return json.loads(pkgutil.get_data(__name__, 'vega-schema.json'))
 
 
 class VegaSchema(SchemaBase):

--- a/altair/vegalite/v1/display.py
+++ b/altair/vegalite/v1/display.py
@@ -84,7 +84,7 @@ class VegaLite(Displayable):
     """An IPython/Jupyter display class for rendering VegaLite 1."""
 
     renderers = renderers
-    schema_path = os.path.join(here, 'schema', 'vega-lite-schema.json')
+    schema_path = (__name__, 'schema/vega-lite-schema.json')
 
 
 def vegalite(spec: dict, validate=True):

--- a/altair/vegalite/v1/schema/core.py
+++ b/altair/vegalite/v1/schema/core.py
@@ -3,14 +3,12 @@
 
 from altair.utils.schemapi import SchemaBase, Undefined
 
-import os
+import pkgutil
 import json
 
 def load_schema():
     """Load the json schema associated with this module's functions"""
-    directory = os.path.dirname(__file__)
-    with open(os.path.join(directory, 'vega-lite-schema.json'), encoding='utf8') as f:
-        return json.load(f)
+    return json.loads(pkgutil.get_data(__name__, 'vega-lite-schema.json'))
 
 
 class VegaLiteSchema(SchemaBase):

--- a/altair/vegalite/v1/schema/core.py
+++ b/altair/vegalite/v1/schema/core.py
@@ -8,7 +8,7 @@ import json
 
 def load_schema():
     """Load the json schema associated with this module's functions"""
-    return json.loads(pkgutil.get_data(__name__, 'vega-lite-schema.json'))
+    return json.loads(pkgutil.get_data(__name__, 'vega-lite-schema.json').decode())
 
 
 class VegaLiteSchema(SchemaBase):

--- a/altair/vegalite/v2/display.py
+++ b/altair/vegalite/v2/display.py
@@ -82,7 +82,7 @@ class VegaLite(Displayable):
     """An IPython/Jupyter display class for rendering VegaLite 2."""
 
     renderers = renderers
-    schema_path = os.path.join(here, 'schema', 'vega-lite-schema.json')
+    schema_path = (__name__, 'schema/vega-lite-schema.json')
 
 
 def vegalite(spec: dict, validate=True):

--- a/altair/vegalite/v2/examples/tests/test_examples.py
+++ b/altair/vegalite/v2/examples/tests/test_examples.py
@@ -1,27 +1,21 @@
-import os
-from os.path import join, dirname, abspath
+import pkgutil
 
 import pytest
 
 from altair.utils.execeval import eval_block
-
-EXAMPLE_DIR = abspath(join(dirname(__file__), '..'))
+from altair.vegalite.v2 import examples
 
 
 def iter_example_filenames():
-    for filename in os.listdir(EXAMPLE_DIR):
-        if filename.startswith('__'):
+    for importer, modname, ispkg in pkgutil.iter_modules(examples.__path__):
+        if ispkg or modname.startswith('_'):
             continue
-        if not filename.endswith('.py'):
-            continue
-        yield filename
+        yield modname + '.py'
 
 
 @pytest.mark.parametrize('filename', iter_example_filenames())
 def test_examples(filename):
-    with open(join(EXAMPLE_DIR, filename)) as f:
-        source = f.read()
-
+    source = pkgutil.get_data(examples.__name__, filename)
     chart = eval_block(source)
 
     if chart is None:

--- a/altair/vegalite/v2/schema/core.py
+++ b/altair/vegalite/v2/schema/core.py
@@ -3,14 +3,12 @@
 
 from altair.utils.schemapi import SchemaBase, Undefined
 
-import os
+import pkgutil
 import json
 
 def load_schema():
     """Load the json schema associated with this module's functions"""
-    directory = os.path.dirname(__file__)
-    with open(os.path.join(directory, 'vega-lite-schema.json'), encoding='utf8') as f:
-        return json.load(f)
+    return json.loads(pkgutil.get_data(__name__, 'vega-lite-schema.json'))
 
 
 class VegaLiteSchema(SchemaBase):

--- a/altair/vegalite/v2/schema/core.py
+++ b/altair/vegalite/v2/schema/core.py
@@ -8,7 +8,7 @@ import json
 
 def load_schema():
     """Load the json schema associated with this module's functions"""
-    return json.loads(pkgutil.get_data(__name__, 'vega-lite-schema.json'))
+    return json.loads(pkgutil.get_data(__name__, 'vega-lite-schema.json').decode())
 
 
 class VegaLiteSchema(SchemaBase):

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -37,14 +37,12 @@ class {basename}(SchemaBase):
 """
 
 LOAD_SCHEMA = '''
-import os
+import pkgutil
 import json
 
 def load_schema():
     """Load the json schema associated with this module's functions"""
-    directory = os.path.dirname(__file__)
-    with open(os.path.join(directory, '{schemafile}'), encoding='utf8') as f:
-        return json.load(f)
+    return json.loads(pkgutil.get_data(__name__, '{schemafile}'))
 '''
 
 FIELD_TEMPLATE = '''

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -42,7 +42,7 @@ import json
 
 def load_schema():
     """Load the json schema associated with this module's functions"""
-    return json.loads(pkgutil.get_data(__name__, '{schemafile}'))
+    return json.loads(pkgutil.get_data(__name__, '{schemafile}').decode())
 '''
 
 FIELD_TEMPLATE = '''


### PR DESCRIPTION
This is necessary to work properly within Google's internal Colab deployment.