### PR TITLE
Removes trailing whitespaces from a set of files

### DIFF
--- a/altair/vega/v2/schema/core.py
+++ b/altair/vega/v2/schema/core.py
@@ -21,7 +21,7 @@ class VegaSchema(SchemaBase):
 
 class Root(VegaSchema):
     """Root schema wrapper
-    
+
     allOf(container, Mapping(required=[]))
     """
     _schema = load_schema()
@@ -39,49 +39,49 @@ class Root(VegaSchema):
 
 class axis(VegaSchema):
     """axis schema wrapper
-    
+
     Mapping(required=[type, scale])
-    
+
     Attributes
     ----------
     scale : string
-    
+
     type : enum('x', 'y')
-    
+
     format : string
-    
+
     formatType : enum('time', 'utc', 'string', 'number')
-    
+
     grid : boolean
-    
+
     layer : enum('front', 'back')
-    
+
     offset : oneOf(float, Mapping(required=[scale, value]))
-    
+
     orient : enum('top', 'bottom', 'left', 'right')
-    
+
     properties : Mapping(required=[])
-    
+
     subdivide : float
-    
+
     tickPadding : float
-    
+
     tickSize : float
-    
+
     tickSizeEnd : float
-    
+
     tickSizeMajor : float
-    
+
     tickSizeMinor : float
-    
+
     ticks : float
-    
+
     title : string
-    
+
     titleOffset : float
-    
+
     values : List(anyOf(string, float))
-    
+
     """
     _schema = {'$ref': '#/defs/axis'}
     _rootschema = Root._schema
@@ -102,7 +102,7 @@ class axis(VegaSchema):
 
 class background(VegaSchema):
     """background schema wrapper
-    
+
     string
     """
     _schema = {'$ref': '#/defs/background'}
@@ -114,8 +114,8 @@ class background(VegaSchema):
 
 class data(VegaSchema):
     """data schema wrapper
-    
-    allOf(Mapping(required=[name]), anyOf(Mapping(required=[name, modify]), 
+
+    allOf(Mapping(required=[name]), anyOf(Mapping(required=[name, modify]),
     oneOf(Mapping(required=[source]), Mapping(required=[values]), Mapping(required=[url]))))
     """
     _schema = {'$ref': '#/defs/data'}
@@ -127,10 +127,10 @@ class data(VegaSchema):
 
 class legend(VegaSchema):
     """legend schema wrapper
-    
-    anyOf(Mapping(required=[size]), Mapping(required=[shape]), Mapping(required=[fill]), 
+
+    anyOf(Mapping(required=[size]), Mapping(required=[shape]), Mapping(required=[fill]),
     Mapping(required=[stroke]), Mapping(required=[opacity]))
-    
+
     Attributes
     ----------
     """
@@ -143,35 +143,35 @@ class legend(VegaSchema):
 
 class mark(VegaSchema):
     """mark schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
-    type : enum('rect', 'symbol', 'path', 'arc', 'area', 'line', 'rule', 'image', 'text', 
+    type : enum('rect', 'symbol', 'path', 'arc', 'area', 'line', 'rule', 'image', 'text',
     'group')
-    
+
     delay : numberValue
-    
-    ease : enum('linear-in', 'linear-out', 'linear-in-out', 'linear-out-in', 'quad-in', 
-    'quad-out', 'quad-in-out', 'quad-out-in', 'cubic-in', 'cubic-out', 'cubic-in-out', 
-    'cubic-out-in', 'sin-in', 'sin-out', 'sin-in-out', 'sin-out-in', 'exp-in', 'exp-out', 
-    'exp-in-out', 'exp-out-in', 'circle-in', 'circle-out', 'circle-in-out', 'circle-out-in', 
+
+    ease : enum('linear-in', 'linear-out', 'linear-in-out', 'linear-out-in', 'quad-in',
+    'quad-out', 'quad-in-out', 'quad-out-in', 'cubic-in', 'cubic-out', 'cubic-in-out',
+    'cubic-out-in', 'sin-in', 'sin-out', 'sin-in-out', 'sin-out-in', 'exp-in', 'exp-out',
+    'exp-in-out', 'exp-out-in', 'circle-in', 'circle-out', 'circle-in-out', 'circle-out-in',
     'bounce-in', 'bounce-out', 'bounce-in-out', 'bounce-out-in')
-    
+
     interactive : boolean
-    
+
     key : string
-    
+
     name : string
-    
+
     properties : anyOf(Mapping(required=[enter]), Mapping(required=[update]))
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'from' : Mapping(required=[])
-    
+
     """
     _schema = {'$ref': '#/defs/mark'}
     _rootschema = Root._schema
@@ -184,21 +184,21 @@ class mark(VegaSchema):
 
 class container(VegaSchema):
     """container schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     axes : List(axis)
-    
+
     legends : List(legend)
-    
+
     marks : List(oneOf(groupMark, visualMark))
-    
+
     scales : List(scale)
-    
+
     scene : Mapping(required=[])
-    
+
     """
     _schema = {'$ref': '#/defs/container'}
     _rootschema = Root._schema
@@ -211,7 +211,7 @@ class container(VegaSchema):
 
 class groupMark(VegaSchema):
     """groupMark schema wrapper
-    
+
     allOf(Mapping(required=[type]), mark, container)
     """
     _schema = {'$ref': '#/defs/groupMark'}
@@ -228,7 +228,7 @@ class groupMark(VegaSchema):
 
 class visualMark(VegaSchema):
     """visualMark schema wrapper
-    
+
     allOf(not Mapping(required=[]), mark)
     """
     _schema = {'$ref': '#/defs/visualMark'}
@@ -242,8 +242,8 @@ class visualMark(VegaSchema):
 
 class modify(VegaSchema):
     """modify schema wrapper
-    
-    List(oneOf(Mapping(required=[type, signal]), Mapping(required=[type, predicate]), 
+
+    List(oneOf(Mapping(required=[type, signal]), Mapping(required=[type, predicate]),
     Mapping(required=[type, test])))
     """
     _schema = {'$ref': '#/defs/modify'}
@@ -255,7 +255,7 @@ class modify(VegaSchema):
 
 class padding(VegaSchema):
     """padding schema wrapper
-    
+
     oneOf(enum('strict', 'auto'), float, Mapping(required=[]))
     """
     _schema = {'$ref': '#/defs/padding'}
@@ -267,8 +267,8 @@ class padding(VegaSchema):
 
 class predicate(VegaSchema):
     """predicate schema wrapper
-    
-    oneOf(Mapping(required=[name, type, operands]), Mapping(required=[name, type, operands]), 
+
+    oneOf(Mapping(required=[name, type, operands]), Mapping(required=[name, type, operands]),
     oneOf(Mapping(required=[range]), Mapping(required=[data, field])))
     """
     _schema = {'$ref': '#/defs/predicate'}
@@ -280,7 +280,7 @@ class predicate(VegaSchema):
 
 class rule(VegaSchema):
     """rule schema wrapper
-    
+
     anyOf(Mapping(required=[]), Mapping(required=[]))
     """
     _schema = {'$ref': '#/defs/rule'}
@@ -292,109 +292,109 @@ class rule(VegaSchema):
 
 class propset(VegaSchema):
     """propset schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
-    align : oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, 
-    oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[band]))))), allOf(stringModifiers, oneOf(signal, 
+    align : oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers,
+    oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[band]))))), allOf(stringModifiers, oneOf(signal,
     Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))
-    
+
     angle : numberValue
-    
-    baseline : oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, 
-    oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[band]))))), allOf(stringModifiers, oneOf(signal, 
+
+    baseline : oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers,
+    oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[band]))))), allOf(stringModifiers, oneOf(signal,
     Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))
-    
+
     clip : booleanValue
-    
+
     cursor : stringValue
-    
+
     dx : numberValue
-    
+
     dy : numberValue
-    
+
     endAngle : numberValue
-    
+
     fill : colorValue
-    
+
     fillOpacity : numberValue
-    
+
     font : stringValue
-    
+
     fontSize : numberValue
-    
+
     fontStyle : stringValue
-    
+
     fontWeight : stringValue
-    
+
     height : numberValue
-    
+
     innerRadius : numberValue
-    
-    interpolate : oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, 
-    oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[band]))))), allOf(stringModifiers, oneOf(signal, 
+
+    interpolate : oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers,
+    oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[band]))))), allOf(stringModifiers, oneOf(signal,
     Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))
-    
+
     opacity : numberValue
-    
-    orient : oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, 
-    oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[band]))))), allOf(stringModifiers, oneOf(signal, 
+
+    orient : oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers,
+    oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[band]))))), allOf(stringModifiers, oneOf(signal,
     Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))
-    
+
     outerRadius : numberValue
-    
+
     path : stringValue
-    
+
     radius : numberValue
-    
-    shape : anyOf(oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, 
-    oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[band]))))), allOf(stringModifiers, oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band])))), 
+
+    shape : anyOf(oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers,
+    oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[band]))))), allOf(stringModifiers, oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band])))),
     stringValue)
-    
+
     size : numberValue
-    
+
     startAngle : numberValue
-    
+
     stroke : colorValue
-    
+
     strokeDash : arrayValue
-    
+
     strokeDashOffset : numberValue
-    
+
     strokeOpacity : numberValue
-    
+
     strokeWidth : numberValue
-    
+
     tension : numberValue
-    
+
     text : stringValue
-    
+
     theta : numberValue
-    
+
     url : stringValue
-    
+
     width : numberValue
-    
+
     x : numberValue
-    
+
     x2 : numberValue
-    
+
     xc : numberValue
-    
+
     y : numberValue
-    
+
     y2 : numberValue
-    
+
     yc : numberValue
-    
+
     """
     _schema = {'$ref': '#/defs/propset'}
     _rootschema = Root._schema
@@ -424,23 +424,23 @@ class propset(VegaSchema):
 
 class signal(VegaSchema):
     """signal schema wrapper
-    
+
     Mapping(required=[name])
-    
+
     Attributes
     ----------
     name : not Mapping(required=[])
-    
+
     expr : string
-    
+
     init : Mapping(required=[])
-    
+
     scale : scopedScale
-    
+
     streams : streams
-    
+
     verbose : boolean
-    
+
     """
     _schema = {'$ref': '#/defs/signal'}
     _rootschema = Root._schema
@@ -453,7 +453,7 @@ class signal(VegaSchema):
 
 class spec(VegaSchema):
     """spec schema wrapper
-    
+
     allOf(container, Mapping(required=[]))
     """
     _schema = {'$ref': '#/defs/spec'}
@@ -471,7 +471,7 @@ class spec(VegaSchema):
 
 class streams(VegaSchema):
     """streams schema wrapper
-    
+
     List(Mapping(required=[type, expr]))
     """
     _schema = {'$ref': '#/defs/streams'}
@@ -483,18 +483,18 @@ class streams(VegaSchema):
 
 class aggregateTransform(VegaSchema):
     """aggregateTransform schema wrapper
-    
+
     Mapping(required=[type])
     Compute summary aggregate statistics
-    
+
     Attributes
     ----------
     type : enum('aggregate')
-    
+
     groupby : List(oneOf(string, signal))
         A list of fields to split the data into groups.
     summarize : oneOf(Mapping(required=[]), List(Mapping(required=[field, ops])))
-    
+
     """
     _schema = {'$ref': '#/defs/aggregateTransform'}
     _rootschema = Root._schema
@@ -505,16 +505,16 @@ class aggregateTransform(VegaSchema):
 
 class binTransform(VegaSchema):
     """binTransform schema wrapper
-    
+
     Mapping(required=[type, field])
     Bins values into quantitative bins (e.g., for a histogram).
-    
+
     Attributes
     ----------
     field : oneOf(string, signal)
         The name of the field to bin values from.
     type : enum('bin')
-    
+
     base : oneOf(float, signal)
         The number base to use for automatic bin determination.
     div : oneOf(List(float), signal)
@@ -548,27 +548,27 @@ class binTransform(VegaSchema):
 
 class crossTransform(VegaSchema):
     """crossTransform schema wrapper
-    
+
     Mapping(required=[type])
     Compute the cross-product of two data sets.
-    
+
     Attributes
     ----------
     type : enum('cross')
-    
+
     diagonal : oneOf(boolean, signal)
-        If false, items along the "diagonal" of the cross-product (those elements with the 
+        If false, items along the "diagonal" of the cross-product (those elements with the
         same index in their respective array) will not be included in the output.
     filter : string
-        A string containing an expression (in JavaScript syntax) to filter the resulting 
+        A string containing an expression (in JavaScript syntax) to filter the resulting
         data elements.
     output : Mapping(required=[])
         Rename the output data fields
-    
+
     Dict-Only Attributes
     --------------------
     'with' : string
-        The name of the secondary data set to cross with the primary data. If unspecified, 
+        The name of the secondary data set to cross with the primary data. If unspecified,
         the primary data is crossed with itself.
     """
     _schema = {'$ref': '#/defs/crossTransform'}
@@ -581,13 +581,13 @@ class crossTransform(VegaSchema):
 
 class countpatternTransform(VegaSchema):
     """countpatternTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('countpattern')
-    
+
     case : oneOf(enum('lower', 'upper', 'none'), signal)
         Text case transformation to apply.
     field : oneOf(string, signal)
@@ -610,17 +610,17 @@ class countpatternTransform(VegaSchema):
 
 class linkpathTransform(VegaSchema):
     """linkpathTransform schema wrapper
-    
+
     Mapping(required=[type])
     Computes a path definition for connecting nodes within a node-link network or tree diagram.
-    
+
     Attributes
     ----------
     type : enum('linkpath')
-    
+
     output : Mapping(required=[])
         Rename the output data fields
-    shape : oneOf(enum('line', 'curve', 'cornerX', 'cornerY', 'cornerR', 'diagonalX', 
+    shape : oneOf(enum('line', 'curve', 'cornerX', 'cornerY', 'cornerR', 'diagonalX',
     'diagonalY', 'diagonalR'), signal)
         The path shape to use
     sourceX : oneOf(string, signal)
@@ -646,20 +646,20 @@ class linkpathTransform(VegaSchema):
 
 class facetTransform(VegaSchema):
     """facetTransform schema wrapper
-    
+
     Mapping(required=[type])
     A special aggregate transform that organizes a data set into groups or "facets".
-    
+
     Attributes
     ----------
     type : enum('facet')
-    
+
     groupby : List(oneOf(string, signal))
         A list of fields to split the data into groups.
     summarize : oneOf(Mapping(required=[]), List(Mapping(required=[field, ops])))
-    
+
     transform : transform
-    
+
     """
     _schema = {'$ref': '#/defs/facetTransform'}
     _rootschema = Root._schema
@@ -672,16 +672,16 @@ class facetTransform(VegaSchema):
 
 class filterTransform(VegaSchema):
     """filterTransform schema wrapper
-    
+
     Mapping(required=[type, test])
     Filters elements from a data set to remove unwanted items.
-    
+
     Attributes
     ----------
     test : string
         A string containing an expression (in JavaScript syntax) for the filter predicate.
     type : enum('filter')
-    
+
     """
     _schema = {'$ref': '#/defs/filterTransform'}
     _rootschema = Root._schema
@@ -692,16 +692,16 @@ class filterTransform(VegaSchema):
 
 class foldTransform(VegaSchema):
     """foldTransform schema wrapper
-    
+
     Mapping(required=[type, fields])
     Collapse ("fold") one or more data properties into two properties.
-    
+
     Attributes
     ----------
     fields : oneOf(List(oneOf(string, signal)), signal)
-    
+
     type : enum('fold')
-    
+
     output : Mapping(required=[])
         Rename the output data fields
     """
@@ -714,20 +714,20 @@ class foldTransform(VegaSchema):
 
 class forceTransform(VegaSchema):
     """forceTransform schema wrapper
-    
+
     Mapping(required=[type, links])
     Performs force-directed layout for network data.
-    
+
     Attributes
     ----------
     links : string
         The name of the link (edge) data set.
     type : enum('force')
-    
+
     active : signal
         A signal representing the active node.
     alpha : oneOf(float, signal)
-        A "temperature" parameter that determines how much node positions are adjusted at 
+        A "temperature" parameter that determines how much node positions are adjusted at
         each step.
     charge : oneOf(float, string, signal)
         The strength of the charge each node exerts.
@@ -738,7 +738,7 @@ class forceTransform(VegaSchema):
     friction : oneOf(float, signal)
         The strength of the friction force used to stabilize the layout.
     gravity : oneOf(float, signal)
-        The strength of the pseudo-gravity force that pulls nodes towards the center of the 
+        The strength of the pseudo-gravity force that pulls nodes towards the center of the
         layout area.
     interactive : oneOf(boolean, signal)
         Enables an interactive force-directed layout.
@@ -753,7 +753,7 @@ class forceTransform(VegaSchema):
     size : oneOf(List(oneOf(float, signal)), signal)
         The dimensions [width, height] of this force layout.
     theta : oneOf(float, signal)
-        The theta parameter for the Barnes-Hut algorithm, which is used to compute charge 
+        The theta parameter for the Barnes-Hut algorithm, which is used to compute charge
         forces between nodes.
     """
     _schema = {'$ref': '#/defs/forceTransform'}
@@ -773,10 +773,10 @@ class forceTransform(VegaSchema):
 
 class formulaTransform(VegaSchema):
     """formulaTransform schema wrapper
-    
+
     Mapping(required=[type, field, expr])
     Extends data elements with new values according to a calculation formula.
-    
+
     Attributes
     ----------
     expr : string
@@ -784,7 +784,7 @@ class formulaTransform(VegaSchema):
     field : string
         The property name in which to store the computed formula value.
     type : enum('formula')
-    
+
     """
     _schema = {'$ref': '#/defs/formulaTransform'}
     _rootschema = Root._schema
@@ -795,11 +795,11 @@ class formulaTransform(VegaSchema):
 
 class geoTransform(VegaSchema):
     """geoTransform schema wrapper
-    
+
     Mapping(required=[type, lon, lat])
-    Performs a cartographic projection. Given longitude and latitude values, sets corresponding 
+    Performs a cartographic projection. Given longitude and latitude values, sets corresponding
     x and y properties for a mark.
-    
+
     Attributes
     ----------
     lat : oneOf(string, signal)
@@ -807,7 +807,7 @@ class geoTransform(VegaSchema):
     lon : oneOf(string, signal)
         The input longitude values.
     type : enum('geo')
-    
+
     center : oneOf(List(oneOf(float, signal)), signal)
         The center of the projection.
     clipAngle : oneOf(float, signal)
@@ -841,14 +841,14 @@ class geoTransform(VegaSchema):
 
 class geopathTransform(VegaSchema):
     """geopathTransform schema wrapper
-    
+
     Mapping(required=[type])
     Creates paths for geographic regions, such as countries, states and counties.
-    
+
     Attributes
     ----------
     type : enum('geopath')
-    
+
     center : oneOf(List(oneOf(float, signal)), signal)
         The center of the projection.
     clipAngle : oneOf(float, signal)
@@ -884,13 +884,13 @@ class geopathTransform(VegaSchema):
 
 class hierarchyTransform(VegaSchema):
     """hierarchyTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('hierarchy')
-    
+
     children : oneOf(string, signal)
         The data field for the children node array
     field : oneOf(string, signal)
@@ -923,10 +923,10 @@ class hierarchyTransform(VegaSchema):
 
 class imputeTransform(VegaSchema):
     """imputeTransform schema wrapper
-    
+
     Mapping(required=[type, groupby, orderby, field])
     Performs imputation of missing values.
-    
+
     Attributes
     ----------
     field : oneOf(string, signal)
@@ -936,7 +936,7 @@ class imputeTransform(VegaSchema):
     orderby : oneOf(List(oneOf(string, signal)), signal)
         A list of fields to determine ordering within series.
     type : enum('impute')
-    
+
     method : oneOf(enum('value', 'mean', 'median', 'min', 'max'), signal)
         The imputation method to use.
     value : oneOf(float, string, boolean, None, signal)
@@ -953,10 +953,10 @@ class imputeTransform(VegaSchema):
 
 class lookupTransform(VegaSchema):
     """lookupTransform schema wrapper
-    
+
     Mapping(required=[type, on, as, keys])
     Extends a data set by looking up values in another data set.
-    
+
     Attributes
     ----------
     keys : List(oneOf(string, signal))
@@ -964,12 +964,12 @@ class lookupTransform(VegaSchema):
     on : string
         The name of the secondary data set on which to lookup values.
     type : enum('lookup')
-    
+
     default : Mapping(required=[])
         The default value to use if a lookup match fails.
     onKey : oneOf(string, signal)
         The key field to lookup, or null for index-based lookup.
-    
+
     Dict-Only Attributes
     --------------------
     'as' : List(string)
@@ -986,25 +986,25 @@ class lookupTransform(VegaSchema):
 
 class pieTransform(VegaSchema):
     """pieTransform schema wrapper
-    
+
     Mapping(required=[type])
     Computes a pie chart layout.
-    
+
     Attributes
     ----------
     type : enum('pie')
-    
+
     endAngle : oneOf(float, signal)
-    
+
     field : oneOf(string, signal)
-        The data values to encode as angular spans. If this property is omitted, all pie 
+        The data values to encode as angular spans. If this property is omitted, all pie
         slices will have equal spans.
     output : Mapping(required=[])
         Rename the output data fields
     sort : oneOf(boolean, signal)
          If true, will sort the data prior to computing angles.
     startAngle : oneOf(float, signal)
-    
+
     """
     _schema = {'$ref': '#/defs/pieTransform'}
     _rootschema = Root._schema
@@ -1017,16 +1017,16 @@ class pieTransform(VegaSchema):
 
 class rankTransform(VegaSchema):
     """rankTransform schema wrapper
-    
+
     Mapping(required=[type])
     Computes ascending rank scores for data tuples.
-    
+
     Attributes
     ----------
     type : enum('rank')
-    
+
     field : oneOf(string, signal)
-        A key field to used to rank tuples. If undefined, tuples will be ranked in their 
+        A key field to used to rank tuples. If undefined, tuples will be ranked in their
         observed order.
     normalize : oneOf(boolean, signal)
         If true, values of the output field will lie in the range [0, 1].
@@ -1043,16 +1043,16 @@ class rankTransform(VegaSchema):
 
 class sortTransform(VegaSchema):
     """sortTransform schema wrapper
-    
+
     Mapping(required=[type, by])
     Sorts the values of a data set.
-    
+
     Attributes
     ----------
     by : oneOf(string, List(string))
         A list of fields to use as sort criteria.
     type : enum('sort')
-    
+
     """
     _schema = {'$ref': '#/defs/sortTransform'}
     _rootschema = Root._schema
@@ -1063,10 +1063,10 @@ class sortTransform(VegaSchema):
 
 class stackTransform(VegaSchema):
     """stackTransform schema wrapper
-    
+
     Mapping(required=[type, groupby, field])
     Computes layout values for stacked graphs, as in stacked bar charts or stream graphs.
-    
+
     Attributes
     ----------
     field : oneOf(string, signal)
@@ -1074,7 +1074,7 @@ class stackTransform(VegaSchema):
     groupby : oneOf(List(oneOf(string, signal)), signal)
         A list of fields to split the data into groups (stacks).
     type : enum('stack')
-    
+
     offset : oneOf(enum('zero', 'center', 'normalize'), signal)
         The baseline offset
     output : Mapping(required=[])
@@ -1093,15 +1093,15 @@ class stackTransform(VegaSchema):
 
 class treeifyTransform(VegaSchema):
     """treeifyTransform schema wrapper
-    
+
     Mapping(required=[type, groupby])
-    
+
     Attributes
     ----------
     groupby : oneOf(List(oneOf(string, signal)), signal)
         An ordered list of fields by which to group tuples into a tree.
     type : enum('treeify')
-    
+
     output : Mapping(required=[])
         Rename the output data fields
     """
@@ -1114,13 +1114,13 @@ class treeifyTransform(VegaSchema):
 
 class treemapTransform(VegaSchema):
     """treemapTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('treemap')
-    
+
     children : oneOf(string, signal)
         The data field for the children node array
     field : oneOf(string, signal)
@@ -1158,13 +1158,13 @@ class treemapTransform(VegaSchema):
 
 class voronoiTransform(VegaSchema):
     """voronoiTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('voronoi')
-    
+
     clipExtent : oneOf(List(oneOf(List(oneOf(float, signal)), signal)), signal)
         The min and max points at which to clip the voronoi diagram.
     output : Mapping(required=[])
@@ -1185,13 +1185,13 @@ class voronoiTransform(VegaSchema):
 
 class wordcloudTransform(VegaSchema):
     """wordcloudTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('wordcloud')
-    
+
     font : oneOf(string, oneOf(Mapping(required=[field]), Mapping(required=[value])), signal)
         The font face to use for a word.
     fontScale : oneOf(None, List(oneOf(float, signal)))
@@ -1199,24 +1199,24 @@ class wordcloudTransform(VegaSchema):
     fontSize : oneOf(float, oneOf(Mapping(required=[field]), Mapping(required=[value])), string,
      signal)
         The font size to use for a word.
-    fontStyle : oneOf(string, oneOf(Mapping(required=[field]), Mapping(required=[value])), 
+    fontStyle : oneOf(string, oneOf(Mapping(required=[field]), Mapping(required=[value])),
     signal)
         The font style to use for a word.
-    fontWeight : oneOf(string, oneOf(Mapping(required=[field]), Mapping(required=[value])), 
+    fontWeight : oneOf(string, oneOf(Mapping(required=[field]), Mapping(required=[value])),
     signal)
         The font weight to use for a word.
     output : Mapping(required=[])
         Rename the output data fields
     padding : oneOf(float, oneOf(Mapping(required=[field]), Mapping(required=[value])), signal)
         The padding around each word.
-    rotate : oneOf(float, string, oneOf(Mapping(required=[field]), Mapping(required=[value])), 
+    rotate : oneOf(float, string, oneOf(Mapping(required=[field]), Mapping(required=[value])),
     signal)
         The field or number to set the roration angle (in degrees).
     size : oneOf(List(oneOf(float, signal)), signal)
         The dimensions of the wordcloud layout
-    spiral : oneOf(enum('archimedean', 'rectangular'), oneOf(Mapping(required=[field]), 
+    spiral : oneOf(enum('archimedean', 'rectangular'), oneOf(Mapping(required=[field]),
     Mapping(required=[value])), signal)
-        The type of spiral used for positioning words, either 'archimedean' or 
+        The type of spiral used for positioning words, either 'archimedean' or
         'rectangular'.
     text : oneOf(string, oneOf(Mapping(required=[field]), Mapping(required=[value])), signal)
         The field containing the text to use for each word.
@@ -1236,11 +1236,11 @@ class wordcloudTransform(VegaSchema):
 
 class transform(VegaSchema):
     """transform schema wrapper
-    
-    List(oneOf(aggregateTransform, binTransform, crossTransform, countpatternTransform, 
-    linkpathTransform, facetTransform, filterTransform, foldTransform, forceTransform, 
-    formulaTransform, geoTransform, geopathTransform, hierarchyTransform, imputeTransform, 
-    lookupTransform, pieTransform, rankTransform, sortTransform, stackTransform, 
+
+    List(oneOf(aggregateTransform, binTransform, crossTransform, countpatternTransform,
+    linkpathTransform, facetTransform, filterTransform, foldTransform, forceTransform,
+    formulaTransform, geoTransform, geopathTransform, hierarchyTransform, imputeTransform,
+    lookupTransform, pieTransform, rankTransform, sortTransform, stackTransform,
     treeifyTransform, treemapTransform, voronoiTransform, wordcloudTransform))
     """
     _schema = {'$ref': '#/defs/transform'}
@@ -1252,8 +1252,8 @@ class transform(VegaSchema):
 
 class scale(VegaSchema):
     """scale schema wrapper
-    
-    allOf(Mapping(required=[name]), oneOf(Mapping(required=[type]), Mapping(required=[type]), 
+
+    allOf(Mapping(required=[name]), oneOf(Mapping(required=[type]), Mapping(required=[type]),
     anyOf(Mapping(required=[]), Mapping(required=[type]))))
     """
     _schema = {'$ref': '#/defs/scale'}
@@ -1269,8 +1269,8 @@ class scale(VegaSchema):
 
 class operand(VegaSchema):
     """operand schema wrapper
-    
-    oneOf(Mapping(required=[value]), Mapping(required=[arg]), signal, 
+
+    oneOf(Mapping(required=[value]), Mapping(required=[arg]), signal,
     Mapping(required=[predicate]))
     """
     _schema = {'$ref': '#/refs/operand'}
@@ -1282,8 +1282,8 @@ class operand(VegaSchema):
 
 class field(VegaSchema):
     """field schema wrapper
-    
-    oneOf(string, oneOf(signal, Mapping(required=[datum]), Mapping(required=[group]), 
+
+    oneOf(string, oneOf(signal, Mapping(required=[datum]), Mapping(required=[group]),
     Mapping(required=[parent])))
     """
     _schema = {'$ref': '#/refs/field'}
@@ -1295,7 +1295,7 @@ class field(VegaSchema):
 
 class scale(VegaSchema):
     """scale schema wrapper
-    
+
     oneOf(field, Mapping(required=[name]))
     """
     _schema = {'$ref': '#/refs/scale'}
@@ -1307,13 +1307,13 @@ class scale(VegaSchema):
 
 class stringModifiers(VegaSchema):
     """stringModifiers schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     scale : scale
-    
+
     """
     _schema = {'$ref': '#/refs/stringModifiers'}
     _rootschema = Root._schema
@@ -1324,17 +1324,17 @@ class stringModifiers(VegaSchema):
 
 class numberModifiers(VegaSchema):
     """numberModifiers schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     mult : float
-    
+
     offset : float
-    
+
     scale : scale
-    
+
     """
     _schema = {'$ref': '#/refs/numberModifiers'}
     _rootschema = Root._schema
@@ -1345,10 +1345,10 @@ class numberModifiers(VegaSchema):
 
 class value(VegaSchema):
     """value schema wrapper
-    
-    oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))), 
-    allOf(stringModifiers, oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
+
+    oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))),
+    allOf(stringModifiers, oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
     Mapping(required=[band]))))
     """
     _schema = {'$ref': '#/refs/value'}
@@ -1360,10 +1360,10 @@ class value(VegaSchema):
 
 class numberValue(VegaSchema):
     """numberValue schema wrapper
-    
-    oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(numberModifiers, oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))), 
-    allOf(numberModifiers, oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
+
+    oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(numberModifiers, oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))),
+    allOf(numberModifiers, oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
     Mapping(required=[band]))))
     """
     _schema = {'$ref': '#/refs/numberValue'}
@@ -1375,11 +1375,11 @@ class numberValue(VegaSchema):
 
 class stringValue(VegaSchema):
     """stringValue schema wrapper
-    
-    oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]), 
-    Mapping(required=[template]))))), allOf(stringModifiers, oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]), 
+
+    oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]),
+    Mapping(required=[template]))))), allOf(stringModifiers, oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]),
     Mapping(required=[template]))))
     """
     _schema = {'$ref': '#/refs/stringValue'}
@@ -1391,10 +1391,10 @@ class stringValue(VegaSchema):
 
 class booleanValue(VegaSchema):
     """booleanValue schema wrapper
-    
-    oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))), 
-    allOf(stringModifiers, oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
+
+    oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))),
+    allOf(stringModifiers, oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
     Mapping(required=[band]))))
     """
     _schema = {'$ref': '#/refs/booleanValue'}
@@ -1406,10 +1406,10 @@ class booleanValue(VegaSchema):
 
 class arrayValue(VegaSchema):
     """arrayValue schema wrapper
-    
-    oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))), 
-    allOf(stringModifiers, oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
+
+    oneOf(Mapping(required=[rule]), List(allOf(rule, allOf(stringModifiers, oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[band]))))),
+    allOf(stringModifiers, oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
     Mapping(required=[band]))))
     """
     _schema = {'$ref': '#/refs/arrayValue'}
@@ -1421,8 +1421,8 @@ class arrayValue(VegaSchema):
 
 class colorValue(VegaSchema):
     """colorValue schema wrapper
-    
-    oneOf(stringValue, Mapping(required=[r, g, b]), Mapping(required=[h, s, l]), 
+
+    oneOf(stringValue, Mapping(required=[r, g, b]), Mapping(required=[h, s, l]),
     Mapping(required=[l, a, b]), Mapping(required=[h, c, l]))
     """
     _schema = {'$ref': '#/refs/colorValue'}
@@ -1434,13 +1434,13 @@ class colorValue(VegaSchema):
 
 class signal(VegaSchema):
     """signal schema wrapper
-    
+
     Mapping(required=[signal])
-    
+
     Attributes
     ----------
     signal : string
-    
+
     """
     _schema = {'$ref': '#/refs/signal'}
     _rootschema = Root._schema
@@ -1451,7 +1451,7 @@ class signal(VegaSchema):
 
 class scopedScale(VegaSchema):
     """scopedScale schema wrapper
-    
+
     oneOf(string, Mapping(required=[name]))
     """
     _schema = {'$ref': '#/refs/scopedScale'}
@@ -1463,22 +1463,21 @@ class scopedScale(VegaSchema):
 
 class data(VegaSchema):
     """data schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     data : oneOf(string, Mapping(required=[fields]))
-    
-    field : oneOf(string, List(string), Mapping(required=[parent]), 
+
+    field : oneOf(string, List(string), Mapping(required=[parent]),
     List(Mapping(required=[parent])))
-    
+
     sort : oneOf(boolean, Mapping(required=[]))
-    
+
     """
     _schema = {'$ref': '#/refs/data'}
     _rootschema = Root._schema
 
     def __init__(self, data=Undefined, field=Undefined, sort=Undefined, **kwds):
         super(data, self).__init__(data=data, field=field, sort=sort, **kwds)
-

--- a/altair/vega/v3/schema/core.py
+++ b/altair/vega/v3/schema/core.py
@@ -21,7 +21,7 @@ class VegaSchema(SchemaBase):
 
 class Root(VegaSchema):
     """Root schema wrapper
-    
+
     allOf(scope, Mapping(required=[]))
     """
     _schema = load_schema()
@@ -41,7 +41,7 @@ class Root(VegaSchema):
 
 class autosize(VegaSchema):
     """autosize schema wrapper
-    
+
     oneOf(enum('pad', 'fit', 'fit-x', 'fit-y', 'none'), Mapping(required=[type]))
     """
     _schema = {'$ref': '#/defs/autosize'}
@@ -53,59 +53,59 @@ class autosize(VegaSchema):
 
 class axis(VegaSchema):
     """axis schema wrapper
-    
+
     Mapping(required=[orient, scale])
-    
+
     Attributes
     ----------
     orient : enum('top', 'bottom', 'left', 'right')
-    
+
     scale : string
-    
+
     domain : boolean
-    
+
     encode : Mapping(required=[])
-    
+
     format : stringOrSignal
-    
+
     grid : boolean
-    
+
     gridScale : string
-    
+
     labelBound : oneOf(boolean, float)
-    
+
     labelFlush : oneOf(boolean, float)
-    
+
     labelFlushOffset : float
-    
+
     labelOverlap : oneOf(boolean, enum('parity', 'greedy'))
-    
+
     labelPadding : float
-    
+
     labels : boolean
-    
+
     maxExtent : oneOf(float, numberValue)
-    
+
     minExtent : oneOf(float, numberValue)
-    
+
     offset : oneOf(float, numberValue)
-    
+
     position : oneOf(float, numberValue)
-    
+
     tickCount : tickCount
-    
+
     tickSize : float
-    
+
     ticks : boolean
-    
+
     title : stringOrSignal
-    
+
     titlePadding : oneOf(float, numberValue)
-    
+
     values : oneOf(List(Mapping(required=[])), signal)
-    
+
     zindex : float
-    
+
     """
     _schema = {'$ref': '#/defs/axis'}
     _rootschema = Root._schema
@@ -129,7 +129,7 @@ class axis(VegaSchema):
 
 class background(VegaSchema):
     """background schema wrapper
-    
+
     string
     """
     _schema = {'$ref': '#/defs/background'}
@@ -141,8 +141,8 @@ class background(VegaSchema):
 
 class bind(VegaSchema):
     """bind schema wrapper
-    
-    oneOf(Mapping(required=[input]), Mapping(required=[input, options]), 
+
+    oneOf(Mapping(required=[input]), Mapping(required=[input, options]),
     Mapping(required=[input]), Mapping(required=[]))
     """
     _schema = {'$ref': '#/defs/bind'}
@@ -154,8 +154,8 @@ class bind(VegaSchema):
 
 class dataFormat(VegaSchema):
     """dataFormat schema wrapper
-    
-    anyOf(Mapping(required=[]), Mapping(required=[]), Mapping(required=[]), 
+
+    anyOf(Mapping(required=[]), Mapping(required=[]), Mapping(required=[]),
     oneOf(Mapping(required=[]), Mapping(required=[])))
     """
     _schema = {'$ref': '#/defs/dataFormat'}
@@ -167,8 +167,8 @@ class dataFormat(VegaSchema):
 
 class data(VegaSchema):
     """data schema wrapper
-    
-    allOf(Mapping(required=[name]), anyOf(Mapping(required=[name]), 
+
+    allOf(Mapping(required=[name]), anyOf(Mapping(required=[name]),
     oneOf(Mapping(required=[source]), Mapping(required=[values]), Mapping(required=[url]))))
     """
     _schema = {'$ref': '#/defs/data'}
@@ -180,13 +180,13 @@ class data(VegaSchema):
 
 class rule(VegaSchema):
     """rule schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     test : string
-    
+
     """
     _schema = {'$ref': '#/defs/rule'}
     _rootschema = Root._schema
@@ -197,117 +197,117 @@ class rule(VegaSchema):
 
 class encodeEntry(VegaSchema):
     """encodeEntry schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
-    align : oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])), 
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]), 
-    Mapping(required=[offset]))))), allOf(stringModifiers, anyOf(oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])), 
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]), 
+    align : oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
+    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
+    Mapping(required=[offset]))))), allOf(stringModifiers, anyOf(oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
+    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
     Mapping(required=[offset]))))
-    
+
     angle : numberValue
-    
-    baseline : oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])), 
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]), 
-    Mapping(required=[offset]))))), allOf(stringModifiers, anyOf(oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])), 
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]), 
+
+    baseline : oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
+    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
+    Mapping(required=[offset]))))), allOf(stringModifiers, anyOf(oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
+    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
     Mapping(required=[offset]))))
-    
+
     clip : booleanValue
-    
+
     cursor : stringValue
-    
+
     dir : stringValue
-    
+
     dx : numberValue
-    
+
     dy : numberValue
-    
+
     ellipsis : stringValue
-    
+
     endAngle : numberValue
-    
+
     fill : colorValue
-    
+
     fillOpacity : numberValue
-    
+
     font : stringValue
-    
+
     fontSize : numberValue
-    
+
     fontStyle : stringValue
-    
+
     fontWeight : fontWeightValue
-    
+
     height : numberValue
-    
+
     innerRadius : numberValue
-    
+
     interpolate : stringValue
-    
+
     limit : numberValue
-    
+
     opacity : numberValue
-    
-    orient : oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])), 
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]), 
-    Mapping(required=[offset]))))), allOf(stringModifiers, anyOf(oneOf(signal, 
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])), 
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]), 
+
+    orient : oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
+    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
+    Mapping(required=[offset]))))), allOf(stringModifiers, anyOf(oneOf(signal,
+    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
+    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
     Mapping(required=[offset]))))
-    
+
     outerRadius : numberValue
-    
+
     path : stringValue
-    
+
     radius : numberValue
-    
+
     shape : anyOf(string, stringValue)
-    
+
     size : numberValue
-    
+
     startAngle : numberValue
-    
+
     stroke : colorValue
-    
+
     strokeDash : arrayValue
-    
+
     strokeDashOffset : numberValue
-    
+
     strokeOpacity : numberValue
-    
+
     strokeWidth : numberValue
-    
+
     tension : numberValue
-    
+
     text : stringValue
-    
+
     theta : numberValue
-    
+
     url : stringValue
-    
+
     width : numberValue
-    
+
     x : numberValue
-    
+
     x2 : numberValue
-    
+
     xc : numberValue
-    
+
     y : numberValue
-    
+
     y2 : numberValue
-    
+
     yc : numberValue
-    
+
     """
     _schema = {'$ref': '#/defs/encodeEntry'}
     _rootschema = Root._schema
@@ -340,7 +340,7 @@ class encodeEntry(VegaSchema):
 
 class encode(VegaSchema):
     """encode schema wrapper
-    
+
     Mapping(required=[])
     """
     _schema = {'$ref': '#/defs/encode'}
@@ -352,7 +352,7 @@ class encode(VegaSchema):
 
 class layout(VegaSchema):
     """layout schema wrapper
-    
+
     oneOf(Mapping(required=[]), signal)
     """
     _schema = {'$ref': '#/defs/layout'}
@@ -364,17 +364,17 @@ class layout(VegaSchema):
 
 class guideEncode(VegaSchema):
     """guideEncode schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     interactive : boolean
-    
+
     name : string
-    
+
     style : style
-    
+
     """
     _schema = {'$ref': '#/defs/guideEncode'}
     _rootschema = Root._schema
@@ -385,10 +385,10 @@ class guideEncode(VegaSchema):
 
 class legend(VegaSchema):
     """legend schema wrapper
-    
-    anyOf(Mapping(required=[size]), Mapping(required=[shape]), Mapping(required=[fill]), 
+
+    anyOf(Mapping(required=[size]), Mapping(required=[shape]), Mapping(required=[fill]),
     Mapping(required=[stroke]), Mapping(required=[opacity]), Mapping(required=[strokeDash]))
-    
+
     Attributes
     ----------
     """
@@ -401,33 +401,33 @@ class legend(VegaSchema):
 
 class mark(VegaSchema):
     """mark schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : marktype
-    
+
     clip : markclip
-    
+
     encode : encode
-    
+
     interactive : booleanOrSignal
-    
+
     key : string
-    
+
     name : string
-    
+
     on : onMarkTrigger
-    
+
     role : string
-    
+
     sort : compare
-    
+
     style : style
-    
+
     transform : List(transformMark)
-    
+
     """
     _schema = {'$ref': '#/defs/mark'}
     _rootschema = Root._schema
@@ -442,7 +442,7 @@ class mark(VegaSchema):
 
 class markGroup(VegaSchema):
     """markGroup schema wrapper
-    
+
     allOf(Mapping(required=[type]), mark, scope, Mapping(required=[]))
     """
     _schema = {'$ref': '#/defs/markGroup'}
@@ -463,7 +463,7 @@ class markGroup(VegaSchema):
 
 class markVisual(VegaSchema):
     """markVisual schema wrapper
-    
+
     allOf(not Mapping(required=[]), mark, Mapping(required=[]))
     """
     _schema = {'$ref': '#/defs/markVisual'}
@@ -479,7 +479,7 @@ class markVisual(VegaSchema):
 
 class listener(VegaSchema):
     """listener schema wrapper
-    
+
     oneOf(signal, Mapping(required=[scale]), stream)
     """
     _schema = {'$ref': '#/defs/listener'}
@@ -491,8 +491,8 @@ class listener(VegaSchema):
 
 class onEvents(VegaSchema):
     """onEvents schema wrapper
-    
-    List(allOf(Mapping(required=[events]), oneOf(Mapping(required=[encode]), 
+
+    List(allOf(Mapping(required=[events]), oneOf(Mapping(required=[encode]),
     Mapping(required=[update]))))
     """
     _schema = {'$ref': '#/defs/onEvents'}
@@ -504,7 +504,7 @@ class onEvents(VegaSchema):
 
 class onTrigger(VegaSchema):
     """onTrigger schema wrapper
-    
+
     List(Mapping(required=[trigger]))
     """
     _schema = {'$ref': '#/defs/onTrigger'}
@@ -516,7 +516,7 @@ class onTrigger(VegaSchema):
 
 class onMarkTrigger(VegaSchema):
     """onMarkTrigger schema wrapper
-    
+
     List(Mapping(required=[trigger]))
     """
     _schema = {'$ref': '#/defs/onMarkTrigger'}
@@ -528,7 +528,7 @@ class onMarkTrigger(VegaSchema):
 
 class padding(VegaSchema):
     """padding schema wrapper
-    
+
     oneOf(float, Mapping(required=[]))
     """
     _schema = {'$ref': '#/defs/padding'}
@@ -540,39 +540,39 @@ class padding(VegaSchema):
 
 class projection(VegaSchema):
     """projection schema wrapper
-    
+
     Mapping(required=[name])
-    
+
     Attributes
     ----------
     name : string
-    
+
     center : oneOf(signal, List(numberOrSignal))
-    
+
     clipAngle : numberOrSignal
-    
+
     clipExtent : oneOf(signal, List(oneOf(signal, List(numberOrSignal))))
-    
+
     extent : oneOf(signal, List(oneOf(signal, List(numberOrSignal))))
-    
+
     fit : oneOf(Mapping(required=[]), List(Mapping(required=[])))
-    
+
     parallels : oneOf(signal, List(numberOrSignal))
-    
+
     pointRadius : numberOrSignal
-    
+
     precision : numberOrSignal
-    
+
     rotate : oneOf(signal, List(numberOrSignal))
-    
+
     scale : numberOrSignal
-    
+
     size : oneOf(signal, List(numberOrSignal))
-    
+
     translate : oneOf(signal, List(numberOrSignal))
-    
+
     type : stringOrSignal
-    
+
     """
     _schema = {'$ref': '#/defs/projection'}
     _rootschema = Root._schema
@@ -590,10 +590,10 @@ class projection(VegaSchema):
 
 class scale(VegaSchema):
     """scale schema wrapper
-    
-    allOf(Mapping(required=[name]), oneOf(Mapping(required=[type]), Mapping(required=[type]), 
-    Mapping(required=[type]), Mapping(required=[type, range]), Mapping(required=[type]), 
-    Mapping(required=[type]), Mapping(required=[type]), not Mapping(required=[]), 
+
+    allOf(Mapping(required=[name]), oneOf(Mapping(required=[type]), Mapping(required=[type]),
+    Mapping(required=[type]), Mapping(required=[type, range]), Mapping(required=[type]),
+    Mapping(required=[type]), Mapping(required=[type]), not Mapping(required=[]),
     Mapping(required=[type]), Mapping(required=[type]), Mapping(required=[type])))
     """
     _schema = {'$ref': '#/defs/scale'}
@@ -609,31 +609,31 @@ class scale(VegaSchema):
 
 class scope(VegaSchema):
     """scope schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     axes : List(axis)
-    
+
     data : List(data)
-    
+
     encode : encode
-    
+
     layout : layout
-    
+
     legends : List(legend)
-    
+
     marks : List(oneOf(markGroup, markVisual))
-    
+
     projections : List(projection)
-    
+
     scales : List(scale)
-    
+
     signals : List(signal)
-    
+
     title : title
-    
+
     """
     _schema = {'$ref': '#/defs/scope'}
     _rootschema = Root._schema
@@ -648,7 +648,7 @@ class scope(VegaSchema):
 
 class signal(VegaSchema):
     """signal schema wrapper
-    
+
     oneOf(signalPush, signalNew)
     """
     _schema = {'$ref': '#/defs/signal'}
@@ -660,7 +660,7 @@ class signal(VegaSchema):
 
 class signalName(VegaSchema):
     """signalName schema wrapper
-    
+
     not Mapping(required=[])
     """
     _schema = {'$ref': '#/defs/signalName'}
@@ -672,25 +672,25 @@ class signalName(VegaSchema):
 
 class signalNew(VegaSchema):
     """signalNew schema wrapper
-    
+
     Mapping(required=[name])
-    
+
     Attributes
     ----------
     name : signalName
-    
+
     bind : bind
-    
+
     description : string
-    
+
     on : onEvents
-    
+
     react : boolean
-    
+
     update : exprString
-    
+
     value : Mapping(required=[])
-    
+
     """
     _schema = {'$ref': '#/defs/signalNew'}
     _rootschema = Root._schema
@@ -703,19 +703,19 @@ class signalNew(VegaSchema):
 
 class signalPush(VegaSchema):
     """signalPush schema wrapper
-    
+
     Mapping(required=[name, push])
-    
+
     Attributes
     ----------
     name : signalName
-    
+
     push : enum('outer')
-    
+
     description : string
-    
+
     on : onEvents
-    
+
     """
     _schema = {'$ref': '#/defs/signalPush'}
     _rootschema = Root._schema
@@ -726,25 +726,25 @@ class signalPush(VegaSchema):
 
 class streamParams(VegaSchema):
     """streamParams schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     between : List(stream)
-    
+
     consume : boolean
-    
+
     debounce : float
-    
+
     filter : oneOf(exprString, List(exprString))
-    
+
     markname : string
-    
+
     marktype : string
-    
+
     throttle : float
-    
+
     """
     _schema = {'$ref': '#/defs/streamParams'}
     _rootschema = Root._schema
@@ -758,15 +758,15 @@ class streamParams(VegaSchema):
 
 class streamEvents(VegaSchema):
     """streamEvents schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : string
-    
+
     source : string
-    
+
     """
     _schema = {'$ref': '#/defs/streamEvents'}
     _rootschema = Root._schema
@@ -777,8 +777,8 @@ class streamEvents(VegaSchema):
 
 class stream(VegaSchema):
     """stream schema wrapper
-    
-    allOf(streamParams, oneOf(streamEvents, Mapping(required=[stream]), 
+
+    allOf(streamParams, oneOf(streamEvents, Mapping(required=[stream]),
     Mapping(required=[merge])))
     """
     _schema = {'$ref': '#/defs/stream'}
@@ -792,7 +792,7 @@ class stream(VegaSchema):
 
 class titleEncode(VegaSchema):
     """titleEncode schema wrapper
-    
+
     Mapping(required=[])
     """
     _schema = {'$ref': '#/defs/titleEncode'}
@@ -804,7 +804,7 @@ class titleEncode(VegaSchema):
 
 class title(VegaSchema):
     """title schema wrapper
-    
+
     oneOf(string, Mapping(required=[text]))
     """
     _schema = {'$ref': '#/defs/title'}
@@ -816,15 +816,15 @@ class title(VegaSchema):
 
 class transform(VegaSchema):
     """transform schema wrapper
-    
-    oneOf(aggregateTransform, binTransform, collectTransform, countpatternTransform, 
-    crossTransform, densityTransform, extentTransform, filterTransform, flattenTransform, 
-    foldTransform, formulaTransform, imputeTransform, joinaggregateTransform, lookupTransform, 
-    pivotTransform, projectTransform, sampleTransform, sequenceTransform, windowTransform, 
-    identifierTransform, linkpathTransform, pieTransform, stackTransform, contourTransform, 
-    geojsonTransform, geopathTransform, geopointTransform, geoshapeTransform, 
-    graticuleTransform, forceTransform, nestTransform, packTransform, partitionTransform, 
-    stratifyTransform, treeTransform, treelinksTransform, treemapTransform, voronoiTransform, 
+
+    oneOf(aggregateTransform, binTransform, collectTransform, countpatternTransform,
+    crossTransform, densityTransform, extentTransform, filterTransform, flattenTransform,
+    foldTransform, formulaTransform, imputeTransform, joinaggregateTransform, lookupTransform,
+    pivotTransform, projectTransform, sampleTransform, sequenceTransform, windowTransform,
+    identifierTransform, linkpathTransform, pieTransform, stackTransform, contourTransform,
+    geojsonTransform, geopathTransform, geopointTransform, geoshapeTransform,
+    graticuleTransform, forceTransform, nestTransform, packTransform, partitionTransform,
+    stratifyTransform, treeTransform, treelinksTransform, treemapTransform, voronoiTransform,
     wordcloudTransform, crossfilterTransform, resolvefilterTransform)
     """
     _schema = {'$ref': '#/defs/transform'}
@@ -836,12 +836,12 @@ class transform(VegaSchema):
 
 class transformMark(VegaSchema):
     """transformMark schema wrapper
-    
-    oneOf(binTransform, collectTransform, extentTransform, formulaTransform, 
-    joinaggregateTransform, lookupTransform, sampleTransform, windowTransform, 
-    identifierTransform, linkpathTransform, pieTransform, stackTransform, geojsonTransform, 
-    geopathTransform, geopointTransform, geoshapeTransform, forceTransform, packTransform, 
-    partitionTransform, stratifyTransform, treeTransform, treemapTransform, voronoiTransform, 
+
+    oneOf(binTransform, collectTransform, extentTransform, formulaTransform,
+    joinaggregateTransform, lookupTransform, sampleTransform, windowTransform,
+    identifierTransform, linkpathTransform, pieTransform, stackTransform, geojsonTransform,
+    geopathTransform, geopointTransform, geoshapeTransform, forceTransform, packTransform,
+    partitionTransform, stratifyTransform, treeTransform, treemapTransform, voronoiTransform,
     wordcloudTransform, crossfilterTransform, resolvefilterTransform)
     """
     _schema = {'$ref': '#/defs/transformMark'}
@@ -853,34 +853,34 @@ class transformMark(VegaSchema):
 
 class aggregateTransform(VegaSchema):
     """aggregateTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('aggregate')
-    
+
     cross : anyOf(boolean, signal)
-    
+
     drop : anyOf(boolean, signal)
-    
+
     fields : oneOf(List(oneOf(scaleField, paramField, expr, None)), signal)
-    
+
     groupby : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     key : oneOf(scaleField, paramField, expr)
-    
-    ops : oneOf(List(anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum', 
-    'mean', 'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr', 'distinct', 'ci0', 
+
+    ops : oneOf(List(anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum',
+    'mean', 'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr', 'distinct', 'ci0',
     'ci1', 'median', 'q1', 'q3', 'argmin', 'argmax', 'min', 'max'), signal)), signal)
-    
+
     signal : string
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal, None)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/aggregateTransform'}
     _rootschema = Root._schema
@@ -894,42 +894,42 @@ class aggregateTransform(VegaSchema):
 
 class binTransform(VegaSchema):
     """binTransform schema wrapper
-    
+
     Mapping(required=[type, field, extent])
-    
+
     Attributes
     ----------
     extent : oneOf(List(anyOf(float, signal)), signal)
-    
+
     field : oneOf(scaleField, paramField, expr)
-    
+
     type : enum('bin')
-    
+
     anchor : anyOf(float, signal)
-    
+
     base : anyOf(float, signal)
-    
+
     divide : oneOf(List(anyOf(float, signal)), signal)
-    
+
     maxbins : anyOf(float, signal)
-    
+
     minstep : anyOf(float, signal)
-    
+
     name : anyOf(string, signal)
-    
+
     nice : anyOf(boolean, signal)
-    
+
     signal : string
-    
+
     step : anyOf(float, signal)
-    
+
     steps : oneOf(List(anyOf(float, signal)), signal)
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/binTransform'}
     _rootschema = Root._schema
@@ -945,17 +945,17 @@ class binTransform(VegaSchema):
 
 class collectTransform(VegaSchema):
     """collectTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('collect')
-    
+
     signal : string
-    
+
     sort : compare
-    
+
     """
     _schema = {'$ref': '#/defs/collectTransform'}
     _rootschema = Root._schema
@@ -966,28 +966,28 @@ class collectTransform(VegaSchema):
 
 class countpatternTransform(VegaSchema):
     """countpatternTransform schema wrapper
-    
+
     Mapping(required=[type, field])
-    
+
     Attributes
     ----------
     field : oneOf(scaleField, paramField, expr)
-    
+
     type : enum('countpattern')
-    
+
     case : anyOf(enum('upper', 'lower', 'mixed'), signal)
-    
+
     pattern : anyOf(string, signal)
-    
+
     signal : string
-    
+
     stopwords : anyOf(string, signal)
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/countpatternTransform'}
     _rootschema = Root._schema
@@ -1000,22 +1000,22 @@ class countpatternTransform(VegaSchema):
 
 class crossTransform(VegaSchema):
     """crossTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('cross')
-    
+
     filter : exprString
-    
+
     signal : string
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/crossTransform'}
     _rootschema = Root._schema
@@ -1026,29 +1026,29 @@ class crossTransform(VegaSchema):
 
 class densityTransform(VegaSchema):
     """densityTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('density')
-    
-    distribution : oneOf(Mapping(required=[function]), Mapping(required=[function]), 
+
+    distribution : oneOf(Mapping(required=[function]), Mapping(required=[function]),
     Mapping(required=[function, field]), Mapping(required=[function]))
-    
+
     extent : oneOf(List(anyOf(float, signal)), signal)
-    
+
     method : anyOf(string, signal)
-    
+
     signal : string
-    
+
     steps : anyOf(float, signal)
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/densityTransform'}
     _rootschema = Root._schema
@@ -1061,17 +1061,17 @@ class densityTransform(VegaSchema):
 
 class extentTransform(VegaSchema):
     """extentTransform schema wrapper
-    
+
     Mapping(required=[type, field])
-    
+
     Attributes
     ----------
     field : oneOf(scaleField, paramField, expr)
-    
+
     type : enum('extent')
-    
+
     signal : string
-    
+
     """
     _schema = {'$ref': '#/defs/extentTransform'}
     _rootschema = Root._schema
@@ -1082,17 +1082,17 @@ class extentTransform(VegaSchema):
 
 class filterTransform(VegaSchema):
     """filterTransform schema wrapper
-    
+
     Mapping(required=[type, expr])
-    
+
     Attributes
     ----------
     expr : exprString
-    
+
     type : enum('filter')
-    
+
     signal : string
-    
+
     """
     _schema = {'$ref': '#/defs/filterTransform'}
     _rootschema = Root._schema
@@ -1103,22 +1103,22 @@ class filterTransform(VegaSchema):
 
 class flattenTransform(VegaSchema):
     """flattenTransform schema wrapper
-    
+
     Mapping(required=[type, fields])
-    
+
     Attributes
     ----------
     fields : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     type : enum('flatten')
-    
+
     signal : string
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/flattenTransform'}
     _rootschema = Root._schema
@@ -1129,22 +1129,22 @@ class flattenTransform(VegaSchema):
 
 class foldTransform(VegaSchema):
     """foldTransform schema wrapper
-    
+
     Mapping(required=[type, fields])
-    
+
     Attributes
     ----------
     fields : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     type : enum('fold')
-    
+
     signal : string
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/foldTransform'}
     _rootschema = Root._schema
@@ -1155,24 +1155,24 @@ class foldTransform(VegaSchema):
 
 class formulaTransform(VegaSchema):
     """formulaTransform schema wrapper
-    
+
     Mapping(required=[type, expr, as])
-    
+
     Attributes
     ----------
     expr : exprString
-    
+
     type : enum('formula')
-    
+
     initonly : anyOf(boolean, signal)
-    
+
     signal : string
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : anyOf(string, signal)
-    
+
     """
     _schema = {'$ref': '#/defs/formulaTransform'}
     _rootschema = Root._schema
@@ -1184,27 +1184,27 @@ class formulaTransform(VegaSchema):
 
 class imputeTransform(VegaSchema):
     """imputeTransform schema wrapper
-    
+
     Mapping(required=[type, field, key])
-    
+
     Attributes
     ----------
     field : oneOf(scaleField, paramField, expr)
-    
+
     key : oneOf(scaleField, paramField, expr)
-    
+
     type : enum('impute')
-    
+
     groupby : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     keyvals : oneOf(List(Mapping(required=[])), signal)
-    
+
     method : anyOf(enum('value', 'mean', 'median', 'max', 'min'), signal)
-    
+
     signal : string
-    
+
     value : Mapping(required=[])
-    
+
     """
     _schema = {'$ref': '#/defs/imputeTransform'}
     _rootschema = Root._schema
@@ -1218,30 +1218,30 @@ class imputeTransform(VegaSchema):
 
 class joinaggregateTransform(VegaSchema):
     """joinaggregateTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('joinaggregate')
-    
+
     fields : oneOf(List(oneOf(scaleField, paramField, expr, None)), signal)
-    
+
     groupby : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     key : oneOf(scaleField, paramField, expr)
-    
-    ops : oneOf(List(anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum', 
-    'mean', 'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr', 'distinct', 'ci0', 
+
+    ops : oneOf(List(anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum',
+    'mean', 'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr', 'distinct', 'ci0',
     'ci1', 'median', 'q1', 'q3', 'argmin', 'argmax', 'min', 'max'), signal)), signal)
-    
+
     signal : string
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal, None)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/joinaggregateTransform'}
     _rootschema = Root._schema
@@ -1254,30 +1254,30 @@ class joinaggregateTransform(VegaSchema):
 
 class lookupTransform(VegaSchema):
     """lookupTransform schema wrapper
-    
+
     Mapping(required=[type, from, key, fields])
-    
+
     Attributes
     ----------
     fields : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     key : oneOf(scaleField, paramField, expr)
-    
+
     type : enum('lookup')
-    
+
     default : Mapping(required=[])
-    
+
     signal : string
-    
+
     values : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     'from' : string
-    
+
     """
     _schema = {'$ref': '#/defs/lookupTransform'}
     _rootschema = Root._schema
@@ -1290,29 +1290,29 @@ class lookupTransform(VegaSchema):
 
 class pivotTransform(VegaSchema):
     """pivotTransform schema wrapper
-    
+
     Mapping(required=[type, field, value])
-    
+
     Attributes
     ----------
     field : oneOf(scaleField, paramField, expr)
-    
+
     type : enum('pivot')
-    
+
     value : oneOf(scaleField, paramField, expr)
-    
+
     groupby : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     key : oneOf(scaleField, paramField, expr)
-    
+
     limit : anyOf(float, signal)
-    
-    op : anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum', 'mean', 
-    'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr', 'distinct', 'ci0', 'ci1', 
+
+    op : anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum', 'mean',
+    'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr', 'distinct', 'ci0', 'ci1',
     'median', 'q1', 'q3', 'argmin', 'argmax', 'min', 'max'), signal)
-    
+
     signal : string
-    
+
     """
     _schema = {'$ref': '#/defs/pivotTransform'}
     _rootschema = Root._schema
@@ -1325,22 +1325,22 @@ class pivotTransform(VegaSchema):
 
 class projectTransform(VegaSchema):
     """projectTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('project')
-    
+
     fields : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     signal : string
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal, None)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/projectTransform'}
     _rootschema = Root._schema
@@ -1351,17 +1351,17 @@ class projectTransform(VegaSchema):
 
 class sampleTransform(VegaSchema):
     """sampleTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('sample')
-    
+
     signal : string
-    
+
     size : anyOf(float, signal)
-    
+
     """
     _schema = {'$ref': '#/defs/sampleTransform'}
     _rootschema = Root._schema
@@ -1372,21 +1372,21 @@ class sampleTransform(VegaSchema):
 
 class sequenceTransform(VegaSchema):
     """sequenceTransform schema wrapper
-    
+
     Mapping(required=[type, start, stop])
-    
+
     Attributes
     ----------
     start : anyOf(float, signal)
-    
+
     stop : anyOf(float, signal)
-    
+
     type : enum('sequence')
-    
+
     signal : string
-    
+
     step : anyOf(float, signal)
-    
+
     """
     _schema = {'$ref': '#/defs/sequenceTransform'}
     _rootschema = Root._schema
@@ -1399,38 +1399,38 @@ class sequenceTransform(VegaSchema):
 
 class windowTransform(VegaSchema):
     """windowTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('window')
-    
+
     fields : oneOf(List(oneOf(scaleField, paramField, expr, None)), signal)
-    
+
     frame : oneOf(List(anyOf(float, signal, None)), signal)
-    
+
     groupby : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     ignorePeers : anyOf(boolean, signal)
-    
+
     ops : oneOf(List(anyOf(enum('row_number', 'rank', 'dense_rank', 'percent_rank', 'cume_dist',
-     'ntile', 'lag', 'lead', 'first_value', 'last_value', 'nth_value', 'values', 'count', 
+     'ntile', 'lag', 'lead', 'first_value', 'last_value', 'nth_value', 'values', 'count',
     '__count__', 'missing', 'valid', 'sum', 'mean', 'average', 'variance', 'variancep', 'stdev',
-     'stdevp', 'stderr', 'distinct', 'ci0', 'ci1', 'median', 'q1', 'q3', 'argmin', 'argmax', 
+     'stdevp', 'stderr', 'distinct', 'ci0', 'ci1', 'median', 'q1', 'q3', 'argmin', 'argmax',
     'min', 'max'), signal)), signal)
-    
+
     params : oneOf(List(anyOf(float, signal, None)), signal)
-    
+
     signal : string
-    
+
     sort : compare
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal, None)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/windowTransform'}
     _rootschema = Root._schema
@@ -1445,20 +1445,20 @@ class windowTransform(VegaSchema):
 
 class identifierTransform(VegaSchema):
     """identifierTransform schema wrapper
-    
+
     Mapping(required=[type, as])
-    
+
     Attributes
     ----------
     type : enum('identifier')
-    
+
     signal : string
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : anyOf(string, signal)
-    
+
     """
     _schema = {'$ref': '#/defs/identifierTransform'}
     _rootschema = Root._schema
@@ -1469,32 +1469,32 @@ class identifierTransform(VegaSchema):
 
 class linkpathTransform(VegaSchema):
     """linkpathTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('linkpath')
-    
+
     orient : anyOf(enum('horizontal', 'vertical', 'radial'), signal)
-    
+
     shape : anyOf(enum('line', 'arc', 'curve', 'diagonal', 'orthogonal'), signal)
-    
+
     signal : string
-    
+
     sourceX : oneOf(scaleField, paramField, expr)
-    
+
     sourceY : oneOf(scaleField, paramField, expr)
-    
+
     targetX : oneOf(scaleField, paramField, expr)
-    
+
     targetY : oneOf(scaleField, paramField, expr)
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : anyOf(string, signal)
-    
+
     """
     _schema = {'$ref': '#/defs/linkpathTransform'}
     _rootschema = Root._schema
@@ -1508,28 +1508,28 @@ class linkpathTransform(VegaSchema):
 
 class pieTransform(VegaSchema):
     """pieTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('pie')
-    
+
     endAngle : anyOf(float, signal)
-    
+
     field : oneOf(scaleField, paramField, expr)
-    
+
     signal : string
-    
+
     sort : anyOf(boolean, signal)
-    
+
     startAngle : anyOf(float, signal)
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/pieTransform'}
     _rootschema = Root._schema
@@ -1542,28 +1542,28 @@ class pieTransform(VegaSchema):
 
 class stackTransform(VegaSchema):
     """stackTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('stack')
-    
+
     field : oneOf(scaleField, paramField, expr)
-    
+
     groupby : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     offset : anyOf(enum('zero', 'center', 'normalize'), signal)
-    
+
     signal : string
-    
+
     sort : compare
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/stackTransform'}
     _rootschema = Root._schema
@@ -1576,33 +1576,33 @@ class stackTransform(VegaSchema):
 
 class contourTransform(VegaSchema):
     """contourTransform schema wrapper
-    
+
     Mapping(required=[type, size])
-    
+
     Attributes
     ----------
     size : oneOf(List(anyOf(float, signal)), signal)
-    
+
     type : enum('contour')
-    
+
     bandwidth : anyOf(float, signal)
-    
+
     cellSize : anyOf(float, signal)
-    
+
     count : anyOf(float, signal)
-    
+
     nice : anyOf(float, signal)
-    
+
     signal : string
-    
+
     thresholds : oneOf(List(anyOf(float, signal)), signal)
-    
+
     values : oneOf(List(anyOf(float, signal)), signal)
-    
+
     x : oneOf(scaleField, paramField, expr)
-    
+
     y : oneOf(scaleField, paramField, expr)
-    
+
     """
     _schema = {'$ref': '#/defs/contourTransform'}
     _rootschema = Root._schema
@@ -1617,19 +1617,19 @@ class contourTransform(VegaSchema):
 
 class geojsonTransform(VegaSchema):
     """geojsonTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('geojson')
-    
+
     fields : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     geojson : oneOf(scaleField, paramField, expr)
-    
+
     signal : string
-    
+
     """
     _schema = {'$ref': '#/defs/geojsonTransform'}
     _rootschema = Root._schema
@@ -1641,26 +1641,26 @@ class geojsonTransform(VegaSchema):
 
 class geopathTransform(VegaSchema):
     """geopathTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('geopath')
-    
+
     field : oneOf(scaleField, paramField, expr)
-    
+
     pointRadius : anyOf(float, signal, expr, paramField)
-    
+
     projection : string
-    
+
     signal : string
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : anyOf(string, signal)
-    
+
     """
     _schema = {'$ref': '#/defs/geopathTransform'}
     _rootschema = Root._schema
@@ -1673,24 +1673,24 @@ class geopathTransform(VegaSchema):
 
 class geopointTransform(VegaSchema):
     """geopointTransform schema wrapper
-    
+
     Mapping(required=[type, projection, fields])
-    
+
     Attributes
     ----------
     fields : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     projection : string
-    
+
     type : enum('geopoint')
-    
+
     signal : string
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/geopointTransform'}
     _rootschema = Root._schema
@@ -1702,26 +1702,26 @@ class geopointTransform(VegaSchema):
 
 class geoshapeTransform(VegaSchema):
     """geoshapeTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('geoshape')
-    
+
     field : oneOf(scaleField, paramField, expr)
-    
+
     pointRadius : anyOf(float, signal, expr, paramField)
-    
+
     projection : string
-    
+
     signal : string
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : anyOf(string, signal)
-    
+
     """
     _schema = {'$ref': '#/defs/geoshapeTransform'}
     _rootschema = Root._schema
@@ -1734,29 +1734,29 @@ class geoshapeTransform(VegaSchema):
 
 class graticuleTransform(VegaSchema):
     """graticuleTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('graticule')
-    
+
     extent : oneOf(List(Mapping(required=[])), signal)
-    
+
     extentMajor : oneOf(List(Mapping(required=[])), signal)
-    
+
     extentMinor : oneOf(List(Mapping(required=[])), signal)
-    
+
     precision : anyOf(float, signal)
-    
+
     signal : string
-    
+
     step : oneOf(List(anyOf(float, signal)), signal)
-    
+
     stepMajor : oneOf(List(anyOf(float, signal)), signal)
-    
+
     stepMinor : oneOf(List(anyOf(float, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/graticuleTransform'}
     _rootschema = Root._schema
@@ -1772,38 +1772,38 @@ class graticuleTransform(VegaSchema):
 
 class forceTransform(VegaSchema):
     """forceTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('force')
-    
+
     alpha : anyOf(float, signal)
-    
+
     alphaMin : anyOf(float, signal)
-    
+
     alphaTarget : anyOf(float, signal)
-    
-    forces : List(oneOf(Mapping(required=[force]), Mapping(required=[force]), 
-    Mapping(required=[force]), Mapping(required=[force]), Mapping(required=[force]), 
+
+    forces : List(oneOf(Mapping(required=[force]), Mapping(required=[force]),
+    Mapping(required=[force]), Mapping(required=[force]), Mapping(required=[force]),
     Mapping(required=[force])))
-    
+
     iterations : anyOf(float, signal)
-    
+
     restart : anyOf(boolean, signal)
-    
+
     signal : string
-    
+
     static : anyOf(boolean, signal)
-    
+
     velocityDecay : anyOf(float, signal)
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/forceTransform'}
     _rootschema = Root._schema
@@ -1819,21 +1819,21 @@ class forceTransform(VegaSchema):
 
 class nestTransform(VegaSchema):
     """nestTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('nest')
-    
+
     generate : anyOf(boolean, signal)
-    
+
     key : oneOf(scaleField, paramField, expr)
-    
+
     keys : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     signal : string
-    
+
     """
     _schema = {'$ref': '#/defs/nestTransform'}
     _rootschema = Root._schema
@@ -1846,30 +1846,30 @@ class nestTransform(VegaSchema):
 
 class packTransform(VegaSchema):
     """packTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('pack')
-    
+
     field : oneOf(scaleField, paramField, expr)
-    
+
     padding : anyOf(float, signal)
-    
+
     radius : oneOf(scaleField, paramField, expr)
-    
+
     signal : string
-    
+
     size : oneOf(List(anyOf(float, signal)), signal)
-    
+
     sort : compare
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/packTransform'}
     _rootschema = Root._schema
@@ -1882,30 +1882,30 @@ class packTransform(VegaSchema):
 
 class partitionTransform(VegaSchema):
     """partitionTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('partition')
-    
+
     field : oneOf(scaleField, paramField, expr)
-    
+
     padding : anyOf(float, signal)
-    
+
     round : anyOf(boolean, signal)
-    
+
     signal : string
-    
+
     size : oneOf(List(anyOf(float, signal)), signal)
-    
+
     sort : compare
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/partitionTransform'}
     _rootschema = Root._schema
@@ -1918,19 +1918,19 @@ class partitionTransform(VegaSchema):
 
 class stratifyTransform(VegaSchema):
     """stratifyTransform schema wrapper
-    
+
     Mapping(required=[type, key, parentKey])
-    
+
     Attributes
     ----------
     key : oneOf(scaleField, paramField, expr)
-    
+
     parentKey : oneOf(scaleField, paramField, expr)
-    
+
     type : enum('stratify')
-    
+
     signal : string
-    
+
     """
     _schema = {'$ref': '#/defs/stratifyTransform'}
     _rootschema = Root._schema
@@ -1942,30 +1942,30 @@ class stratifyTransform(VegaSchema):
 
 class treeTransform(VegaSchema):
     """treeTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('tree')
-    
+
     field : oneOf(scaleField, paramField, expr)
-    
+
     method : anyOf(enum('tidy', 'cluster'), signal)
-    
+
     nodeSize : oneOf(List(anyOf(float, signal)), signal)
-    
+
     signal : string
-    
+
     size : oneOf(List(anyOf(float, signal)), signal)
-    
+
     sort : compare
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/treeTransform'}
     _rootschema = Root._schema
@@ -1978,17 +1978,17 @@ class treeTransform(VegaSchema):
 
 class treelinksTransform(VegaSchema):
     """treelinksTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('treelinks')
-    
+
     key : oneOf(scaleField, paramField, expr)
-    
+
     signal : string
-    
+
     """
     _schema = {'$ref': '#/defs/treelinksTransform'}
     _rootschema = Root._schema
@@ -1999,47 +1999,47 @@ class treelinksTransform(VegaSchema):
 
 class treemapTransform(VegaSchema):
     """treemapTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('treemap')
-    
+
     field : oneOf(scaleField, paramField, expr)
-    
-    method : anyOf(enum('squarify', 'resquarify', 'binary', 'dice', 'slice', 'slicedice'), 
+
+    method : anyOf(enum('squarify', 'resquarify', 'binary', 'dice', 'slice', 'slicedice'),
     signal)
-    
+
     padding : anyOf(float, signal)
-    
+
     paddingBottom : anyOf(float, signal)
-    
+
     paddingInner : anyOf(float, signal)
-    
+
     paddingLeft : anyOf(float, signal)
-    
+
     paddingOuter : anyOf(float, signal)
-    
+
     paddingRight : anyOf(float, signal)
-    
+
     paddingTop : anyOf(float, signal)
-    
+
     ratio : anyOf(float, signal)
-    
+
     round : anyOf(boolean, signal)
-    
+
     signal : string
-    
+
     size : oneOf(List(anyOf(float, signal)), signal)
-    
+
     sort : compare
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/treemapTransform'}
     _rootschema = Root._schema
@@ -2058,28 +2058,28 @@ class treemapTransform(VegaSchema):
 
 class voronoiTransform(VegaSchema):
     """voronoiTransform schema wrapper
-    
+
     Mapping(required=[type, x, y])
-    
+
     Attributes
     ----------
     type : enum('voronoi')
-    
+
     x : oneOf(scaleField, paramField, expr)
-    
+
     y : oneOf(scaleField, paramField, expr)
-    
+
     extent : oneOf(List(Mapping(required=[])), signal)
-    
+
     signal : string
-    
+
     size : oneOf(List(anyOf(float, signal)), signal)
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : anyOf(string, signal)
-    
+
     """
     _schema = {'$ref': '#/defs/voronoiTransform'}
     _rootschema = Root._schema
@@ -2092,40 +2092,40 @@ class voronoiTransform(VegaSchema):
 
 class wordcloudTransform(VegaSchema):
     """wordcloudTransform schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('wordcloud')
-    
+
     font : anyOf(string, signal, expr, paramField)
-    
+
     fontSize : anyOf(float, signal, expr, paramField)
-    
+
     fontSizeRange : oneOf(List(anyOf(float, signal)), signal, None)
-    
+
     fontStyle : anyOf(string, signal, expr, paramField)
-    
+
     fontWeight : anyOf(string, signal, expr, paramField)
-    
+
     padding : anyOf(float, signal, expr, paramField)
-    
+
     rotate : anyOf(float, signal, expr, paramField)
-    
+
     signal : string
-    
+
     size : oneOf(List(anyOf(float, signal)), signal)
-    
+
     spiral : anyOf(string, signal)
-    
+
     text : oneOf(scaleField, paramField, expr)
-    
-    
+
+
     Dict-Only Attributes
     --------------------
     'as' : oneOf(List(anyOf(string, signal)), signal)
-    
+
     """
     _schema = {'$ref': '#/defs/wordcloudTransform'}
     _rootschema = Root._schema
@@ -2142,19 +2142,19 @@ class wordcloudTransform(VegaSchema):
 
 class crossfilterTransform(VegaSchema):
     """crossfilterTransform schema wrapper
-    
+
     Mapping(required=[type, fields, query])
-    
+
     Attributes
     ----------
     fields : oneOf(List(oneOf(scaleField, paramField, expr)), signal)
-    
+
     query : oneOf(List(Mapping(required=[])), signal)
-    
+
     type : enum('crossfilter')
-    
+
     signal : string
-    
+
     """
     _schema = {'$ref': '#/defs/crossfilterTransform'}
     _rootschema = Root._schema
@@ -2166,19 +2166,19 @@ class crossfilterTransform(VegaSchema):
 
 class resolvefilterTransform(VegaSchema):
     """resolvefilterTransform schema wrapper
-    
+
     Mapping(required=[type, ignore, filter])
-    
+
     Attributes
     ----------
     filter : Mapping(required=[])
-    
+
     ignore : anyOf(float, signal)
-    
+
     type : enum('resolvefilter')
-    
+
     signal : string
-    
+
     """
     _schema = {'$ref': '#/defs/resolvefilterTransform'}
     _rootschema = Root._schema
@@ -2190,8 +2190,8 @@ class resolvefilterTransform(VegaSchema):
 
 class tickCount(VegaSchema):
     """tickCount schema wrapper
-    
-    oneOf(float, enum('millisecond', 'second', 'minute', 'hour', 'day', 'week', 'month', 
+
+    oneOf(float, enum('millisecond', 'second', 'minute', 'hour', 'day', 'week', 'month',
     'year'), Mapping(required=[interval]), signal)
     """
     _schema = {'$ref': '#/refs/tickCount'}
@@ -2203,7 +2203,7 @@ class tickCount(VegaSchema):
 
 class element(VegaSchema):
     """element schema wrapper
-    
+
     string
     """
     _schema = {'$ref': '#/refs/element'}
@@ -2215,13 +2215,13 @@ class element(VegaSchema):
 
 class paramField(VegaSchema):
     """paramField schema wrapper
-    
+
     Mapping(required=[field])
-    
+
     Attributes
     ----------
     field : string
-    
+
     """
     _schema = {'$ref': '#/refs/paramField'}
     _rootschema = Root._schema
@@ -2232,8 +2232,8 @@ class paramField(VegaSchema):
 
 class field(VegaSchema):
     """field schema wrapper
-    
-    oneOf(string, oneOf(signal, Mapping(required=[datum]), Mapping(required=[group]), 
+
+    oneOf(string, oneOf(signal, Mapping(required=[datum]), Mapping(required=[group]),
     Mapping(required=[parent])))
     """
     _schema = {'$ref': '#/refs/field'}
@@ -2245,8 +2245,8 @@ class field(VegaSchema):
 
 class scale(VegaSchema):
     """scale schema wrapper
-    
-    oneOf(string, oneOf(signal, Mapping(required=[datum]), Mapping(required=[group]), 
+
+    oneOf(string, oneOf(signal, Mapping(required=[datum]), Mapping(required=[group]),
     Mapping(required=[parent])))
     """
     _schema = {'$ref': '#/refs/scale'}
@@ -2258,13 +2258,13 @@ class scale(VegaSchema):
 
 class stringModifiers(VegaSchema):
     """stringModifiers schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     scale : scale
-    
+
     """
     _schema = {'$ref': '#/refs/stringModifiers'}
     _rootschema = Root._schema
@@ -2275,25 +2275,25 @@ class stringModifiers(VegaSchema):
 
 class numberModifiers(VegaSchema):
     """numberModifiers schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     band : anyOf(float, boolean)
-    
+
     exponent : oneOf(float, numberValue)
-    
+
     extra : boolean
-    
+
     mult : oneOf(float, numberValue)
-    
+
     offset : oneOf(float, numberValue)
-    
+
     round : boolean
-    
+
     scale : scale
-    
+
     """
     _schema = {'$ref': '#/refs/numberModifiers'}
     _rootschema = Root._schema
@@ -2306,12 +2306,12 @@ class numberModifiers(VegaSchema):
 
 class value(VegaSchema):
     """value schema wrapper
-    
+
     oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal, Mapping(required=[value]),
-     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]), 
-    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers, 
-    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale, 
+     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]),
+    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers,
+    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
     band]), Mapping(required=[offset]))))
     """
     _schema = {'$ref': '#/refs/value'}
@@ -2323,12 +2323,12 @@ class value(VegaSchema):
 
 class numberValue(VegaSchema):
     """numberValue schema wrapper
-    
+
     oneOf(List(allOf(rule, allOf(numberModifiers, anyOf(oneOf(signal, Mapping(required=[value]),
-     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]), 
-    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(numberModifiers, 
-    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale, 
+     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]),
+    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(numberModifiers,
+    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
     band]), Mapping(required=[offset]))))
     """
     _schema = {'$ref': '#/refs/numberValue'}
@@ -2340,12 +2340,12 @@ class numberValue(VegaSchema):
 
 class stringValue(VegaSchema):
     """stringValue schema wrapper
-    
+
     oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal, Mapping(required=[value]),
-     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]), 
-    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers, 
-    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale, 
+     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]),
+    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers,
+    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
     band]), Mapping(required=[offset]))))
     """
     _schema = {'$ref': '#/refs/stringValue'}
@@ -2357,12 +2357,12 @@ class stringValue(VegaSchema):
 
 class booleanValue(VegaSchema):
     """booleanValue schema wrapper
-    
+
     oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal, Mapping(required=[value]),
-     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]), 
-    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers, 
-    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale, 
+     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]),
+    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers,
+    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
     band]), Mapping(required=[offset]))))
     """
     _schema = {'$ref': '#/refs/booleanValue'}
@@ -2374,12 +2374,12 @@ class booleanValue(VegaSchema):
 
 class arrayValue(VegaSchema):
     """arrayValue schema wrapper
-    
+
     oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal, Mapping(required=[value]),
-     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]), 
-    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers, 
-    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale, 
+     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]),
+    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers,
+    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
     band]), Mapping(required=[offset]))))
     """
     _schema = {'$ref': '#/refs/arrayValue'}
@@ -2391,12 +2391,12 @@ class arrayValue(VegaSchema):
 
 class nullableStringValue(VegaSchema):
     """nullableStringValue schema wrapper
-    
+
     oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal, Mapping(required=[value]),
-     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]), 
-    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers, 
-    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale, 
+     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]),
+    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers,
+    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
     band]), Mapping(required=[offset]))))
     """
     _schema = {'$ref': '#/refs/nullableStringValue'}
@@ -2408,12 +2408,12 @@ class nullableStringValue(VegaSchema):
 
 class fontWeightValue(VegaSchema):
     """fontWeightValue schema wrapper
-    
+
     oneOf(List(allOf(rule, allOf(stringModifiers, anyOf(oneOf(signal, Mapping(required=[value]),
-     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]), 
-    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers, 
-    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]), 
-    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale, 
+     Mapping(required=[field]), Mapping(required=[range])), Mapping(required=[scale, value]),
+    Mapping(required=[scale, band]), Mapping(required=[offset]))))), allOf(stringModifiers,
+    anyOf(oneOf(signal, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
     band]), Mapping(required=[offset]))))
     """
     _schema = {'$ref': '#/refs/fontWeightValue'}
@@ -2425,17 +2425,17 @@ class fontWeightValue(VegaSchema):
 
 class colorRGB(VegaSchema):
     """colorRGB schema wrapper
-    
+
     Mapping(required=[r, g, b])
-    
+
     Attributes
     ----------
     b : numberValue
-    
+
     g : numberValue
-    
+
     r : numberValue
-    
+
     """
     _schema = {'$ref': '#/refs/colorRGB'}
     _rootschema = Root._schema
@@ -2446,17 +2446,17 @@ class colorRGB(VegaSchema):
 
 class colorHSL(VegaSchema):
     """colorHSL schema wrapper
-    
+
     Mapping(required=[h, s, l])
-    
+
     Attributes
     ----------
     h : numberValue
-    
+
     l : numberValue
-    
+
     s : numberValue
-    
+
     """
     _schema = {'$ref': '#/refs/colorHSL'}
     _rootschema = Root._schema
@@ -2467,17 +2467,17 @@ class colorHSL(VegaSchema):
 
 class colorLAB(VegaSchema):
     """colorLAB schema wrapper
-    
+
     Mapping(required=[l, a, b])
-    
+
     Attributes
     ----------
     a : numberValue
-    
+
     b : numberValue
-    
+
     l : numberValue
-    
+
     """
     _schema = {'$ref': '#/refs/colorLAB'}
     _rootschema = Root._schema
@@ -2488,17 +2488,17 @@ class colorLAB(VegaSchema):
 
 class colorHCL(VegaSchema):
     """colorHCL schema wrapper
-    
+
     Mapping(required=[h, c, l])
-    
+
     Attributes
     ----------
     c : numberValue
-    
+
     h : numberValue
-    
+
     l : numberValue
-    
+
     """
     _schema = {'$ref': '#/refs/colorHCL'}
     _rootschema = Root._schema
@@ -2509,7 +2509,7 @@ class colorHCL(VegaSchema):
 
 class colorValue(VegaSchema):
     """colorValue schema wrapper
-    
+
     oneOf(nullableStringValue, Mapping(required=[gradient]), Mapping(required=[color]))
     """
     _schema = {'$ref': '#/refs/colorValue'}
@@ -2521,13 +2521,13 @@ class colorValue(VegaSchema):
 
 class expr(VegaSchema):
     """expr schema wrapper
-    
+
     Mapping(required=[expr])
-    
+
     Attributes
     ----------
     expr : string
-    
+
     """
     _schema = {'$ref': '#/refs/expr'}
     _rootschema = Root._schema
@@ -2538,7 +2538,7 @@ class expr(VegaSchema):
 
 class exprString(VegaSchema):
     """exprString schema wrapper
-    
+
     string
     """
     _schema = {'$ref': '#/refs/exprString'}
@@ -2550,7 +2550,7 @@ class exprString(VegaSchema):
 
 class compare(VegaSchema):
     """compare schema wrapper
-    
+
     oneOf(Mapping(required=[]), Mapping(required=[]))
     """
     _schema = {'$ref': '#/refs/compare'}
@@ -2562,13 +2562,13 @@ class compare(VegaSchema):
 
 class from_(VegaSchema):
     """from_ schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     data : string
-    
+
     """
     _schema = {'$ref': '#/refs/from'}
     _rootschema = Root._schema
@@ -2579,16 +2579,16 @@ class from_(VegaSchema):
 
 class facet(VegaSchema):
     """facet schema wrapper
-    
+
     Mapping(required=[facet])
-    
+
     Attributes
     ----------
-    facet : oneOf(Mapping(required=[name, data, field]), Mapping(required=[name, data, 
+    facet : oneOf(Mapping(required=[name, data, field]), Mapping(required=[name, data,
     groupby]))
-    
+
     data : string
-    
+
     """
     _schema = {'$ref': '#/refs/facet'}
     _rootschema = Root._schema
@@ -2599,7 +2599,7 @@ class facet(VegaSchema):
 
 class markclip(VegaSchema):
     """markclip schema wrapper
-    
+
     oneOf(booleanOrSignal, Mapping(required=[path]), Mapping(required=[sphere]))
     """
     _schema = {'$ref': '#/refs/markclip'}
@@ -2611,7 +2611,7 @@ class markclip(VegaSchema):
 
 class style(VegaSchema):
     """style schema wrapper
-    
+
     oneOf(string, List(string))
     """
     _schema = {'$ref': '#/refs/style'}
@@ -2623,7 +2623,7 @@ class style(VegaSchema):
 
 class marktype(VegaSchema):
     """marktype schema wrapper
-    
+
     string
     """
     _schema = {'$ref': '#/refs/marktype'}
@@ -2635,7 +2635,7 @@ class marktype(VegaSchema):
 
 class sortOrder(VegaSchema):
     """sortOrder schema wrapper
-    
+
     oneOf(enum('ascending', 'descending'), signal)
     """
     _schema = {'$ref': '#/refs/sortOrder'}
@@ -2647,7 +2647,7 @@ class sortOrder(VegaSchema):
 
 class scaleField(VegaSchema):
     """scaleField schema wrapper
-    
+
     oneOf(string, signal)
     """
     _schema = {'$ref': '#/refs/scaleField'}
@@ -2659,7 +2659,7 @@ class scaleField(VegaSchema):
 
 class scaleInterpolate(VegaSchema):
     """scaleInterpolate schema wrapper
-    
+
     oneOf(string, signal, Mapping(required=[type]))
     """
     _schema = {'$ref': '#/refs/scaleInterpolate'}
@@ -2671,8 +2671,8 @@ class scaleInterpolate(VegaSchema):
 
 class scaleData(VegaSchema):
     """scaleData schema wrapper
-    
-    oneOf(Mapping(required=[data, field]), Mapping(required=[data, fields]), 
+
+    oneOf(Mapping(required=[data, field]), Mapping(required=[data, fields]),
     Mapping(required=[fields]))
     """
     _schema = {'$ref': '#/refs/scaleData'}
@@ -2684,7 +2684,7 @@ class scaleData(VegaSchema):
 
 class selector(VegaSchema):
     """selector schema wrapper
-    
+
     string
     """
     _schema = {'$ref': '#/refs/selector'}
@@ -2696,13 +2696,13 @@ class selector(VegaSchema):
 
 class signal(VegaSchema):
     """signal schema wrapper
-    
+
     Mapping(required=[signal])
-    
+
     Attributes
     ----------
     signal : string
-    
+
     """
     _schema = {'$ref': '#/refs/signal'}
     _rootschema = Root._schema
@@ -2713,7 +2713,7 @@ class signal(VegaSchema):
 
 class booleanOrSignal(VegaSchema):
     """booleanOrSignal schema wrapper
-    
+
     oneOf(boolean, signal)
     """
     _schema = {'$ref': '#/refs/booleanOrSignal'}
@@ -2725,7 +2725,7 @@ class booleanOrSignal(VegaSchema):
 
 class numberOrSignal(VegaSchema):
     """numberOrSignal schema wrapper
-    
+
     oneOf(float, signal)
     """
     _schema = {'$ref': '#/refs/numberOrSignal'}
@@ -2737,7 +2737,7 @@ class numberOrSignal(VegaSchema):
 
 class stringOrSignal(VegaSchema):
     """stringOrSignal schema wrapper
-    
+
     oneOf(string, signal)
     """
     _schema = {'$ref': '#/refs/stringOrSignal'}
@@ -2745,4 +2745,3 @@ class stringOrSignal(VegaSchema):
 
     def __init__(self, *args, **kwds):
         super(stringOrSignal, self).__init__(*args, **kwds)
-

--- a/altair/vegalite/v1/schema/channels.py
+++ b/altair/vegalite/v1/schema/channels.py
@@ -14,33 +14,33 @@ class Row(core.PositionChannelDef):
     """Row schema wrapper
     
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     axis : Axis
-    
+
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     scale : Scale
-    
+
     sort : anyOf(SortOrder, SortField)
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -90,35 +90,35 @@ class Row(core.PositionChannelDef):
 
 class Column(core.PositionChannelDef):
     """Column schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     axis : Axis
-    
+
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     scale : Scale
-    
+
     sort : anyOf(SortOrder, SortField)
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -168,35 +168,35 @@ class Column(core.PositionChannelDef):
 
 class X(core.PositionChannelDef):
     """X schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     axis : Axis
-    
+
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     scale : Scale
-    
+
     sort : anyOf(SortOrder, SortField)
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -246,35 +246,35 @@ class X(core.PositionChannelDef):
 
 class Y(core.PositionChannelDef):
     """Y schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     axis : Axis
-    
+
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     scale : Scale
-    
+
     sort : anyOf(SortOrder, SortField)
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -324,18 +324,18 @@ class Y(core.PositionChannelDef):
 
 class X2(core.FieldDef):
     """X2 schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -344,9 +344,9 @@ class X2(core.FieldDef):
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -394,18 +394,18 @@ class X2(core.FieldDef):
 
 class Y2(core.FieldDef):
     """Y2 schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -414,9 +414,9 @@ class Y2(core.FieldDef):
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -464,35 +464,35 @@ class Y2(core.FieldDef):
 
 class Color(core.ChannelDefWithLegend):
     """Color schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     legend : Legend
-    
+
     scale : Scale
-    
+
     sort : anyOf(SortOrder, SortField)
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -542,35 +542,35 @@ class Color(core.ChannelDefWithLegend):
 
 class Opacity(core.ChannelDefWithLegend):
     """Opacity schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     legend : Legend
-    
+
     scale : Scale
-    
+
     sort : anyOf(SortOrder, SortField)
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -620,35 +620,35 @@ class Opacity(core.ChannelDefWithLegend):
 
 class Size(core.ChannelDefWithLegend):
     """Size schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     legend : Legend
-    
+
     scale : Scale
-    
+
     sort : anyOf(SortOrder, SortField)
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -698,35 +698,35 @@ class Size(core.ChannelDefWithLegend):
 
 class Shape(core.ChannelDefWithLegend):
     """Shape schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     legend : Legend
-    
+
     scale : Scale
-    
+
     sort : anyOf(SortOrder, SortField)
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -776,18 +776,18 @@ class Shape(core.ChannelDefWithLegend):
 
 class Detail(core.FieldDef):
     """Detail schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -796,9 +796,9 @@ class Detail(core.FieldDef):
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -846,18 +846,18 @@ class Detail(core.FieldDef):
 
 class Text(core.FieldDef):
     """Text schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -866,9 +866,9 @@ class Text(core.FieldDef):
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -916,18 +916,18 @@ class Text(core.FieldDef):
 
 class Label(core.FieldDef):
     """Label schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -936,9 +936,9 @@ class Label(core.FieldDef):
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -986,31 +986,31 @@ class Label(core.FieldDef):
 
 class Path(core.OrderChannelDef):
     """Path schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     sort : SortOrder
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -1060,31 +1060,31 @@ class Path(core.OrderChannelDef):
 
 class Order(core.OrderChannelDef):
     """Order schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     sort : SortOrder
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.

--- a/altair/vegalite/v1/schema/core.py
+++ b/altair/vegalite/v1/schema/core.py
@@ -21,7 +21,7 @@ class VegaLiteSchema(SchemaBase):
 
 class Root(VegaLiteSchema):
     """Root schema wrapper
-    
+
     anyOf(ExtendedUnitSpec, FacetSpec, LayerSpec)
     """
     _schema = load_schema()
@@ -33,40 +33,40 @@ class Root(VegaLiteSchema):
 
 class ExtendedUnitSpec(VegaLiteSchema):
     """ExtendedUnitSpec schema wrapper
-    
+
     Mapping(required=[mark])
     Schema for a unit Vega-Lite specification, with the syntactic sugar extensions:
-    
+
     - `row` and `column` are included in the encoding.
-    
+
     - (Future) label, box plot
-    
-    
-    
+
+
+
     Note: the spec could contain facet.
-    
+
     Attributes
     ----------
     mark : Mark
-        The mark type.  One of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`,  
+        The mark type.  One of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`,
         `"area"`, `"point"`, `"rule"`, and `"text"`.
     config : Config
         Configuration object
     data : Data
         An object describing the data source
     description : string
-        An optional description of this mark for commenting purpose.  This property has no 
+        An optional description of this mark for commenting purpose.  This property has no
         effect on the output visualization.
     encoding : Encoding
         A key-value mapping between encoding channels and definition of fields.
     height : float
-    
+
     name : string
         Name of the visualization for later reference.
     transform : Transform
         An object describing filter and new field calculation.
     width : float
-    
+
     """
     _schema = {'$ref': '#/definitions/ExtendedUnitSpec'}
     _rootschema = Root._schema
@@ -82,7 +82,7 @@ class ExtendedUnitSpec(VegaLiteSchema):
 
 class Mark(VegaLiteSchema):
     """Mark schema wrapper
-    
+
     enum('area', 'bar', 'line', 'point', 'text', 'tick', 'rule', 'circle', 'square', 'errorBar')
     """
     _schema = {'$ref': '#/definitions/Mark'}
@@ -94,22 +94,22 @@ class Mark(VegaLiteSchema):
 
 class Encoding(VegaLiteSchema):
     """Encoding schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     color : ChannelDefWithLegend
-        Color of the marks – either fill or stroke color based on mark type.  (By default, 
+        Color of the marks – either fill or stroke color based on mark type.  (By default,
         fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /  stroke color
          for `line` and `point`.)
     column : PositionChannelDef
         Horizontal facets for trellis plots.
     detail : anyOf(FieldDef, List(FieldDef))
-        Additional levels of detail for grouping data in aggregate views and  in line and 
+        Additional levels of detail for grouping data in aggregate views and  in line and
         area marks without mapping data to a specific visual channel.
     label : FieldDef
-    
+
     opacity : ChannelDefWithLegend
         Opacity of the marks – either can be a value or in a range.
     order : anyOf(OrderChannelDef, List(OrderChannelDef))
@@ -119,22 +119,22 @@ class Encoding(VegaLiteSchema):
     row : PositionChannelDef
         Vertical facets for trellis plots.
     shape : ChannelDefWithLegend
-        The symbol's shape (only for `point` marks). The supported values are  `"circle"` 
-        (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,  or 
+        The symbol's shape (only for `point` marks). The supported values are  `"circle"`
+        (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,  or
         `"triangle-down"`, or else a custom SVG path string.
     size : ChannelDefWithLegend
         Size of the mark.  - For `point`, `square` and `circle`  – the symbol size, or pixel
-         area of the mark.  - For `bar` and `tick` – the bar and tick's size.  - For `text` 
+         area of the mark.  - For `bar` and `tick` – the bar and tick's size.  - For `text`
         – the text's font size.  - Size is currently unsupported for `line` and `area`.
     text : FieldDef
         Text of the `text` mark.
     x : PositionChannelDef
-        X coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`  
+        X coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`
         (or to width and height for `bar` and `area` marks).
     x2 : FieldDef
         X2 coordinates for ranged `bar`, `rule`, `area`
     y : PositionChannelDef
-        Y coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`  
+        Y coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`
         (or to width and height for `bar` and `area` marks).
     y2 : FieldDef
         Y2 coordinates for ranged `bar`, `rule`, `area`
@@ -153,33 +153,33 @@ class Encoding(VegaLiteSchema):
 
 class PositionChannelDef(VegaLiteSchema):
     """PositionChannelDef schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     axis : Axis
-    
+
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     scale : Scale
-    
+
     sort : anyOf(SortOrder, SortField)
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -197,7 +197,7 @@ class PositionChannelDef(VegaLiteSchema):
 
 class Axis(VegaLiteSchema):
     """Axis schema wrapper
-    
+
     anyOf(Mapping(required=[]), None)
     """
     _schema = {'$ref': '#/definitions/Axis'}
@@ -209,7 +209,7 @@ class Axis(VegaLiteSchema):
 
 class AxisOrient(VegaLiteSchema):
     """AxisOrient schema wrapper
-    
+
     enum('top', 'right', 'left', 'bottom')
     """
     _schema = {'$ref': '#/definitions/AxisOrient'}
@@ -221,25 +221,25 @@ class AxisOrient(VegaLiteSchema):
 
 class DateTime(VegaLiteSchema):
     """DateTime schema wrapper
-    
+
     Mapping(required=[])
     Object for defining datetime in Vega-Lite Filter.
-    
+
     If both month and quarter are provided, month has higher precedence.
-    
+
     `day` cannot be combined with other date.
-    
+
     We accept string for month and day names.
-    
+
     Attributes
     ----------
     date : float
         Integer value representing the date from 1-31.
     day : anyOf(string, float)
-        Value representing the day of week.  This can be one of: (1) integer value -- `1` 
-        represents Monday; (2) case-insensitive day name (e.g., `"Monday"`);  (3) 
+        Value representing the day of week.  This can be one of: (1) integer value -- `1`
+        represents Monday; (2) case-insensitive day name (e.g., `"Monday"`);  (3)
         case-insensitive, 3-character short day name (e.g., `"Mon"`).   <br/> **Warning:** A
-         DateTime definition object with `day`** should not be combined with `year`, 
+         DateTime definition object with `day`** should not be combined with `year`,
         `quarter`, `month`, or `date`.
     hours : float
         Integer value representing the hour of day from 0-23.
@@ -248,8 +248,8 @@ class DateTime(VegaLiteSchema):
     minutes : float
         Integer value representing minute segment of a time from 0-59.
     month : anyOf(string, float)
-        One of: (1) integer value representing the month from `1`-`12`. `1` represents 
-        January;  (2) case-insensitive month name (e.g., `"January"`);  (3) 
+        One of: (1) integer value representing the month from `1`-`12`. `1` represents
+        January;  (2) case-insensitive month name (e.g., `"January"`);  (3)
         case-insensitive, 3-character short month name (e.g., `"Jan"`).
     quarter : float
         Integer value representing the quarter of the year (from 1-4).
@@ -271,60 +271,60 @@ class DateTime(VegaLiteSchema):
 
 class Scale(VegaLiteSchema):
     """Scale schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     bandSize : anyOf(BandSize, float)
-    
+
     clamp : boolean
-        If true, values that exceed the data domain are clamped to either the minimum or 
+        If true, values that exceed the data domain are clamped to either the minimum or
         maximum range value
     domain : anyOf(List(string), List(float), List(DateTime))
         The domain of the scale, representing the set of data values. For quantitative data,
-         this can take the form of a two-element array with minimum and maximum values. For 
+         this can take the form of a two-element array with minimum and maximum values. For
         ordinal/categorical data, this may be an array of valid input values.
     exponent : float
-        Sets the exponent of the scale transformation. For pow scale types only, otherwise 
+        Sets the exponent of the scale transformation. For pow scale types only, otherwise
         ignored.
     nice : anyOf(NiceTime, boolean)
         If specified, modifies the scale domain to use a more human-friendly value range. If
          specified as a true boolean, modifies the scale domain to use a more human-friendly
-         number range (e.g., 7 instead of 6.96). If specified as a string, modifies the 
-        scale domain to use a more human-friendly value range. For time and utc scale types 
+         number range (e.g., 7 instead of 6.96). If specified as a string, modifies the
+        scale domain to use a more human-friendly value range. For time and utc scale types
         only, the nice value should be a string indicating the desired time interval.
     padding : float
         Applies spacing among ordinal elements in the scale range. The actual effect depends
-         on how the scale is configured. If the __points__ parameter is `true`, the padding 
+         on how the scale is configured. If the __points__ parameter is `true`, the padding
         value is interpreted as a multiple of the spacing between points. A reasonable value
-         is 1.0, such that the first and last point will be offset from the minimum and 
-        maximum value by half the distance between points. Otherwise, padding is typically 
-        in the range [0, 1] and corresponds to the fraction of space in the range interval 
+         is 1.0, such that the first and last point will be offset from the minimum and
+        maximum value by half the distance between points. Otherwise, padding is typically
+        in the range [0, 1] and corresponds to the fraction of space in the range interval
         to allocate to padding. A value of 0.5 means that the range band width will be equal
-         to the padding width. For more, see the [D3 ordinal scale 
+         to the padding width. For more, see the [D3 ordinal scale
         documentation](https://github.com/mbostock/d3/wiki/Ordinal-Scales).
     range : anyOf(List(string), List(float), string)
-        The range of the scale, representing the set of visual values. For numeric values, 
-        the range can take the form of a two-element array with minimum and maximum values. 
-        For ordinal or quantized data, the range may by an array of desired output values, 
-        which are mapped to elements in the specified domain. For ordinal scales only, the 
-        range can be defined using a DataRef: the range values are then drawn dynamically 
+        The range of the scale, representing the set of visual values. For numeric values,
+        the range can take the form of a two-element array with minimum and maximum values.
+        For ordinal or quantized data, the range may by an array of desired output values,
+        which are mapped to elements in the specified domain. For ordinal scales only, the
+        range can be defined using a DataRef: the range values are then drawn dynamically
         from a backing data set.
     round : boolean
-        If true, rounds numeric output values to integers. This can be helpful for snapping 
+        If true, rounds numeric output values to integers. This can be helpful for snapping
         to the pixel grid.
     type : ScaleType
-    
+
     useRawDomain : boolean
-        Uses the source data range as scale domain instead of aggregated data for aggregate 
-        axis.  This property only works with aggregate functions that produce values within 
-        the raw data domain (`"mean"`, `"average"`, `"stdev"`, `"stdevp"`, `"median"`, 
-        `"q1"`, `"q3"`, `"min"`, `"max"`). For other aggregations that produce values 
+        Uses the source data range as scale domain instead of aggregated data for aggregate
+        axis.  This property only works with aggregate functions that produce values within
+        the raw data domain (`"mean"`, `"average"`, `"stdev"`, `"stdevp"`, `"median"`,
+        `"q1"`, `"q3"`, `"min"`, `"max"`). For other aggregations that produce values
         outside of the raw data domain (e.g. `"count"`, `"sum"`), this property is ignored.
     zero : boolean
-        If `true`, ensures that a zero baseline value is included in the scale domain.  
-        Default value: `true` for `x` and `y` channel if the quantitative field is not 
+        If `true`, ensures that a zero baseline value is included in the scale domain.
+        Default value: `true` for `x` and `y` channel if the quantitative field is not
         binned  and no custom `domain` is provided; `false` otherwise.
     """
     _schema = {'$ref': '#/definitions/Scale'}
@@ -340,7 +340,7 @@ class Scale(VegaLiteSchema):
 
 class ScaleType(VegaLiteSchema):
     """ScaleType schema wrapper
-    
+
     enum('linear', 'log', 'pow', 'sqrt', 'quantile', 'quantize', 'ordinal', 'time', 'utc')
     """
     _schema = {'$ref': '#/definitions/ScaleType'}
@@ -352,7 +352,7 @@ class ScaleType(VegaLiteSchema):
 
 class BandSize(VegaLiteSchema):
     """BandSize schema wrapper
-    
+
     enum('fit')
     """
     _schema = {'$ref': '#/definitions/BandSize'}
@@ -364,7 +364,7 @@ class BandSize(VegaLiteSchema):
 
 class NiceTime(VegaLiteSchema):
     """NiceTime schema wrapper
-    
+
     enum('second', 'minute', 'hour', 'day', 'week', 'month', 'year')
     """
     _schema = {'$ref': '#/definitions/NiceTime'}
@@ -376,7 +376,7 @@ class NiceTime(VegaLiteSchema):
 
 class SortOrder(VegaLiteSchema):
     """SortOrder schema wrapper
-    
+
     enum('ascending', 'descending', 'none')
     """
     _schema = {'$ref': '#/definitions/SortOrder'}
@@ -388,9 +388,9 @@ class SortOrder(VegaLiteSchema):
 
 class SortField(VegaLiteSchema):
     """SortField schema wrapper
-    
+
     Mapping(required=[field, op])
-    
+
     Attributes
     ----------
     field : string
@@ -398,7 +398,7 @@ class SortField(VegaLiteSchema):
     op : AggregateOp
         The sort aggregation operator
     order : SortOrder
-    
+
     """
     _schema = {'$ref': '#/definitions/SortField'}
     _rootschema = Root._schema
@@ -409,9 +409,9 @@ class SortField(VegaLiteSchema):
 
 class AggregateOp(VegaLiteSchema):
     """AggregateOp schema wrapper
-    
-    enum('values', 'count', 'valid', 'missing', 'distinct', 'sum', 'mean', 'average', 
-    'variance', 'variancep', 'stdev', 'stdevp', 'median', 'q1', 'q3', 'modeskew', 'min', 'max', 
+
+    enum('values', 'count', 'valid', 'missing', 'distinct', 'sum', 'mean', 'average',
+    'variance', 'variancep', 'stdev', 'stdevp', 'median', 'q1', 'q3', 'modeskew', 'min', 'max',
     'argmin', 'argmax')
     """
     _schema = {'$ref': '#/definitions/AggregateOp'}
@@ -423,7 +423,7 @@ class AggregateOp(VegaLiteSchema):
 
 class Type(VegaLiteSchema):
     """Type schema wrapper
-    
+
     enum('quantitative', 'ordinal', 'temporal', 'nominal')
     """
     _schema = {'$ref': '#/definitions/Type'}
@@ -435,11 +435,11 @@ class Type(VegaLiteSchema):
 
 class TimeUnit(VegaLiteSchema):
     """TimeUnit schema wrapper
-    
-    enum('year', 'month', 'day', 'date', 'hours', 'minutes', 'seconds', 'milliseconds', 
-    'yearmonth', 'yearmonthdate', 'yearmonthdatehours', 'yearmonthdatehoursminutes', 
-    'yearmonthdatehoursminutesseconds', 'monthdate', 'hoursminutes', 'hoursminutesseconds', 
-    'minutesseconds', 'secondsmilliseconds', 'quarter', 'yearquarter', 'quartermonth', 
+
+    enum('year', 'month', 'day', 'date', 'hours', 'minutes', 'seconds', 'milliseconds',
+    'yearmonth', 'yearmonthdate', 'yearmonthdatehours', 'yearmonthdatehoursminutes',
+    'yearmonthdatehoursminutesseconds', 'monthdate', 'hoursminutes', 'hoursminutesseconds',
+    'minutesseconds', 'secondsmilliseconds', 'quarter', 'yearquarter', 'quartermonth',
     'yearquartermonth')
     """
     _schema = {'$ref': '#/definitions/TimeUnit'}
@@ -451,27 +451,27 @@ class TimeUnit(VegaLiteSchema):
 
 class Bin(VegaLiteSchema):
     """Bin schema wrapper
-    
+
     Mapping(required=[])
     Binning properties or boolean flag for determining whether to bin data or not.
-    
+
     Attributes
     ----------
     base : float
         The number base to use for automatic bin determination (default is base 10).
     div : List(float)
-        Scale factors indicating allowable subdivisions. The default value is [5, 2], which 
-        indicates that for base 10 numbers (the default base), the method may consider 
-        dividing bin sizes by 5 and/or 2. For example, for an initial step size of 10, the 
-        method can check if bin sizes of 2 (= 10/5), 5 (= 10/2), or 1 (= 10/(5*2)) might 
+        Scale factors indicating allowable subdivisions. The default value is [5, 2], which
+        indicates that for base 10 numbers (the default base), the method may consider
+        dividing bin sizes by 5 and/or 2. For example, for an initial step size of 10, the
+        method can check if bin sizes of 2 (= 10/5), 5 (= 10/2), or 1 (= 10/(5*2)) might
         also satisfy the given constraints.
     max : float
-        The maximum bin value to consider. If unspecified, the maximum value of the 
+        The maximum bin value to consider. If unspecified, the maximum value of the
         specified field is used.
     maxbins : float
         Maximum number of bins.
     min : float
-        The minimum bin value to consider. If unspecified, the minimum value of the 
+        The minimum bin value to consider. If unspecified, the minimum value of the
         specified field is used.
     minstep : float
         A minimum allowable step size (particularly useful for integer values).
@@ -492,16 +492,16 @@ class Bin(VegaLiteSchema):
 
 class FieldDef(VegaLiteSchema):
     """FieldDef schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -510,9 +510,9 @@ class FieldDef(VegaLiteSchema):
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -528,33 +528,33 @@ class FieldDef(VegaLiteSchema):
 
 class ChannelDefWithLegend(VegaLiteSchema):
     """ChannelDefWithLegend schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     legend : Legend
-    
+
     scale : Scale
-    
+
     sort : anyOf(SortOrder, SortField)
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -573,7 +573,7 @@ class ChannelDefWithLegend(VegaLiteSchema):
 
 class Legend(VegaLiteSchema):
     """Legend schema wrapper
-    
+
     anyOf(Mapping(required=[]), None)
     """
     _schema = {'$ref': '#/definitions/Legend'}
@@ -585,29 +585,29 @@ class Legend(VegaLiteSchema):
 
 class OrderChannelDef(VegaLiteSchema):
     """OrderChannelDef schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning 
+        Flag for binning a `quantitative` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     sort : SortOrder
-    
+
     timeUnit : TimeUnit
         Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name 
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial 
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case 
+        The encoded field's type of measurement. This can be either a full type  name
+        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
+        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
         insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
@@ -624,15 +624,15 @@ class OrderChannelDef(VegaLiteSchema):
 
 class Data(VegaLiteSchema):
     """Data schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     format : DataFormat
         An object that specifies the format for the data file or values.
     url : string
-        A URL from which to load the data set. Use the format.type property  to ensure the 
+        A URL from which to load the data set. Use the format.type property  to ensure the
         loaded data is correctly parsed.
     values : List(Mapping(required=[]))
         Pass array of objects instead of a url to a file.
@@ -646,40 +646,40 @@ class Data(VegaLiteSchema):
 
 class DataFormat(VegaLiteSchema):
     """DataFormat schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     feature : string
         The name of the TopoJSON object set to convert to a GeoJSON feature collection.  For
-         example, in a map of the world, there may be an object set named `"countries"`.  
-        Using the feature property, we can extract this set and generate a GeoJSON feature 
+         example, in a map of the world, there may be an object set named `"countries"`.
+        Using the feature property, we can extract this set and generate a GeoJSON feature
         object for each country.
     mesh : string
-        The name of the TopoJSON object set to convert to a mesh.  Similar to the `feature` 
-        option, `mesh` extracts a named TopoJSON object set.  Unlike the `feature` option, 
-        the corresponding geo data is returned as a single, unified mesh instance, not as 
-        individual GeoJSON features.  Extracting a mesh is useful for more efficiently 
-        drawing borders or other geographic elements that you do not need to associate with 
+        The name of the TopoJSON object set to convert to a mesh.  Similar to the `feature`
+        option, `mesh` extracts a named TopoJSON object set.  Unlike the `feature` option,
+        the corresponding geo data is returned as a single, unified mesh instance, not as
+        individual GeoJSON features.  Extracting a mesh is useful for more efficiently
+        drawing borders or other geographic elements that you do not need to associate with
         specific regions such as individual countries, states or counties.
     parse : Mapping(required=[])
-        A collection of parsing instructions can be used to define the data types of 
-        string-valued attributes in the JSON file. Each instruction is a name-value pair, 
-        where the name is the name of the attribute, and the value is the desired data type 
-        (one of `"number"`, `"boolean"` or `"date"`). For example, `"parse": 
-        {"modified_on":"date"}` ensures that the `modified_on` value in each row of the 
-        input data is parsed as a Date value. (See Datalib's [`dl.read.types` 
-        method](https://github.com/vega/datalib/wiki/Import#dl_read_types) for more 
+        A collection of parsing instructions can be used to define the data types of
+        string-valued attributes in the JSON file. Each instruction is a name-value pair,
+        where the name is the name of the attribute, and the value is the desired data type
+        (one of `"number"`, `"boolean"` or `"date"`). For example, `"parse":
+        {"modified_on":"date"}` ensures that the `modified_on` value in each row of the
+        input data is parsed as a Date value. (See Datalib's [`dl.read.types`
+        method](https://github.com/vega/datalib/wiki/Import#dl_read_types) for more
         information.)
     property : string
-        JSON only) The JSON property containing the desired data.  This parameter can be 
-        used when the loaded JSON file may have surrounding structure or meta-data.  For 
-        example `"property": "values.features"` is equivalent to retrieving 
+        JSON only) The JSON property containing the desired data.  This parameter can be
+        used when the loaded JSON file may have surrounding structure or meta-data.  For
+        example `"property": "values.features"` is equivalent to retrieving
         `json.values.features`  from the loaded JSON object.
     type : DataFormatType
-        Type of input data: `"json"`, `"csv"`, `"tsv"`.  The default format type is 
-        determined by the extension of the file url.  If no extension is detected, `"json"` 
+        Type of input data: `"json"`, `"csv"`, `"tsv"`.  The default format type is
+        determined by the extension of the file url.  If no extension is detected, `"json"`
         will be used by default.
     """
     _schema = {'$ref': '#/definitions/DataFormat'}
@@ -693,7 +693,7 @@ class DataFormat(VegaLiteSchema):
 
 class DataFormatType(VegaLiteSchema):
     """DataFormatType schema wrapper
-    
+
     enum('json', 'csv', 'tsv', 'topojson')
     """
     _schema = {'$ref': '#/definitions/DataFormatType'}
@@ -705,22 +705,22 @@ class DataFormatType(VegaLiteSchema):
 
 class Transform(VegaLiteSchema):
     """Transform schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     calculate : List(Formula)
-        Calculate new field(s) using the provided expresssion(s). Calculation are applied 
+        Calculate new field(s) using the provided expresssion(s). Calculation are applied
         before filter.
-    filter : anyOf(EqualFilter, RangeFilter, OneOfFilter, List(anyOf(EqualFilter, RangeFilter, 
+    filter : anyOf(EqualFilter, RangeFilter, OneOfFilter, List(anyOf(EqualFilter, RangeFilter,
     OneOfFilter, string)), string)
-        A string containing the filter Vega expression. Use `datum` to refer to the current 
+        A string containing the filter Vega expression. Use `datum` to refer to the current
         data object.
     filterInvalid : boolean
-        Whether to filter invalid values (`null` and `NaN`) from the data. By default 
+        Whether to filter invalid values (`null` and `NaN`) from the data. By default
         (`undefined`), only quantitative and temporal fields are filtered. If set to `true`,
-         all data items with null values are filtered. If `false`, all data items are 
+         all data items with null values are filtered. If `false`, all data items are
         included.
     """
     _schema = {'$ref': '#/definitions/Transform'}
@@ -733,9 +733,9 @@ class Transform(VegaLiteSchema):
 
 class EqualFilter(VegaLiteSchema):
     """EqualFilter schema wrapper
-    
+
     Mapping(required=[field, equal])
-    
+
     Attributes
     ----------
     equal : anyOf(DateTime, anyOf(string, float, boolean))
@@ -754,15 +754,15 @@ class EqualFilter(VegaLiteSchema):
 
 class RangeFilter(VegaLiteSchema):
     """RangeFilter schema wrapper
-    
+
     Mapping(required=[field, range])
-    
+
     Attributes
     ----------
     field : string
         Field to be filtered
     range : List(anyOf(DateTime, float))
-        Array of inclusive minimum and maximum values  for a field value of a data item to 
+        Array of inclusive minimum and maximum values  for a field value of a data item to
         be included in the filtered data.
     timeUnit : TimeUnit
         time unit for the field to be filtered.
@@ -776,15 +776,15 @@ class RangeFilter(VegaLiteSchema):
 
 class OneOfFilter(VegaLiteSchema):
     """OneOfFilter schema wrapper
-    
+
     Mapping(required=[field, oneOf])
-    
+
     Attributes
     ----------
     field : string
         Field to be filtered
     oneOf : List(anyOf(DateTime, anyOf(string, float, boolean)))
-        A set of values that the `field`'s value should be a member of,  for a data item 
+        A set of values that the `field`'s value should be a member of,  for a data item
         included in the filtered data.
     timeUnit : TimeUnit
         time unit for the field to be filtered.
@@ -798,14 +798,14 @@ class OneOfFilter(VegaLiteSchema):
 
 class Formula(VegaLiteSchema):
     """Formula schema wrapper
-    
+
     Mapping(required=[field, expr])
     Formula object for calculate.
-    
+
     Attributes
     ----------
     expr : string
-        A string containing an expression for the formula. Use the variable `datum` to to 
+        A string containing an expression for the formula. Use the variable `datum` to to
         refer to the current data object.
     field : string
         The field in which to store the computed formula value.
@@ -819,15 +819,15 @@ class Formula(VegaLiteSchema):
 
 class Config(VegaLiteSchema):
     """Config schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     axis : AxisConfig
         Axis Config
     background : string
-        CSS color property to use as background of visualization. Default is 
+        CSS color property to use as background of visualization. Default is
         `"transparent"`.
     cell : CellConfig
         Cell Config
@@ -846,10 +846,10 @@ class Config(VegaLiteSchema):
     scale : ScaleConfig
         Scale Config
     timeFormat : string
-        Default datetime format for axis and legend labels. The format can be set directly 
+        Default datetime format for axis and legend labels. The format can be set directly
         on each axis and legend.
     viewport : float
-        The width and height of the on-screen viewport, in pixels. If necessary, clipping 
+        The width and height of the on-screen viewport, in pixels. If necessary, clipping
         and scrolling will be applied.
     """
     _schema = {'$ref': '#/definitions/Config'}
@@ -866,19 +866,19 @@ class Config(VegaLiteSchema):
 
 class CellConfig(VegaLiteSchema):
     """CellConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     clip : boolean
-    
+
     fill : string
         The fill color.
     fillOpacity : float
         The fill opacity (value between [0,1]).
     height : float
-    
+
     stroke : string
         The stroke color.
     strokeDash : List(float)
@@ -890,7 +890,7 @@ class CellConfig(VegaLiteSchema):
     strokeWidth : float
         The stroke width, in pixels.
     width : float
-    
+
     """
     _schema = {'$ref': '#/definitions/CellConfig'}
     _rootschema = Root._schema
@@ -906,9 +906,9 @@ class CellConfig(VegaLiteSchema):
 
 class MarkConfig(VegaLiteSchema):
     """MarkConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     align : HorizontalAlign
@@ -918,7 +918,7 @@ class MarkConfig(VegaLiteSchema):
     applyColorToBackground : boolean
         Apply color field to background color instead of the text.
     barSize : float
-        The size of the bars.  If unspecified, the default size is  `bandSize-1`,  which 
+        The size of the bars.  If unspecified, the default size is  `bandSize-1`,  which
         provides 1 pixel offset between bars.
     barThinSize : float
         The size of the bars on continuous scales.
@@ -927,19 +927,19 @@ class MarkConfig(VegaLiteSchema):
     color : string
         Default color.
     dx : float
-        The horizontal offset, in pixels, between the text label and its anchor point. The 
+        The horizontal offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the angle property.
     dy : float
-        The vertical offset, in pixels, between the text label and its anchor point. The 
+        The vertical offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the angle property.
     fill : string
         Default Fill Color.  This has higher precedence than config.color
     fillOpacity : float
-    
+
     filled : boolean
-        Whether the shape\'s color should be used as fill color instead of stroke color.  
-        This is only applicable for "bar", "point", and "area".  All marks except "point" 
-        marks are filled by default.  See Mark Documentation 
+        Whether the shape\'s color should be used as fill color instead of stroke color.
+        This is only applicable for "bar", "point", and "area".  All marks except "point"
+        marks are filled by default.  See Mark Documentation
         (http://vega.github.io/vega-lite/docs/marks.html)  for usage example.
     font : string
         The typeface to set the text in (e.g., Helvetica Neue).
@@ -950,7 +950,7 @@ class MarkConfig(VegaLiteSchema):
     fontWeight : FontWeight
         The font weight (e.g., bold).
     format : string
-        The formatting pattern for text value. If not defined, this will be determined 
+        The formatting pattern for text value. If not defined, this will be determined
         automatically.
     interpolate : Interpolate
         The line interpolation method to use. One of linear, step-before, step-after, basis,
@@ -958,31 +958,31 @@ class MarkConfig(VegaLiteSchema):
     lineSize : float
         Size of line mark.
     opacity : float
-    
+
     orient : Orient
-        The orientation of a non-stacked bar, tick, area, and line charts.  The value is 
-        either horizontal (default) or vertical.  - For bar, rule and tick, this determines 
-        whether the size of the bar and tick  should be applied to x or y dimension.  - For 
-        area, this property determines the orient property of the Vega output.  - For line, 
-        this property determines the sort order of the points in the line  if 
+        The orientation of a non-stacked bar, tick, area, and line charts.  The value is
+        either horizontal (default) or vertical.  - For bar, rule and tick, this determines
+        whether the size of the bar and tick  should be applied to x or y dimension.  - For
+        area, this property determines the orient property of the Vega output.  - For line,
+        this property determines the sort order of the points in the line  if
         `config.sortLineBy` is not specified.  For stacked charts, this is always determined
-         by the orientation of the stack;  therefore explicitly specified value will be 
+         by the orientation of the stack;  therefore explicitly specified value will be
         ignored.
     radius : float
-        Polar coordinate radial offset, in pixels, of the text label from the origin 
+        Polar coordinate radial offset, in pixels, of the text label from the origin
         determined by the x and y properties.
     ruleSize : float
         Size of rule mark.
     shape : anyOf(Shape, string)
-        The symbol shape to use. One of circle (default), square, cross, diamond, 
+        The symbol shape to use. One of circle (default), square, cross, diamond,
         triangle-up, or triangle-down, or a custom SVG path.
     shortTimeLabels : boolean
         Whether month names and weekday names should be abbreviated.
     size : float
-        The pixel area each the point. For example: in the case of circles, the radius is 
+        The pixel area each the point. For example: in the case of circles, the radius is
         determined in part by the square root of the size value.
     stacked : StackOffset
-    
+
     stroke : string
         Default Stroke Color.  This has higher precedence than config.color
     strokeDash : List(float)
@@ -990,17 +990,17 @@ class MarkConfig(VegaLiteSchema):
     strokeDashOffset : float
         The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeOpacity : float
-    
+
     strokeWidth : float
-    
+
     tension : float
         Depending on the interpolation type, sets the tension parameter.
     text : string
         Placeholder Text
     theta : float
-        Polar coordinate angle, in radians, of the text label from the origin determined by 
-        the x and y properties. Values for theta follow the same convention of arc mark 
-        startAngle and endAngle properties: angles are measured in radians, with 0 
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the x and y properties. Values for theta follow the same convention of arc mark
+        startAngle and endAngle properties: angles are measured in radians, with 0
         indicating "north".
     tickSize : float
         The width of the ticks.
@@ -1038,7 +1038,7 @@ class MarkConfig(VegaLiteSchema):
 
 class StackOffset(VegaLiteSchema):
     """StackOffset schema wrapper
-    
+
     enum('zero', 'center', 'normalize', 'none')
     """
     _schema = {'$ref': '#/definitions/StackOffset'}
@@ -1050,7 +1050,7 @@ class StackOffset(VegaLiteSchema):
 
 class Orient(VegaLiteSchema):
     """Orient schema wrapper
-    
+
     enum('horizontal', 'vertical')
     """
     _schema = {'$ref': '#/definitions/Orient'}
@@ -1062,8 +1062,8 @@ class Orient(VegaLiteSchema):
 
 class Interpolate(VegaLiteSchema):
     """Interpolate schema wrapper
-    
-    enum('linear', 'linear-closed', 'step', 'step-before', 'step-after', 'basis', 'basis-open', 
+
+    enum('linear', 'linear-closed', 'step', 'step-before', 'step-after', 'basis', 'basis-open',
     'basis-closed', 'cardinal', 'cardinal-open', 'cardinal-closed', 'bundle', 'monotone')
     """
     _schema = {'$ref': '#/definitions/Interpolate'}
@@ -1075,7 +1075,7 @@ class Interpolate(VegaLiteSchema):
 
 class Shape(VegaLiteSchema):
     """Shape schema wrapper
-    
+
     enum('circle', 'square', 'cross', 'diamond', 'triangle-up', 'triangle-down')
     """
     _schema = {'$ref': '#/definitions/Shape'}
@@ -1087,7 +1087,7 @@ class Shape(VegaLiteSchema):
 
 class HorizontalAlign(VegaLiteSchema):
     """HorizontalAlign schema wrapper
-    
+
     enum('left', 'right', 'center')
     """
     _schema = {'$ref': '#/definitions/HorizontalAlign'}
@@ -1099,7 +1099,7 @@ class HorizontalAlign(VegaLiteSchema):
 
 class VerticalAlign(VegaLiteSchema):
     """VerticalAlign schema wrapper
-    
+
     enum('top', 'middle', 'bottom')
     """
     _schema = {'$ref': '#/definitions/VerticalAlign'}
@@ -1111,7 +1111,7 @@ class VerticalAlign(VegaLiteSchema):
 
 class FontStyle(VegaLiteSchema):
     """FontStyle schema wrapper
-    
+
     enum('normal', 'italic')
     """
     _schema = {'$ref': '#/definitions/FontStyle'}
@@ -1123,7 +1123,7 @@ class FontStyle(VegaLiteSchema):
 
 class FontWeight(VegaLiteSchema):
     """FontWeight schema wrapper
-    
+
     enum('normal', 'bold')
     """
     _schema = {'$ref': '#/definitions/FontWeight'}
@@ -1135,9 +1135,9 @@ class FontWeight(VegaLiteSchema):
 
 class OverlayConfig(VegaLiteSchema):
     """OverlayConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     area : AreaOverlay
@@ -1159,7 +1159,7 @@ class OverlayConfig(VegaLiteSchema):
 
 class AreaOverlay(VegaLiteSchema):
     """AreaOverlay schema wrapper
-    
+
     enum('line', 'linepoint', 'none')
     """
     _schema = {'$ref': '#/definitions/AreaOverlay'}
@@ -1171,13 +1171,13 @@ class AreaOverlay(VegaLiteSchema):
 
 class ScaleConfig(VegaLiteSchema):
     """ScaleConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     bandSize : anyOf(BandSize, float)
-        Default band size for (1) `y` ordinal scale,  and (2) `x` ordinal scale when the 
+        Default band size for (1) `y` ordinal scale,  and (2) `x` ordinal scale when the
         mark is not `text`.
     barSizeRange : List(float)
         Default range for bar size scale
@@ -1193,7 +1193,7 @@ class ScaleConfig(VegaLiteSchema):
         Default range for bar size scale
     round : boolean
         If true, rounds numeric output values to integers.  This can be helpful for snapping
-         to the pixel grid.  (Only available for `x`, `y`, `size`, `row`, and `column` 
+         to the pixel grid.  (Only available for `x`, `y`, `size`, `row`, and `column`
         scales.)
     ruleSizeRange : List(float)
         Default range for rule stroke widths
@@ -1206,10 +1206,10 @@ class ScaleConfig(VegaLiteSchema):
     tickSizeRange : List(float)
         Default range for tick spans
     useRawDomain : boolean
-        Uses the source data range as scale domain instead of aggregated data for aggregate 
-        axis.  This property only works with aggregate functions that produce values within 
-        the raw data domain (`"mean"`, `"average"`, `"stdev"`, `"stdevp"`, `"median"`, 
-        `"q1"`, `"q3"`, `"min"`, `"max"`). For other aggregations that produce values 
+        Uses the source data range as scale domain instead of aggregated data for aggregate
+        axis.  This property only works with aggregate functions that produce values within
+        the raw data domain (`"mean"`, `"average"`, `"stdev"`, `"stdevp"`, `"median"`,
+        `"q1"`, `"q3"`, `"min"`, `"max"`). For other aggregations that produce values
         outside of the raw data domain (e.g. `"count"`, `"sum"`), this property is ignored.
     """
     _schema = {'$ref': '#/definitions/ScaleConfig'}
@@ -1232,9 +1232,9 @@ class ScaleConfig(VegaLiteSchema):
 
 class AxisConfig(VegaLiteSchema):
     """AxisConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     axisColor : string
@@ -1244,8 +1244,8 @@ class AxisConfig(VegaLiteSchema):
     characterWidth : float
         Character width for automatically determining title max length.
     grid : boolean
-        A flag indicate if gridlines should be created in addition to ticks. If `grid` is 
-        unspecified, the default value is `true` for ROW and COL. For X and Y, the default 
+        A flag indicate if gridlines should be created in addition to ticks. If `grid` is
+        unspecified, the default value is `true` for ROW and COL. For X and Y, the default
         value is `true` for quantitative and time fields and `false` otherwise.
     gridColor : string
         Color of gridlines.
@@ -1266,10 +1266,10 @@ class AxisConfig(VegaLiteSchema):
     labels : boolean
         Enable or disable labels.
     layer : string
-        A string indicating if the axis (and any gridlines) should be placed above or below 
+        A string indicating if the axis (and any gridlines) should be placed above or below
         the data marks.
     offset : float
-        The offset, in pixels, by which to displace the axis from the edge of the enclosing 
+        The offset, in pixels, by which to displace the axis from the edge of the enclosing
         group or data rectangle.
     properties : Mapping(required=[])
         Optional mark property definitions for custom axis styling.
@@ -1299,8 +1299,8 @@ class AxisConfig(VegaLiteSchema):
     tickWidth : float
         The width, in pixels, of ticks.
     ticks : float
-        A desired number of ticks, for axes visualizing quantitative scales. The resulting 
-        number may be different so that values are "nice" (multiples of 2, 5, 10) and lie 
+        A desired number of ticks, for axes visualizing quantitative scales. The resulting
+        number may be different so that values are "nice" (multiples of 2, 5, 10) and lie
         within the underlying scale's range.
     titleColor : string
         Color of the title, can be in hex color code or regular color name.
@@ -1311,7 +1311,7 @@ class AxisConfig(VegaLiteSchema):
     titleFontWeight : string
         Weight of the title.
     titleMaxLength : float
-        Max length for axis title if the title is automatically generated from the field's 
+        Max length for axis title if the title is automatically generated from the field's
         description. By default, this is automatically based on cell size and characterWidth
          property.
     titleOffset : float
@@ -1352,9 +1352,9 @@ class AxisConfig(VegaLiteSchema):
 
 class LegendConfig(VegaLiteSchema):
     """LegendConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     gradientHeight : float
@@ -1380,10 +1380,10 @@ class LegendConfig(VegaLiteSchema):
     margin : float
         The margin around the legend, in pixels
     offset : float
-        The offset, in pixels, by which to displace the legend from the edge of the 
+        The offset, in pixels, by which to displace the legend from the edge of the
         enclosing group or data rectangle.
     orient : string
-        The orientation of the legend. One of "left" or "right". This determines how the 
+        The orientation of the legend. One of "left" or "right". This determines how the
         legend is positioned within the scene. The default is "right".
     padding : float
         The padding, in pixels, between the legend and axis.
@@ -1394,14 +1394,14 @@ class LegendConfig(VegaLiteSchema):
     symbolColor : string
         The color of the legend symbol,
     symbolShape : string
-        The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',  
+        The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',
         'triangle-up', 'triangle-down', or else a custom SVG path string.
     symbolSize : float
         The size of the legend symbol, in pixels.
     symbolStrokeWidth : float
         The width of the symbol's stroke.
     titleColor : string
-        Optional mark property definitions for custom legend styling.  The color of the 
+        Optional mark property definitions for custom legend styling.  The color of the
         legend title, can be in hex color code or regular color name.
     titleFont : string
         The font of the legend title.
@@ -1438,9 +1438,9 @@ class LegendConfig(VegaLiteSchema):
 
 class FacetConfig(VegaLiteSchema):
     """FacetConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     axis : AxisConfig
@@ -1461,15 +1461,15 @@ class FacetConfig(VegaLiteSchema):
 
 class FacetScaleConfig(VegaLiteSchema):
     """FacetScaleConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     padding : float
-    
+
     round : boolean
-    
+
     """
     _schema = {'$ref': '#/definitions/FacetScaleConfig'}
     _rootschema = Root._schema
@@ -1480,17 +1480,17 @@ class FacetScaleConfig(VegaLiteSchema):
 
 class FacetGridConfig(VegaLiteSchema):
     """FacetGridConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     color : string
-    
+
     offset : float
-    
+
     opacity : float
-    
+
     """
     _schema = {'$ref': '#/definitions/FacetGridConfig'}
     _rootschema = Root._schema
@@ -1501,21 +1501,21 @@ class FacetGridConfig(VegaLiteSchema):
 
 class FacetSpec(VegaLiteSchema):
     """FacetSpec schema wrapper
-    
+
     Mapping(required=[facet, spec])
-    
+
     Attributes
     ----------
     facet : Facet
-    
+
     spec : anyOf(UnitSpec, LayerSpec)
-    
+
     config : Config
         Configuration object
     data : Data
         An object describing the data source
     description : string
-        An optional description of this mark for commenting purpose.  This property has no 
+        An optional description of this mark for commenting purpose.  This property has no
         effect on the output visualization.
     name : string
         Name of the visualization for later reference.
@@ -1533,15 +1533,15 @@ class FacetSpec(VegaLiteSchema):
 
 class Facet(VegaLiteSchema):
     """Facet schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     column : PositionChannelDef
-    
+
     row : PositionChannelDef
-    
+
     """
     _schema = {'$ref': '#/definitions/Facet'}
     _rootschema = Root._schema
@@ -1552,31 +1552,31 @@ class Facet(VegaLiteSchema):
 
 class UnitSpec(VegaLiteSchema):
     """UnitSpec schema wrapper
-    
+
     Mapping(required=[mark])
-    
+
     Attributes
     ----------
     mark : Mark
-        The mark type.  One of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`,  
+        The mark type.  One of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`,
         `"area"`, `"point"`, `"rule"`, and `"text"`.
     config : Config
         Configuration object
     data : Data
         An object describing the data source
     description : string
-        An optional description of this mark for commenting purpose.  This property has no 
+        An optional description of this mark for commenting purpose.  This property has no
         effect on the output visualization.
     encoding : UnitEncoding
         A key-value mapping between encoding channels and definition of fields.
     height : float
-    
+
     name : string
         Name of the visualization for later reference.
     transform : Transform
         An object describing filter and new field calculation.
     width : float
-    
+
     """
     _schema = {'$ref': '#/definitions/UnitSpec'}
     _rootschema = Root._schema
@@ -1591,20 +1591,20 @@ class UnitSpec(VegaLiteSchema):
 
 class UnitEncoding(VegaLiteSchema):
     """UnitEncoding schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     color : ChannelDefWithLegend
-        Color of the marks – either fill or stroke color based on mark type.  (By default, 
+        Color of the marks – either fill or stroke color based on mark type.  (By default,
         fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /  stroke color
          for `line` and `point`.)
     detail : anyOf(FieldDef, List(FieldDef))
-        Additional levels of detail for grouping data in aggregate views and  in line and 
+        Additional levels of detail for grouping data in aggregate views and  in line and
         area marks without mapping data to a specific visual channel.
     label : FieldDef
-    
+
     opacity : ChannelDefWithLegend
         Opacity of the marks – either can be a value or in a range.
     order : anyOf(OrderChannelDef, List(OrderChannelDef))
@@ -1612,22 +1612,22 @@ class UnitEncoding(VegaLiteSchema):
     path : anyOf(OrderChannelDef, List(OrderChannelDef))
         Order of data points in line marks.
     shape : ChannelDefWithLegend
-        The symbol's shape (only for `point` marks). The supported values are  `"circle"` 
-        (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,  or 
+        The symbol's shape (only for `point` marks). The supported values are  `"circle"`
+        (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,  or
         `"triangle-down"`, or else a custom SVG path string.
     size : ChannelDefWithLegend
         Size of the mark.  - For `point`, `square` and `circle`  – the symbol size, or pixel
-         area of the mark.  - For `bar` and `tick` – the bar and tick's size.  - For `text` 
+         area of the mark.  - For `bar` and `tick` – the bar and tick's size.  - For `text`
         – the text's font size.  - Size is currently unsupported for `line` and `area`.
     text : FieldDef
         Text of the `text` mark.
     x : PositionChannelDef
-        X coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`  
+        X coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`
         (or to width and height for `bar` and `area` marks).
     x2 : FieldDef
         X2 coordinates for ranged `bar`, `rule`, `area`
     y : PositionChannelDef
-        Y coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`  
+        Y coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`
         (or to width and height for `bar` and `area` marks).
     y2 : FieldDef
         Y2 coordinates for ranged `bar`, `rule`, `area`
@@ -1645,9 +1645,9 @@ class UnitEncoding(VegaLiteSchema):
 
 class LayerSpec(VegaLiteSchema):
     """LayerSpec schema wrapper
-    
+
     Mapping(required=[layers])
-    
+
     Attributes
     ----------
     layers : List(UnitSpec)
@@ -1657,16 +1657,16 @@ class LayerSpec(VegaLiteSchema):
     data : Data
         An object describing the data source
     description : string
-        An optional description of this mark for commenting purpose.  This property has no 
+        An optional description of this mark for commenting purpose.  This property has no
         effect on the output visualization.
     height : float
-    
+
     name : string
         Name of the visualization for later reference.
     transform : Transform
         An object describing filter and new field calculation.
     width : float
-    
+
     """
     _schema = {'$ref': '#/definitions/LayerSpec'}
     _rootschema = Root._schema
@@ -1676,4 +1676,3 @@ class LayerSpec(VegaLiteSchema):
         super(LayerSpec, self).__init__(layers=layers, config=config, data=data,
                                         description=description, height=height, name=name,
                                         transform=transform, width=width, **kwds)
-

--- a/altair/vegalite/v2/schema/channels.py
+++ b/altair/vegalite/v2/schema/channels.py
@@ -12,7 +12,7 @@ from altair.utils import parse_shorthand
 
 class Color(core.MarkPropFieldDefWithCondition):
     """Color schema wrapper
-    
+
     Mapping(required=[shorthand])
     A FieldDef with Condition<ValueDef>
     {
@@ -20,61 +20,61 @@ class Color(core.MarkPropFieldDefWithCondition):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding 
-        channel will be removed.  __Default value:__ If undefined, default [legend 
+        An object defining properties of the legend. If `null`, the legend for the encoding
+        channel will be removed.  __Default value:__ If undefined, default [legend
         properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -122,17 +122,17 @@ class Color(core.MarkPropFieldDefWithCondition):
 
 class ColorValue(core.MarkPropValueDefWithCondition):
     """ColorValue schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
-    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef, 
+    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef,
     List(ConditionalValueDef))
         A field definition or one or more value definition(s) with a selection predicate.
     value : anyOf(float, string, boolean)
@@ -161,29 +161,29 @@ class ColorValue(core.MarkPropValueDefWithCondition):
 
 class Column(core.FacetFieldDef):
     """Column schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     header : Header
@@ -191,14 +191,14 @@ class Column(core.FacetFieldDef):
     sort : SortOrder
         Sort order for a facet field. This can be `"ascending"`, `"descending"`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -244,41 +244,41 @@ class Column(core.FacetFieldDef):
 
 class Detail(core.FieldDef):
     """Detail schema wrapper
-    
+
     Mapping(required=[shorthand])
     Definition object for a data field, its type and transformation of an encoding channel.
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -324,7 +324,7 @@ class Detail(core.FieldDef):
 
 class Fill(core.MarkPropFieldDefWithCondition):
     """Fill schema wrapper
-    
+
     Mapping(required=[shorthand])
     A FieldDef with Condition<ValueDef>
     {
@@ -332,61 +332,61 @@ class Fill(core.MarkPropFieldDefWithCondition):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding 
-        channel will be removed.  __Default value:__ If undefined, default [legend 
+        An object defining properties of the legend. If `null`, the legend for the encoding
+        channel will be removed.  __Default value:__ If undefined, default [legend
         properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -434,17 +434,17 @@ class Fill(core.MarkPropFieldDefWithCondition):
 
 class FillValue(core.MarkPropValueDefWithCondition):
     """FillValue schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
-    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef, 
+    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef,
     List(ConditionalValueDef))
         A field definition or one or more value definition(s) with a selection predicate.
     value : anyOf(float, string, boolean)
@@ -473,7 +473,7 @@ class FillValue(core.MarkPropValueDefWithCondition):
 
 class Href(core.FieldDefWithCondition):
     """Href schema wrapper
-    
+
     Mapping(required=[shorthand])
     A FieldDef with Condition<ValueDef>
     {
@@ -481,43 +481,43 @@ class Href(core.FieldDefWithCondition):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -564,14 +564,14 @@ class Href(core.FieldDefWithCondition):
 
 class HrefValue(core.ValueDefWithCondition):
     """HrefValue schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
     condition : anyOf(ConditionalFieldDef, ConditionalValueDef, List(ConditionalValueDef))
@@ -602,41 +602,41 @@ class HrefValue(core.ValueDefWithCondition):
 
 class Key(core.FieldDef):
     """Key schema wrapper
-    
+
     Mapping(required=[shorthand])
     Definition object for a data field, its type and transformation of an encoding channel.
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -682,41 +682,41 @@ class Key(core.FieldDef):
 
 class Latitude(core.FieldDef):
     """Latitude schema wrapper
-    
+
     Mapping(required=[shorthand])
     Definition object for a data field, its type and transformation of an encoding channel.
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -762,41 +762,41 @@ class Latitude(core.FieldDef):
 
 class Latitude2(core.FieldDef):
     """Latitude2 schema wrapper
-    
+
     Mapping(required=[shorthand])
     Definition object for a data field, its type and transformation of an encoding channel.
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -842,41 +842,41 @@ class Latitude2(core.FieldDef):
 
 class Longitude(core.FieldDef):
     """Longitude schema wrapper
-    
+
     Mapping(required=[shorthand])
     Definition object for a data field, its type and transformation of an encoding channel.
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -922,41 +922,41 @@ class Longitude(core.FieldDef):
 
 class Longitude2(core.FieldDef):
     """Longitude2 schema wrapper
-    
+
     Mapping(required=[shorthand])
     Definition object for a data field, its type and transformation of an encoding channel.
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -1002,7 +1002,7 @@ class Longitude2(core.FieldDef):
 
 class Opacity(core.MarkPropFieldDefWithCondition):
     """Opacity schema wrapper
-    
+
     Mapping(required=[shorthand])
     A FieldDef with Condition<ValueDef>
     {
@@ -1010,61 +1010,61 @@ class Opacity(core.MarkPropFieldDefWithCondition):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding 
-        channel will be removed.  __Default value:__ If undefined, default [legend 
+        An object defining properties of the legend. If `null`, the legend for the encoding
+        channel will be removed.  __Default value:__ If undefined, default [legend
         properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -1112,17 +1112,17 @@ class Opacity(core.MarkPropFieldDefWithCondition):
 
 class OpacityValue(core.MarkPropValueDefWithCondition):
     """OpacityValue schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
-    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef, 
+    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef,
     List(ConditionalValueDef))
         A field definition or one or more value definition(s) with a selection predicate.
     value : anyOf(float, string, boolean)
@@ -1151,42 +1151,42 @@ class OpacityValue(core.MarkPropValueDefWithCondition):
 
 class Order(core.OrderFieldDef):
     """Order schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     sort : SortOrder
         The sort order. One of `"ascending"` (default) or `"descending"`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -1232,29 +1232,29 @@ class Order(core.OrderFieldDef):
 
 class Row(core.FacetFieldDef):
     """Row schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     header : Header
@@ -1262,14 +1262,14 @@ class Row(core.FacetFieldDef):
     sort : SortOrder
         Sort order for a facet field. This can be `"ascending"`, `"descending"`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -1315,7 +1315,7 @@ class Row(core.FacetFieldDef):
 
 class Shape(core.MarkPropFieldDefWithCondition):
     """Shape schema wrapper
-    
+
     Mapping(required=[shorthand])
     A FieldDef with Condition<ValueDef>
     {
@@ -1323,61 +1323,61 @@ class Shape(core.MarkPropFieldDefWithCondition):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding 
-        channel will be removed.  __Default value:__ If undefined, default [legend 
+        An object defining properties of the legend. If `null`, the legend for the encoding
+        channel will be removed.  __Default value:__ If undefined, default [legend
         properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -1425,17 +1425,17 @@ class Shape(core.MarkPropFieldDefWithCondition):
 
 class ShapeValue(core.MarkPropValueDefWithCondition):
     """ShapeValue schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
-    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef, 
+    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef,
     List(ConditionalValueDef))
         A field definition or one or more value definition(s) with a selection predicate.
     value : anyOf(float, string, boolean)
@@ -1464,7 +1464,7 @@ class ShapeValue(core.MarkPropValueDefWithCondition):
 
 class Size(core.MarkPropFieldDefWithCondition):
     """Size schema wrapper
-    
+
     Mapping(required=[shorthand])
     A FieldDef with Condition<ValueDef>
     {
@@ -1472,61 +1472,61 @@ class Size(core.MarkPropFieldDefWithCondition):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding 
-        channel will be removed.  __Default value:__ If undefined, default [legend 
+        An object defining properties of the legend. If `null`, the legend for the encoding
+        channel will be removed.  __Default value:__ If undefined, default [legend
         properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -1574,17 +1574,17 @@ class Size(core.MarkPropFieldDefWithCondition):
 
 class SizeValue(core.MarkPropValueDefWithCondition):
     """SizeValue schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
-    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef, 
+    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef,
     List(ConditionalValueDef))
         A field definition or one or more value definition(s) with a selection predicate.
     value : anyOf(float, string, boolean)
@@ -1613,7 +1613,7 @@ class SizeValue(core.MarkPropValueDefWithCondition):
 
 class Stroke(core.MarkPropFieldDefWithCondition):
     """Stroke schema wrapper
-    
+
     Mapping(required=[shorthand])
     A FieldDef with Condition<ValueDef>
     {
@@ -1621,61 +1621,61 @@ class Stroke(core.MarkPropFieldDefWithCondition):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding 
-        channel will be removed.  __Default value:__ If undefined, default [legend 
+        An object defining properties of the legend. If `null`, the legend for the encoding
+        channel will be removed.  __Default value:__ If undefined, default [legend
         properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -1723,17 +1723,17 @@ class Stroke(core.MarkPropFieldDefWithCondition):
 
 class StrokeValue(core.MarkPropValueDefWithCondition):
     """StrokeValue schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
-    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef, 
+    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef,
     List(ConditionalValueDef))
         A field definition or one or more value definition(s) with a selection predicate.
     value : anyOf(float, string, boolean)
@@ -1762,7 +1762,7 @@ class StrokeValue(core.MarkPropValueDefWithCondition):
 
 class Text(core.TextFieldDefWithCondition):
     """Text schema wrapper
-    
+
     Mapping(required=[shorthand])
     A FieldDef with Condition<ValueDef>
     {
@@ -1770,46 +1770,46 @@ class Text(core.TextFieldDefWithCondition):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     format : string
-        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a 
+        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a
         text field. If not defined, this will be determined automatically.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -1856,14 +1856,14 @@ class Text(core.TextFieldDefWithCondition):
 
 class TextValue(core.TextValueDefWithCondition):
     """TextValue schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
     condition : anyOf(ConditionalTextFieldDef, ConditionalValueDef, List(ConditionalValueDef))
@@ -1894,7 +1894,7 @@ class TextValue(core.TextValueDefWithCondition):
 
 class Tooltip(core.TextFieldDefWithCondition):
     """Tooltip schema wrapper
-    
+
     Mapping(required=[shorthand])
     A FieldDef with Condition<ValueDef>
     {
@@ -1902,46 +1902,46 @@ class Tooltip(core.TextFieldDefWithCondition):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     format : string
-        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a 
+        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a
         text field. If not defined, this will be determined automatically.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -1988,14 +1988,14 @@ class Tooltip(core.TextFieldDefWithCondition):
 
 class TooltipValue(core.TextValueDefWithCondition):
     """TooltipValue schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
     condition : anyOf(ConditionalTextFieldDef, ConditionalValueDef, List(ConditionalValueDef))
@@ -2026,77 +2026,77 @@ class TooltipValue(core.TextValueDefWithCondition):
 
 class X(core.PositionFieldDef):
     """X schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     axis : anyOf(Axis, None)
-        An object defining properties of axis's gridlines, ticks and labels. If `null`, the 
-        axis for the encoding channel will be removed.  __Default value:__ If undefined, 
-        default [axis properties](https://vega.github.io/vega-lite/docs/axis.html) are 
+        An object defining properties of axis's gridlines, ticks and labels. If `null`, the
+        axis for the encoding channel will be removed.  __Default value:__ If undefined,
+        default [axis properties](https://vega.github.io/vega-lite/docs/axis.html) are
         applied.
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     stack : anyOf(StackOffset, None)
-        Type of stacking offset if the field should be stacked. `stack` is only applicable 
+        Type of stacking offset if the field should be stacked. `stack` is only applicable
         for `x` and `y` channels with continuous domains. For example, `stack` of `y` can be
-         used to customize stacking for a vertical bar chart.  `stack` can be one of the 
-        following values: - `"zero"`: stacking with baseline offset at zero value of the 
-        scale (for creating typical stacked 
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and 
-        [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart). - 
-        `"normalize"` - stacking with normalized domain (for creating [normalized stacked 
-        bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). 
-        <br/> -`"center"` - stacking with center baseline (for 
-        [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)). - 
-        `null` - No-stacking. This will produce layered 
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area 
+         used to customize stacking for a vertical bar chart.  `stack` can be one of the
+        following values: - `"zero"`: stacking with baseline offset at zero value of the
+        scale (for creating typical stacked
+        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and
+        [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart). -
+        `"normalize"` - stacking with normalized domain (for creating [normalized stacked
+        bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized).
+        <br/> -`"center"` - stacking with center baseline (for
+        [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)). -
+        `null` - No-stacking. This will produce layered
+        [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area
         chart.  __Default value:__ `zero` for plots with all of the following conditions are
          true: (1) the mark is `bar` or `area`; (2) the stacked measure channel (x or y) has
          a linear scale; (3) At least one of non-position channels mapped to an unaggregated
          field that is different from x and y.  Otherwise, `null` by default.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -2144,14 +2144,14 @@ class X(core.PositionFieldDef):
 
 class XValue(core.ValueDef):
     """XValue schema wrapper
-    
+
     Mapping(required=[value])
     Definition object for a constant value of an encoding channel.
-    
+
     Attributes
     ----------
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values 
+        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
         between `0` to `1` for opacity).
     """
     _class_is_valid_at_instantiation = False
@@ -2177,41 +2177,41 @@ class XValue(core.ValueDef):
 
 class X2(core.FieldDef):
     """X2 schema wrapper
-    
+
     Mapping(required=[shorthand])
     Definition object for a data field, its type and transformation of an encoding channel.
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -2257,14 +2257,14 @@ class X2(core.FieldDef):
 
 class X2Value(core.ValueDef):
     """X2Value schema wrapper
-    
+
     Mapping(required=[value])
     Definition object for a constant value of an encoding channel.
-    
+
     Attributes
     ----------
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values 
+        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
         between `0` to `1` for opacity).
     """
     _class_is_valid_at_instantiation = False
@@ -2290,77 +2290,77 @@ class X2Value(core.ValueDef):
 
 class Y(core.PositionFieldDef):
     """Y schema wrapper
-    
+
     Mapping(required=[shorthand])
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     axis : anyOf(Axis, None)
-        An object defining properties of axis's gridlines, ticks and labels. If `null`, the 
-        axis for the encoding channel will be removed.  __Default value:__ If undefined, 
-        default [axis properties](https://vega.github.io/vega-lite/docs/axis.html) are 
+        An object defining properties of axis's gridlines, ticks and labels. If `null`, the
+        axis for the encoding channel will be removed.  __Default value:__ If undefined,
+        default [axis properties](https://vega.github.io/vega-lite/docs/axis.html) are
         applied.
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     stack : anyOf(StackOffset, None)
-        Type of stacking offset if the field should be stacked. `stack` is only applicable 
+        Type of stacking offset if the field should be stacked. `stack` is only applicable
         for `x` and `y` channels with continuous domains. For example, `stack` of `y` can be
-         used to customize stacking for a vertical bar chart.  `stack` can be one of the 
-        following values: - `"zero"`: stacking with baseline offset at zero value of the 
-        scale (for creating typical stacked 
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and 
-        [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart). - 
-        `"normalize"` - stacking with normalized domain (for creating [normalized stacked 
-        bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). 
-        <br/> -`"center"` - stacking with center baseline (for 
-        [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)). - 
-        `null` - No-stacking. This will produce layered 
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area 
+         used to customize stacking for a vertical bar chart.  `stack` can be one of the
+        following values: - `"zero"`: stacking with baseline offset at zero value of the
+        scale (for creating typical stacked
+        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and
+        [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart). -
+        `"normalize"` - stacking with normalized domain (for creating [normalized stacked
+        bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized).
+        <br/> -`"center"` - stacking with center baseline (for
+        [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)). -
+        `null` - No-stacking. This will produce layered
+        [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area
         chart.  __Default value:__ `zero` for plots with all of the following conditions are
          true: (1) the mark is `bar` or `area`; (2) the stacked measure channel (x or y) has
          a linear scale; (3) At least one of non-position channels mapped to an unaggregated
          field that is different from x and y.  Otherwise, `null` by default.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -2408,14 +2408,14 @@ class Y(core.PositionFieldDef):
 
 class YValue(core.ValueDef):
     """YValue schema wrapper
-    
+
     Mapping(required=[value])
     Definition object for a constant value of an encoding channel.
-    
+
     Attributes
     ----------
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values 
+        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
         between `0` to `1` for opacity).
     """
     _class_is_valid_at_instantiation = False
@@ -2441,41 +2441,41 @@ class YValue(core.ValueDef):
 
 class Y2(core.FieldDef):
     """Y2 schema wrapper
-    
+
     Mapping(required=[shorthand])
     Definition object for a data field, its type and transformation of an encoding channel.
-    
+
     Attributes
     ----------
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     """
     _class_is_valid_at_instantiation = False
@@ -2521,14 +2521,14 @@ class Y2(core.FieldDef):
 
 class Y2Value(core.ValueDef):
     """Y2Value schema wrapper
-    
+
     Mapping(required=[value])
     Definition object for a constant value of an encoding channel.
-    
+
     Attributes
     ----------
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values 
+        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
         between `0` to `1` for opacity).
     """
     _class_is_valid_at_instantiation = False

--- a/altair/vegalite/v2/schema/core.py
+++ b/altair/vegalite/v2/schema/core.py
@@ -21,8 +21,8 @@ class VegaLiteSchema(SchemaBase):
 
 class Root(VegaLiteSchema):
     """Root schema wrapper
-    
-    anyOf(TopLevelFacetedUnitSpec, TopLevelFacetSpec, TopLevelLayerSpec, TopLevelRepeatSpec, 
+
+    anyOf(TopLevelFacetedUnitSpec, TopLevelFacetSpec, TopLevelLayerSpec, TopLevelRepeatSpec,
     TopLevelVConcatSpec, TopLevelHConcatSpec)
     """
     _schema = load_schema()
@@ -34,9 +34,9 @@ class Root(VegaLiteSchema):
 
 class Aggregate(VegaLiteSchema):
     """Aggregate schema wrapper
-    
-    enum('argmax', 'argmin', 'average', 'count', 'distinct', 'max', 'mean', 'median', 'min', 
-    'missing', 'q1', 'q3', 'ci0', 'ci1', 'stderr', 'stdev', 'stdevp', 'sum', 'valid', 'values', 
+
+    enum('argmax', 'argmin', 'average', 'count', 'distinct', 'max', 'mean', 'median', 'min',
+    'missing', 'q1', 'q3', 'ci0', 'ci1', 'stderr', 'stdev', 'stdevp', 'sum', 'valid', 'values',
     'variance', 'variancep')
     """
     _schema = {'$ref': '#/definitions/Aggregate'}
@@ -48,9 +48,9 @@ class Aggregate(VegaLiteSchema):
 
 class AggregateOp(VegaLiteSchema):
     """AggregateOp schema wrapper
-    
-    enum('argmax', 'argmin', 'average', 'count', 'distinct', 'max', 'mean', 'median', 'min', 
-    'missing', 'q1', 'q3', 'ci0', 'ci1', 'stderr', 'stdev', 'stdevp', 'sum', 'valid', 'values', 
+
+    enum('argmax', 'argmin', 'average', 'count', 'distinct', 'max', 'mean', 'median', 'min',
+    'missing', 'q1', 'q3', 'ci0', 'ci1', 'stderr', 'stdev', 'stdevp', 'sum', 'valid', 'values',
     'variance', 'variancep')
     """
     _schema = {'$ref': '#/definitions/AggregateOp'}
@@ -62,15 +62,15 @@ class AggregateOp(VegaLiteSchema):
 
 class AggregateTransform(VegaLiteSchema):
     """AggregateTransform schema wrapper
-    
+
     Mapping(required=[aggregate])
-    
+
     Attributes
     ----------
     aggregate : List(AggregatedFieldDef)
         Array of objects that define fields to aggregate.
     groupby : List(string)
-        The data fields to group by. If not specified, a single group containing all data 
+        The data fields to group by. If not specified, a single group containing all data
         objects will be used.
     """
     _schema = {'$ref': '#/definitions/AggregateTransform'}
@@ -82,19 +82,19 @@ class AggregateTransform(VegaLiteSchema):
 
 class AggregatedFieldDef(VegaLiteSchema):
     """AggregatedFieldDef schema wrapper
-    
+
     Mapping(required=[op, field, as])
-    
+
     Attributes
     ----------
     field : string
         The data field for which to compute aggregate function.
     op : AggregateOp
-        The aggregation operations to apply to the fields, such as sum, average or count. 
-        See the [full list of supported aggregation 
-        operations](https://vega.github.io/vega-lite/docs/aggregate.html#ops) for more 
+        The aggregation operations to apply to the fields, such as sum, average or count.
+        See the [full list of supported aggregation
+        operations](https://vega.github.io/vega-lite/docs/aggregate.html#ops) for more
         information.
-    
+
     Dict-Only Attributes
     --------------------
     'as' : string
@@ -109,7 +109,7 @@ class AggregatedFieldDef(VegaLiteSchema):
 
 class Anchor(VegaLiteSchema):
     """Anchor schema wrapper
-    
+
     enum('start', 'middle', 'end')
     """
     _schema = {'$ref': '#/definitions/Anchor'}
@@ -121,7 +121,7 @@ class Anchor(VegaLiteSchema):
 
 class AnyMark(VegaLiteSchema):
     """AnyMark schema wrapper
-    
+
     anyOf(Mark, MarkDef)
     """
     _schema = {'$ref': '#/definitions/AnyMark'}
@@ -133,24 +133,24 @@ class AnyMark(VegaLiteSchema):
 
 class AutoSizeParams(VegaLiteSchema):
     """AutoSizeParams schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     contains : enum('content', 'padding')
-        Determines how size calculation should be performed, one of `"content"` or 
-        `"padding"`. The default setting (`"content"`) interprets the width and height 
-        settings as the data rectangle (plotting) dimensions, to which padding is then 
-        added. In contrast, the `"padding"` setting includes the padding within the view 
-        size calculations, such that the width and height settings indicate the **total** 
+        Determines how size calculation should be performed, one of `"content"` or
+        `"padding"`. The default setting (`"content"`) interprets the width and height
+        settings as the data rectangle (plotting) dimensions, to which padding is then
+        added. In contrast, the `"padding"` setting includes the padding within the view
+        size calculations, such that the width and height settings indicate the **total**
         intended size of the view.  __Default value__: `"content"`
     resize : boolean
-        A boolean flag indicating if autosize layout should be re-calculated on every view 
+        A boolean flag indicating if autosize layout should be re-calculated on every view
         update.  __Default value__: `false`
     type : AutosizeType
-        The sizing format type. One of `"pad"`, `"fit"` or `"none"`. See the [autosize 
-        type](https://vega.github.io/vega-lite/docs/size.html#autosize) documentation for 
+        The sizing format type. One of `"pad"`, `"fit"` or `"none"`. See the [autosize
+        type](https://vega.github.io/vega-lite/docs/size.html#autosize) documentation for
         descriptions of each.  __Default value__: `"pad"`
     """
     _schema = {'$ref': '#/definitions/AutoSizeParams'}
@@ -162,7 +162,7 @@ class AutoSizeParams(VegaLiteSchema):
 
 class AutosizeType(VegaLiteSchema):
     """AutosizeType schema wrapper
-    
+
     enum('pad', 'fit', 'none')
     """
     _schema = {'$ref': '#/definitions/AutosizeType'}
@@ -174,107 +174,107 @@ class AutosizeType(VegaLiteSchema):
 
 class Axis(VegaLiteSchema):
     """Axis schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     domain : boolean
-        A boolean flag indicating if the domain (the axis baseline) should be included as 
+        A boolean flag indicating if the domain (the axis baseline) should be included as
         part of the axis.  __Default value:__ `true`
     format : string
-        The formatting pattern for labels. This is D3's [number format 
-        pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and 
-        D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for 
-        time field.  See the [format documentation](format.html) for more information.  
-        __Default value:__  derived from [numberFormat](config.html#format) config for 
-        quantitative fields and from [timeFormat](config.html#format) config for temporal 
+        The formatting pattern for labels. This is D3's [number format
+        pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and
+        D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for
+        time field.  See the [format documentation](format.html) for more information.
+        __Default value:__  derived from [numberFormat](config.html#format) config for
+        quantitative fields and from [timeFormat](config.html#format) config for temporal
         fields.
     grid : boolean
-        A boolean flag indicating if grid lines should be included as part of the axis  
-        __Default value:__ `true` for [continuous scales](scale.html#continuous) that are 
+        A boolean flag indicating if grid lines should be included as part of the axis
+        __Default value:__ `true` for [continuous scales](scale.html#continuous) that are
         not binned; otherwise, `false`.
     labelAngle : float
-        The rotation angle of the axis labels.  __Default value:__ `-90` for nominal and 
+        The rotation angle of the axis labels.  __Default value:__ `-90` for nominal and
         ordinal fields; `0` otherwise.
     labelBound : anyOf(boolean, float)
-        Indicates if labels should be hidden if they exceed the axis range. If `false `(the 
-        default) no bounds overlap analysis is performed. If `true`, labels will be hidden 
+        Indicates if labels should be hidden if they exceed the axis range. If `false `(the
+        default) no bounds overlap analysis is performed. If `true`, labels will be hidden
         if they exceed the axis range by more than 1 pixel. If this property is a number, it
          specifies the pixel tolerance: the maximum amount by which a label bounding box may
          exceed the axis range.  __Default value:__ `false`.
     labelFlush : anyOf(boolean, float)
-        Indicates if the first and last axis labels should be aligned flush with the scale 
-        range. Flush alignment for a horizontal axis will left-align the first label and 
-        right-align the last label. For vertical axes, bottom and top text baselines are 
-        applied instead. If this property is a number, it also indicates the number of 
-        pixels by which to offset the first and last labels; for example, a value of 2 will 
-        flush-align the first and last labels and also push them 2 pixels outward from the 
-        center of the axis. The additional adjustment can sometimes help the labels better 
+        Indicates if the first and last axis labels should be aligned flush with the scale
+        range. Flush alignment for a horizontal axis will left-align the first label and
+        right-align the last label. For vertical axes, bottom and top text baselines are
+        applied instead. If this property is a number, it also indicates the number of
+        pixels by which to offset the first and last labels; for example, a value of 2 will
+        flush-align the first and last labels and also push them 2 pixels outward from the
+        center of the axis. The additional adjustment can sometimes help the labels better
         visually group with corresponding axis ticks.  __Default value:__ `true` for axis of
          a continuous x-scale. Otherwise, `false`.
     labelOverlap : anyOf(boolean, enum('parity'), enum('greedy'))
-        The strategy to use for resolving overlap of axis labels. If `false` (the default), 
-        no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of 
-        removing every other label is used (this works well for standard linear axes). If 
-        set to `"greedy"`, a linear scan of the labels is performed, removing any labels 
-        that overlaps with the last visible label (this often works better for log-scaled 
-        axes).  __Default value:__ `true` for non-nominal fields with non-log scales; 
+        The strategy to use for resolving overlap of axis labels. If `false` (the default),
+        no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of
+        removing every other label is used (this works well for standard linear axes). If
+        set to `"greedy"`, a linear scan of the labels is performed, removing any labels
+        that overlaps with the last visible label (this often works better for log-scaled
+        axes).  __Default value:__ `true` for non-nominal fields with non-log scales;
         `"greedy"` for log scales; otherwise `false`.
     labelPadding : float
         The padding, in pixels, between axis and text labels.
     labels : boolean
-        A boolean flag indicating if labels should be included as part of the axis.  
+        A boolean flag indicating if labels should be included as part of the axis.
         __Default value:__  `true`.
     maxExtent : float
-        The maximum extent in pixels that axis ticks and labels should use. This determines 
+        The maximum extent in pixels that axis ticks and labels should use. This determines
         a maximum offset value for axis titles.  __Default value:__ `undefined`.
     minExtent : float
-        The minimum extent in pixels that axis ticks and labels should use. This determines 
-        a minimum offset value for axis titles.  __Default value:__ `30` for y-axis; 
+        The minimum extent in pixels that axis ticks and labels should use. This determines
+        a minimum offset value for axis titles.  __Default value:__ `30` for y-axis;
         `undefined` for x-axis.
     offset : float
-        The offset, in pixels, by which to displace the axis from the edge of the enclosing 
-        group or data rectangle.  __Default value:__ derived from the [axis 
+        The offset, in pixels, by which to displace the axis from the edge of the enclosing
+        group or data rectangle.  __Default value:__ derived from the [axis
         config](config.html#facet-scale-config)'s `offset` (`0` by default)
     orient : AxisOrient
-        The orientation of the axis. One of `"top"`, `"bottom"`, `"left"` or `"right"`. The 
+        The orientation of the axis. One of `"top"`, `"bottom"`, `"left"` or `"right"`. The
         orientation can be used to further specialize the axis type (e.g., a y axis oriented
-         for the right edge of the chart).  __Default value:__ `"bottom"` for x-axes and 
+         for the right edge of the chart).  __Default value:__ `"bottom"` for x-axes and
         `"left"` for y-axes.
     position : float
-        The anchor position of the axis in pixels. For x-axis with top or bottom 
-        orientation, this sets the axis group x coordinate. For y-axis with left or right 
+        The anchor position of the axis in pixels. For x-axis with top or bottom
+        orientation, this sets the axis group x coordinate. For y-axis with left or right
         orientation, this sets the axis group y coordinate.  __Default value__: `0`
     tickCount : float
-        A desired number of ticks, for axes visualizing quantitative scales. The resulting 
-        number may be different so that values are "nice" (multiples of 2, 5, 10) and lie 
+        A desired number of ticks, for axes visualizing quantitative scales. The resulting
+        number may be different so that values are "nice" (multiples of 2, 5, 10) and lie
         within the underlying scale's range.
     tickSize : float
         The size in pixels of axis ticks.
     ticks : boolean
         Boolean value that determines whether the axis should include ticks.
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__  
-        derived from the field's name and transformation function (`aggregate`, `bin` and 
+        A title for the field. If `null`, the title will be removed.  __Default value:__
+        derived from the field's name and transformation function (`aggregate`, `bin` and
         `timeUnit`).  If the field has an aggregate function, the function is displayed as a
-         part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time 
-        unit applied, the applied function will be denoted in parentheses (e.g., `"Profit 
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the 
+         part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
+        unit applied, the applied function will be denoted in parentheses (e.g., `"Profit
+        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
         field name.  __Note__: You can customize the default field title format by providing
-         the [`fieldTitle` property in the [config](config.html) or [`fieldTitle` function 
+         the [`fieldTitle` property in the [config](config.html) or [`fieldTitle` function
         via the `compile` function's options](compile.html#field-title).
     titleMaxLength : float
-        Max length for axis title if the title is automatically generated from the field's 
+        Max length for axis title if the title is automatically generated from the field's
         description.
     titlePadding : float
         The padding, in pixels, between title and axis.
     values : anyOf(List(float), List(DateTime))
         Explicitly set the visible axis tick values.
     zindex : float
-        A non-positive integer indicating z-index of the axis. If zindex is 0, axes should 
-        be drawn behind all chart elements. To put them in front, use `"zindex = 1"`.  
-        __Default value:__ `1` (in front of the marks) for actual axis and `0` (behind the 
+        A non-positive integer indicating z-index of the axis. If zindex is 0, axes should
+        be drawn behind all chart elements. To put them in front, use `"zindex = 1"`.
+        __Default value:__ `1` (in front of the marks) for actual axis and `0` (behind the
         marks) for grids.
     """
     _schema = {'$ref': '#/definitions/Axis'}
@@ -298,54 +298,54 @@ class Axis(VegaLiteSchema):
 
 class AxisConfig(VegaLiteSchema):
     """AxisConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     bandPosition : float
-        An interpolation fraction indicating where, for `band` scales, axis ticks should be 
-        positioned. A value of `0` places ticks at the left edge of their bands. A value of 
+        An interpolation fraction indicating where, for `band` scales, axis ticks should be
+        positioned. A value of `0` places ticks at the left edge of their bands. A value of
         `0.5` places ticks in the middle of their bands.
     domain : boolean
-        A boolean flag indicating if the domain (the axis baseline) should be included as 
+        A boolean flag indicating if the domain (the axis baseline) should be included as
         part of the axis.  __Default value:__ `true`
     domainColor : string
         Color of axis domain line.  __Default value:__  (none, using Vega default).
     domainWidth : float
         Stroke width of axis domain line  __Default value:__  (none, using Vega default).
     grid : boolean
-        A boolean flag indicating if grid lines should be included as part of the axis  
-        __Default value:__ `true` for [continuous scales](scale.html#continuous) that are 
+        A boolean flag indicating if grid lines should be included as part of the axis
+        __Default value:__ `true` for [continuous scales](scale.html#continuous) that are
         not binned; otherwise, `false`.
     gridColor : string
         Color of gridlines.
     gridDash : List(float)
         The offset (in pixels) into which to begin drawing with the grid dash array.
     gridOpacity : float
-        The stroke opacity of grid (value between [0,1])  __Default value:__ (`1` by 
+        The stroke opacity of grid (value between [0,1])  __Default value:__ (`1` by
         default)
     gridWidth : float
         The grid width, in pixels.
     labelAngle : float
-        The rotation angle of the axis labels.  __Default value:__ `-90` for nominal and 
+        The rotation angle of the axis labels.  __Default value:__ `-90` for nominal and
         ordinal fields; `0` otherwise.
     labelBound : anyOf(boolean, float)
-        Indicates if labels should be hidden if they exceed the axis range. If `false `(the 
-        default) no bounds overlap analysis is performed. If `true`, labels will be hidden 
+        Indicates if labels should be hidden if they exceed the axis range. If `false `(the
+        default) no bounds overlap analysis is performed. If `true`, labels will be hidden
         if they exceed the axis range by more than 1 pixel. If this property is a number, it
          specifies the pixel tolerance: the maximum amount by which a label bounding box may
          exceed the axis range.  __Default value:__ `false`.
     labelColor : string
         The color of the tick label, can be in hex color code or regular color name.
     labelFlush : anyOf(boolean, float)
-        Indicates if the first and last axis labels should be aligned flush with the scale 
-        range. Flush alignment for a horizontal axis will left-align the first label and 
-        right-align the last label. For vertical axes, bottom and top text baselines are 
-        applied instead. If this property is a number, it also indicates the number of 
-        pixels by which to offset the first and last labels; for example, a value of 2 will 
-        flush-align the first and last labels and also push them 2 pixels outward from the 
-        center of the axis. The additional adjustment can sometimes help the labels better 
+        Indicates if the first and last axis labels should be aligned flush with the scale
+        range. Flush alignment for a horizontal axis will left-align the first label and
+        right-align the last label. For vertical axes, bottom and top text baselines are
+        applied instead. If this property is a number, it also indicates the number of
+        pixels by which to offset the first and last labels; for example, a value of 2 will
+        flush-align the first and last labels and also push them 2 pixels outward from the
+        center of the axis. The additional adjustment can sometimes help the labels better
         visually group with corresponding axis ticks.  __Default value:__ `true` for axis of
          a continuous x-scale. Otherwise, `false`.
     labelFont : string
@@ -355,32 +355,32 @@ class AxisConfig(VegaLiteSchema):
     labelLimit : float
         Maximum allowed pixel width of axis tick labels.
     labelOverlap : anyOf(boolean, enum('parity'), enum('greedy'))
-        The strategy to use for resolving overlap of axis labels. If `false` (the default), 
-        no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of 
-        removing every other label is used (this works well for standard linear axes). If 
-        set to `"greedy"`, a linear scan of the labels is performed, removing any labels 
-        that overlaps with the last visible label (this often works better for log-scaled 
-        axes).  __Default value:__ `true` for non-nominal fields with non-log scales; 
+        The strategy to use for resolving overlap of axis labels. If `false` (the default),
+        no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of
+        removing every other label is used (this works well for standard linear axes). If
+        set to `"greedy"`, a linear scan of the labels is performed, removing any labels
+        that overlaps with the last visible label (this often works better for log-scaled
+        axes).  __Default value:__ `true` for non-nominal fields with non-log scales;
         `"greedy"` for log scales; otherwise `false`.
     labelPadding : float
         The padding, in pixels, between axis and text labels.
     labels : boolean
-        A boolean flag indicating if labels should be included as part of the axis.  
+        A boolean flag indicating if labels should be included as part of the axis.
         __Default value:__  `true`.
     maxExtent : float
-        The maximum extent in pixels that axis ticks and labels should use. This determines 
+        The maximum extent in pixels that axis ticks and labels should use. This determines
         a maximum offset value for axis titles.  __Default value:__ `undefined`.
     minExtent : float
-        The minimum extent in pixels that axis ticks and labels should use. This determines 
-        a minimum offset value for axis titles.  __Default value:__ `30` for y-axis; 
+        The minimum extent in pixels that axis ticks and labels should use. This determines
+        a minimum offset value for axis titles.  __Default value:__ `30` for y-axis;
         `undefined` for x-axis.
     shortTimeLabels : boolean
-        Whether month names and weekday names should be abbreviated.  __Default value:__  
+        Whether month names and weekday names should be abbreviated.  __Default value:__
         `false`
     tickColor : string
         The color of the axis's tick.
     tickRound : boolean
-        Boolean flag indicating if pixel position values should be rounded to the nearest 
+        Boolean flag indicating if pixel position values should be rounded to the nearest
         integer.
     tickSize : float
         The size in pixels of axis ticks.
@@ -401,13 +401,13 @@ class AxisConfig(VegaLiteSchema):
     titleFontSize : float
         Font size of the title.
     titleFontWeight : FontWeight
-        Font weight of the title. This can be either a string (e.g `"bold"`, `"normal"`) or 
-        a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = 
+        Font weight of the title. This can be either a string (e.g `"bold"`, `"normal"`) or
+        a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` =
         `700`).
     titleLimit : float
         Maximum allowed pixel width of axis titles.
     titleMaxLength : float
-        Max length for axis title if the title is automatically generated from the field's 
+        Max length for axis title if the title is automatically generated from the field's
         description.
     titlePadding : float
         The padding, in pixels, between title and axis.
@@ -452,7 +452,7 @@ class AxisConfig(VegaLiteSchema):
 
 class AxisOrient(VegaLiteSchema):
     """AxisOrient schema wrapper
-    
+
     enum('top', 'right', 'left', 'bottom')
     """
     _schema = {'$ref': '#/definitions/AxisOrient'}
@@ -464,15 +464,15 @@ class AxisOrient(VegaLiteSchema):
 
 class AxisResolveMap(VegaLiteSchema):
     """AxisResolveMap schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     x : ResolveMode
-    
+
     y : ResolveMode
-    
+
     """
     _schema = {'$ref': '#/definitions/AxisResolveMap'}
     _rootschema = Root._schema
@@ -483,9 +483,9 @@ class AxisResolveMap(VegaLiteSchema):
 
 class BarConfig(VegaLiteSchema):
     """BarConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     align : HorizontalAlign
@@ -493,42 +493,42 @@ class BarConfig(VegaLiteSchema):
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.  
+        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
         __Default value:__ `"middle"`
     binSpacing : float
         Offset between bar for binned field.  Ideal value for this is either 0 (Preferred by
          statisticians) or 1 (Vega-Lite Default, D3 example style).  __Default value:__ `1`
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color` 
-        and will override `color`.  __Default value:__ <span style="color: 
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a 
+        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
+        and will override `color`.  __Default value:__ <span style="color:
+        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
         [style config](mark.html#style-config).
     continuousBandSize : float
         The default size of the bars on continuous scales.  __Default value:__ `5`
-    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress', 
-    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop', 
-    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize', 
-    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize', 
+    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
+    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
+    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
+    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor 
+        The mouse cursor used over the mark. Any valid [CSS cursor
         type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
     discreteBandSize : float
-        The size of the bars.  If unspecified, the default size is  `bandSize-1`, which 
+        The size of the bars.  If unspecified, the default size is  `bandSize-1`, which
         provides 1 pixel offset between bars.
     dx : float
-        The horizontal offset, in pixels, between the text label and its anchor point. The 
+        The horizontal offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     dy : float
-        The vertical offset, in pixels, between the text label and its anchor point. The 
+        The vertical offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     fill : string
-        Default Fill Color.  This has higher precedence than config.color  __Default 
+        Default Fill Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     fillOpacity : float
         The fill opacity (value between [0,1]).  __Default value:__ `1`
     filled : boolean
-        Whether the mark's color should be used as fill color instead of stroke color.  
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.  
+        Whether the mark's color should be used as fill color instead of stroke color.
+        __Default value:__ `true` for all marks except `point` and `false` for `point`.
         __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
          This property cannot be used in a [style config](mark.html#style-config).
     font : string
@@ -538,54 +538,54 @@ class BarConfig(VegaLiteSchema):
     fontStyle : FontStyle
         The font style (e.g., `"italic"`).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number 
+        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
         (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
-        The line interpolation method to use for line and area marks. One of the following: 
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`: 
-        close the linear segments to form a polygon. - `"step"`: alternate between 
-        horizontal and vertical segments, as in a step function. - `"step-before"`: 
-        alternate between vertical and horizontal segments, as in a step function. - 
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step 
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. - 
-        `"basis-open"`: an open B-spline; may not intersect the start or end. - 
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal 
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open 
-        Cardinal spline; may not intersect the start or end, but will intersect other 
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. - 
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten 
+        The line interpolation method to use for line and area marks. One of the following:
+        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
+        close the linear segments to form a polygon. - `"step"`: alternate between
+        horizontal and vertical segments, as in a step function. - `"step-before"`:
+        alternate between vertical and horizontal segments, as in a step function. -
+        `"step-after"`: alternate between horizontal and vertical segments, as in a step
+        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
+        `"basis-open"`: an open B-spline; may not intersect the start or end. -
+        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
+        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
+        Cardinal spline; may not intersect the start or end, but will intersect other
+        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
+        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
         the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
     limit : float
-        The maximum length of the text mark in pixels (default 0, indicating no limit). The 
+        The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for 
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered 
+        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
+        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
         `bar` charts and `1` otherwise.
     orient : Orient
-        The orientation of a non-stacked bar, tick, area, and line charts. The value is 
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines 
-        whether the size of the bar and tick should be applied to x or y dimension. - For 
-        area, this property determines the orient property of the Vega output. - For line, 
-        this property determines the sort order of the points in the line if 
-        `config.sortLineBy` is not specified. For stacked charts, this is always determined 
-        by the orientation of the stack; therefore explicitly specified value will be 
+        The orientation of a non-stacked bar, tick, area, and line charts. The value is
+        either horizontal (default) or vertical. - For bar, rule and tick, this determines
+        whether the size of the bar and tick should be applied to x or y dimension. - For
+        area, this property determines the orient property of the Vega output. - For line,
+        this property determines the sort order of the points in the line if
+        `config.sortLineBy` is not specified. For stacked charts, this is always determined
+        by the orientation of the stack; therefore explicitly specified value will be
         ignored.
     radius : float
-        Polar coordinate radial offset, in pixels, of the text label from the origin 
+        Polar coordinate radial offset, in pixels, of the text label from the origin
         determined by the `x` and `y` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`, 
+        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
         `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
           __Default value:__ `"circle"`
     size : float
-        The pixel area each the point/circle/square. For example: in the case of circles, 
-        the radius is determined in part by the square root of the size value.  __Default 
+        The pixel area each the point/circle/square. For example: in the case of circles,
+        the radius is determined in part by the square root of the size value.  __Default
         value:__ `30`
     stroke : string
-        Default Stroke Color.  This has higher precedence than config.color  __Default 
+        Default Stroke Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
@@ -596,14 +596,14 @@ class BarConfig(VegaLiteSchema):
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
-        Depending on the interpolation type, sets the tension parameter (for line and area 
+        Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
         Placeholder text if the `text` channel is not specified
     theta : float
-        Polar coordinate angle, in radians, of the text label from the origin determined by 
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc` 
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with 
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
+        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
         `0` indicating "north".
     """
     _schema = {'$ref': '#/definitions/BarConfig'}
@@ -634,7 +634,7 @@ class BarConfig(VegaLiteSchema):
 
 class BasicType(VegaLiteSchema):
     """BasicType schema wrapper
-    
+
     enum('quantitative', 'ordinal', 'temporal', 'nominal')
     """
     _schema = {'$ref': '#/definitions/BasicType'}
@@ -646,33 +646,33 @@ class BasicType(VegaLiteSchema):
 
 class BinParams(VegaLiteSchema):
     """BinParams schema wrapper
-    
+
     Mapping(required=[])
     Binning properties or boolean flag for determining whether to bin data or not.
-    
+
     Attributes
     ----------
     base : float
-        The number base to use for automatic bin determination (default is base 10).  
+        The number base to use for automatic bin determination (default is base 10).
         __Default value:__ `10`
     divide : List(float)
-        Scale factors indicating allowable subdivisions. The default value is [5, 2], which 
-        indicates that for base 10 numbers (the default base), the method may consider 
-        dividing bin sizes by 5 and/or 2. For example, for an initial step size of 10, the 
-        method can check if bin sizes of 2 (= 10/5), 5 (= 10/2), or 1 (= 10/(5*2)) might 
+        Scale factors indicating allowable subdivisions. The default value is [5, 2], which
+        indicates that for base 10 numbers (the default base), the method may consider
+        dividing bin sizes by 5 and/or 2. For example, for an initial step size of 10, the
+        method can check if bin sizes of 2 (= 10/5), 5 (= 10/2), or 1 (= 10/(5*2)) might
         also satisfy the given constraints.  __Default value:__ `[5, 2]`
     extent : List(float)
         A two-element (`[min, max]`) array indicating the range of desired bin values.
     maxbins : float
-        Maximum number of bins.  __Default value:__ `6` for `row`, `column` and `shape` 
+        Maximum number of bins.  __Default value:__ `6` for `row`, `column` and `shape`
         channels; `10` for other channels
     minstep : float
         A minimum allowable step size (particularly useful for integer values).
     nice : boolean
-        If true (the default), attempts to make the bin boundaries use human-friendly 
+        If true (the default), attempts to make the bin boundaries use human-friendly
         boundaries, such as multiples of ten.
     step : float
-        An exact step size to use between bins.  __Note:__ If provided, options such as 
+        An exact step size to use between bins.  __Note:__ If provided, options such as
         maxbins will be ignored.
     steps : List(float)
         An array of allowable step sizes to choose from.
@@ -688,17 +688,17 @@ class BinParams(VegaLiteSchema):
 
 class BinTransform(VegaLiteSchema):
     """BinTransform schema wrapper
-    
+
     Mapping(required=[bin, field, as])
-    
+
     Attributes
     ----------
     bin : anyOf(boolean, BinParams)
-        An object indicating bin properties, or simply `true` for using default bin 
+        An object indicating bin properties, or simply `true` for using default bin
         parameters.
     field : string
         The data field to bin.
-    
+
     Dict-Only Attributes
     --------------------
     'as' : string
@@ -713,9 +713,9 @@ class BinTransform(VegaLiteSchema):
 
 class BrushConfig(VegaLiteSchema):
     """BrushConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     fill : string
@@ -726,7 +726,7 @@ class BrushConfig(VegaLiteSchema):
     stroke : string
         The stroke color of the interval mark.  __Default value:__ `#ffffff`
     strokeDash : List(float)
-        An array of alternating stroke and space lengths, for creating dashed or dotted 
+        An array of alternating stroke and space lengths, for creating dashed or dotted
         lines.
     strokeDashOffset : float
         The offset (in pixels) with which to begin drawing the stroke dash array.
@@ -747,15 +747,15 @@ class BrushConfig(VegaLiteSchema):
 
 class CalculateTransform(VegaLiteSchema):
     """CalculateTransform schema wrapper
-    
+
     Mapping(required=[calculate, as])
-    
+
     Attributes
     ----------
     calculate : string
-        A [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string. 
+        A [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string.
         Use the variable `datum` to refer to the current data object.
-    
+
     Dict-Only Attributes
     --------------------
     'as' : string
@@ -770,14 +770,14 @@ class CalculateTransform(VegaLiteSchema):
 
 class CompositeUnitSpec(VegaLiteSchema):
     """CompositeUnitSpec schema wrapper
-    
+
     Mapping(required=[mark])
-    
+
     Attributes
     ----------
     mark : AnyMark
         A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
-         `"line"`, * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark 
+         `"line"`, * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark
         definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
     data : Data
         An object describing the data source
@@ -786,29 +786,29 @@ class CompositeUnitSpec(VegaLiteSchema):
     encoding : Encoding
         A key-value mapping between encoding channels and definition of fields.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its y-channel has a [continuous 
+        The height of a visualization.  __Default value:__ - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its y-channel has a [continuous
         scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of 
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - 
-        For y-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
+         be the value of
+        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
+        For y-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
         value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to 
+         cardinality of the field mapped to
         y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of 
+         `rangeStep` is `null`, the height will be the value of
         [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.  
-        __Note__: For plots with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the height of a single view.  __See also:__ The documentation for [width 
+         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
+        __Note__: For plots with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the height of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
     name : string
         Name of the visualization for later reference.
     projection : Projection
-        An object defining properties of geographic projection.  Works with `"geoshape"` 
-        marks and `"point"` or `"line"` marks that have `latitude` and `"longitude"` 
+        An object defining properties of geographic projection.  Works with `"geoshape"`
+        marks and `"point"` or `"line"` marks that have `latitude` and `"longitude"`
         channels.
     selection : Mapping(required=[])
         A key-value mapping between selection names and definitions.
@@ -817,26 +817,26 @@ class CompositeUnitSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the 
-        following rules:  - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its x-channel has a [continuous 
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will 
-        be the value of 
+        The width of a visualization.  __Default value:__ This will be determined by the
+        following rules:  - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its x-channel has a [continuous
+        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
+        be the value of
         [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
-        value or unspecified, the width is [determined by the range step, paddings, and the 
-        cardinality of the field mapped to 
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if 
-        the `rangeStep` is `null`, the width will be the value of 
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If 
-        no field is mapped to `x` channel, the `width` will be the value of 
+         x-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
+        value or unspecified, the width is [determined by the range step, paddings, and the
+        cardinality of the field mapped to
+        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
+        the `rangeStep` is `null`, the width will be the value of
+        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
+        no field is mapped to `x` channel, the `width` will be the value of
         [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots 
-        with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the width of a single view.  __See also:__ The documentation for [width 
+         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
+        with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the width of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
     """
     _schema = {'$ref': '#/definitions/CompositeUnitSpec'}
@@ -853,7 +853,7 @@ class CompositeUnitSpec(VegaLiteSchema):
 
 class ConditionalFieldDef(VegaLiteSchema):
     """ConditionalFieldDef schema wrapper
-    
+
     anyOf(ConditionalPredicateFieldDef, ConditionalSelectionFieldDef)
     """
     _schema = {'$ref': '#/definitions/Conditional<FieldDef>'}
@@ -865,7 +865,7 @@ class ConditionalFieldDef(VegaLiteSchema):
 
 class ConditionalMarkPropFieldDef(VegaLiteSchema):
     """ConditionalMarkPropFieldDef schema wrapper
-    
+
     anyOf(ConditionalPredicateMarkPropFieldDef, ConditionalSelectionMarkPropFieldDef)
     """
     _schema = {'$ref': '#/definitions/Conditional<MarkPropFieldDef>'}
@@ -877,7 +877,7 @@ class ConditionalMarkPropFieldDef(VegaLiteSchema):
 
 class ConditionalTextFieldDef(VegaLiteSchema):
     """ConditionalTextFieldDef schema wrapper
-    
+
     anyOf(ConditionalPredicateTextFieldDef, ConditionalSelectionTextFieldDef)
     """
     _schema = {'$ref': '#/definitions/Conditional<TextFieldDef>'}
@@ -889,7 +889,7 @@ class ConditionalTextFieldDef(VegaLiteSchema):
 
 class ConditionalValueDef(VegaLiteSchema):
     """ConditionalValueDef schema wrapper
-    
+
     anyOf(ConditionalPredicateValueDef, ConditionalSelectionValueDef)
     """
     _schema = {'$ref': '#/definitions/Conditional<ValueDef>'}
@@ -901,40 +901,40 @@ class ConditionalValueDef(VegaLiteSchema):
 
 class ConditionalPredicateFieldDef(VegaLiteSchema):
     """ConditionalPredicateFieldDef schema wrapper
-    
+
     Mapping(required=[test, type])
-    
+
     Attributes
     ----------
     test : LogicalOperandPredicate
-    
+
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/ConditionalPredicate<FieldDef>'}
@@ -949,58 +949,58 @@ class ConditionalPredicateFieldDef(VegaLiteSchema):
 
 class ConditionalPredicateMarkPropFieldDef(VegaLiteSchema):
     """ConditionalPredicateMarkPropFieldDef schema wrapper
-    
+
     Mapping(required=[test, type])
-    
+
     Attributes
     ----------
     test : LogicalOperandPredicate
-    
+
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding 
-        channel will be removed.  __Default value:__ If undefined, default [legend 
+        An object defining properties of the legend. If `null`, the legend for the encoding
+        channel will be removed.  __Default value:__ If undefined, default [legend
         properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/ConditionalPredicate<MarkPropFieldDef>'}
@@ -1018,43 +1018,43 @@ class ConditionalPredicateMarkPropFieldDef(VegaLiteSchema):
 
 class ConditionalPredicateTextFieldDef(VegaLiteSchema):
     """ConditionalPredicateTextFieldDef schema wrapper
-    
+
     Mapping(required=[test, type])
-    
+
     Attributes
     ----------
     test : LogicalOperandPredicate
-    
+
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     format : string
-        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a 
+        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a
         text field. If not defined, this will be determined automatically.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/ConditionalPredicate<TextFieldDef>'}
@@ -1070,15 +1070,15 @@ class ConditionalPredicateTextFieldDef(VegaLiteSchema):
 
 class ConditionalPredicateValueDef(VegaLiteSchema):
     """ConditionalPredicateValueDef schema wrapper
-    
+
     Mapping(required=[test, value])
-    
+
     Attributes
     ----------
     test : LogicalOperandPredicate
-    
+
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values 
+        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
         between `0` to `1` for opacity).
     """
     _schema = {'$ref': '#/definitions/ConditionalPredicate<ValueDef>'}
@@ -1090,42 +1090,42 @@ class ConditionalPredicateValueDef(VegaLiteSchema):
 
 class ConditionalSelectionFieldDef(VegaLiteSchema):
     """ConditionalSelectionFieldDef schema wrapper
-    
+
     Mapping(required=[selection, type])
-    
+
     Attributes
     ----------
     selection : SelectionOperand
-        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a 
-        series of [composed 
+        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a
+        series of [composed
         selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/ConditionalSelection<FieldDef>'}
@@ -1140,60 +1140,60 @@ class ConditionalSelectionFieldDef(VegaLiteSchema):
 
 class ConditionalSelectionMarkPropFieldDef(VegaLiteSchema):
     """ConditionalSelectionMarkPropFieldDef schema wrapper
-    
+
     Mapping(required=[selection, type])
-    
+
     Attributes
     ----------
     selection : SelectionOperand
-        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a 
-        series of [composed 
+        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a
+        series of [composed
         selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding 
-        channel will be removed.  __Default value:__ If undefined, default [legend 
+        An object defining properties of the legend. If `null`, the legend for the encoding
+        channel will be removed.  __Default value:__ If undefined, default [legend
         properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/ConditionalSelection<MarkPropFieldDef>'}
@@ -1211,45 +1211,45 @@ class ConditionalSelectionMarkPropFieldDef(VegaLiteSchema):
 
 class ConditionalSelectionTextFieldDef(VegaLiteSchema):
     """ConditionalSelectionTextFieldDef schema wrapper
-    
+
     Mapping(required=[selection, type])
-    
+
     Attributes
     ----------
     selection : SelectionOperand
-        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a 
-        series of [composed 
+        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a
+        series of [composed
         selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     format : string
-        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a 
+        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a
         text field. If not defined, this will be determined automatically.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/ConditionalSelection<TextFieldDef>'}
@@ -1265,17 +1265,17 @@ class ConditionalSelectionTextFieldDef(VegaLiteSchema):
 
 class ConditionalSelectionValueDef(VegaLiteSchema):
     """ConditionalSelectionValueDef schema wrapper
-    
+
     Mapping(required=[selection, value])
-    
+
     Attributes
     ----------
     selection : SelectionOperand
-        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a 
-        series of [composed 
+        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a
+        series of [composed
         selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values 
+        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
         between `0` to `1` for opacity).
     """
     _schema = {'$ref': '#/definitions/ConditionalSelection<ValueDef>'}
@@ -1287,21 +1287,21 @@ class ConditionalSelectionValueDef(VegaLiteSchema):
 
 class Config(VegaLiteSchema):
     """Config schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     area : MarkConfig
-        Area-Specific Config 
+        Area-Specific Config
     autosize : anyOf(AutosizeType, AutoSizeParams)
-        Sets how the visualization size should be determined. If a string, should be one of 
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for 
-        content sizing and automatic resizing. `"fit"` is only supported for single and 
+        Sets how the visualization size should be determined. If a string, should be one of
+        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
+        content sizing and automatic resizing. `"fit"` is only supported for single and
         layered views that don't use `rangeStep`.  __Default value__: `pad`
     axis : AxisConfig
-        Axis configuration, which determines default properties for all `x` and `y` 
-        [axes](axis.html). For a full list of axis configuration options, please see the 
+        Axis configuration, which determines default properties for all `x` and `y`
+        [axes](axis.html). For a full list of axis configuration options, please see the
         [corresponding section of the axis documentation](axis.html#config).
     axisBand : VgAxisConfig
         Specific axis config for axes with "band" scales.
@@ -1318,94 +1318,94 @@ class Config(VegaLiteSchema):
     axisY : VgAxisConfig
         Y-axis specific config.
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__ 
+        CSS color property to use as the background of visualization.  __Default value:__
         none (transparent)
     bar : BarConfig
-        Bar-Specific Config 
+        Bar-Specific Config
     circle : MarkConfig
-        Circle-Specific Config 
+        Circle-Specific Config
     countTitle : string
-        Default axis and legend title for count fields.  __Default value:__ `'Number of 
+        Default axis and legend title for count fields.  __Default value:__ `'Number of
         Records'`.
     datasets : Datasets
-        A global data store for named datasets. This is a mapping from names to inline 
+        A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
          primitive values are ingested as objects with a `data` property.
     fieldTitle : enum('verbal', 'functional', 'plain')
-        Defines how Vega-Lite generates title for fields.  There are three possible styles: 
-        - `"verbal"` (Default) - displays function in a verbal style (e.g., "Sum of field", 
-        "Year-month of date", "field (binned)"). - `"function"` - displays function using 
-        parentheses and capitalized texts (e.g., "SUM(field)", "YEARMONTH(date)", 
-        "BIN(field)"). - `"plain"` - displays only the field name without functions (e.g., 
+        Defines how Vega-Lite generates title for fields.  There are three possible styles:
+        - `"verbal"` (Default) - displays function in a verbal style (e.g., "Sum of field",
+        "Year-month of date", "field (binned)"). - `"function"` - displays function using
+        parentheses and capitalized texts (e.g., "SUM(field)", "YEARMONTH(date)",
+        "BIN(field)"). - `"plain"` - displays only the field name without functions (e.g.,
         "field", "date", "field").
     geoshape : MarkConfig
-        Geoshape-Specific Config 
+        Geoshape-Specific Config
     invalidValues : enum('filter', None)
-        Defines how Vega-Lite should handle invalid values (`null` and `NaN`). - If set to 
+        Defines how Vega-Lite should handle invalid values (`null` and `NaN`). - If set to
         `"filter"` (default), all data items with null values are filtered. - If `null`, all
-         data items are included. In this case, invalid values will be interpreted as 
+         data items are included. In this case, invalid values will be interpreted as
         zeroes.
     legend : LegendConfig
-        Legend configuration, which determines default properties for all 
-        [legends](legend.html). For a full list of legend configuration options, please see 
+        Legend configuration, which determines default properties for all
+        [legends](legend.html). For a full list of legend configuration options, please see
         the [corresponding section of in the legend documentation](legend.html#config).
     line : MarkConfig
-        Line-Specific Config 
+        Line-Specific Config
     mark : MarkConfig
-        Mark Config 
+        Mark Config
     numberFormat : string
-        D3 Number format for axis labels and text tables. For example "s" for SI units. Use 
+        D3 Number format for axis labels and text tables. For example "s" for SI units. Use
         [D3's number format pattern](https://github.com/d3/d3-format#locale_format).
     padding : Padding
-        The default visualization padding, in pixels, from the edge of the visualization 
-        canvas to the data rectangle.  If a number, specifies padding for all sides. If an 
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5, 
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default 
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides. If an
+        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}` to specify padding for each side of the visualization.  __Default
         value__: `5`
     point : MarkConfig
-        Point-Specific Config 
+        Point-Specific Config
     projection : ProjectionConfig
-        Projection configuration, which determines default properties for all 
+        Projection configuration, which determines default properties for all
         [projections](projection.html). For a full list of projection configuration options,
-         please see the [corresponding section of the projection 
+         please see the [corresponding section of the projection
         documentation](projection.html#config).
     range : RangeConfig
-        An object hash that defines default range arrays or schemes for using with scales. 
-        For a full list of scale range configuration options, please see the [corresponding 
+        An object hash that defines default range arrays or schemes for using with scales.
+        For a full list of scale range configuration options, please see the [corresponding
         section of the scale documentation](scale.html#config).
     rect : MarkConfig
-        Rect-Specific Config 
+        Rect-Specific Config
     rule : MarkConfig
-        Rule-Specific Config 
+        Rule-Specific Config
     scale : ScaleConfig
-        Scale configuration determines default properties for all [scales](scale.html). For 
+        Scale configuration determines default properties for all [scales](scale.html). For
         a full list of scale configuration options, please see the [corresponding section of
          the scale documentation](scale.html#config).
     selection : SelectionConfig
-        An object hash for defining default properties for each type of selections. 
+        An object hash for defining default properties for each type of selections.
     square : MarkConfig
-        Square-Specific Config 
+        Square-Specific Config
     stack : StackOffset
-        Default stack offset for stackable mark. 
+        Default stack offset for stackable mark.
     style : StyleConfigIndex
-        An object hash that defines key-value mappings to determine default properties for 
-        marks with a given [style](mark.html#mark-def).  The keys represent styles names; 
-        the value are valid [mark configuration objects](mark.html#config).  
+        An object hash that defines key-value mappings to determine default properties for
+        marks with a given [style](mark.html#mark-def).  The keys represent styles names;
+        the value are valid [mark configuration objects](mark.html#config).
     text : TextConfig
-        Text-Specific Config 
+        Text-Specific Config
     tick : TickConfig
-        Tick-Specific Config 
+        Tick-Specific Config
     timeFormat : string
-        Default datetime format for axis and legend labels. The format can be set directly 
-        on each axis and legend. Use [D3's time format 
-        pattern](https://github.com/d3/d3-time-format#locale_format).  __Default value:__ 
+        Default datetime format for axis and legend labels. The format can be set directly
+        on each axis and legend. Use [D3's time format
+        pattern](https://github.com/d3/d3-time-format#locale_format).  __Default value:__
         `'%b %d, %Y'`.
     title : VgTitleConfig
-        Title configuration, which determines default properties for all 
+        Title configuration, which determines default properties for all
         [titles](title.html). For a full list of title configuration options, please see the
          [corresponding section of the title documentation](title.html#config).
     view : ViewConfig
-        Default properties for [single view plots](spec.html#single). 
+        Default properties for [single view plots](spec.html#single).
     """
     _schema = {'$ref': '#/definitions/Config'}
     _rootschema = Root._schema
@@ -1435,26 +1435,26 @@ class Config(VegaLiteSchema):
 
 class CsvDataFormat(VegaLiteSchema):
     """CsvDataFormat schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     parse : anyOf(enum('auto'), Mapping(required=[]))
-        If set to auto (the default), perform automatic type inference to determine the 
-        desired data types. Alternatively, a parsing directive object can be provided for 
-        explicit data types. Each property of the object corresponds to a field name, and 
+        If set to auto (the default), perform automatic type inference to determine the
+        desired data types. Alternatively, a parsing directive object can be provided for
+        explicit data types. Each property of the object corresponds to a field name, and
         the value to the desired data type (one of `"number"`, `"boolean"` or `"date"`). For
-         example, `"parse": {"modified_on": "date"}` parses the `modified_on` field in each 
-        input record a Date value.  For `"date"`, we parse data based using Javascript's 
+         example, `"parse": {"modified_on": "date"}` parses the `modified_on` field in each
+        input record a Date value.  For `"date"`, we parse data based using Javascript's
         [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).
-         For Specific date formats can be provided (e.g., `{foo: 'date:"%m%d%Y"'}`), using 
+         For Specific date formats can be provided (e.g., `{foo: 'date:"%m%d%Y"'}`), using
         the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC
-         date format parsing is supported similarly (e.g., `{foo: 'utc:"%m%d%Y"'}`). See 
+         date format parsing is supported similarly (e.g., `{foo: 'utc:"%m%d%Y"'}`). See
         more about [UTC time](timeunit.html#utc)
     type : enum('csv', 'tsv')
-        Type of input data: `"json"`, `"csv"`, `"tsv"`. The default format type is 
-        determined by the extension of the file URL. If no extension is detected, `"json"` 
+        Type of input data: `"json"`, `"csv"`, `"tsv"`. The default format type is
+        determined by the extension of the file URL. If no extension is detected, `"json"`
         will be used by default.
     """
     _schema = {'$ref': '#/definitions/CsvDataFormat'}
@@ -1466,7 +1466,7 @@ class CsvDataFormat(VegaLiteSchema):
 
 class Data(VegaLiteSchema):
     """Data schema wrapper
-    
+
     anyOf(UrlData, InlineData, NamedData)
     """
     _schema = {'$ref': '#/definitions/Data'}
@@ -1478,7 +1478,7 @@ class Data(VegaLiteSchema):
 
 class DataFormat(VegaLiteSchema):
     """DataFormat schema wrapper
-    
+
     anyOf(CsvDataFormat, JsonDataFormat, TopoDataFormat)
     """
     _schema = {'$ref': '#/definitions/DataFormat'}
@@ -1490,7 +1490,7 @@ class DataFormat(VegaLiteSchema):
 
 class Datasets(VegaLiteSchema):
     """Datasets schema wrapper
-    
+
     Mapping(required=[])
     """
     _schema = {'$ref': '#/definitions/Datasets'}
@@ -1502,22 +1502,22 @@ class Datasets(VegaLiteSchema):
 
 class DateTime(VegaLiteSchema):
     """DateTime schema wrapper
-    
+
     Mapping(required=[])
     Object for defining datetime in Vega-Lite Filter.
     If both month and quarter are provided, month has higher precedence.
     `day` cannot be combined with other date.
     We accept string for month and day names.
-    
+
     Attributes
     ----------
     date : float
         Integer value representing the date from 1-31.
     day : anyOf(Day, string)
-        Value representing the day of a week.  This can be one of: (1) integer value -- `1` 
-        represents Monday; (2) case-insensitive day name (e.g., `"Monday"`);  (3) 
+        Value representing the day of a week.  This can be one of: (1) integer value -- `1`
+        represents Monday; (2) case-insensitive day name (e.g., `"Monday"`);  (3)
         case-insensitive, 3-character short day name (e.g., `"Mon"`).   <br/> **Warning:** A
-         DateTime definition object with `day`** should not be combined with `year`, 
+         DateTime definition object with `day`** should not be combined with `year`,
         `quarter`, `month`, or `date`.
     hours : float
         Integer value representing the hour of a day from 0-23.
@@ -1526,9 +1526,9 @@ class DateTime(VegaLiteSchema):
     minutes : float
         Integer value representing the minute segment of time from 0-59.
     month : anyOf(Month, string)
-        One of: (1) integer value representing the month from `1`-`12`. `1` represents 
-        January;  (2) case-insensitive month name (e.g., `"January"`);  (3) 
-        case-insensitive, 3-character short month name (e.g., `"Jan"`). 
+        One of: (1) integer value representing the month from `1`-`12`. `1` represents
+        January;  (2) case-insensitive month name (e.g., `"January"`);  (3)
+        case-insensitive, 3-character short month name (e.g., `"Jan"`).
     quarter : float
         Integer value representing the quarter of the year (from 1-4).
     seconds : float
@@ -1552,7 +1552,7 @@ class DateTime(VegaLiteSchema):
 
 class Day(VegaLiteSchema):
     """Day schema wrapper
-    
+
     float
     """
     _schema = {'$ref': '#/definitions/Day'}
@@ -1564,7 +1564,7 @@ class Day(VegaLiteSchema):
 
 class DictInlineDataset(VegaLiteSchema):
     """DictInlineDataset schema wrapper
-    
+
     Mapping(required=[])
     """
     _schema = {'$ref': '#/definitions/Dict<InlineDataset>'}
@@ -1576,32 +1576,32 @@ class DictInlineDataset(VegaLiteSchema):
 
 class Encoding(VegaLiteSchema):
     """Encoding schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     color : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Color of the marks – either fill or stroke color based on  the `filled` property of 
-        mark definition. By default, `color` represents fill color for `"area"`, `"bar"`, 
-        `"tick"`, `"text"`, `"circle"`, and `"square"` / stroke color for `"line"` and 
-        `"point"`.  __Default value:__ If undefined, the default color depends on [mark 
-        config](config.html#mark)'s `color` property.  _Note:_ 1) For fine-grained control 
-        over both fill and stroke colors of the marks, please use the `fill` and `stroke` 
-        channels. 2) See the scale documentation for more information about customizing 
+        Color of the marks – either fill or stroke color based on  the `filled` property of
+        mark definition. By default, `color` represents fill color for `"area"`, `"bar"`,
+        `"tick"`, `"text"`, `"circle"`, and `"square"` / stroke color for `"line"` and
+        `"point"`.  __Default value:__ If undefined, the default color depends on [mark
+        config](config.html#mark)'s `color` property.  _Note:_ 1) For fine-grained control
+        over both fill and stroke colors of the marks, please use the `fill` and `stroke`
+        channels. 2) See the scale documentation for more information about customizing
         [color scheme](scale.html#scheme).
     detail : anyOf(FieldDef, List(FieldDef))
-        Additional levels of detail for grouping data in aggregate views and in line and 
+        Additional levels of detail for grouping data in aggregate views and in line and
         area marks without mapping data to a specific visual channel.
     fill : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Fill color of the marks. __Default value:__ If undefined, the default color depends 
-        on [mark config](config.html#mark)'s `color` property.  _Note:_ The `fill` channel 
+        Fill color of the marks. __Default value:__ If undefined, the default color depends
+        on [mark config](config.html#mark)'s `color` property.  _Note:_ The `fill` channel
         has higher precedence than `color` and will override color value.
     href : anyOf(FieldDefWithCondition, ValueDefWithCondition)
         A URL to load upon mouse click.
     key : FieldDef
         A data field to use as a unique key for data binding. When a visualization’s data is
-         updated, the key value will be used to match data elements to existing mark 
+         updated, the key value will be used to match data elements to existing mark
         instances. Use a key channel to enable object constancy for transitions over dynamic
          data.
     latitude : FieldDef
@@ -1612,33 +1612,33 @@ class Encoding(VegaLiteSchema):
     longitude : FieldDef
         Longitude position of geographically projected marks.
     longitude2 : FieldDef
-        Longitude-2 position for geographically projected ranged `"area"`, `"bar"`, 
+        Longitude-2 position for geographically projected ranged `"area"`, `"bar"`,
         `"rect"`, and  `"rule"`.
     opacity : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Opacity of the marks – either can be a value or a range.  __Default value:__ If 
-        undefined, the default opacity depends on [mark config](config.html#mark)'s 
+        Opacity of the marks – either can be a value or a range.  __Default value:__ If
+        undefined, the default opacity depends on [mark config](config.html#mark)'s
         `opacity` property.
     order : anyOf(OrderFieldDef, List(OrderFieldDef))
         Order of the marks. - For stacked marks, this `order` channel encodes stack order. -
-         For line marks, this `order` channel encodes order of data points in the lines. 
-        This can be useful for creating [a connected 
+         For line marks, this `order` channel encodes order of data points in the lines.
+        This can be useful for creating [a connected
         scatterplot](https://vega.github.io/vega-lite/examples/layer_connected_scatterplot.html).
-         - Otherwise, this `order` channel encodes layer order of the marks.  __Note__: In 
-        aggregate plots, `order` field should be `aggregate`d to avoid creating additional 
+         - Otherwise, this `order` channel encodes layer order of the marks.  __Note__: In
+        aggregate plots, `order` field should be `aggregate`d to avoid creating additional
         aggregation grouping.
     shape : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        For `point` marks the supported values are `"circle"` (default), `"square"`, 
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or else a custom SVG 
-        path string. For `geoshape` marks it should be a field definition of the geojson 
-        data  __Default value:__ If undefined, the default shape depends on [mark 
+        For `point` marks the supported values are `"circle"` (default), `"square"`,
+        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or else a custom SVG
+        path string. For `geoshape` marks it should be a field definition of the geojson
+        data  __Default value:__ If undefined, the default shape depends on [mark
         config](config.html#point-config)'s `shape` property.
     size : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Size of the mark. - For `"point"`, `"square"` and `"circle"`, – the symbol size, or 
-        pixel area of the mark. - For `"bar"` and `"tick"` – the bar and tick's size. - For 
-        `"text"` – the text's font size. - Size is currently unsupported for `"line"`, 
+        Size of the mark. - For `"point"`, `"square"` and `"circle"`, – the symbol size, or
+        pixel area of the mark. - For `"bar"` and `"tick"` – the bar and tick's size. - For
+        `"text"` – the text's font size. - Size is currently unsupported for `"line"`,
         `"area"`, and `"rect"`.
     stroke : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Stroke color of the marks. __Default value:__ If undefined, the default color 
+        Stroke color of the marks. __Default value:__ If undefined, the default color
         depends on [mark config](config.html#mark)'s `color` property.  _Note:_ The `stroke`
          channel has higher precedence than `color` and will override color value.
     text : anyOf(TextFieldDefWithCondition, TextValueDefWithCondition)
@@ -1671,34 +1671,34 @@ class Encoding(VegaLiteSchema):
 
 class EncodingWithFacet(VegaLiteSchema):
     """EncodingWithFacet schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     color : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Color of the marks – either fill or stroke color based on  the `filled` property of 
-        mark definition. By default, `color` represents fill color for `"area"`, `"bar"`, 
-        `"tick"`, `"text"`, `"circle"`, and `"square"` / stroke color for `"line"` and 
-        `"point"`.  __Default value:__ If undefined, the default color depends on [mark 
-        config](config.html#mark)'s `color` property.  _Note:_ 1) For fine-grained control 
-        over both fill and stroke colors of the marks, please use the `fill` and `stroke` 
-        channels. 2) See the scale documentation for more information about customizing 
+        Color of the marks – either fill or stroke color based on  the `filled` property of
+        mark definition. By default, `color` represents fill color for `"area"`, `"bar"`,
+        `"tick"`, `"text"`, `"circle"`, and `"square"` / stroke color for `"line"` and
+        `"point"`.  __Default value:__ If undefined, the default color depends on [mark
+        config](config.html#mark)'s `color` property.  _Note:_ 1) For fine-grained control
+        over both fill and stroke colors of the marks, please use the `fill` and `stroke`
+        channels. 2) See the scale documentation for more information about customizing
         [color scheme](scale.html#scheme).
     column : FacetFieldDef
         Horizontal facets for trellis plots.
     detail : anyOf(FieldDef, List(FieldDef))
-        Additional levels of detail for grouping data in aggregate views and in line and 
+        Additional levels of detail for grouping data in aggregate views and in line and
         area marks without mapping data to a specific visual channel.
     fill : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Fill color of the marks. __Default value:__ If undefined, the default color depends 
-        on [mark config](config.html#mark)'s `color` property.  _Note:_ The `fill` channel 
+        Fill color of the marks. __Default value:__ If undefined, the default color depends
+        on [mark config](config.html#mark)'s `color` property.  _Note:_ The `fill` channel
         has higher precedence than `color` and will override color value.
     href : anyOf(FieldDefWithCondition, ValueDefWithCondition)
         A URL to load upon mouse click.
     key : FieldDef
         A data field to use as a unique key for data binding. When a visualization’s data is
-         updated, the key value will be used to match data elements to existing mark 
+         updated, the key value will be used to match data elements to existing mark
         instances. Use a key channel to enable object constancy for transitions over dynamic
          data.
     latitude : FieldDef
@@ -1709,35 +1709,35 @@ class EncodingWithFacet(VegaLiteSchema):
     longitude : FieldDef
         Longitude position of geographically projected marks.
     longitude2 : FieldDef
-        Longitude-2 position for geographically projected ranged `"area"`, `"bar"`, 
+        Longitude-2 position for geographically projected ranged `"area"`, `"bar"`,
         `"rect"`, and  `"rule"`.
     opacity : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Opacity of the marks – either can be a value or a range.  __Default value:__ If 
-        undefined, the default opacity depends on [mark config](config.html#mark)'s 
+        Opacity of the marks – either can be a value or a range.  __Default value:__ If
+        undefined, the default opacity depends on [mark config](config.html#mark)'s
         `opacity` property.
     order : anyOf(OrderFieldDef, List(OrderFieldDef))
         Order of the marks. - For stacked marks, this `order` channel encodes stack order. -
-         For line marks, this `order` channel encodes order of data points in the lines. 
-        This can be useful for creating [a connected 
+         For line marks, this `order` channel encodes order of data points in the lines.
+        This can be useful for creating [a connected
         scatterplot](https://vega.github.io/vega-lite/examples/layer_connected_scatterplot.html).
-         - Otherwise, this `order` channel encodes layer order of the marks.  __Note__: In 
-        aggregate plots, `order` field should be `aggregate`d to avoid creating additional 
+         - Otherwise, this `order` channel encodes layer order of the marks.  __Note__: In
+        aggregate plots, `order` field should be `aggregate`d to avoid creating additional
         aggregation grouping.
     row : FacetFieldDef
         Vertical facets for trellis plots.
     shape : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        For `point` marks the supported values are `"circle"` (default), `"square"`, 
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or else a custom SVG 
-        path string. For `geoshape` marks it should be a field definition of the geojson 
-        data  __Default value:__ If undefined, the default shape depends on [mark 
+        For `point` marks the supported values are `"circle"` (default), `"square"`,
+        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or else a custom SVG
+        path string. For `geoshape` marks it should be a field definition of the geojson
+        data  __Default value:__ If undefined, the default shape depends on [mark
         config](config.html#point-config)'s `shape` property.
     size : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Size of the mark. - For `"point"`, `"square"` and `"circle"`, – the symbol size, or 
-        pixel area of the mark. - For `"bar"` and `"tick"` – the bar and tick's size. - For 
-        `"text"` – the text's font size. - Size is currently unsupported for `"line"`, 
+        Size of the mark. - For `"point"`, `"square"` and `"circle"`, – the symbol size, or
+        pixel area of the mark. - For `"bar"` and `"tick"` – the bar and tick's size. - For
+        `"text"` – the text's font size. - Size is currently unsupported for `"line"`,
         `"area"`, and `"rect"`.
     stroke : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Stroke color of the marks. __Default value:__ If undefined, the default color 
+        Stroke color of the marks. __Default value:__ If undefined, the default color
         depends on [mark config](config.html#mark)'s `color` property.  _Note:_ The `stroke`
          channel has higher precedence than `color` and will override color value.
     text : anyOf(TextFieldDefWithCondition, TextValueDefWithCondition)
@@ -1772,15 +1772,15 @@ class EncodingWithFacet(VegaLiteSchema):
 
 class LayerSpec(VegaLiteSchema):
     """LayerSpec schema wrapper
-    
+
     Mapping(required=[layer])
     Layer Spec with encoding and projection
-    
+
     Attributes
     ----------
     layer : List(anyOf(LayerSpec, CompositeUnitSpec))
-        Layer or single view specifications to be layered.  __Note__: Specifications inside 
-        `layer` cannot use `row` and `column` channels as layering facet specifications is 
+        Layer or single view specifications to be layered.  __Note__: Specifications inside
+        `layer` cannot use `row` and `column` channels as layering facet specifications is
         not allowed.
     data : Data
         An object describing the data source
@@ -1790,28 +1790,28 @@ class LayerSpec(VegaLiteSchema):
         A shared key-value mapping between encoding channels and definition of fields in the
          underlying layers.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its y-channel has a [continuous 
+        The height of a visualization.  __Default value:__ - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its y-channel has a [continuous
         scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of 
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - 
-        For y-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
+         be the value of
+        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
+        For y-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
         value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to 
+         cardinality of the field mapped to
         y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of 
+         `rangeStep` is `null`, the height will be the value of
         [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.  
-        __Note__: For plots with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the height of a single view.  __See also:__ The documentation for [width 
+         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
+        __Note__: For plots with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the height of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
     name : string
         Name of the visualization for later reference.
     projection : Projection
-        An object defining properties of the geographic projection shared by underlying 
+        An object defining properties of the geographic projection shared by underlying
         layers.
     resolve : Resolve
         Scale, axis, and legend resolutions for layers.
@@ -1820,26 +1820,26 @@ class LayerSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the 
-        following rules:  - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its x-channel has a [continuous 
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will 
-        be the value of 
+        The width of a visualization.  __Default value:__ This will be determined by the
+        following rules:  - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its x-channel has a [continuous
+        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
+        be the value of
         [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
-        value or unspecified, the width is [determined by the range step, paddings, and the 
-        cardinality of the field mapped to 
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if 
-        the `rangeStep` is `null`, the width will be the value of 
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If 
-        no field is mapped to `x` channel, the `width` will be the value of 
+         x-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
+        value or unspecified, the width is [determined by the range step, paddings, and the
+        cardinality of the field mapped to
+        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
+        the `rangeStep` is `null`, the width will be the value of
+        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
+        no field is mapped to `x` channel, the `width` will be the value of
         [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots 
-        with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the width of a single view.  __See also:__ The documentation for [width 
+         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
+        with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the width of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
     """
     _schema = {'$ref': '#/definitions/LayerSpec'}
@@ -1856,32 +1856,32 @@ class LayerSpec(VegaLiteSchema):
 
 class FacetFieldDef(VegaLiteSchema):
     """FacetFieldDef schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     header : Header
@@ -1889,9 +1889,9 @@ class FacetFieldDef(VegaLiteSchema):
     sort : SortOrder
         Sort order for a facet field. This can be `"ascending"`, `"descending"`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/FacetFieldDef'}
@@ -1905,9 +1905,9 @@ class FacetFieldDef(VegaLiteSchema):
 
 class FacetMapping(VegaLiteSchema):
     """FacetMapping schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     column : FacetFieldDef
@@ -1924,39 +1924,39 @@ class FacetMapping(VegaLiteSchema):
 
 class FieldDef(VegaLiteSchema):
     """FieldDef schema wrapper
-    
+
     Mapping(required=[type])
     Definition object for a data field, its type and transformation of an encoding channel.
-    
+
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/FieldDef'}
@@ -1970,7 +1970,7 @@ class FieldDef(VegaLiteSchema):
 
 class FieldDefWithCondition(VegaLiteSchema):
     """FieldDefWithCondition schema wrapper
-    
+
     Mapping(required=[type])
     A FieldDef with Condition<ValueDef>
     {
@@ -1978,41 +1978,41 @@ class FieldDefWithCondition(VegaLiteSchema):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/FieldDefWithCondition'}
@@ -2027,7 +2027,7 @@ class FieldDefWithCondition(VegaLiteSchema):
 
 class MarkPropFieldDefWithCondition(VegaLiteSchema):
     """MarkPropFieldDefWithCondition schema wrapper
-    
+
     Mapping(required=[type])
     A FieldDef with Condition<ValueDef>
     {
@@ -2035,59 +2035,59 @@ class MarkPropFieldDefWithCondition(VegaLiteSchema):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding 
-        channel will be removed.  __Default value:__ If undefined, default [legend 
+        An object defining properties of the legend. If `null`, the legend for the encoding
+        channel will be removed.  __Default value:__ If undefined, default [legend
         properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/MarkPropFieldDefWithCondition'}
@@ -2104,7 +2104,7 @@ class MarkPropFieldDefWithCondition(VegaLiteSchema):
 
 class TextFieldDefWithCondition(VegaLiteSchema):
     """TextFieldDefWithCondition schema wrapper
-    
+
     Mapping(required=[type])
     A FieldDef with Condition<ValueDef>
     {
@@ -2112,44 +2112,44 @@ class TextFieldDefWithCondition(VegaLiteSchema):
        field: ...,
        ...
     }
-    
+
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field 
-        definition's `condition` property can only contain [value 
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since 
+        One or more value definition(s) with a selection predicate.  __Note:__ A field
+        definition's `condition` property can only contain [value
+        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
         Vega-Lite only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     format : string
-        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a 
+        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a
         text field. If not defined, this will be determined automatically.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/TextFieldDefWithCondition'}
@@ -2164,9 +2164,9 @@ class TextFieldDefWithCondition(VegaLiteSchema):
 
 class FieldEqualPredicate(VegaLiteSchema):
     """FieldEqualPredicate schema wrapper
-    
+
     Mapping(required=[field, equal])
-    
+
     Attributes
     ----------
     equal : anyOf(string, float, boolean, DateTime)
@@ -2185,15 +2185,15 @@ class FieldEqualPredicate(VegaLiteSchema):
 
 class FieldOneOfPredicate(VegaLiteSchema):
     """FieldOneOfPredicate schema wrapper
-    
+
     Mapping(required=[field, oneOf])
-    
+
     Attributes
     ----------
     field : string
         Field to be filtered
     oneOf : anyOf(List(string), List(float), List(boolean), List(DateTime))
-        A set of values that the `field`'s value should be a member of, for a data item 
+        A set of values that the `field`'s value should be a member of, for a data item
         included in the filtered data.
     timeUnit : TimeUnit
         time unit for the field to be filtered.
@@ -2207,9 +2207,9 @@ class FieldOneOfPredicate(VegaLiteSchema):
 
 class FieldRangePredicate(VegaLiteSchema):
     """FieldRangePredicate schema wrapper
-    
+
     Mapping(required=[field, range])
-    
+
     Attributes
     ----------
     field : string
@@ -2229,21 +2229,21 @@ class FieldRangePredicate(VegaLiteSchema):
 
 class FilterTransform(VegaLiteSchema):
     """FilterTransform schema wrapper
-    
+
     Mapping(required=[filter])
-    
+
     Attributes
     ----------
     filter : LogicalOperandPredicate
-        The `filter` property must be one of the predicate definitions: (1) an 
-        [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string, 
-        where `datum` can be used to refer to the current data object; (2) one of the field 
-        predicates: [equal 
-        predicate](https://vega.github.io/vega-lite/docs/filter.html#equal-predicate); 
-        [range predicate](filter.html#range-predicate), [one-of 
-        predicate](https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate); (3) 
-        a [selection 
-        predicate](https://vega.github.io/vega-lite/docs/filter.html#selection-predicate); 
+        The `filter` property must be one of the predicate definitions: (1) an
+        [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string,
+        where `datum` can be used to refer to the current data object; (2) one of the field
+        predicates: [equal
+        predicate](https://vega.github.io/vega-lite/docs/filter.html#equal-predicate);
+        [range predicate](filter.html#range-predicate), [one-of
+        predicate](https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate); (3)
+        a [selection
+        predicate](https://vega.github.io/vega-lite/docs/filter.html#selection-predicate);
         or (4) a logical operand that combines (1), (2), or (3).
     """
     _schema = {'$ref': '#/definitions/FilterTransform'}
@@ -2255,7 +2255,7 @@ class FilterTransform(VegaLiteSchema):
 
 class FontStyle(VegaLiteSchema):
     """FontStyle schema wrapper
-    
+
     enum('normal', 'italic')
     """
     _schema = {'$ref': '#/definitions/FontStyle'}
@@ -2267,7 +2267,7 @@ class FontStyle(VegaLiteSchema):
 
 class FontWeight(VegaLiteSchema):
     """FontWeight schema wrapper
-    
+
     anyOf(FontWeightString, FontWeightNumber)
     """
     _schema = {'$ref': '#/definitions/FontWeight'}
@@ -2279,7 +2279,7 @@ class FontWeight(VegaLiteSchema):
 
 class FontWeightNumber(VegaLiteSchema):
     """FontWeightNumber schema wrapper
-    
+
     float
     """
     _schema = {'$ref': '#/definitions/FontWeightNumber'}
@@ -2291,7 +2291,7 @@ class FontWeightNumber(VegaLiteSchema):
 
 class FontWeightString(VegaLiteSchema):
     """FontWeightString schema wrapper
-    
+
     enum('normal', 'bold')
     """
     _schema = {'$ref': '#/definitions/FontWeightString'}
@@ -2303,13 +2303,13 @@ class FontWeightString(VegaLiteSchema):
 
 class FacetSpec(VegaLiteSchema):
     """FacetSpec schema wrapper
-    
+
     Mapping(required=[facet, spec])
-    
+
     Attributes
     ----------
     facet : FacetMapping
-        An object that describes mappings between `row` and `column` channels and their 
+        An object that describes mappings between `row` and `column` channels and their
         field definitions.
     spec : anyOf(LayerSpec, CompositeUnitSpec)
         A specification of the view that gets faceted.
@@ -2338,9 +2338,9 @@ class FacetSpec(VegaLiteSchema):
 
 class HConcatSpec(VegaLiteSchema):
     """HConcatSpec schema wrapper
-    
+
     Mapping(required=[hconcat])
-    
+
     Attributes
     ----------
     hconcat : List(Spec)
@@ -2370,16 +2370,16 @@ class HConcatSpec(VegaLiteSchema):
 
 class RepeatSpec(VegaLiteSchema):
     """RepeatSpec schema wrapper
-    
+
     Mapping(required=[repeat, spec])
-    
+
     Attributes
     ----------
     repeat : Repeat
         An object that describes what fields should be repeated into views that are laid out
          as a `row` or `column`.
     spec : Spec
-    
+
     data : Data
         An object describing the data source
     description : string
@@ -2405,7 +2405,7 @@ class RepeatSpec(VegaLiteSchema):
 
 class Spec(VegaLiteSchema):
     """Spec schema wrapper
-    
+
     anyOf(CompositeUnitSpec, LayerSpec, FacetSpec, RepeatSpec, VConcatSpec, HConcatSpec)
     """
     _schema = {'$ref': '#/definitions/Spec'}
@@ -2417,14 +2417,14 @@ class Spec(VegaLiteSchema):
 
 class CompositeUnitSpecAlias(VegaLiteSchema):
     """CompositeUnitSpecAlias schema wrapper
-    
+
     Mapping(required=[mark])
-    
+
     Attributes
     ----------
     mark : AnyMark
         A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
-         `"line"`, * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark 
+         `"line"`, * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark
         definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
     data : Data
         An object describing the data source
@@ -2433,29 +2433,29 @@ class CompositeUnitSpecAlias(VegaLiteSchema):
     encoding : Encoding
         A key-value mapping between encoding channels and definition of fields.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its y-channel has a [continuous 
+        The height of a visualization.  __Default value:__ - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its y-channel has a [continuous
         scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of 
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - 
-        For y-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
+         be the value of
+        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
+        For y-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
         value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to 
+         cardinality of the field mapped to
         y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of 
+         `rangeStep` is `null`, the height will be the value of
         [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.  
-        __Note__: For plots with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the height of a single view.  __See also:__ The documentation for [width 
+         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
+        __Note__: For plots with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the height of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
     name : string
         Name of the visualization for later reference.
     projection : Projection
-        An object defining properties of geographic projection.  Works with `"geoshape"` 
-        marks and `"point"` or `"line"` marks that have `latitude` and `"longitude"` 
+        An object defining properties of geographic projection.  Works with `"geoshape"`
+        marks and `"point"` or `"line"` marks that have `latitude` and `"longitude"`
         channels.
     selection : Mapping(required=[])
         A key-value mapping between selection names and definitions.
@@ -2464,26 +2464,26 @@ class CompositeUnitSpecAlias(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the 
-        following rules:  - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its x-channel has a [continuous 
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will 
-        be the value of 
+        The width of a visualization.  __Default value:__ This will be determined by the
+        following rules:  - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its x-channel has a [continuous
+        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
+        be the value of
         [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
-        value or unspecified, the width is [determined by the range step, paddings, and the 
-        cardinality of the field mapped to 
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if 
-        the `rangeStep` is `null`, the width will be the value of 
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If 
-        no field is mapped to `x` channel, the `width` will be the value of 
+         x-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
+        value or unspecified, the width is [determined by the range step, paddings, and the
+        cardinality of the field mapped to
+        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
+        the `rangeStep` is `null`, the width will be the value of
+        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
+        no field is mapped to `x` channel, the `width` will be the value of
         [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots 
-        with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the width of a single view.  __See also:__ The documentation for [width 
+         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
+        with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the width of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
     """
     _schema = {'$ref': '#/definitions/CompositeUnitSpecAlias'}
@@ -2501,14 +2501,14 @@ class CompositeUnitSpecAlias(VegaLiteSchema):
 
 class FacetedCompositeUnitSpecAlias(VegaLiteSchema):
     """FacetedCompositeUnitSpecAlias schema wrapper
-    
+
     Mapping(required=[mark])
-    
+
     Attributes
     ----------
     mark : AnyMark
         A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
-         `"line"`, * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark 
+         `"line"`, * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark
         definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
     data : Data
         An object describing the data source
@@ -2517,29 +2517,29 @@ class FacetedCompositeUnitSpecAlias(VegaLiteSchema):
     encoding : EncodingWithFacet
         A key-value mapping between encoding channels and definition of fields.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its y-channel has a [continuous 
+        The height of a visualization.  __Default value:__ - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its y-channel has a [continuous
         scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of 
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - 
-        For y-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
+         be the value of
+        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
+        For y-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
         value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to 
+         cardinality of the field mapped to
         y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of 
+         `rangeStep` is `null`, the height will be the value of
         [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.  
-        __Note__: For plots with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the height of a single view.  __See also:__ The documentation for [width 
+         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
+        __Note__: For plots with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the height of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
     name : string
         Name of the visualization for later reference.
     projection : Projection
-        An object defining properties of geographic projection.  Works with `"geoshape"` 
-        marks and `"point"` or `"line"` marks that have `latitude` and `"longitude"` 
+        An object defining properties of geographic projection.  Works with `"geoshape"`
+        marks and `"point"` or `"line"` marks that have `latitude` and `"longitude"`
         channels.
     selection : Mapping(required=[])
         A key-value mapping between selection names and definitions.
@@ -2548,26 +2548,26 @@ class FacetedCompositeUnitSpecAlias(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the 
-        following rules:  - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its x-channel has a [continuous 
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will 
-        be the value of 
+        The width of a visualization.  __Default value:__ This will be determined by the
+        following rules:  - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its x-channel has a [continuous
+        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
+        be the value of
         [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
-        value or unspecified, the width is [determined by the range step, paddings, and the 
-        cardinality of the field mapped to 
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if 
-        the `rangeStep` is `null`, the width will be the value of 
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If 
-        no field is mapped to `x` channel, the `width` will be the value of 
+         x-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
+        value or unspecified, the width is [determined by the range step, paddings, and the
+        cardinality of the field mapped to
+        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
+        the `rangeStep` is `null`, the width will be the value of
+        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
+        no field is mapped to `x` channel, the `width` will be the value of
         [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots 
-        with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the width of a single view.  __See also:__ The documentation for [width 
+         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
+        with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the width of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
     """
     _schema = {'$ref': '#/definitions/FacetedCompositeUnitSpecAlias'}
@@ -2586,9 +2586,9 @@ class FacetedCompositeUnitSpecAlias(VegaLiteSchema):
 
 class VConcatSpec(VegaLiteSchema):
     """VConcatSpec schema wrapper
-    
+
     Mapping(required=[vconcat])
-    
+
     Attributes
     ----------
     vconcat : List(Spec)
@@ -2618,7 +2618,7 @@ class VConcatSpec(VegaLiteSchema):
 
 class GeoType(VegaLiteSchema):
     """GeoType schema wrapper
-    
+
     enum('latitude', 'longitude', 'geojson')
     """
     _schema = {'$ref': '#/definitions/GeoType'}
@@ -2630,31 +2630,31 @@ class GeoType(VegaLiteSchema):
 
 class Header(VegaLiteSchema):
     """Header schema wrapper
-    
+
     Mapping(required=[])
     Headers of row / column channels for faceted plots.
-    
+
     Attributes
     ----------
     format : string
-        The formatting pattern for labels. This is D3's [number format 
-        pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and 
-        D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for 
-        time field.  See the [format documentation](format.html) for more information.  
-        __Default value:__  derived from [numberFormat](config.html#format) config for 
-        quantitative fields and from [timeFormat](config.html#format) config for temporal 
+        The formatting pattern for labels. This is D3's [number format
+        pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and
+        D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for
+        time field.  See the [format documentation](format.html) for more information.
+        __Default value:__  derived from [numberFormat](config.html#format) config for
+        quantitative fields and from [timeFormat](config.html#format) config for temporal
         fields.
     labelAngle : float
         The rotation angle of the header labels.  __Default value:__ `0`.
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__  
-        derived from the field's name and transformation function (`aggregate`, `bin` and 
+        A title for the field. If `null`, the title will be removed.  __Default value:__
+        derived from the field's name and transformation function (`aggregate`, `bin` and
         `timeUnit`).  If the field has an aggregate function, the function is displayed as a
-         part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time 
-        unit applied, the applied function will be denoted in parentheses (e.g., `"Profit 
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the 
+         part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
+        unit applied, the applied function will be denoted in parentheses (e.g., `"Profit
+        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
         field name.  __Note__: You can customize the default field title format by providing
-         the [`fieldTitle` property in the [config](config.html) or [`fieldTitle` function 
+         the [`fieldTitle` property in the [config](config.html) or [`fieldTitle` function
         via the `compile` function's options](compile.html#field-title).
     """
     _schema = {'$ref': '#/definitions/Header'}
@@ -2666,7 +2666,7 @@ class Header(VegaLiteSchema):
 
 class HorizontalAlign(VegaLiteSchema):
     """HorizontalAlign schema wrapper
-    
+
     enum('left', 'right', 'center')
     """
     _schema = {'$ref': '#/definitions/HorizontalAlign'}
@@ -2678,13 +2678,13 @@ class HorizontalAlign(VegaLiteSchema):
 
 class InlineData(VegaLiteSchema):
     """InlineData schema wrapper
-    
+
     Mapping(required=[values])
-    
+
     Attributes
     ----------
     values : InlineDataset
-        The full data set, included inline. This can be an array of objects or primitive 
+        The full data set, included inline. This can be an array of objects or primitive
         values or a string. Arrays of primitive values are ingested as objects with a `data`
          property. Strings are parsed according to the specified format type.
     format : DataFormat
@@ -2699,8 +2699,8 @@ class InlineData(VegaLiteSchema):
 
 class InlineDataset(VegaLiteSchema):
     """InlineDataset schema wrapper
-    
-    anyOf(List(float), List(string), List(boolean), List(Mapping(required=[])), string, 
+
+    anyOf(List(float), List(string), List(boolean), List(Mapping(required=[])), string,
     Mapping(required=[]))
     """
     _schema = {'$ref': '#/definitions/InlineDataset'}
@@ -2712,8 +2712,8 @@ class InlineDataset(VegaLiteSchema):
 
 class Interpolate(VegaLiteSchema):
     """Interpolate schema wrapper
-    
-    enum('linear', 'linear-closed', 'step', 'step-before', 'step-after', 'basis', 'basis-open', 
+
+    enum('linear', 'linear-closed', 'step', 'step-before', 'step-after', 'basis', 'basis-open',
     'basis-closed', 'cardinal', 'cardinal-open', 'cardinal-closed', 'bundle', 'monotone')
     """
     _schema = {'$ref': '#/definitions/Interpolate'}
@@ -2725,49 +2725,49 @@ class Interpolate(VegaLiteSchema):
 
 class IntervalSelection(VegaLiteSchema):
     """IntervalSelection schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('interval')
-    
+
     bind : enum('scales')
-        Establishes a two-way binding between the interval selection and the scales used 
+        Establishes a two-way binding between the interval selection and the scales used
         within the same view. This allows a user to interactively pan and zoom the view.
     empty : enum('all', 'none')
-        By default, all data values are considered to lie within an empty selection. When 
+        By default, all data values are considered to lie within an empty selection. When
         set to `none`, empty selections contain no data values.
     encodings : List(SingleDefChannel)
-        An array of encoding channels. The corresponding data field values must match for a 
+        An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
     fields : List(string)
-        An array of field names whose values must match for a data tuple to fall within the 
+        An array of field names whose values must match for a data tuple to fall within the
         selection.
     mark : BrushConfig
-        An interval selection also adds a rectangle mark to depict the extents of the 
+        An interval selection also adds a rectangle mark to depict the extents of the
         interval. The `mark` property can be used to customize the appearance of the mark.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or 
-        selector) that triggers the selection. For interval selections, the event stream 
-        must specify a [start and 
+        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        selector) that triggers the selection. For interval selections, the event stream
+        must specify a [start and
         end](https://vega.github.io/vega/docs/event-streams/#between-filters).
     resolve : SelectionResolution
-        With layered and multi-view displays, a strategy that determines how selections' 
-        data queries are resolved when applied in a filter transform, conditional encoding 
+        With layered and multi-view displays, a strategy that determines how selections'
+        data queries are resolved when applied in a filter transform, conditional encoding
         rule, or scale domain.
     translate : anyOf(string, boolean)
-        When truthy, allows a user to interactively move an interval selection 
+        When truthy, allows a user to interactively move an interval selection
         back-and-forth. Can be `true`, `false` (to disable panning), or a [Vega event stream
-         definition](https://vega.github.io/vega/docs/event-streams/) which must include a 
+         definition](https://vega.github.io/vega/docs/event-streams/) which must include a
         start and end event to trigger continuous panning.  __Default value:__ `true`, which
-         corresponds to `[mousedown, window:mouseup] > window:mousemove!` which corresponds 
+         corresponds to `[mousedown, window:mouseup] > window:mousemove!` which corresponds
         to clicks and dragging within an interval selection to reposition it.
     zoom : anyOf(string, boolean)
-        When truthy, allows a user to interactively resize an interval selection. Can be 
-        `true`, `false` (to disable zooming), or a [Vega event stream 
-        definition](https://vega.github.io/vega/docs/event-streams/). Currently, only 
-        `wheel` events are supported.   __Default value:__ `true`, which corresponds to 
+        When truthy, allows a user to interactively resize an interval selection. Can be
+        `true`, `false` (to disable zooming), or a [Vega event stream
+        definition](https://vega.github.io/vega/docs/event-streams/). Currently, only
+        `wheel` events are supported.   __Default value:__ `true`, which corresponds to
         `wheel!`.
     """
     _schema = {'$ref': '#/definitions/IntervalSelection'}
@@ -2783,47 +2783,47 @@ class IntervalSelection(VegaLiteSchema):
 
 class IntervalSelectionConfig(VegaLiteSchema):
     """IntervalSelectionConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     bind : enum('scales')
-        Establishes a two-way binding between the interval selection and the scales used 
+        Establishes a two-way binding between the interval selection and the scales used
         within the same view. This allows a user to interactively pan and zoom the view.
     empty : enum('all', 'none')
-        By default, all data values are considered to lie within an empty selection. When 
+        By default, all data values are considered to lie within an empty selection. When
         set to `none`, empty selections contain no data values.
     encodings : List(SingleDefChannel)
-        An array of encoding channels. The corresponding data field values must match for a 
+        An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
     fields : List(string)
-        An array of field names whose values must match for a data tuple to fall within the 
+        An array of field names whose values must match for a data tuple to fall within the
         selection.
     mark : BrushConfig
-        An interval selection also adds a rectangle mark to depict the extents of the 
+        An interval selection also adds a rectangle mark to depict the extents of the
         interval. The `mark` property can be used to customize the appearance of the mark.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or 
-        selector) that triggers the selection. For interval selections, the event stream 
-        must specify a [start and 
+        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        selector) that triggers the selection. For interval selections, the event stream
+        must specify a [start and
         end](https://vega.github.io/vega/docs/event-streams/#between-filters).
     resolve : SelectionResolution
-        With layered and multi-view displays, a strategy that determines how selections' 
-        data queries are resolved when applied in a filter transform, conditional encoding 
+        With layered and multi-view displays, a strategy that determines how selections'
+        data queries are resolved when applied in a filter transform, conditional encoding
         rule, or scale domain.
     translate : anyOf(string, boolean)
-        When truthy, allows a user to interactively move an interval selection 
+        When truthy, allows a user to interactively move an interval selection
         back-and-forth. Can be `true`, `false` (to disable panning), or a [Vega event stream
-         definition](https://vega.github.io/vega/docs/event-streams/) which must include a 
+         definition](https://vega.github.io/vega/docs/event-streams/) which must include a
         start and end event to trigger continuous panning.  __Default value:__ `true`, which
-         corresponds to `[mousedown, window:mouseup] > window:mousemove!` which corresponds 
+         corresponds to `[mousedown, window:mouseup] > window:mousemove!` which corresponds
         to clicks and dragging within an interval selection to reposition it.
     zoom : anyOf(string, boolean)
-        When truthy, allows a user to interactively resize an interval selection. Can be 
-        `true`, `false` (to disable zooming), or a [Vega event stream 
-        definition](https://vega.github.io/vega/docs/event-streams/). Currently, only 
-        `wheel` events are supported.   __Default value:__ `true`, which corresponds to 
+        When truthy, allows a user to interactively resize an interval selection. Can be
+        `true`, `false` (to disable zooming), or a [Vega event stream
+        definition](https://vega.github.io/vega/docs/event-streams/). Currently, only
+        `wheel` events are supported.   __Default value:__ `true`, which corresponds to
         `wheel!`.
     """
     _schema = {'$ref': '#/definitions/IntervalSelectionConfig'}
@@ -2839,31 +2839,31 @@ class IntervalSelectionConfig(VegaLiteSchema):
 
 class JsonDataFormat(VegaLiteSchema):
     """JsonDataFormat schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     parse : anyOf(enum('auto'), Mapping(required=[]))
-        If set to auto (the default), perform automatic type inference to determine the 
-        desired data types. Alternatively, a parsing directive object can be provided for 
-        explicit data types. Each property of the object corresponds to a field name, and 
+        If set to auto (the default), perform automatic type inference to determine the
+        desired data types. Alternatively, a parsing directive object can be provided for
+        explicit data types. Each property of the object corresponds to a field name, and
         the value to the desired data type (one of `"number"`, `"boolean"` or `"date"`). For
-         example, `"parse": {"modified_on": "date"}` parses the `modified_on` field in each 
-        input record a Date value.  For `"date"`, we parse data based using Javascript's 
+         example, `"parse": {"modified_on": "date"}` parses the `modified_on` field in each
+        input record a Date value.  For `"date"`, we parse data based using Javascript's
         [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).
-         For Specific date formats can be provided (e.g., `{foo: 'date:"%m%d%Y"'}`), using 
+         For Specific date formats can be provided (e.g., `{foo: 'date:"%m%d%Y"'}`), using
         the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC
-         date format parsing is supported similarly (e.g., `{foo: 'utc:"%m%d%Y"'}`). See 
+         date format parsing is supported similarly (e.g., `{foo: 'utc:"%m%d%Y"'}`). See
         more about [UTC time](timeunit.html#utc)
     property : string
-        The JSON property containing the desired data. This parameter can be used when the 
-        loaded JSON file may have surrounding structure or meta-data. For example 
-        `"property": "values.features"` is equivalent to retrieving `json.values.features` 
+        The JSON property containing the desired data. This parameter can be used when the
+        loaded JSON file may have surrounding structure or meta-data. For example
+        `"property": "values.features"` is equivalent to retrieving `json.values.features`
         from the loaded JSON object.
     type : enum('json')
-        Type of input data: `"json"`, `"csv"`, `"tsv"`. The default format type is 
-        determined by the extension of the file URL. If no extension is detected, `"json"` 
+        Type of input data: `"json"`, `"csv"`, `"tsv"`. The default format type is
+        determined by the extension of the file URL. If no extension is detected, `"json"`
         will be used by default.
     """
     _schema = {'$ref': '#/definitions/JsonDataFormat'}
@@ -2875,51 +2875,51 @@ class JsonDataFormat(VegaLiteSchema):
 
 class Legend(VegaLiteSchema):
     """Legend schema wrapper
-    
+
     Mapping(required=[])
     Properties of a legend or boolean flag for determining whether to show it.
-    
+
     Attributes
     ----------
     entryPadding : float
         Padding (in pixels) between legend entries in a symbol legend.
     format : string
-        The formatting pattern for labels. This is D3's [number format 
-        pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and 
-        D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for 
-        time field.  See the [format documentation](format.html) for more information.  
-        __Default value:__  derived from [numberFormat](config.html#format) config for 
-        quantitative fields and from [timeFormat](config.html#format) config for temporal 
+        The formatting pattern for labels. This is D3's [number format
+        pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and
+        D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for
+        time field.  See the [format documentation](format.html) for more information.
+        __Default value:__  derived from [numberFormat](config.html#format) config for
+        quantitative fields and from [timeFormat](config.html#format) config for temporal
         fields.
     offset : float
-        The offset, in pixels, by which to displace the legend from the edge of the 
+        The offset, in pixels, by which to displace the legend from the edge of the
         enclosing group or data rectangle.  __Default value:__  `0`
     orient : LegendOrient
-        The orientation of the legend, which determines how the legend is positioned within 
-        the scene. One of "left", "right", "top-left", "top-right", "bottom-left", 
+        The orientation of the legend, which determines how the legend is positioned within
+        the scene. One of "left", "right", "top-left", "top-right", "bottom-left",
         "bottom-right", "none".  __Default value:__ `"right"`
     padding : float
         The padding, in pixels, between the legend and axis.
     tickCount : float
         The desired number of tick values for quantitative legends.
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__  
-        derived from the field's name and transformation function (`aggregate`, `bin` and 
+        A title for the field. If `null`, the title will be removed.  __Default value:__
+        derived from the field's name and transformation function (`aggregate`, `bin` and
         `timeUnit`).  If the field has an aggregate function, the function is displayed as a
-         part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time 
-        unit applied, the applied function will be denoted in parentheses (e.g., `"Profit 
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the 
+         part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
+        unit applied, the applied function will be denoted in parentheses (e.g., `"Profit
+        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
         field name.  __Note__: You can customize the default field title format by providing
-         the [`fieldTitle` property in the [config](config.html) or [`fieldTitle` function 
+         the [`fieldTitle` property in the [config](config.html) or [`fieldTitle` function
         via the `compile` function's options](compile.html#field-title).
     type : enum('symbol', 'gradient')
-        The type of the legend. Use `"symbol"` to create a discrete legend and `"gradient"` 
-        for a continuous color gradient.  __Default value:__ `"gradient"` for non-binned 
+        The type of the legend. Use `"symbol"` to create a discrete legend and `"gradient"`
+        for a continuous color gradient.  __Default value:__ `"gradient"` for non-binned
         quantitative fields and temporal fields; `"symbol"` otherwise.
     values : anyOf(List(float), List(string), List(DateTime))
         Explicitly set the visible legend values.
     zindex : float
-        A non-positive integer indicating z-index of the legend. If zindex is 0, legend 
+        A non-positive integer indicating z-index of the legend. If zindex is 0, legend
         should be drawn behind all chart elements. To put them in front, use zindex = 1.
     """
     _schema = {'$ref': '#/definitions/Legend'}
@@ -2935,9 +2935,9 @@ class Legend(VegaLiteSchema):
 
 class LegendConfig(VegaLiteSchema):
     """LegendConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     cornerRadius : float
@@ -2975,16 +2975,16 @@ class LegendConfig(VegaLiteSchema):
     labelOffset : float
         The offset of the legend label.
     offset : float
-        The offset, in pixels, by which to displace the legend from the edge of the 
+        The offset, in pixels, by which to displace the legend from the edge of the
         enclosing group or data rectangle.  __Default value:__  `0`
     orient : LegendOrient
-        The orientation of the legend, which determines how the legend is positioned within 
-        the scene. One of "left", "right", "top-left", "top-right", "bottom-left", 
+        The orientation of the legend, which determines how the legend is positioned within
+        the scene. One of "left", "right", "top-left", "top-right", "bottom-left",
         "bottom-right", "none".  __Default value:__ `"right"`
     padding : float
         The padding, in pixels, between the legend and axis.
     shortTimeLabels : boolean
-        Whether month names and weekday names should be abbreviated.  __Default value:__  
+        Whether month names and weekday names should be abbreviated.  __Default value:__
         `false`
     strokeColor : string
         Border stroke color for the full legend.
@@ -3011,8 +3011,8 @@ class LegendConfig(VegaLiteSchema):
     titleFontSize : float
         The font size of the legend title.
     titleFontWeight : FontWeight
-        The font weight of the legend title. This can be either a string (e.g `"bold"`, 
-        `"normal"`) or a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` 
+        The font weight of the legend title. This can be either a string (e.g `"bold"`,
+        `"normal"`) or a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400`
         and `"bold"` = `700`).
     titleLimit : float
         Maximum allowed pixel width of axis titles.
@@ -3059,7 +3059,7 @@ class LegendConfig(VegaLiteSchema):
 
 class LegendOrient(VegaLiteSchema):
     """LegendOrient schema wrapper
-    
+
     enum('left', 'right', 'top-left', 'top-right', 'bottom-left', 'bottom-right', 'none')
     """
     _schema = {'$ref': '#/definitions/LegendOrient'}
@@ -3071,23 +3071,23 @@ class LegendOrient(VegaLiteSchema):
 
 class LegendResolveMap(VegaLiteSchema):
     """LegendResolveMap schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     color : ResolveMode
-    
+
     fill : ResolveMode
-    
+
     opacity : ResolveMode
-    
+
     shape : ResolveMode
-    
+
     size : ResolveMode
-    
+
     stroke : ResolveMode
-    
+
     """
     _schema = {'$ref': '#/definitions/LegendResolveMap'}
     _rootschema = Root._schema
@@ -3100,9 +3100,9 @@ class LegendResolveMap(VegaLiteSchema):
 
 class LocalMultiTimeUnit(VegaLiteSchema):
     """LocalMultiTimeUnit schema wrapper
-    
-    enum('yearquarter', 'yearquartermonth', 'yearmonth', 'yearmonthdate', 'yearmonthdatehours', 
-    'yearmonthdatehoursminutes', 'yearmonthdatehoursminutesseconds', 'quartermonth', 
+
+    enum('yearquarter', 'yearquartermonth', 'yearmonth', 'yearmonthdate', 'yearmonthdatehours',
+    'yearmonthdatehoursminutes', 'yearmonthdatehoursminutesseconds', 'quartermonth',
     'monthdate', 'hoursminutes', 'hoursminutesseconds', 'minutesseconds', 'secondsmilliseconds')
     """
     _schema = {'$ref': '#/definitions/LocalMultiTimeUnit'}
@@ -3114,8 +3114,8 @@ class LocalMultiTimeUnit(VegaLiteSchema):
 
 class LocalSingleTimeUnit(VegaLiteSchema):
     """LocalSingleTimeUnit schema wrapper
-    
-    enum('year', 'quarter', 'month', 'day', 'date', 'hours', 'minutes', 'seconds', 
+
+    enum('year', 'quarter', 'month', 'day', 'date', 'hours', 'minutes', 'seconds',
     'milliseconds')
     """
     _schema = {'$ref': '#/definitions/LocalSingleTimeUnit'}
@@ -3127,16 +3127,16 @@ class LocalSingleTimeUnit(VegaLiteSchema):
 
 class LogicalAndPredicate(VegaLiteSchema):
     """LogicalAndPredicate schema wrapper
-    
+
     Mapping(required=[and])
-    
+
     Attributes
     ----------
-    
+
     Dict-Only Attributes
     --------------------
     'and' : List(LogicalOperandPredicate)
-    
+
     """
     _schema = {'$ref': '#/definitions/LogicalAnd<Predicate>'}
     _rootschema = Root._schema
@@ -3147,16 +3147,16 @@ class LogicalAndPredicate(VegaLiteSchema):
 
 class SelectionAnd(VegaLiteSchema):
     """SelectionAnd schema wrapper
-    
+
     Mapping(required=[and])
-    
+
     Attributes
     ----------
-    
+
     Dict-Only Attributes
     --------------------
     'and' : List(SelectionOperand)
-    
+
     """
     _schema = {'$ref': '#/definitions/SelectionAnd'}
     _rootschema = Root._schema
@@ -3167,16 +3167,16 @@ class SelectionAnd(VegaLiteSchema):
 
 class LogicalNotPredicate(VegaLiteSchema):
     """LogicalNotPredicate schema wrapper
-    
+
     Mapping(required=[not])
-    
+
     Attributes
     ----------
-    
+
     Dict-Only Attributes
     --------------------
     'not' : LogicalOperandPredicate
-    
+
     """
     _schema = {'$ref': '#/definitions/LogicalNot<Predicate>'}
     _rootschema = Root._schema
@@ -3187,16 +3187,16 @@ class LogicalNotPredicate(VegaLiteSchema):
 
 class SelectionNot(VegaLiteSchema):
     """SelectionNot schema wrapper
-    
+
     Mapping(required=[not])
-    
+
     Attributes
     ----------
-    
+
     Dict-Only Attributes
     --------------------
     'not' : SelectionOperand
-    
+
     """
     _schema = {'$ref': '#/definitions/SelectionNot'}
     _rootschema = Root._schema
@@ -3207,7 +3207,7 @@ class SelectionNot(VegaLiteSchema):
 
 class LogicalOperandPredicate(VegaLiteSchema):
     """LogicalOperandPredicate schema wrapper
-    
+
     anyOf(LogicalNotPredicate, LogicalAndPredicate, LogicalOrPredicate, Predicate)
     """
     _schema = {'$ref': '#/definitions/LogicalOperand<Predicate>'}
@@ -3219,7 +3219,7 @@ class LogicalOperandPredicate(VegaLiteSchema):
 
 class SelectionOperand(VegaLiteSchema):
     """SelectionOperand schema wrapper
-    
+
     anyOf(SelectionNot, SelectionAnd, SelectionOr, string)
     """
     _schema = {'$ref': '#/definitions/SelectionOperand'}
@@ -3231,16 +3231,16 @@ class SelectionOperand(VegaLiteSchema):
 
 class LogicalOrPredicate(VegaLiteSchema):
     """LogicalOrPredicate schema wrapper
-    
+
     Mapping(required=[or])
-    
+
     Attributes
     ----------
-    
+
     Dict-Only Attributes
     --------------------
     'or' : List(LogicalOperandPredicate)
-    
+
     """
     _schema = {'$ref': '#/definitions/LogicalOr<Predicate>'}
     _rootschema = Root._schema
@@ -3251,16 +3251,16 @@ class LogicalOrPredicate(VegaLiteSchema):
 
 class SelectionOr(VegaLiteSchema):
     """SelectionOr schema wrapper
-    
+
     Mapping(required=[or])
-    
+
     Attributes
     ----------
-    
+
     Dict-Only Attributes
     --------------------
     'or' : List(SelectionOperand)
-    
+
     """
     _schema = {'$ref': '#/definitions/SelectionOr'}
     _rootschema = Root._schema
@@ -3271,9 +3271,9 @@ class SelectionOr(VegaLiteSchema):
 
 class LookupData(VegaLiteSchema):
     """LookupData schema wrapper
-    
+
     Mapping(required=[data, key])
-    
+
     Attributes
     ----------
     data : Data
@@ -3292,22 +3292,22 @@ class LookupData(VegaLiteSchema):
 
 class LookupTransform(VegaLiteSchema):
     """LookupTransform schema wrapper
-    
+
     Mapping(required=[lookup, from])
-    
+
     Attributes
     ----------
     lookup : string
         Key in primary data source.
     default : string
         The default value to use if lookup fails.  __Default value:__ `null`
-    
+
     Dict-Only Attributes
     --------------------
     'as' : anyOf(string, List(string))
-        The field or fields for storing the computed formula value. If `from.fields` is 
-        specified, the transform will use the same names for `as`. If `from.fields` is not 
-        specified, `as` has to be a string and we put the whole object into the data under 
+        The field or fields for storing the computed formula value. If `from.fields` is
+        specified, the transform will use the same names for `as`. If `from.fields` is not
+        specified, `as` has to be a string and we put the whole object into the data under
         the specified name.
     'from' : LookupData
         Secondary data reference.
@@ -3321,8 +3321,8 @@ class LookupTransform(VegaLiteSchema):
 
 class Mark(VegaLiteSchema):
     """Mark schema wrapper
-    
-    enum('area', 'bar', 'line', 'point', 'text', 'tick', 'rect', 'rule', 'circle', 'square', 
+
+    enum('area', 'bar', 'line', 'point', 'text', 'tick', 'rect', 'rule', 'circle', 'square',
     'geoshape')
     All types of primitive marks.
     """
@@ -3335,9 +3335,9 @@ class Mark(VegaLiteSchema):
 
 class MarkConfig(VegaLiteSchema):
     """MarkConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     align : HorizontalAlign
@@ -3345,34 +3345,34 @@ class MarkConfig(VegaLiteSchema):
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.  
+        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
         __Default value:__ `"middle"`
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color` 
-        and will override `color`.  __Default value:__ <span style="color: 
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a 
+        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
+        and will override `color`.  __Default value:__ <span style="color:
+        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
         [style config](mark.html#style-config).
-    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress', 
-    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop', 
-    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize', 
-    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize', 
+    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
+    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
+    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
+    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor 
+        The mouse cursor used over the mark. Any valid [CSS cursor
         type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
     dx : float
-        The horizontal offset, in pixels, between the text label and its anchor point. The 
+        The horizontal offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     dy : float
-        The vertical offset, in pixels, between the text label and its anchor point. The 
+        The vertical offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     fill : string
-        Default Fill Color.  This has higher precedence than config.color  __Default 
+        Default Fill Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     fillOpacity : float
         The fill opacity (value between [0,1]).  __Default value:__ `1`
     filled : boolean
-        Whether the mark's color should be used as fill color instead of stroke color.  
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.  
+        Whether the mark's color should be used as fill color instead of stroke color.
+        __Default value:__ `true` for all marks except `point` and `false` for `point`.
         __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
          This property cannot be used in a [style config](mark.html#style-config).
     font : string
@@ -3382,54 +3382,54 @@ class MarkConfig(VegaLiteSchema):
     fontStyle : FontStyle
         The font style (e.g., `"italic"`).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number 
+        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
         (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
-        The line interpolation method to use for line and area marks. One of the following: 
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`: 
-        close the linear segments to form a polygon. - `"step"`: alternate between 
-        horizontal and vertical segments, as in a step function. - `"step-before"`: 
-        alternate between vertical and horizontal segments, as in a step function. - 
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step 
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. - 
-        `"basis-open"`: an open B-spline; may not intersect the start or end. - 
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal 
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open 
-        Cardinal spline; may not intersect the start or end, but will intersect other 
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. - 
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten 
+        The line interpolation method to use for line and area marks. One of the following:
+        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
+        close the linear segments to form a polygon. - `"step"`: alternate between
+        horizontal and vertical segments, as in a step function. - `"step-before"`:
+        alternate between vertical and horizontal segments, as in a step function. -
+        `"step-after"`: alternate between horizontal and vertical segments, as in a step
+        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
+        `"basis-open"`: an open B-spline; may not intersect the start or end. -
+        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
+        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
+        Cardinal spline; may not intersect the start or end, but will intersect other
+        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
+        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
         the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
     limit : float
-        The maximum length of the text mark in pixels (default 0, indicating no limit). The 
+        The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for 
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered 
+        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
+        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
         `bar` charts and `1` otherwise.
     orient : Orient
-        The orientation of a non-stacked bar, tick, area, and line charts. The value is 
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines 
-        whether the size of the bar and tick should be applied to x or y dimension. - For 
-        area, this property determines the orient property of the Vega output. - For line, 
-        this property determines the sort order of the points in the line if 
-        `config.sortLineBy` is not specified. For stacked charts, this is always determined 
-        by the orientation of the stack; therefore explicitly specified value will be 
+        The orientation of a non-stacked bar, tick, area, and line charts. The value is
+        either horizontal (default) or vertical. - For bar, rule and tick, this determines
+        whether the size of the bar and tick should be applied to x or y dimension. - For
+        area, this property determines the orient property of the Vega output. - For line,
+        this property determines the sort order of the points in the line if
+        `config.sortLineBy` is not specified. For stacked charts, this is always determined
+        by the orientation of the stack; therefore explicitly specified value will be
         ignored.
     radius : float
-        Polar coordinate radial offset, in pixels, of the text label from the origin 
+        Polar coordinate radial offset, in pixels, of the text label from the origin
         determined by the `x` and `y` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`, 
+        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
         `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
           __Default value:__ `"circle"`
     size : float
-        The pixel area each the point/circle/square. For example: in the case of circles, 
-        the radius is determined in part by the square root of the size value.  __Default 
+        The pixel area each the point/circle/square. For example: in the case of circles,
+        the radius is determined in part by the square root of the size value.  __Default
         value:__ `30`
     stroke : string
-        Default Stroke Color.  This has higher precedence than config.color  __Default 
+        Default Stroke Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
@@ -3440,14 +3440,14 @@ class MarkConfig(VegaLiteSchema):
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
-        Depending on the interpolation type, sets the tension parameter (for line and area 
+        Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
         Placeholder text if the `text` channel is not specified
     theta : float
-        Polar coordinate angle, in radians, of the text label from the origin determined by 
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc` 
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with 
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
+        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
         `0` indicating "north".
     """
     _schema = {'$ref': '#/definitions/MarkConfig'}
@@ -3475,9 +3475,9 @@ class MarkConfig(VegaLiteSchema):
 
 class MarkDef(VegaLiteSchema):
     """MarkDef schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : Mark
@@ -3488,36 +3488,36 @@ class MarkDef(VegaLiteSchema):
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.  
+        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
         __Default value:__ `"middle"`
     clip : boolean
         Whether a mark be clipped to the enclosing group’s width and height.
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color` 
-        and will override `color`.  __Default value:__ <span style="color: 
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a 
+        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
+        and will override `color`.  __Default value:__ <span style="color:
+        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
         [style config](mark.html#style-config).
-    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress', 
-    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop', 
-    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize', 
-    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize', 
+    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
+    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
+    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
+    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor 
+        The mouse cursor used over the mark. Any valid [CSS cursor
         type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
     dx : float
-        The horizontal offset, in pixels, between the text label and its anchor point. The 
+        The horizontal offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     dy : float
-        The vertical offset, in pixels, between the text label and its anchor point. The 
+        The vertical offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     fill : string
-        Default Fill Color.  This has higher precedence than config.color  __Default 
+        Default Fill Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     fillOpacity : float
         The fill opacity (value between [0,1]).  __Default value:__ `1`
     filled : boolean
-        Whether the mark's color should be used as fill color instead of stroke color.  
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.  
+        Whether the mark's color should be used as fill color instead of stroke color.
+        __Default value:__ `true` for all marks except `point` and `false` for `point`.
         __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
          This property cannot be used in a [style config](mark.html#style-config).
     font : string
@@ -3527,54 +3527,54 @@ class MarkDef(VegaLiteSchema):
     fontStyle : FontStyle
         The font style (e.g., `"italic"`).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number 
+        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
         (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
-        The line interpolation method to use for line and area marks. One of the following: 
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`: 
-        close the linear segments to form a polygon. - `"step"`: alternate between 
-        horizontal and vertical segments, as in a step function. - `"step-before"`: 
-        alternate between vertical and horizontal segments, as in a step function. - 
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step 
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. - 
-        `"basis-open"`: an open B-spline; may not intersect the start or end. - 
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal 
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open 
-        Cardinal spline; may not intersect the start or end, but will intersect other 
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. - 
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten 
+        The line interpolation method to use for line and area marks. One of the following:
+        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
+        close the linear segments to form a polygon. - `"step"`: alternate between
+        horizontal and vertical segments, as in a step function. - `"step-before"`:
+        alternate between vertical and horizontal segments, as in a step function. -
+        `"step-after"`: alternate between horizontal and vertical segments, as in a step
+        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
+        `"basis-open"`: an open B-spline; may not intersect the start or end. -
+        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
+        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
+        Cardinal spline; may not intersect the start or end, but will intersect other
+        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
+        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
         the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
     limit : float
-        The maximum length of the text mark in pixels (default 0, indicating no limit). The 
+        The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for 
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered 
+        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
+        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
         `bar` charts and `1` otherwise.
     orient : Orient
-        The orientation of a non-stacked bar, tick, area, and line charts. The value is 
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines 
-        whether the size of the bar and tick should be applied to x or y dimension. - For 
-        area, this property determines the orient property of the Vega output. - For line, 
-        this property determines the sort order of the points in the line if 
-        `config.sortLineBy` is not specified. For stacked charts, this is always determined 
-        by the orientation of the stack; therefore explicitly specified value will be 
+        The orientation of a non-stacked bar, tick, area, and line charts. The value is
+        either horizontal (default) or vertical. - For bar, rule and tick, this determines
+        whether the size of the bar and tick should be applied to x or y dimension. - For
+        area, this property determines the orient property of the Vega output. - For line,
+        this property determines the sort order of the points in the line if
+        `config.sortLineBy` is not specified. For stacked charts, this is always determined
+        by the orientation of the stack; therefore explicitly specified value will be
         ignored.
     radius : float
-        Polar coordinate radial offset, in pixels, of the text label from the origin 
+        Polar coordinate radial offset, in pixels, of the text label from the origin
         determined by the `x` and `y` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`, 
+        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
         `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
           __Default value:__ `"circle"`
     size : float
-        The pixel area each the point/circle/square. For example: in the case of circles, 
-        the radius is determined in part by the square root of the size value.  __Default 
+        The pixel area each the point/circle/square. For example: in the case of circles,
+        the radius is determined in part by the square root of the size value.  __Default
         value:__ `30`
     stroke : string
-        Default Stroke Color.  This has higher precedence than config.color  __Default 
+        Default Stroke Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
@@ -3585,24 +3585,24 @@ class MarkDef(VegaLiteSchema):
     strokeWidth : float
         The stroke width, in pixels.
     style : anyOf(string, List(string))
-        A string or array of strings indicating the name of custom styles to apply to the 
-        mark. A style is a named collection of mark property defaults defined within the 
-        [style configuration](mark.html#style-config). If style is an array, later styles 
-        will override earlier styles. Any [mark properties](encoding.html#mark-prop) 
-        explicitly defined within the `encoding` will override a style default.  __Default 
-        value:__ The mark's name.  For example, a bar mark will have style `"bar"` by 
-        default. __Note:__ Any specified style will augment the default style. For example, 
-        a bar mark with `"style": "foo"` will receive from `config.style.bar` and 
+        A string or array of strings indicating the name of custom styles to apply to the
+        mark. A style is a named collection of mark property defaults defined within the
+        [style configuration](mark.html#style-config). If style is an array, later styles
+        will override earlier styles. Any [mark properties](encoding.html#mark-prop)
+        explicitly defined within the `encoding` will override a style default.  __Default
+        value:__ The mark's name.  For example, a bar mark will have style `"bar"` by
+        default. __Note:__ Any specified style will augment the default style. For example,
+        a bar mark with `"style": "foo"` will receive from `config.style.bar` and
         `config.style.foo` (the specified style `"foo"` has higher precedence).
     tension : float
-        Depending on the interpolation type, sets the tension parameter (for line and area 
+        Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
         Placeholder text if the `text` channel is not specified
     theta : float
-        Polar coordinate angle, in radians, of the text label from the origin determined by 
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc` 
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with 
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
+        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
         `0` indicating "north".
     """
     _schema = {'$ref': '#/definitions/MarkDef'}
@@ -3631,7 +3631,7 @@ class MarkDef(VegaLiteSchema):
 
 class Month(VegaLiteSchema):
     """Month schema wrapper
-    
+
     float
     """
     _schema = {'$ref': '#/definitions/Month'}
@@ -3643,40 +3643,40 @@ class Month(VegaLiteSchema):
 
 class MultiSelection(VegaLiteSchema):
     """MultiSelection schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('multi')
-    
+
     empty : enum('all', 'none')
-        By default, all data values are considered to lie within an empty selection. When 
+        By default, all data values are considered to lie within an empty selection. When
         set to `none`, empty selections contain no data values.
     encodings : List(SingleDefChannel)
-        An array of encoding channels. The corresponding data field values must match for a 
+        An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
     fields : List(string)
-        An array of field names whose values must match for a data tuple to fall within the 
+        An array of field names whose values must match for a data tuple to fall within the
         selection.
     nearest : boolean
-        When true, an invisible voronoi diagram is computed to accelerate discrete 
+        When true, an invisible voronoi diagram is computed to accelerate discrete
         selection. The data value _nearest_ the mouse cursor is added to the selection.  See
          the [nearest transform](nearest.html) documentation for more information.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or 
-        selector) that triggers the selection. For interval selections, the event stream 
-        must specify a [start and 
+        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        selector) that triggers the selection. For interval selections, the event stream
+        must specify a [start and
         end](https://vega.github.io/vega/docs/event-streams/#between-filters).
     resolve : SelectionResolution
-        With layered and multi-view displays, a strategy that determines how selections' 
-        data queries are resolved when applied in a filter transform, conditional encoding 
+        With layered and multi-view displays, a strategy that determines how selections'
+        data queries are resolved when applied in a filter transform, conditional encoding
         rule, or scale domain.
     toggle : anyOf(string, boolean)
-        Controls whether data values should be toggled or only ever inserted into multi 
-        selections. Can be `true`, `false` (for insertion only), or a [Vega 
-        expression](https://vega.github.io/vega/docs/expressions/).  __Default value:__ 
-        `true`, which corresponds to `event.shiftKey` (i.e., data values are toggled when a 
+        Controls whether data values should be toggled or only ever inserted into multi
+        selections. Can be `true`, `false` (for insertion only), or a [Vega
+        expression](https://vega.github.io/vega/docs/expressions/).  __Default value:__
+        `true`, which corresponds to `event.shiftKey` (i.e., data values are toggled when a
         user interacts with the shift-key pressed).  See the [toggle transform](toggle.html)
          documentation for more information.
     """
@@ -3692,38 +3692,38 @@ class MultiSelection(VegaLiteSchema):
 
 class MultiSelectionConfig(VegaLiteSchema):
     """MultiSelectionConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     empty : enum('all', 'none')
-        By default, all data values are considered to lie within an empty selection. When 
+        By default, all data values are considered to lie within an empty selection. When
         set to `none`, empty selections contain no data values.
     encodings : List(SingleDefChannel)
-        An array of encoding channels. The corresponding data field values must match for a 
+        An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
     fields : List(string)
-        An array of field names whose values must match for a data tuple to fall within the 
+        An array of field names whose values must match for a data tuple to fall within the
         selection.
     nearest : boolean
-        When true, an invisible voronoi diagram is computed to accelerate discrete 
+        When true, an invisible voronoi diagram is computed to accelerate discrete
         selection. The data value _nearest_ the mouse cursor is added to the selection.  See
          the [nearest transform](nearest.html) documentation for more information.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or 
-        selector) that triggers the selection. For interval selections, the event stream 
-        must specify a [start and 
+        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        selector) that triggers the selection. For interval selections, the event stream
+        must specify a [start and
         end](https://vega.github.io/vega/docs/event-streams/#between-filters).
     resolve : SelectionResolution
-        With layered and multi-view displays, a strategy that determines how selections' 
-        data queries are resolved when applied in a filter transform, conditional encoding 
+        With layered and multi-view displays, a strategy that determines how selections'
+        data queries are resolved when applied in a filter transform, conditional encoding
         rule, or scale domain.
     toggle : anyOf(string, boolean)
-        Controls whether data values should be toggled or only ever inserted into multi 
-        selections. Can be `true`, `false` (for insertion only), or a [Vega 
-        expression](https://vega.github.io/vega/docs/expressions/).  __Default value:__ 
-        `true`, which corresponds to `event.shiftKey` (i.e., data values are toggled when a 
+        Controls whether data values should be toggled or only ever inserted into multi
+        selections. Can be `true`, `false` (for insertion only), or a [Vega
+        expression](https://vega.github.io/vega/docs/expressions/).  __Default value:__
+        `true`, which corresponds to `event.shiftKey` (i.e., data values are toggled when a
         user interacts with the shift-key pressed).  See the [toggle transform](toggle.html)
          documentation for more information.
     """
@@ -3739,7 +3739,7 @@ class MultiSelectionConfig(VegaLiteSchema):
 
 class MultiTimeUnit(VegaLiteSchema):
     """MultiTimeUnit schema wrapper
-    
+
     anyOf(LocalMultiTimeUnit, UtcMultiTimeUnit)
     """
     _schema = {'$ref': '#/definitions/MultiTimeUnit'}
@@ -3751,9 +3751,9 @@ class MultiTimeUnit(VegaLiteSchema):
 
 class NamedData(VegaLiteSchema):
     """NamedData schema wrapper
-    
+
     Mapping(required=[name])
-    
+
     Attributes
     ----------
     name : string
@@ -3770,7 +3770,7 @@ class NamedData(VegaLiteSchema):
 
 class NiceTime(VegaLiteSchema):
     """NiceTime schema wrapper
-    
+
     enum('second', 'minute', 'hour', 'day', 'week', 'month', 'year')
     """
     _schema = {'$ref': '#/definitions/NiceTime'}
@@ -3782,40 +3782,40 @@ class NiceTime(VegaLiteSchema):
 
 class OrderFieldDef(VegaLiteSchema):
     """OrderFieldDef schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     sort : SortOrder
         The sort order. One of `"ascending"` (default) or `"descending"`.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/OrderFieldDef'}
@@ -3829,7 +3829,7 @@ class OrderFieldDef(VegaLiteSchema):
 
 class Orient(VegaLiteSchema):
     """Orient schema wrapper
-    
+
     enum('horizontal', 'vertical')
     """
     _schema = {'$ref': '#/definitions/Orient'}
@@ -3841,7 +3841,7 @@ class Orient(VegaLiteSchema):
 
 class Padding(VegaLiteSchema):
     """Padding schema wrapper
-    
+
     anyOf(float, Mapping(required=[]))
     """
     _schema = {'$ref': '#/definitions/Padding'}
@@ -3853,75 +3853,75 @@ class Padding(VegaLiteSchema):
 
 class PositionFieldDef(VegaLiteSchema):
     """PositionFieldDef schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`, 
-        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`, 
-        `"longitude"`, and `"geojson"`) when a [geographic 
+        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
+        `"ordinal"`, or `"nominal"`). It can also be a geo type (`"latitude"`,
+        `"longitude"`, and `"geojson"`) when a [geographic
         projection](https://vega.github.io/vega-lite/docs/projection.html) is applied.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, 
+        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
         `count`).  __Default value:__ `undefined` (None)
     axis : anyOf(Axis, None)
-        An object defining properties of axis's gridlines, ticks and labels. If `null`, the 
-        axis for the encoding channel will be removed.  __Default value:__ If undefined, 
-        default [axis properties](https://vega.github.io/vega-lite/docs/axis.html) are 
+        An object defining properties of axis's gridlines, ticks and labels. If `null`, the
+        axis for the encoding channel will be removed.  __Default value:__ If undefined,
+        default [axis properties](https://vega.github.io/vega-lite/docs/axis.html) are
         applied.
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning 
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`, 
+        A flag for binning a `quantitative` field, or [an object defining binning
+        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
         default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
          applied.  __Default value:__ `false`
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data 
-        value or an object defining iterated values from the 
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__ 
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., 
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or 
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g., 
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field 
+        __Required.__ A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the
+        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
+        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
+        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
+        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
+        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
         documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
          is not required if `aggregate` is `count`.
     scale : anyOf(Scale, None)
-        An object defining properties of the channel's scale, which is the function that 
+        An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be 
-        [disabled and the data value will be directly 
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default 
-        value:__ If undefined, default [scale 
+         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
+        [disabled and the data value will be directly
+        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
+        value:__ If undefined, default [scale
         properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
     sort : anyOf(SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`, 
+        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
         `"descending"` and `null` (no sorting). For fields with discrete domains, `sort` can
-         also be a [sort field definition 
-        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default 
+         also be a [sort field definition
+        object](https://vega.github.io/vega-lite/docs/sort.html#sort-field).  __Default
         value:__ `"ascending"`
     stack : anyOf(StackOffset, None)
-        Type of stacking offset if the field should be stacked. `stack` is only applicable 
+        Type of stacking offset if the field should be stacked. `stack` is only applicable
         for `x` and `y` channels with continuous domains. For example, `stack` of `y` can be
-         used to customize stacking for a vertical bar chart.  `stack` can be one of the 
-        following values: - `"zero"`: stacking with baseline offset at zero value of the 
-        scale (for creating typical stacked 
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and 
-        [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart). - 
-        `"normalize"` - stacking with normalized domain (for creating [normalized stacked 
-        bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). 
-        <br/> -`"center"` - stacking with center baseline (for 
-        [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)). - 
-        `null` - No-stacking. This will produce layered 
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area 
+         used to customize stacking for a vertical bar chart.  `stack` can be one of the
+        following values: - `"zero"`: stacking with baseline offset at zero value of the
+        scale (for creating typical stacked
+        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and
+        [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart). -
+        `"normalize"` - stacking with normalized domain (for creating [normalized stacked
+        bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized).
+        <br/> -`"center"` - stacking with center baseline (for
+        [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)). -
+        `null` - No-stacking. This will produce layered
+        [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area
         chart.  __Default value:__ `zero` for plots with all of the following conditions are
          true: (1) the mark is `bar` or `area`; (2) the stacked measure channel (x or y) has
          a linear scale; (3) At least one of non-position channels mapped to an unaggregated
          field that is different from x and y.  Otherwise, `null` by default.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a 
-        temporal field that gets casted as 
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__ 
+        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
+        temporal field that gets casted as
+        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
         `undefined` (None)
     """
     _schema = {'$ref': '#/definitions/PositionFieldDef'}
@@ -3937,8 +3937,8 @@ class PositionFieldDef(VegaLiteSchema):
 
 class Predicate(VegaLiteSchema):
     """Predicate schema wrapper
-    
-    anyOf(FieldEqualPredicate, FieldRangePredicate, FieldOneOfPredicate, SelectionPredicate, 
+
+    anyOf(FieldEqualPredicate, FieldRangePredicate, FieldOneOfPredicate, SelectionPredicate,
     string)
     """
     _schema = {'$ref': '#/definitions/Predicate'}
@@ -3950,57 +3950,57 @@ class Predicate(VegaLiteSchema):
 
 class Projection(VegaLiteSchema):
     """Projection schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     center : List(float)
-        Sets the projection’s center to the specified center, a two-element array of 
+        Sets the projection’s center to the specified center, a two-element array of
         longitude and latitude in degrees.  __Default value:__ `[0, 0]`
     clipAngle : float
-        Sets the projection’s clipping circle radius to the specified angle in degrees. If 
-        `null`, switches to [antimeridian](http://bl.ocks.org/mbostock/3788999) cutting 
+        Sets the projection’s clipping circle radius to the specified angle in degrees. If
+        `null`, switches to [antimeridian](http://bl.ocks.org/mbostock/3788999) cutting
         rather than small-circle clipping.
     clipExtent : List(List(float))
-        Sets the projection’s viewport clip extent to the specified bounds in pixels. The 
-        extent bounds are specified as an array `[[x0, y0], [x1, y1]]`, where `x0` is the 
-        left-side of the viewport, `y0` is the top, `x1` is the right and `y1` is the 
+        Sets the projection’s viewport clip extent to the specified bounds in pixels. The
+        extent bounds are specified as an array `[[x0, y0], [x1, y1]]`, where `x0` is the
+        left-side of the viewport, `y0` is the top, `x1` is the right and `y1` is the
         bottom. If `null`, no viewport clipping is performed.
     coefficient : float
-    
+
     distance : float
-    
+
     fraction : float
-    
+
     lobes : float
-    
+
     parallel : float
-    
+
     precision : Mapping(required=[length])
-        Sets the threshold for the projection’s [adaptive 
-        resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels. 
-        This value corresponds to the [Douglas–Peucker 
+        Sets the threshold for the projection’s [adaptive
+        resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels.
+        This value corresponds to the [Douglas–Peucker
         distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm).
-         If precision is not specified, returns the projection’s current resampling 
+         If precision is not specified, returns the projection’s current resampling
         precision which defaults to `√0.5 ≅ 0.70710…`.
     radius : float
-    
+
     ratio : float
-    
+
     rotate : List(float)
-        Sets the projection’s three-axis rotation to the specified angles, which must be a 
-        two- or three-element array of numbers [`lambda`, `phi`, `gamma`] specifying the 
-        rotation angles in degrees about each spherical axis. (These correspond to yaw, 
+        Sets the projection’s three-axis rotation to the specified angles, which must be a
+        two- or three-element array of numbers [`lambda`, `phi`, `gamma`] specifying the
+        rotation angles in degrees about each spherical axis. (These correspond to yaw,
         pitch and roll.)  __Default value:__ `[0, 0, 0]`
     spacing : float
-    
+
     tilt : float
-    
+
     type : ProjectionType
-        The cartographic projection to use. This value is case-insensitive, for example 
-        `"albers"` and `"Albers"` indicate the same projection type. You can find all valid 
-        projection types [in the 
+        The cartographic projection to use. This value is case-insensitive, for example
+        `"albers"` and `"Albers"` indicate the same projection type. You can find all valid
+        projection types [in the
         documentation](https://vega.github.io/vega-lite/docs/projection.html#projection-types).
           __Default value:__ `mercator`
     """
@@ -4020,58 +4020,58 @@ class Projection(VegaLiteSchema):
 
 class ProjectionConfig(VegaLiteSchema):
     """ProjectionConfig schema wrapper
-    
+
     Mapping(required=[])
     Any property of Projection can be in config
-    
+
     Attributes
     ----------
     center : List(float)
-        Sets the projection’s center to the specified center, a two-element array of 
+        Sets the projection’s center to the specified center, a two-element array of
         longitude and latitude in degrees.  __Default value:__ `[0, 0]`
     clipAngle : float
-        Sets the projection’s clipping circle radius to the specified angle in degrees. If 
-        `null`, switches to [antimeridian](http://bl.ocks.org/mbostock/3788999) cutting 
+        Sets the projection’s clipping circle radius to the specified angle in degrees. If
+        `null`, switches to [antimeridian](http://bl.ocks.org/mbostock/3788999) cutting
         rather than small-circle clipping.
     clipExtent : List(List(float))
-        Sets the projection’s viewport clip extent to the specified bounds in pixels. The 
-        extent bounds are specified as an array `[[x0, y0], [x1, y1]]`, where `x0` is the 
-        left-side of the viewport, `y0` is the top, `x1` is the right and `y1` is the 
+        Sets the projection’s viewport clip extent to the specified bounds in pixels. The
+        extent bounds are specified as an array `[[x0, y0], [x1, y1]]`, where `x0` is the
+        left-side of the viewport, `y0` is the top, `x1` is the right and `y1` is the
         bottom. If `null`, no viewport clipping is performed.
     coefficient : float
-    
+
     distance : float
-    
+
     fraction : float
-    
+
     lobes : float
-    
+
     parallel : float
-    
+
     precision : Mapping(required=[length])
-        Sets the threshold for the projection’s [adaptive 
-        resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels. 
-        This value corresponds to the [Douglas–Peucker 
+        Sets the threshold for the projection’s [adaptive
+        resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels.
+        This value corresponds to the [Douglas–Peucker
         distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm).
-         If precision is not specified, returns the projection’s current resampling 
+         If precision is not specified, returns the projection’s current resampling
         precision which defaults to `√0.5 ≅ 0.70710…`.
     radius : float
-    
+
     ratio : float
-    
+
     rotate : List(float)
-        Sets the projection’s three-axis rotation to the specified angles, which must be a 
-        two- or three-element array of numbers [`lambda`, `phi`, `gamma`] specifying the 
-        rotation angles in degrees about each spherical axis. (These correspond to yaw, 
+        Sets the projection’s three-axis rotation to the specified angles, which must be a
+        two- or three-element array of numbers [`lambda`, `phi`, `gamma`] specifying the
+        rotation angles in degrees about each spherical axis. (These correspond to yaw,
         pitch and roll.)  __Default value:__ `[0, 0, 0]`
     spacing : float
-    
+
     tilt : float
-    
+
     type : ProjectionType
-        The cartographic projection to use. This value is case-insensitive, for example 
-        `"albers"` and `"Albers"` indicate the same projection type. You can find all valid 
-        projection types [in the 
+        The cartographic projection to use. This value is case-insensitive, for example
+        `"albers"` and `"Albers"` indicate the same projection type. You can find all valid
+        projection types [in the
         documentation](https://vega.github.io/vega-lite/docs/projection.html#projection-types).
           __Default value:__ `mercator`
     """
@@ -4092,9 +4092,9 @@ class ProjectionConfig(VegaLiteSchema):
 
 class ProjectionType(VegaLiteSchema):
     """ProjectionType schema wrapper
-    
-    enum('albers', 'albersUsa', 'azimuthalEqualArea', 'azimuthalEquidistant', 'conicConformal', 
-    'conicEqualArea', 'conicEquidistant', 'equirectangular', 'gnomonic', 'mercator', 
+
+    enum('albers', 'albersUsa', 'azimuthalEqualArea', 'azimuthalEquidistant', 'conicConformal',
+    'conicEqualArea', 'conicEquidistant', 'equirectangular', 'gnomonic', 'mercator',
     'orthographic', 'stereographic', 'transverseMercator')
     """
     _schema = {'$ref': '#/definitions/ProjectionType'}
@@ -4106,9 +4106,9 @@ class ProjectionType(VegaLiteSchema):
 
 class RangeConfig(VegaLiteSchema):
     """RangeConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     category : anyOf(List(string), VgScheme)
@@ -4135,7 +4135,7 @@ class RangeConfig(VegaLiteSchema):
 
 class RangeConfigValue(VegaLiteSchema):
     """RangeConfigValue schema wrapper
-    
+
     anyOf(List(anyOf(float, string)), VgScheme, Mapping(required=[step]))
     """
     _schema = {'$ref': '#/definitions/RangeConfigValue'}
@@ -4147,9 +4147,9 @@ class RangeConfigValue(VegaLiteSchema):
 
 class Repeat(VegaLiteSchema):
     """Repeat schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     column : List(string)
@@ -4166,14 +4166,14 @@ class Repeat(VegaLiteSchema):
 
 class RepeatRef(VegaLiteSchema):
     """RepeatRef schema wrapper
-    
+
     Mapping(required=[repeat])
     Reference to a repeated value.
-    
+
     Attributes
     ----------
     repeat : enum('row', 'column')
-    
+
     """
     _schema = {'$ref': '#/definitions/RepeatRef'}
     _rootschema = Root._schema
@@ -4184,19 +4184,19 @@ class RepeatRef(VegaLiteSchema):
 
 class Resolve(VegaLiteSchema):
     """Resolve schema wrapper
-    
+
     Mapping(required=[])
-    Defines how scales, axes, and legends from different specs should be combined. Resolve is a 
+    Defines how scales, axes, and legends from different specs should be combined. Resolve is a
     mapping from `scale`, `axis`, and `legend` to a mapping from channels to resolutions.
-    
+
     Attributes
     ----------
     axis : AxisResolveMap
-    
+
     legend : LegendResolveMap
-    
+
     scale : ScaleResolveMap
-    
+
     """
     _schema = {'$ref': '#/definitions/Resolve'}
     _rootschema = Root._schema
@@ -4207,7 +4207,7 @@ class Resolve(VegaLiteSchema):
 
 class ResolveMode(VegaLiteSchema):
     """ResolveMode schema wrapper
-    
+
     enum('independent', 'shared')
     """
     _schema = {'$ref': '#/definitions/ResolveMode'}
@@ -4219,136 +4219,136 @@ class ResolveMode(VegaLiteSchema):
 
 class Scale(VegaLiteSchema):
     """Scale schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     base : float
         The logarithm base of the `log` scale (default `10`).
     clamp : boolean
-        If `true`, values that exceed the data domain are clamped to either the minimum or 
-        maximum range value  __Default value:__ derived from the [scale 
+        If `true`, values that exceed the data domain are clamped to either the minimum or
+        maximum range value  __Default value:__ derived from the [scale
         config](config.html#scale-config)'s `clamp` (`true` by default).
-    domain : anyOf(List(float), List(string), List(boolean), List(DateTime), 
+    domain : anyOf(List(float), List(string), List(boolean), List(DateTime),
     enum('unaggregated'), SelectionDomain)
-        Customized domain values.  For _quantitative_ fields, `domain` can take the form of 
-        a two-element array with minimum and maximum values.  [Piecewise 
-        scales](scale.html#piecewise) can be created by providing a `domain` with more than 
-        two entries. If the input field is aggregated, `domain` can also be a string value 
-        `"unaggregated"`, indicating that the domain should include the raw data values 
-        prior to the aggregation.  For _temporal_ fields, `domain` can be a two-element 
-        array minimum and maximum values, in the form of either timestamps or the [DateTime 
-        definition objects](types.html#datetime).  For _ordinal_ and _nominal_ fields, 
-        `domain` can be an array that lists valid input values.  The `selection` property 
-        can be used to [interactively determine](selection.html#scale-domains) the scale 
+        Customized domain values.  For _quantitative_ fields, `domain` can take the form of
+        a two-element array with minimum and maximum values.  [Piecewise
+        scales](scale.html#piecewise) can be created by providing a `domain` with more than
+        two entries. If the input field is aggregated, `domain` can also be a string value
+        `"unaggregated"`, indicating that the domain should include the raw data values
+        prior to the aggregation.  For _temporal_ fields, `domain` can be a two-element
+        array minimum and maximum values, in the form of either timestamps or the [DateTime
+        definition objects](types.html#datetime).  For _ordinal_ and _nominal_ fields,
+        `domain` can be an array that lists valid input values.  The `selection` property
+        can be used to [interactively determine](selection.html#scale-domains) the scale
         domain.
     exponent : float
         The exponent of the `pow` scale.
     interpolate : anyOf(ScaleInterpolate, ScaleInterpolateParams)
-        The interpolation method for range values. By default, a general interpolator for 
-        numbers, dates, strings and colors (in RGB space) is used. For color ranges, this 
-        property allows interpolation in alternative color spaces. Legal values include 
+        The interpolation method for range values. By default, a general interpolator for
+        numbers, dates, strings and colors (in RGB space) is used. For color ranges, this
+        property allows interpolation in alternative color spaces. Legal values include
         `rgb`, `hsl`, `hsl-long`, `lab`, `hcl`, `hcl-long`, `cubehelix` and `cubehelix-long`
-         ('-long' variants use longer paths in polar coordinate spaces). If object-valued, 
+         ('-long' variants use longer paths in polar coordinate spaces). If object-valued,
         this property accepts an object with a string-valued _type_ property and an optional
-         numeric _gamma_ property applicable to rgb and cubehelix interpolators. For more, 
-        see the [d3-interpolate documentation](https://github.com/d3/d3-interpolate).  
-        __Note:__ Sequential scales do not support `interpolate` as they have a fixed 
-        interpolator.  Since Vega-Lite uses sequential scales for quantitative fields by 
-        default, you have to set the scale `type` to other quantitative scale type such as 
+         numeric _gamma_ property applicable to rgb and cubehelix interpolators. For more,
+        see the [d3-interpolate documentation](https://github.com/d3/d3-interpolate).
+        __Note:__ Sequential scales do not support `interpolate` as they have a fixed
+        interpolator.  Since Vega-Lite uses sequential scales for quantitative fields by
+        default, you have to set the scale `type` to other quantitative scale type such as
         `"linear"` to customize `interpolate`.
     nice : anyOf(boolean, float, NiceTime, Mapping(required=[interval, step]))
-        Extending the domain so that it starts and ends on nice round values. This method 
+        Extending the domain so that it starts and ends on nice round values. This method
         typically modifies the scale’s domain, and may only extend the bounds to the nearest
-         round value. Nicing is useful if the domain is computed from data and may be 
-        irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain 
+         round value. Nicing is useful if the domain is computed from data and may be
+        irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain
         might be _[0.2, 1.0]_.  For quantitative scales such as linear, `nice` can be either
          a boolean flag or a number. If `nice` is a number, it will represent a desired tick
-         count. This allows greater control over the step size used to extend the bounds, 
-        guaranteeing that the returned ticks will exactly cover the domain.  For temporal 
-        fields with time and utc scales, the `nice` value can be a string indicating the 
-        desired time interval. Legal values are `"millisecond"`, `"second"`, `"minute"`, 
-        `"hour"`, `"day"`, `"week"`, `"month"`, and `"year"`. Alternatively, `time` and 
-        `utc` scales can accept an object-valued interval specifier of the form 
-        `{"interval": "month", "step": 3}`, which includes a desired number of interval 
-        steps. Here, the domain would snap to quarter (Jan, Apr, Jul, Oct) boundaries.  
+         count. This allows greater control over the step size used to extend the bounds,
+        guaranteeing that the returned ticks will exactly cover the domain.  For temporal
+        fields with time and utc scales, the `nice` value can be a string indicating the
+        desired time interval. Legal values are `"millisecond"`, `"second"`, `"minute"`,
+        `"hour"`, `"day"`, `"week"`, `"month"`, and `"year"`. Alternatively, `time` and
+        `utc` scales can accept an object-valued interval specifier of the form
+        `{"interval": "month", "step": 3}`, which includes a desired number of interval
+        steps. Here, the domain would snap to quarter (Jan, Apr, Jul, Oct) boundaries.
         __Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise.
     padding : float
-        For _[continuous](scale.html#continuous)_ scales, expands the scale domain to 
-        accommodate the specified number of pixels on each of the scale range. The scale 
-        range must represent pixels for this parameter to function as intended. Padding 
-        adjustment is performed prior to all other adjustments, including the effects of 
-        the zero, nice, domainMin, and domainMax properties.  For _[band](scale.html#band)_ 
-        scales, shortcut for setting `paddingInner` and `paddingOuter` to the same value.  
-        For _[point](scale.html#point)_ scales, alias for `paddingOuter`.  __Default 
-        value:__ For _continuous_ scales, derived from the [scale 
-        config](scale.html#config)'s `continuousPadding`. For _band and point_ scales, see 
+        For _[continuous](scale.html#continuous)_ scales, expands the scale domain to
+        accommodate the specified number of pixels on each of the scale range. The scale
+        range must represent pixels for this parameter to function as intended. Padding
+        adjustment is performed prior to all other adjustments, including the effects of
+        the zero, nice, domainMin, and domainMax properties.  For _[band](scale.html#band)_
+        scales, shortcut for setting `paddingInner` and `paddingOuter` to the same value.
+        For _[point](scale.html#point)_ scales, alias for `paddingOuter`.  __Default
+        value:__ For _continuous_ scales, derived from the [scale
+        config](scale.html#config)'s `continuousPadding`. For _band and point_ scales, see
         `paddingInner` and `paddingOuter`.
     paddingInner : float
-        The inner padding (spacing) within each band step of band scales, as a fraction of 
-        the step size. This value must lie in the range [0,1].  For point scale, this 
-        property is invalid as point scales do not have internal band widths (only step 
-        sizes between bands).  __Default value:__ derived from the [scale 
+        The inner padding (spacing) within each band step of band scales, as a fraction of
+        the step size. This value must lie in the range [0,1].  For point scale, this
+        property is invalid as point scales do not have internal band widths (only step
+        sizes between bands).  __Default value:__ derived from the [scale
         config](scale.html#config)'s `bandPaddingInner`.
     paddingOuter : float
-        The outer padding (spacing) at the ends of the range of band and point scales, as a 
-        fraction of the step size. This value must lie in the range [0,1].  __Default 
+        The outer padding (spacing) at the ends of the range of band and point scales, as a
+        fraction of the step size. This value must lie in the range [0,1].  __Default
         value:__ derived from the [scale config](scale.html#config)'s `bandPaddingOuter` for
          band scales and `pointPadding` for point scales.
     range : anyOf(List(float), List(string), string)
-        The range of the scale. One of:  - A string indicating a [pre-defined named scale 
-        range](scale.html#range-config) (e.g., example, `"symbol"`, or `"diverging"`).  - 
-        For [continuous scales](scale.html#continuous), two-element array indicating  
-        minimum and maximum values, or an array with more than two entries for specifying a 
-        [piecewise scale](scale.html#piecewise).  - For [discrete](scale.html#discrete) and 
-        [discretizing](scale.html#discretizing) scales, an array of desired output values.  
-        __Notes:__  1) For [sequential](scale.html#sequential), 
+        The range of the scale. One of:  - A string indicating a [pre-defined named scale
+        range](scale.html#range-config) (e.g., example, `"symbol"`, or `"diverging"`).  -
+        For [continuous scales](scale.html#continuous), two-element array indicating
+        minimum and maximum values, or an array with more than two entries for specifying a
+        [piecewise scale](scale.html#piecewise).  - For [discrete](scale.html#discrete) and
+        [discretizing](scale.html#discretizing) scales, an array of desired output values.
+        __Notes:__  1) For [sequential](scale.html#sequential),
         [ordinal](scale.html#ordinal), and discretizing color scales, you can also specify a
-         color [`scheme`](scale.html#scheme) instead of `range`.  2) Any directly specified 
-        `range` for `x` and `y` channels will be ignored. Range can be customized via the 
-        view's corresponding [size](size.html) (`width` and `height`) or via [range steps 
+         color [`scheme`](scale.html#scheme) instead of `range`.  2) Any directly specified
+        `range` for `x` and `y` channels will be ignored. Range can be customized via the
+        view's corresponding [size](size.html) (`width` and `height`) or via [range steps
         and paddings properties](#range-step) for [band](#band) and [point](#point) scales.
     rangeStep : anyOf(float, None)
-        The distance between the starts of adjacent bands or points in 
-        [band](scale.html#band) and [point](scale.html#point) scales.  If `rangeStep` is 
-        `null` or if the view contains the scale's corresponding [size](size.html) (`width` 
-        for `x` scales and `height` for `y` scales), `rangeStep` will be automatically 
-        determined to fit the size of the view.  __Default value:__  derived the [scale 
-        config](config.html#scale-config)'s `textXRangeStep` (`90` by default) for x-scales 
-        of `text` marks and `rangeStep` (`21` by default) for x-scales of other marks and 
-        y-scales.  __Warning__: If `rangeStep` is `null` and the cardinality of the scale's 
-        domain is higher than `width` or `height`, the rangeStep might become less than one 
+        The distance between the starts of adjacent bands or points in
+        [band](scale.html#band) and [point](scale.html#point) scales.  If `rangeStep` is
+        `null` or if the view contains the scale's corresponding [size](size.html) (`width`
+        for `x` scales and `height` for `y` scales), `rangeStep` will be automatically
+        determined to fit the size of the view.  __Default value:__  derived the [scale
+        config](config.html#scale-config)'s `textXRangeStep` (`90` by default) for x-scales
+        of `text` marks and `rangeStep` (`21` by default) for x-scales of other marks and
+        y-scales.  __Warning__: If `rangeStep` is `null` and the cardinality of the scale's
+        domain is higher than `width` or `height`, the rangeStep might become less than one
         pixel and the mark might not appear correctly.
     round : boolean
-        If `true`, rounds numeric output values to integers. This can be helpful for 
+        If `true`, rounds numeric output values to integers. This can be helpful for
         snapping to the pixel grid.  __Default value:__ `false`.
     scheme : anyOf(string, SchemeParams)
-        A string indicating a color [scheme](scale.html#scheme) name (e.g., `"category10"` 
-        or `"viridis"`) or a [scheme parameter object](scale.html#scheme-params).  Discrete 
-        color schemes may be used with [discrete](scale.html#discrete) or 
-        [discretizing](scale.html#discretizing) scales. Continuous color schemes are 
-        intended for use with [sequential](scales.html#sequential) scales.  For the full 
-        list of supported scheme, please refer to the [Vega 
+        A string indicating a color [scheme](scale.html#scheme) name (e.g., `"category10"`
+        or `"viridis"`) or a [scheme parameter object](scale.html#scheme-params).  Discrete
+        color schemes may be used with [discrete](scale.html#discrete) or
+        [discretizing](scale.html#discretizing) scales. Continuous color schemes are
+        intended for use with [sequential](scales.html#sequential) scales.  For the full
+        list of supported scheme, please refer to the [Vega
         Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.
     type : ScaleType
-        The type of scale.  Vega-Lite supports the following categories of scale types:  1) 
-        [**Continuous Scales**](scale.html#continuous) -- mapping continuous domains to 
-        continuous output ranges ([`"linear"`](scale.html#linear), 
-        [`"pow"`](scale.html#pow), [`"sqrt"`](scale.html#sqrt), [`"log"`](scale.html#log), 
-        [`"time"`](scale.html#time), [`"utc"`](scale.html#utc), 
-        [`"sequential"`](scale.html#sequential)).  2) [**Discrete 
-        Scales**](scale.html#discrete) -- mapping discrete domains to discrete 
-        ([`"ordinal"`](scale.html#ordinal)) or continuous ([`"band"`](scale.html#band) and 
-        [`"point"`](scale.html#point)) output ranges.  3) [**Discretizing 
-        Scales**](scale.html#discretizing) -- mapping continuous domains to discrete output 
-        ranges ([`"bin-linear"`](scale.html#bin-linear) and 
-        [`"bin-ordinal"`](scale.html#bin-ordinal)).  __Default value:__ please see the 
+        The type of scale.  Vega-Lite supports the following categories of scale types:  1)
+        [**Continuous Scales**](scale.html#continuous) -- mapping continuous domains to
+        continuous output ranges ([`"linear"`](scale.html#linear),
+        [`"pow"`](scale.html#pow), [`"sqrt"`](scale.html#sqrt), [`"log"`](scale.html#log),
+        [`"time"`](scale.html#time), [`"utc"`](scale.html#utc),
+        [`"sequential"`](scale.html#sequential)).  2) [**Discrete
+        Scales**](scale.html#discrete) -- mapping discrete domains to discrete
+        ([`"ordinal"`](scale.html#ordinal)) or continuous ([`"band"`](scale.html#band) and
+        [`"point"`](scale.html#point)) output ranges.  3) [**Discretizing
+        Scales**](scale.html#discretizing) -- mapping continuous domains to discrete output
+        ranges ([`"bin-linear"`](scale.html#bin-linear) and
+        [`"bin-ordinal"`](scale.html#bin-ordinal)).  __Default value:__ please see the
         [scale type table](scale.html#type).
     zero : boolean
-        If `true`, ensures that a zero baseline value is included in the scale domain.  
-        __Default value:__ `true` for x and y channels if the quantitative field is not 
-        binned and no custom `domain` is provided; `false` otherwise.  __Note:__ Log, time, 
+        If `true`, ensures that a zero baseline value is included in the scale domain.
+        __Default value:__ `true` for x and y channels if the quantitative field is not
+        binned and no custom `domain` is provided; `false` otherwise.  __Note:__ Log, time,
         and utc scales do not support `zero`.
     """
     _schema = {'$ref': '#/definitions/Scale'}
@@ -4367,67 +4367,67 @@ class Scale(VegaLiteSchema):
 
 class ScaleConfig(VegaLiteSchema):
     """ScaleConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     bandPaddingInner : float
         Default inner padding for `x` and `y` band-ordinal scales.  __Default value:__ `0.1`
     bandPaddingOuter : float
-        Default outer padding for `x` and `y` band-ordinal scales. If not specified, by 
+        Default outer padding for `x` and `y` band-ordinal scales. If not specified, by
         default, band scale's paddingOuter is paddingInner/2.
     clamp : boolean
-        If true, values that exceed the data domain are clamped to either the minimum or 
+        If true, values that exceed the data domain are clamped to either the minimum or
         maximum range value
     continuousPadding : float
         Default padding for continuous scales.  __Default:__ `5` for continuous x-scale of a
          vertical bar and continuous y-scale of a horizontal bar.; `0` otherwise.
     maxBandSize : float
-        The default max value for mapping quantitative fields to bar's size/bandSize.  If 
+        The default max value for mapping quantitative fields to bar's size/bandSize.  If
         undefined (default), we will use the scale's `rangeStep` - 1.
     maxFontSize : float
-        The default max value for mapping quantitative fields to text's size/fontSize.  
+        The default max value for mapping quantitative fields to text's size/fontSize.
         __Default value:__ `40`
     maxOpacity : float
         Default max opacity for mapping a field to opacity.  __Default value:__ `0.8`
     maxSize : float
         Default max value for point size scale.
     maxStrokeWidth : float
-        Default max strokeWidth for strokeWidth  (or rule/line's size) scale.  __Default 
+        Default max strokeWidth for strokeWidth  (or rule/line's size) scale.  __Default
         value:__ `4`
     minBandSize : float
-        The default min value for mapping quantitative fields to bar and tick's 
+        The default min value for mapping quantitative fields to bar and tick's
         size/bandSize scale with zero=false.  __Default value:__ `2`
     minFontSize : float
-        The default min value for mapping quantitative fields to tick's size/fontSize scale 
+        The default min value for mapping quantitative fields to tick's size/fontSize scale
         with zero=false  __Default value:__ `8`
     minOpacity : float
         Default minimum opacity for mapping a field to opacity.  __Default value:__ `0.3`
     minSize : float
         Default minimum value for point size scale with zero=false.  __Default value:__ `9`
     minStrokeWidth : float
-        Default minimum strokeWidth for strokeWidth (or rule/line's size) scale with 
+        Default minimum strokeWidth for strokeWidth (or rule/line's size) scale with
         zero=false.  __Default value:__ `1`
     pointPadding : float
-        Default outer padding for `x` and `y` point-ordinal scales.  __Default value:__ 
+        Default outer padding for `x` and `y` point-ordinal scales.  __Default value:__
         `0.5`
     rangeStep : anyOf(float, None)
-        Default range step for band and point scales of (1) the `y` channel and (2) the `x` 
+        Default range step for band and point scales of (1) the `y` channel and (2) the `x`
         channel when the mark is not `text`.  __Default value:__ `21`
     round : boolean
-        If true, rounds numeric output values to integers. This can be helpful for snapping 
+        If true, rounds numeric output values to integers. This can be helpful for snapping
         to the pixel grid. (Only available for `x`, `y`, and `size` scales.)
     textXRangeStep : float
-        Default range step for `x` band and point scales of text marks.  __Default value:__ 
+        Default range step for `x` band and point scales of text marks.  __Default value:__
         `90`
     useUnaggregatedDomain : boolean
-        Use the source data range before aggregation as scale domain instead of aggregated 
-        data for aggregate axis.  This is equivalent to setting `domain` to `"unaggregate"` 
-        for aggregated _quantitative_ fields by default.  This property only works with 
-        aggregate functions that produce values within the raw data domain (`"mean"`, 
-        `"average"`, `"median"`, `"q1"`, `"q3"`, `"min"`, `"max"`). For other aggregations 
-        that produce values outside of the raw data domain (e.g. `"count"`, `"sum"`), this 
+        Use the source data range before aggregation as scale domain instead of aggregated
+        data for aggregate axis.  This is equivalent to setting `domain` to `"unaggregate"`
+        for aggregated _quantitative_ fields by default.  This property only works with
+        aggregate functions that produce values within the raw data domain (`"mean"`,
+        `"average"`, `"median"`, `"q1"`, `"q3"`, `"min"`, `"max"`). For other aggregations
+        that produce values outside of the raw data domain (e.g. `"count"`, `"sum"`), this
         property is ignored.  __Default value:__ `false`
     """
     _schema = {'$ref': '#/definitions/ScaleConfig'}
@@ -4454,7 +4454,7 @@ class ScaleConfig(VegaLiteSchema):
 
 class ScaleInterpolate(VegaLiteSchema):
     """ScaleInterpolate schema wrapper
-    
+
     enum('rgb', 'lab', 'hcl', 'hsl', 'hsl-long', 'hcl-long', 'cubehelix', 'cubehelix-long')
     """
     _schema = {'$ref': '#/definitions/ScaleInterpolate'}
@@ -4466,15 +4466,15 @@ class ScaleInterpolate(VegaLiteSchema):
 
 class ScaleInterpolateParams(VegaLiteSchema):
     """ScaleInterpolateParams schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('rgb', 'cubehelix', 'cubehelix-long')
-    
+
     gamma : float
-    
+
     """
     _schema = {'$ref': '#/definitions/ScaleInterpolateParams'}
     _rootschema = Root._schema
@@ -4485,27 +4485,27 @@ class ScaleInterpolateParams(VegaLiteSchema):
 
 class ScaleResolveMap(VegaLiteSchema):
     """ScaleResolveMap schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     color : ResolveMode
-    
+
     fill : ResolveMode
-    
+
     opacity : ResolveMode
-    
+
     shape : ResolveMode
-    
+
     size : ResolveMode
-    
+
     stroke : ResolveMode
-    
+
     x : ResolveMode
-    
+
     y : ResolveMode
-    
+
     """
     _schema = {'$ref': '#/definitions/ScaleResolveMap'}
     _rootschema = Root._schema
@@ -4518,8 +4518,8 @@ class ScaleResolveMap(VegaLiteSchema):
 
 class ScaleType(VegaLiteSchema):
     """ScaleType schema wrapper
-    
-    enum('linear', 'bin-linear', 'log', 'pow', 'sqrt', 'time', 'utc', 'sequential', 'ordinal', 
+
+    enum('linear', 'bin-linear', 'log', 'pow', 'sqrt', 'time', 'utc', 'sequential', 'ordinal',
     'bin-ordinal', 'point', 'band')
     """
     _schema = {'$ref': '#/definitions/ScaleType'}
@@ -4531,18 +4531,18 @@ class ScaleType(VegaLiteSchema):
 
 class SchemeParams(VegaLiteSchema):
     """SchemeParams schema wrapper
-    
+
     Mapping(required=[name])
-    
+
     Attributes
     ----------
     name : string
-        A color scheme name for sequential/ordinal scales (e.g., `"category10"` or 
-        `"viridis"`).  For the full list of supported scheme, please refer to the [Vega 
+        A color scheme name for sequential/ordinal scales (e.g., `"category10"` or
+        `"viridis"`).  For the full list of supported scheme, please refer to the [Vega
         Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.
     extent : List(float)
-        For sequential and diverging schemes only, determines the extent of the color range 
-        to use. For example `[0.2, 1]` will rescale the color scheme such that color values 
+        For sequential and diverging schemes only, determines the extent of the color range
+        to use. For example `[0.2, 1]` will rescale the color scheme such that color values
         in the range _[0, 0.2)_ are excluded from the scheme.
     """
     _schema = {'$ref': '#/definitions/SchemeParams'}
@@ -4554,26 +4554,26 @@ class SchemeParams(VegaLiteSchema):
 
 class SelectionConfig(VegaLiteSchema):
     """SelectionConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     interval : IntervalSelectionConfig
-        The default definition for an [`interval`](selection.html#type) selection. All 
-        properties and transformations for an interval selection definition (except `type`) 
-        may be specified here.  For instance, setting `interval` to `{"translate": false}` 
+        The default definition for an [`interval`](selection.html#type) selection. All
+        properties and transformations for an interval selection definition (except `type`)
+        may be specified here.  For instance, setting `interval` to `{"translate": false}`
         disables the ability to move interval selections by default.
     multi : MultiSelectionConfig
-        The default definition for a [`multi`](selection.html#type) selection. All 
-        properties and transformations for a multi selection definition (except `type`) may 
-        be specified here.  For instance, setting `multi` to `{"toggle": "event.altKey"}` 
+        The default definition for a [`multi`](selection.html#type) selection. All
+        properties and transformations for a multi selection definition (except `type`) may
+        be specified here.  For instance, setting `multi` to `{"toggle": "event.altKey"}`
         adds additional values to multi selections when clicking with the alt-key pressed by
          default.
     single : SingleSelectionConfig
-        The default definition for a [`single`](selection.html#type) selection. All 
-        properties and transformations   for a single selection definition (except `type`) 
-        may be specified here.  For instance, setting `single` to `{"on": "dblclick"}` 
+        The default definition for a [`single`](selection.html#type) selection. All
+        properties and transformations   for a single selection definition (except `type`)
+        may be specified here.  For instance, setting `single` to `{"on": "dblclick"}`
         populates single selections on double-click by default.
     """
     _schema = {'$ref': '#/definitions/SelectionConfig'}
@@ -4585,7 +4585,7 @@ class SelectionConfig(VegaLiteSchema):
 
 class SelectionDef(VegaLiteSchema):
     """SelectionDef schema wrapper
-    
+
     anyOf(SingleSelection, MultiSelection, IntervalSelection)
     """
     _schema = {'$ref': '#/definitions/SelectionDef'}
@@ -4597,7 +4597,7 @@ class SelectionDef(VegaLiteSchema):
 
 class SelectionDomain(VegaLiteSchema):
     """SelectionDomain schema wrapper
-    
+
     anyOf(Mapping(required=[selection]), Mapping(required=[selection]))
     """
     _schema = {'$ref': '#/definitions/SelectionDomain'}
@@ -4609,9 +4609,9 @@ class SelectionDomain(VegaLiteSchema):
 
 class SelectionPredicate(VegaLiteSchema):
     """SelectionPredicate schema wrapper
-    
+
     Mapping(required=[selection])
-    
+
     Attributes
     ----------
     selection : SelectionOperand
@@ -4626,7 +4626,7 @@ class SelectionPredicate(VegaLiteSchema):
 
 class SelectionResolution(VegaLiteSchema):
     """SelectionResolution schema wrapper
-    
+
     enum('global', 'union', 'intersect')
     """
     _schema = {'$ref': '#/definitions/SelectionResolution'}
@@ -4638,9 +4638,9 @@ class SelectionResolution(VegaLiteSchema):
 
 class SingleDefChannel(VegaLiteSchema):
     """SingleDefChannel schema wrapper
-    
-    enum('x', 'y', 'x2', 'y2', 'longitude', 'latitude', 'longitude2', 'latitude2', 'row', 
-    'column', 'color', 'fill', 'stroke', 'size', 'shape', 'opacity', 'text', 'tooltip', 'href', 
+
+    enum('x', 'y', 'x2', 'y2', 'longitude', 'latitude', 'longitude2', 'latitude2', 'row',
+    'column', 'color', 'fill', 'stroke', 'size', 'shape', 'opacity', 'text', 'tooltip', 'href',
     'key')
     """
     _schema = {'$ref': '#/definitions/SingleDefChannel'}
@@ -4652,40 +4652,40 @@ class SingleDefChannel(VegaLiteSchema):
 
 class SingleSelection(VegaLiteSchema):
     """SingleSelection schema wrapper
-    
+
     Mapping(required=[type])
-    
+
     Attributes
     ----------
     type : enum('single')
-    
+
     bind : anyOf(VgBinding, Mapping(required=[]))
-        Establish a two-way binding between a single selection and input elements (also 
-        known as dynamic query widgets). A binding takes the form of Vega's [input element 
-        binding definition](https://vega.github.io/vega/docs/signals/#bind) or can be a 
-        mapping between projected field/encodings and binding definitions.  See the [bind 
+        Establish a two-way binding between a single selection and input elements (also
+        known as dynamic query widgets). A binding takes the form of Vega's [input element
+        binding definition](https://vega.github.io/vega/docs/signals/#bind) or can be a
+        mapping between projected field/encodings and binding definitions.  See the [bind
         transform](bind.html) documentation for more information.
     empty : enum('all', 'none')
-        By default, all data values are considered to lie within an empty selection. When 
+        By default, all data values are considered to lie within an empty selection. When
         set to `none`, empty selections contain no data values.
     encodings : List(SingleDefChannel)
-        An array of encoding channels. The corresponding data field values must match for a 
+        An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
     fields : List(string)
-        An array of field names whose values must match for a data tuple to fall within the 
+        An array of field names whose values must match for a data tuple to fall within the
         selection.
     nearest : boolean
-        When true, an invisible voronoi diagram is computed to accelerate discrete 
+        When true, an invisible voronoi diagram is computed to accelerate discrete
         selection. The data value _nearest_ the mouse cursor is added to the selection.  See
          the [nearest transform](nearest.html) documentation for more information.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or 
-        selector) that triggers the selection. For interval selections, the event stream 
-        must specify a [start and 
+        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        selector) that triggers the selection. For interval selections, the event stream
+        must specify a [start and
         end](https://vega.github.io/vega/docs/event-streams/#between-filters).
     resolve : SelectionResolution
-        With layered and multi-view displays, a strategy that determines how selections' 
-        data queries are resolved when applied in a filter transform, conditional encoding 
+        With layered and multi-view displays, a strategy that determines how selections'
+        data queries are resolved when applied in a filter transform, conditional encoding
         rule, or scale domain.
     """
     _schema = {'$ref': '#/definitions/SingleSelection'}
@@ -4700,38 +4700,38 @@ class SingleSelection(VegaLiteSchema):
 
 class SingleSelectionConfig(VegaLiteSchema):
     """SingleSelectionConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     bind : anyOf(VgBinding, Mapping(required=[]))
-        Establish a two-way binding between a single selection and input elements (also 
-        known as dynamic query widgets). A binding takes the form of Vega's [input element 
-        binding definition](https://vega.github.io/vega/docs/signals/#bind) or can be a 
-        mapping between projected field/encodings and binding definitions.  See the [bind 
+        Establish a two-way binding between a single selection and input elements (also
+        known as dynamic query widgets). A binding takes the form of Vega's [input element
+        binding definition](https://vega.github.io/vega/docs/signals/#bind) or can be a
+        mapping between projected field/encodings and binding definitions.  See the [bind
         transform](bind.html) documentation for more information.
     empty : enum('all', 'none')
-        By default, all data values are considered to lie within an empty selection. When 
+        By default, all data values are considered to lie within an empty selection. When
         set to `none`, empty selections contain no data values.
     encodings : List(SingleDefChannel)
-        An array of encoding channels. The corresponding data field values must match for a 
+        An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
     fields : List(string)
-        An array of field names whose values must match for a data tuple to fall within the 
+        An array of field names whose values must match for a data tuple to fall within the
         selection.
     nearest : boolean
-        When true, an invisible voronoi diagram is computed to accelerate discrete 
+        When true, an invisible voronoi diagram is computed to accelerate discrete
         selection. The data value _nearest_ the mouse cursor is added to the selection.  See
          the [nearest transform](nearest.html) documentation for more information.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or 
-        selector) that triggers the selection. For interval selections, the event stream 
-        must specify a [start and 
+        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        selector) that triggers the selection. For interval selections, the event stream
+        must specify a [start and
         end](https://vega.github.io/vega/docs/event-streams/#between-filters).
     resolve : SelectionResolution
-        With layered and multi-view displays, a strategy that determines how selections' 
-        data queries are resolved when applied in a filter transform, conditional encoding 
+        With layered and multi-view displays, a strategy that determines how selections'
+        data queries are resolved when applied in a filter transform, conditional encoding
         rule, or scale domain.
     """
     _schema = {'$ref': '#/definitions/SingleSelectionConfig'}
@@ -4746,7 +4746,7 @@ class SingleSelectionConfig(VegaLiteSchema):
 
 class SingleTimeUnit(VegaLiteSchema):
     """SingleTimeUnit schema wrapper
-    
+
     anyOf(LocalSingleTimeUnit, UtcSingleTimeUnit)
     """
     _schema = {'$ref': '#/definitions/SingleTimeUnit'}
@@ -4758,19 +4758,19 @@ class SingleTimeUnit(VegaLiteSchema):
 
 class SortField(VegaLiteSchema):
     """SortField schema wrapper
-    
+
     Mapping(required=[op])
-    
+
     Attributes
     ----------
     op : AggregateOp
-        An [aggregate operation](aggregate.html#ops) to perform on the field prior to 
-        sorting (e.g., `"count"`, `"mean"` and `"median"`). This property is required in 
+        An [aggregate operation](aggregate.html#ops) to perform on the field prior to
+        sorting (e.g., `"count"`, `"mean"` and `"median"`). This property is required in
         cases where the sort field and the data reference field do not match. The input data
-         objects will be aggregated, grouped by the encoded data field.  For a full list of 
+         objects will be aggregated, grouped by the encoded data field.  For a full list of
         operations, please see the documentation for [aggregate](aggregate.html#ops).
     field : anyOf(string, RepeatRef)
-        The data [field](field.html) to sort by.  __Default value:__ If unspecified, 
+        The data [field](field.html) to sort by.  __Default value:__ If unspecified,
         defaults to the field specified in the outer data reference.
     order : SortOrder
         The sort order. One of `"ascending"` (default) or `"descending"`.
@@ -4784,7 +4784,7 @@ class SortField(VegaLiteSchema):
 
 class SortOrder(VegaLiteSchema):
     """SortOrder schema wrapper
-    
+
     enum('ascending', 'descending', None)
     """
     _schema = {'$ref': '#/definitions/SortOrder'}
@@ -4796,7 +4796,7 @@ class SortOrder(VegaLiteSchema):
 
 class StackOffset(VegaLiteSchema):
     """StackOffset schema wrapper
-    
+
     enum('zero', 'center', 'normalize')
     """
     _schema = {'$ref': '#/definitions/StackOffset'}
@@ -4808,7 +4808,7 @@ class StackOffset(VegaLiteSchema):
 
 class StyleConfigIndex(VegaLiteSchema):
     """StyleConfigIndex schema wrapper
-    
+
     Mapping(required=[])
     """
     _schema = {'$ref': '#/definitions/StyleConfigIndex'}
@@ -4820,9 +4820,9 @@ class StyleConfigIndex(VegaLiteSchema):
 
 class TextConfig(VegaLiteSchema):
     """TextConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     align : HorizontalAlign
@@ -4830,34 +4830,34 @@ class TextConfig(VegaLiteSchema):
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.  
+        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
         __Default value:__ `"middle"`
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color` 
-        and will override `color`.  __Default value:__ <span style="color: 
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a 
+        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
+        and will override `color`.  __Default value:__ <span style="color:
+        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
         [style config](mark.html#style-config).
-    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress', 
-    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop', 
-    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize', 
-    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize', 
+    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
+    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
+    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
+    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor 
+        The mouse cursor used over the mark. Any valid [CSS cursor
         type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
     dx : float
-        The horizontal offset, in pixels, between the text label and its anchor point. The 
+        The horizontal offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     dy : float
-        The vertical offset, in pixels, between the text label and its anchor point. The 
+        The vertical offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     fill : string
-        Default Fill Color.  This has higher precedence than config.color  __Default 
+        Default Fill Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     fillOpacity : float
         The fill opacity (value between [0,1]).  __Default value:__ `1`
     filled : boolean
-        Whether the mark's color should be used as fill color instead of stroke color.  
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.  
+        Whether the mark's color should be used as fill color instead of stroke color.
+        __Default value:__ `true` for all marks except `point` and `false` for `point`.
         __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
          This property cannot be used in a [style config](mark.html#style-config).
     font : string
@@ -4867,56 +4867,56 @@ class TextConfig(VegaLiteSchema):
     fontStyle : FontStyle
         The font style (e.g., `"italic"`).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number 
+        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
         (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
-        The line interpolation method to use for line and area marks. One of the following: 
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`: 
-        close the linear segments to form a polygon. - `"step"`: alternate between 
-        horizontal and vertical segments, as in a step function. - `"step-before"`: 
-        alternate between vertical and horizontal segments, as in a step function. - 
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step 
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. - 
-        `"basis-open"`: an open B-spline; may not intersect the start or end. - 
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal 
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open 
-        Cardinal spline; may not intersect the start or end, but will intersect other 
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. - 
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten 
+        The line interpolation method to use for line and area marks. One of the following:
+        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
+        close the linear segments to form a polygon. - `"step"`: alternate between
+        horizontal and vertical segments, as in a step function. - `"step-before"`:
+        alternate between vertical and horizontal segments, as in a step function. -
+        `"step-after"`: alternate between horizontal and vertical segments, as in a step
+        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
+        `"basis-open"`: an open B-spline; may not intersect the start or end. -
+        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
+        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
+        Cardinal spline; may not intersect the start or end, but will intersect other
+        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
+        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
         the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
     limit : float
-        The maximum length of the text mark in pixels (default 0, indicating no limit). The 
+        The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for 
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered 
+        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
+        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
         `bar` charts and `1` otherwise.
     orient : Orient
-        The orientation of a non-stacked bar, tick, area, and line charts. The value is 
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines 
-        whether the size of the bar and tick should be applied to x or y dimension. - For 
-        area, this property determines the orient property of the Vega output. - For line, 
-        this property determines the sort order of the points in the line if 
-        `config.sortLineBy` is not specified. For stacked charts, this is always determined 
-        by the orientation of the stack; therefore explicitly specified value will be 
+        The orientation of a non-stacked bar, tick, area, and line charts. The value is
+        either horizontal (default) or vertical. - For bar, rule and tick, this determines
+        whether the size of the bar and tick should be applied to x or y dimension. - For
+        area, this property determines the orient property of the Vega output. - For line,
+        this property determines the sort order of the points in the line if
+        `config.sortLineBy` is not specified. For stacked charts, this is always determined
+        by the orientation of the stack; therefore explicitly specified value will be
         ignored.
     radius : float
-        Polar coordinate radial offset, in pixels, of the text label from the origin 
+        Polar coordinate radial offset, in pixels, of the text label from the origin
         determined by the `x` and `y` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`, 
+        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
         `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
           __Default value:__ `"circle"`
     shortTimeLabels : boolean
         Whether month names and weekday names should be abbreviated.
     size : float
-        The pixel area each the point/circle/square. For example: in the case of circles, 
-        the radius is determined in part by the square root of the size value.  __Default 
+        The pixel area each the point/circle/square. For example: in the case of circles,
+        the radius is determined in part by the square root of the size value.  __Default
         value:__ `30`
     stroke : string
-        Default Stroke Color.  This has higher precedence than config.color  __Default 
+        Default Stroke Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
@@ -4927,14 +4927,14 @@ class TextConfig(VegaLiteSchema):
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
-        Depending on the interpolation type, sets the tension parameter (for line and area 
+        Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
         Placeholder text if the `text` channel is not specified
     theta : float
-        Polar coordinate angle, in radians, of the text label from the origin determined by 
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc` 
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with 
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
+        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
         `0` indicating "north".
     """
     _schema = {'$ref': '#/definitions/TextConfig'}
@@ -4962,9 +4962,9 @@ class TextConfig(VegaLiteSchema):
 
 class TickConfig(VegaLiteSchema):
     """TickConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     align : HorizontalAlign
@@ -4974,34 +4974,34 @@ class TickConfig(VegaLiteSchema):
     bandSize : float
         The width of the ticks.  __Default value:__  2/3 of rangeStep.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.  
+        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
         __Default value:__ `"middle"`
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color` 
-        and will override `color`.  __Default value:__ <span style="color: 
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a 
+        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
+        and will override `color`.  __Default value:__ <span style="color:
+        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
         [style config](mark.html#style-config).
-    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress', 
-    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop', 
-    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize', 
-    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize', 
+    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
+    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
+    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
+    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor 
+        The mouse cursor used over the mark. Any valid [CSS cursor
         type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
     dx : float
-        The horizontal offset, in pixels, between the text label and its anchor point. The 
+        The horizontal offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     dy : float
-        The vertical offset, in pixels, between the text label and its anchor point. The 
+        The vertical offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     fill : string
-        Default Fill Color.  This has higher precedence than config.color  __Default 
+        Default Fill Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     fillOpacity : float
         The fill opacity (value between [0,1]).  __Default value:__ `1`
     filled : boolean
-        Whether the mark's color should be used as fill color instead of stroke color.  
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.  
+        Whether the mark's color should be used as fill color instead of stroke color.
+        __Default value:__ `true` for all marks except `point` and `false` for `point`.
         __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
          This property cannot be used in a [style config](mark.html#style-config).
     font : string
@@ -5011,54 +5011,54 @@ class TickConfig(VegaLiteSchema):
     fontStyle : FontStyle
         The font style (e.g., `"italic"`).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number 
+        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
         (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
-        The line interpolation method to use for line and area marks. One of the following: 
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`: 
-        close the linear segments to form a polygon. - `"step"`: alternate between 
-        horizontal and vertical segments, as in a step function. - `"step-before"`: 
-        alternate between vertical and horizontal segments, as in a step function. - 
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step 
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. - 
-        `"basis-open"`: an open B-spline; may not intersect the start or end. - 
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal 
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open 
-        Cardinal spline; may not intersect the start or end, but will intersect other 
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. - 
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten 
+        The line interpolation method to use for line and area marks. One of the following:
+        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
+        close the linear segments to form a polygon. - `"step"`: alternate between
+        horizontal and vertical segments, as in a step function. - `"step-before"`:
+        alternate between vertical and horizontal segments, as in a step function. -
+        `"step-after"`: alternate between horizontal and vertical segments, as in a step
+        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
+        `"basis-open"`: an open B-spline; may not intersect the start or end. -
+        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
+        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
+        Cardinal spline; may not intersect the start or end, but will intersect other
+        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
+        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
         the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
     limit : float
-        The maximum length of the text mark in pixels (default 0, indicating no limit). The 
+        The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for 
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered 
+        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
+        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
         `bar` charts and `1` otherwise.
     orient : Orient
-        The orientation of a non-stacked bar, tick, area, and line charts. The value is 
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines 
-        whether the size of the bar and tick should be applied to x or y dimension. - For 
-        area, this property determines the orient property of the Vega output. - For line, 
-        this property determines the sort order of the points in the line if 
-        `config.sortLineBy` is not specified. For stacked charts, this is always determined 
-        by the orientation of the stack; therefore explicitly specified value will be 
+        The orientation of a non-stacked bar, tick, area, and line charts. The value is
+        either horizontal (default) or vertical. - For bar, rule and tick, this determines
+        whether the size of the bar and tick should be applied to x or y dimension. - For
+        area, this property determines the orient property of the Vega output. - For line,
+        this property determines the sort order of the points in the line if
+        `config.sortLineBy` is not specified. For stacked charts, this is always determined
+        by the orientation of the stack; therefore explicitly specified value will be
         ignored.
     radius : float
-        Polar coordinate radial offset, in pixels, of the text label from the origin 
+        Polar coordinate radial offset, in pixels, of the text label from the origin
         determined by the `x` and `y` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`, 
+        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
         `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
           __Default value:__ `"circle"`
     size : float
-        The pixel area each the point/circle/square. For example: in the case of circles, 
-        the radius is determined in part by the square root of the size value.  __Default 
+        The pixel area each the point/circle/square. For example: in the case of circles,
+        the radius is determined in part by the square root of the size value.  __Default
         value:__ `30`
     stroke : string
-        Default Stroke Color.  This has higher precedence than config.color  __Default 
+        Default Stroke Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
@@ -5069,14 +5069,14 @@ class TickConfig(VegaLiteSchema):
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
-        Depending on the interpolation type, sets the tension parameter (for line and area 
+        Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
         Placeholder text if the `text` channel is not specified
     theta : float
-        Polar coordinate angle, in radians, of the text label from the origin determined by 
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc` 
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with 
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
+        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
         `0` indicating "north".
     thickness : float
         Thickness of the tick mark.  __Default value:__  `1`
@@ -5106,7 +5106,7 @@ class TickConfig(VegaLiteSchema):
 
 class TimeUnit(VegaLiteSchema):
     """TimeUnit schema wrapper
-    
+
     anyOf(SingleTimeUnit, MultiTimeUnit)
     """
     _schema = {'$ref': '#/definitions/TimeUnit'}
@@ -5118,16 +5118,16 @@ class TimeUnit(VegaLiteSchema):
 
 class TimeUnitTransform(VegaLiteSchema):
     """TimeUnitTransform schema wrapper
-    
+
     Mapping(required=[timeUnit, field, as])
-    
+
     Attributes
     ----------
     field : string
         The data field to apply time unit.
     timeUnit : TimeUnit
         The timeUnit.
-    
+
     Dict-Only Attributes
     --------------------
     'as' : string
@@ -5142,7 +5142,7 @@ class TimeUnitTransform(VegaLiteSchema):
 
 class TitleOrient(VegaLiteSchema):
     """TitleOrient schema wrapper
-    
+
     enum('top', 'bottom', 'left', 'right')
     """
     _schema = {'$ref': '#/definitions/TitleOrient'}
@@ -5154,29 +5154,29 @@ class TitleOrient(VegaLiteSchema):
 
 class TitleParams(VegaLiteSchema):
     """TitleParams schema wrapper
-    
+
     Mapping(required=[text])
-    
+
     Attributes
     ----------
     text : string
         The title text.
     anchor : Anchor
         The anchor position for placing the title. One of `"start"`, `"middle"`, or `"end"`.
-         For example, with an orientation of top these anchor positions map to a left-, 
-        center-, or right-aligned title.  __Default value:__ `"middle"` for 
-        [single](spec.html) and [layered](layer.html) views. `"start"` for other composite 
+         For example, with an orientation of top these anchor positions map to a left-,
+        center-, or right-aligned title.  __Default value:__ `"middle"` for
+        [single](spec.html) and [layered](layer.html) views. `"start"` for other composite
         views.  __Note:__ [For now](https://github.com/vega/vega-lite/issues/2875), `anchor`
          is only customizable only for [single](spec.html) and [layered](layer.html) views.
           For other composite views, `anchor` is always `"start"`.
     offset : float
-        The orthogonal offset in pixels by which to displace the title from its position 
+        The orthogonal offset in pixels by which to displace the title from its position
         along the edge of the chart.
     orient : TitleOrient
-        The orientation of the title relative to the chart. One of `"top"` (the default), 
+        The orientation of the title relative to the chart. One of `"top"` (the default),
         `"bottom"`, `"left"`, or `"right"`.
     style : anyOf(string, List(string))
-        A [mark style property](config.html#style) to apply to the title text mark.  
+        A [mark style property](config.html#style) to apply to the title text mark.
         __Default value:__ `"group-title"`.
     """
     _schema = {'$ref': '#/definitions/TitleParams'}
@@ -5190,30 +5190,30 @@ class TitleParams(VegaLiteSchema):
 
 class TopLevelLayerSpec(VegaLiteSchema):
     """TopLevelLayerSpec schema wrapper
-    
+
     Mapping(required=[layer])
-    
+
     Attributes
     ----------
     layer : List(anyOf(LayerSpec, CompositeUnitSpec))
-        Layer or single view specifications to be layered.  __Note__: Specifications inside 
-        `layer` cannot use `row` and `column` channels as layering facet specifications is 
+        Layer or single view specifications to be layered.  __Note__: Specifications inside
+        `layer` cannot use `row` and `column` channels as layering facet specifications is
         not allowed.
     autosize : anyOf(AutosizeType, AutoSizeParams)
-        Sets how the visualization size should be determined. If a string, should be one of 
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for 
-        content sizing and automatic resizing. `"fit"` is only supported for single and 
+        Sets how the visualization size should be determined. If a string, should be one of
+        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
+        content sizing and automatic resizing. `"fit"` is only supported for single and
         layered views that don't use `rangeStep`.  __Default value__: `pad`
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__ 
+        CSS color property to use as the background of visualization.  __Default value:__
         none (transparent)
     config : Config
-        Vega-Lite configuration object.  This property can only be defined at the top-level 
+        Vega-Lite configuration object.  This property can only be defined at the top-level
         of a specification.
     data : Data
         An object describing the data source
     datasets : Datasets
-        A global data store for named datasets. This is a mapping from names to inline 
+        A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
          primitive values are ingested as objects with a `data` property.
     description : string
@@ -5222,34 +5222,34 @@ class TopLevelLayerSpec(VegaLiteSchema):
         A shared key-value mapping between encoding channels and definition of fields in the
          underlying layers.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its y-channel has a [continuous 
+        The height of a visualization.  __Default value:__ - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its y-channel has a [continuous
         scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of 
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - 
-        For y-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
+         be the value of
+        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
+        For y-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
         value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to 
+         cardinality of the field mapped to
         y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of 
+         `rangeStep` is `null`, the height will be the value of
         [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.  
-        __Note__: For plots with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the height of a single view.  __See also:__ The documentation for [width 
+         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
+        __Note__: For plots with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the height of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
     name : string
         Name of the visualization for later reference.
     padding : Padding
-        The default visualization padding, in pixels, from the edge of the visualization 
-        canvas to the data rectangle.  If a number, specifies padding for all sides. If an 
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5, 
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default 
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides. If an
+        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}` to specify padding for each side of the visualization.  __Default
         value__: `5`
     projection : Projection
-        An object defining properties of the geographic projection shared by underlying 
+        An object defining properties of the geographic projection shared by underlying
         layers.
     resolve : Resolve
         Scale, axis, and legend resolutions for layers.
@@ -5258,34 +5258,34 @@ class TopLevelLayerSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the 
-        following rules:  - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its x-channel has a [continuous 
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will 
-        be the value of 
+        The width of a visualization.  __Default value:__ This will be determined by the
+        following rules:  - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its x-channel has a [continuous
+        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
+        be the value of
         [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
-        value or unspecified, the width is [determined by the range step, paddings, and the 
-        cardinality of the field mapped to 
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if 
-        the `rangeStep` is `null`, the width will be the value of 
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If 
-        no field is mapped to `x` channel, the `width` will be the value of 
+         x-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
+        value or unspecified, the width is [determined by the range step, paddings, and the
+        cardinality of the field mapped to
+        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
+        the `rangeStep` is `null`, the width will be the value of
+        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
+        no field is mapped to `x` channel, the `width` will be the value of
         [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots 
-        with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the width of a single view.  __See also:__ The documentation for [width 
+         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
+        with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the width of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
-    
+
     Dict-Only Attributes
     --------------------
     '$schema' : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
-        you have a reason to change this, use 
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
+        you have a reason to change this, use
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
         allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelLayerSpec'}
@@ -5305,28 +5305,28 @@ class TopLevelLayerSpec(VegaLiteSchema):
 
 class TopLevelHConcatSpec(VegaLiteSchema):
     """TopLevelHConcatSpec schema wrapper
-    
+
     Mapping(required=[hconcat])
-    
+
     Attributes
     ----------
     hconcat : List(Spec)
         A list of views that should be concatenated and put into a row.
     autosize : anyOf(AutosizeType, AutoSizeParams)
-        Sets how the visualization size should be determined. If a string, should be one of 
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for 
-        content sizing and automatic resizing. `"fit"` is only supported for single and 
+        Sets how the visualization size should be determined. If a string, should be one of
+        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
+        content sizing and automatic resizing. `"fit"` is only supported for single and
         layered views that don't use `rangeStep`.  __Default value__: `pad`
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__ 
+        CSS color property to use as the background of visualization.  __Default value:__
         none (transparent)
     config : Config
-        Vega-Lite configuration object.  This property can only be defined at the top-level 
+        Vega-Lite configuration object.  This property can only be defined at the top-level
         of a specification.
     data : Data
         An object describing the data source
     datasets : Datasets
-        A global data store for named datasets. This is a mapping from names to inline 
+        A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
          primitive values are ingested as objects with a `data` property.
     description : string
@@ -5334,10 +5334,10 @@ class TopLevelHConcatSpec(VegaLiteSchema):
     name : string
         Name of the visualization for later reference.
     padding : Padding
-        The default visualization padding, in pixels, from the edge of the visualization 
-        canvas to the data rectangle.  If a number, specifies padding for all sides. If an 
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5, 
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default 
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides. If an
+        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}` to specify padding for each side of the visualization.  __Default
         value__: `5`
     resolve : Resolve
         Scale, axis, and legend resolutions for horizontally concatenated charts.
@@ -5345,13 +5345,13 @@ class TopLevelHConcatSpec(VegaLiteSchema):
         Title for the plot.
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
-    
+
     Dict-Only Attributes
     --------------------
     '$schema' : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
-        you have a reason to change this, use 
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
+        you have a reason to change this, use
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
         allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelHConcatSpec'}
@@ -5369,31 +5369,31 @@ class TopLevelHConcatSpec(VegaLiteSchema):
 
 class TopLevelRepeatSpec(VegaLiteSchema):
     """TopLevelRepeatSpec schema wrapper
-    
+
     Mapping(required=[repeat, spec])
-    
+
     Attributes
     ----------
     repeat : Repeat
         An object that describes what fields should be repeated into views that are laid out
          as a `row` or `column`.
     spec : Spec
-    
+
     autosize : anyOf(AutosizeType, AutoSizeParams)
-        Sets how the visualization size should be determined. If a string, should be one of 
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for 
-        content sizing and automatic resizing. `"fit"` is only supported for single and 
+        Sets how the visualization size should be determined. If a string, should be one of
+        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
+        content sizing and automatic resizing. `"fit"` is only supported for single and
         layered views that don't use `rangeStep`.  __Default value__: `pad`
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__ 
+        CSS color property to use as the background of visualization.  __Default value:__
         none (transparent)
     config : Config
-        Vega-Lite configuration object.  This property can only be defined at the top-level 
+        Vega-Lite configuration object.  This property can only be defined at the top-level
         of a specification.
     data : Data
         An object describing the data source
     datasets : Datasets
-        A global data store for named datasets. This is a mapping from names to inline 
+        A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
          primitive values are ingested as objects with a `data` property.
     description : string
@@ -5401,10 +5401,10 @@ class TopLevelRepeatSpec(VegaLiteSchema):
     name : string
         Name of the visualization for later reference.
     padding : Padding
-        The default visualization padding, in pixels, from the edge of the visualization 
-        canvas to the data rectangle.  If a number, specifies padding for all sides. If an 
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5, 
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default 
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides. If an
+        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}` to specify padding for each side of the visualization.  __Default
         value__: `5`
     resolve : Resolve
         Scale and legend resolutions for repeated charts.
@@ -5412,13 +5412,13 @@ class TopLevelRepeatSpec(VegaLiteSchema):
         Title for the plot.
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
-    
+
     Dict-Only Attributes
     --------------------
     '$schema' : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
-        you have a reason to change this, use 
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
+        you have a reason to change this, use
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
         allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelRepeatSpec'}
@@ -5437,28 +5437,28 @@ class TopLevelRepeatSpec(VegaLiteSchema):
 
 class TopLevelVConcatSpec(VegaLiteSchema):
     """TopLevelVConcatSpec schema wrapper
-    
+
     Mapping(required=[vconcat])
-    
+
     Attributes
     ----------
     vconcat : List(Spec)
         A list of views that should be concatenated and put into a column.
     autosize : anyOf(AutosizeType, AutoSizeParams)
-        Sets how the visualization size should be determined. If a string, should be one of 
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for 
-        content sizing and automatic resizing. `"fit"` is only supported for single and 
+        Sets how the visualization size should be determined. If a string, should be one of
+        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
+        content sizing and automatic resizing. `"fit"` is only supported for single and
         layered views that don't use `rangeStep`.  __Default value__: `pad`
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__ 
+        CSS color property to use as the background of visualization.  __Default value:__
         none (transparent)
     config : Config
-        Vega-Lite configuration object.  This property can only be defined at the top-level 
+        Vega-Lite configuration object.  This property can only be defined at the top-level
         of a specification.
     data : Data
         An object describing the data source
     datasets : Datasets
-        A global data store for named datasets. This is a mapping from names to inline 
+        A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
          primitive values are ingested as objects with a `data` property.
     description : string
@@ -5466,10 +5466,10 @@ class TopLevelVConcatSpec(VegaLiteSchema):
     name : string
         Name of the visualization for later reference.
     padding : Padding
-        The default visualization padding, in pixels, from the edge of the visualization 
-        canvas to the data rectangle.  If a number, specifies padding for all sides. If an 
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5, 
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default 
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides. If an
+        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}` to specify padding for each side of the visualization.  __Default
         value__: `5`
     resolve : Resolve
         Scale, axis, and legend resolutions for vertically concatenated charts.
@@ -5477,13 +5477,13 @@ class TopLevelVConcatSpec(VegaLiteSchema):
         Title for the plot.
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
-    
+
     Dict-Only Attributes
     --------------------
     '$schema' : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
-        you have a reason to change this, use 
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
+        you have a reason to change this, use
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
         allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelVConcatSpec'}
@@ -5501,31 +5501,31 @@ class TopLevelVConcatSpec(VegaLiteSchema):
 
 class TopLevelFacetSpec(VegaLiteSchema):
     """TopLevelFacetSpec schema wrapper
-    
+
     Mapping(required=[data, facet, spec])
-    
+
     Attributes
     ----------
     data : Data
         An object describing the data source
     facet : FacetMapping
-        An object that describes mappings between `row` and `column` channels and their 
+        An object that describes mappings between `row` and `column` channels and their
         field definitions.
     spec : anyOf(LayerSpec, CompositeUnitSpec)
         A specification of the view that gets faceted.
     autosize : anyOf(AutosizeType, AutoSizeParams)
-        Sets how the visualization size should be determined. If a string, should be one of 
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for 
-        content sizing and automatic resizing. `"fit"` is only supported for single and 
+        Sets how the visualization size should be determined. If a string, should be one of
+        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
+        content sizing and automatic resizing. `"fit"` is only supported for single and
         layered views that don't use `rangeStep`.  __Default value__: `pad`
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__ 
+        CSS color property to use as the background of visualization.  __Default value:__
         none (transparent)
     config : Config
-        Vega-Lite configuration object.  This property can only be defined at the top-level 
+        Vega-Lite configuration object.  This property can only be defined at the top-level
         of a specification.
     datasets : Datasets
-        A global data store for named datasets. This is a mapping from names to inline 
+        A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
          primitive values are ingested as objects with a `data` property.
     description : string
@@ -5533,10 +5533,10 @@ class TopLevelFacetSpec(VegaLiteSchema):
     name : string
         Name of the visualization for later reference.
     padding : Padding
-        The default visualization padding, in pixels, from the edge of the visualization 
-        canvas to the data rectangle.  If a number, specifies padding for all sides. If an 
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5, 
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default 
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides. If an
+        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}` to specify padding for each side of the visualization.  __Default
         value__: `5`
     resolve : Resolve
         Scale, axis, and legend resolutions for facets.
@@ -5544,13 +5544,13 @@ class TopLevelFacetSpec(VegaLiteSchema):
         Title for the plot.
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
-    
+
     Dict-Only Attributes
     --------------------
     '$schema' : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
-        you have a reason to change this, use 
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
+        you have a reason to change this, use
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
         allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelFacetSpec'}
@@ -5569,30 +5569,30 @@ class TopLevelFacetSpec(VegaLiteSchema):
 
 class TopLevelFacetedUnitSpec(VegaLiteSchema):
     """TopLevelFacetedUnitSpec schema wrapper
-    
+
     Mapping(required=[data, mark])
-    
+
     Attributes
     ----------
     data : Data
         An object describing the data source
     mark : AnyMark
         A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
-         `"line"`, * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark 
+         `"line"`, * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark
         definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
     autosize : anyOf(AutosizeType, AutoSizeParams)
-        Sets how the visualization size should be determined. If a string, should be one of 
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for 
-        content sizing and automatic resizing. `"fit"` is only supported for single and 
+        Sets how the visualization size should be determined. If a string, should be one of
+        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
+        content sizing and automatic resizing. `"fit"` is only supported for single and
         layered views that don't use `rangeStep`.  __Default value__: `pad`
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__ 
+        CSS color property to use as the background of visualization.  __Default value:__
         none (transparent)
     config : Config
-        Vega-Lite configuration object.  This property can only be defined at the top-level 
+        Vega-Lite configuration object.  This property can only be defined at the top-level
         of a specification.
     datasets : Datasets
-        A global data store for named datasets. This is a mapping from names to inline 
+        A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
          primitive values are ingested as objects with a `data` property.
     description : string
@@ -5600,35 +5600,35 @@ class TopLevelFacetedUnitSpec(VegaLiteSchema):
     encoding : EncodingWithFacet
         A key-value mapping between encoding channels and definition of fields.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its y-channel has a [continuous 
+        The height of a visualization.  __Default value:__ - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its y-channel has a [continuous
         scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of 
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - 
-        For y-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
+         be the value of
+        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
+        For y-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
         value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to 
+         cardinality of the field mapped to
         y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of 
+         `rangeStep` is `null`, the height will be the value of
         [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.  
-        __Note__: For plots with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the height of a single view.  __See also:__ The documentation for [width 
+         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
+        __Note__: For plots with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the height of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
     name : string
         Name of the visualization for later reference.
     padding : Padding
-        The default visualization padding, in pixels, from the edge of the visualization 
-        canvas to the data rectangle.  If a number, specifies padding for all sides. If an 
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5, 
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default 
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides. If an
+        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}` to specify padding for each side of the visualization.  __Default
         value__: `5`
     projection : Projection
-        An object defining properties of geographic projection.  Works with `"geoshape"` 
-        marks and `"point"` or `"line"` marks that have `latitude` and `"longitude"` 
+        An object defining properties of geographic projection.  Works with `"geoshape"`
+        marks and `"point"` or `"line"` marks that have `latitude` and `"longitude"`
         channels.
     selection : Mapping(required=[])
         A key-value mapping between selection names and definitions.
@@ -5637,34 +5637,34 @@ class TopLevelFacetedUnitSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the 
-        following rules:  - If a view's 
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is 
-        `"fit"` or its x-channel has a [continuous 
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will 
-        be the value of 
+        The width of a visualization.  __Default value:__ This will be determined by the
+        following rules:  - If a view's
+        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
+        `"fit"` or its x-channel has a [continuous
+        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
+        be the value of
         [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if 
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric 
-        value or unspecified, the width is [determined by the range step, paddings, and the 
-        cardinality of the field mapped to 
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if 
-        the `rangeStep` is `null`, the width will be the value of 
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If 
-        no field is mapped to `x` channel, the `width` will be the value of 
+         x-axis with a band or point scale: if
+        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
+        value or unspecified, the width is [determined by the range step, paddings, and the
+        cardinality of the field mapped to
+        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
+        the `rangeStep` is `null`, the width will be the value of
+        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
+        no field is mapped to `x` channel, the `width` will be the value of
         [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots 
-        with [`row` and `column` 
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this 
-        represents the width of a single view.  __See also:__ The documentation for [width 
+         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
+        with [`row` and `column`
+        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
+        represents the width of a single view.  __See also:__ The documentation for [width
         and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
-    
+
     Dict-Only Attributes
     --------------------
     '$schema' : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless 
-        you have a reason to change this, use 
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property 
+        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
+        you have a reason to change this, use
+        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
         allows automatic validation and autocomplete in editors that support JSON schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelFacetedUnitSpec'}
@@ -5685,38 +5685,38 @@ class TopLevelFacetedUnitSpec(VegaLiteSchema):
 
 class TopoDataFormat(VegaLiteSchema):
     """TopoDataFormat schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     feature : string
-        The name of the TopoJSON object set to convert to a GeoJSON feature collection. For 
-        example, in a map of the world, there may be an object set named `"countries"`. 
-        Using the feature property, we can extract this set and generate a GeoJSON feature 
+        The name of the TopoJSON object set to convert to a GeoJSON feature collection. For
+        example, in a map of the world, there may be an object set named `"countries"`.
+        Using the feature property, we can extract this set and generate a GeoJSON feature
         object for each country.
     mesh : string
-        The name of the TopoJSON object set to convert to mesh. Similar to the `feature` 
-        option, `mesh` extracts a named TopoJSON object set.   Unlike the `feature` option, 
-        the corresponding geo data is returned as a single, unified mesh instance, not as 
-        individual GeoJSON features. Extracting a mesh is useful for more efficiently 
-        drawing borders or other geographic elements that you do not need to associate with 
+        The name of the TopoJSON object set to convert to mesh. Similar to the `feature`
+        option, `mesh` extracts a named TopoJSON object set.   Unlike the `feature` option,
+        the corresponding geo data is returned as a single, unified mesh instance, not as
+        individual GeoJSON features. Extracting a mesh is useful for more efficiently
+        drawing borders or other geographic elements that you do not need to associate with
         specific regions such as individual countries, states or counties.
     parse : anyOf(enum('auto'), Mapping(required=[]))
-        If set to auto (the default), perform automatic type inference to determine the 
-        desired data types. Alternatively, a parsing directive object can be provided for 
-        explicit data types. Each property of the object corresponds to a field name, and 
+        If set to auto (the default), perform automatic type inference to determine the
+        desired data types. Alternatively, a parsing directive object can be provided for
+        explicit data types. Each property of the object corresponds to a field name, and
         the value to the desired data type (one of `"number"`, `"boolean"` or `"date"`). For
-         example, `"parse": {"modified_on": "date"}` parses the `modified_on` field in each 
-        input record a Date value.  For `"date"`, we parse data based using Javascript's 
+         example, `"parse": {"modified_on": "date"}` parses the `modified_on` field in each
+        input record a Date value.  For `"date"`, we parse data based using Javascript's
         [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).
-         For Specific date formats can be provided (e.g., `{foo: 'date:"%m%d%Y"'}`), using 
+         For Specific date formats can be provided (e.g., `{foo: 'date:"%m%d%Y"'}`), using
         the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC
-         date format parsing is supported similarly (e.g., `{foo: 'utc:"%m%d%Y"'}`). See 
+         date format parsing is supported similarly (e.g., `{foo: 'utc:"%m%d%Y"'}`). See
         more about [UTC time](timeunit.html#utc)
     type : enum('topojson')
-        Type of input data: `"json"`, `"csv"`, `"tsv"`. The default format type is 
-        determined by the extension of the file URL. If no extension is detected, `"json"` 
+        Type of input data: `"json"`, `"csv"`, `"tsv"`. The default format type is
+        determined by the extension of the file URL. If no extension is detected, `"json"`
         will be used by default.
     """
     _schema = {'$ref': '#/definitions/TopoDataFormat'}
@@ -5728,7 +5728,7 @@ class TopoDataFormat(VegaLiteSchema):
 
 class Transform(VegaLiteSchema):
     """Transform schema wrapper
-    
+
     anyOf(FilterTransform, CalculateTransform, LookupTransform, BinTransform, TimeUnitTransform,
      AggregateTransform)
     """
@@ -5741,10 +5741,10 @@ class Transform(VegaLiteSchema):
 
 class Type(VegaLiteSchema):
     """Type schema wrapper
-    
+
     anyOf(BasicType, GeoType)
-    Constants and utilities for data type  
-     Data type based on level of measurement 
+    Constants and utilities for data type
+     Data type based on level of measurement
     """
     _schema = {'$ref': '#/definitions/Type'}
     _rootschema = Root._schema
@@ -5755,9 +5755,9 @@ class Type(VegaLiteSchema):
 
 class UrlData(VegaLiteSchema):
     """UrlData schema wrapper
-    
+
     Mapping(required=[url])
-    
+
     Attributes
     ----------
     url : string
@@ -5775,9 +5775,9 @@ class UrlData(VegaLiteSchema):
 
 class UtcMultiTimeUnit(VegaLiteSchema):
     """UtcMultiTimeUnit schema wrapper
-    
-    enum('utcyearquarter', 'utcyearquartermonth', 'utcyearmonth', 'utcyearmonthdate', 
-    'utcyearmonthdatehours', 'utcyearmonthdatehoursminutes', 
+
+    enum('utcyearquarter', 'utcyearquartermonth', 'utcyearmonth', 'utcyearmonthdate',
+    'utcyearmonthdatehours', 'utcyearmonthdatehoursminutes',
     'utcyearmonthdatehoursminutesseconds', 'utcquartermonth', 'utcmonthdate', 'utchoursminutes',
      'utchoursminutesseconds', 'utcminutesseconds', 'utcsecondsmilliseconds')
     """
@@ -5790,8 +5790,8 @@ class UtcMultiTimeUnit(VegaLiteSchema):
 
 class UtcSingleTimeUnit(VegaLiteSchema):
     """UtcSingleTimeUnit schema wrapper
-    
-    enum('utcyear', 'utcquarter', 'utcmonth', 'utcday', 'utcdate', 'utchours', 'utcminutes', 
+
+    enum('utcyear', 'utcquarter', 'utcmonth', 'utcday', 'utcdate', 'utchours', 'utcminutes',
     'utcseconds', 'utcmilliseconds')
     """
     _schema = {'$ref': '#/definitions/UtcSingleTimeUnit'}
@@ -5803,14 +5803,14 @@ class UtcSingleTimeUnit(VegaLiteSchema):
 
 class ValueDef(VegaLiteSchema):
     """ValueDef schema wrapper
-    
+
     Mapping(required=[value])
     Definition object for a constant value of an encoding channel.
-    
+
     Attributes
     ----------
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values 
+        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
         between `0` to `1` for opacity).
     """
     _schema = {'$ref': '#/definitions/ValueDef'}
@@ -5822,14 +5822,14 @@ class ValueDef(VegaLiteSchema):
 
 class ValueDefWithCondition(VegaLiteSchema):
     """ValueDefWithCondition schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
     condition : anyOf(ConditionalFieldDef, ConditionalValueDef, List(ConditionalValueDef))
@@ -5846,17 +5846,17 @@ class ValueDefWithCondition(VegaLiteSchema):
 
 class MarkPropValueDefWithCondition(VegaLiteSchema):
     """MarkPropValueDefWithCondition schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
-    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef, 
+    condition : anyOf(ConditionalMarkPropFieldDef, ConditionalValueDef,
     List(ConditionalValueDef))
         A field definition or one or more value definition(s) with a selection predicate.
     value : anyOf(float, string, boolean)
@@ -5871,14 +5871,14 @@ class MarkPropValueDefWithCondition(VegaLiteSchema):
 
 class TextValueDefWithCondition(VegaLiteSchema):
     """TextValueDefWithCondition schema wrapper
-    
+
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef>
     {
        condition: {field: ...} | {value: ...},
        value: ...,
     }
-    
+
     Attributes
     ----------
     condition : anyOf(ConditionalTextFieldDef, ConditionalValueDef, List(ConditionalValueDef))
@@ -5895,7 +5895,7 @@ class TextValueDefWithCondition(VegaLiteSchema):
 
 class VerticalAlign(VegaLiteSchema):
     """VerticalAlign schema wrapper
-    
+
     enum('top', 'middle', 'bottom')
     """
     _schema = {'$ref': '#/definitions/VerticalAlign'}
@@ -5907,54 +5907,54 @@ class VerticalAlign(VegaLiteSchema):
 
 class VgAxisConfig(VegaLiteSchema):
     """VgAxisConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     bandPosition : float
-        An interpolation fraction indicating where, for `band` scales, axis ticks should be 
-        positioned. A value of `0` places ticks at the left edge of their bands. A value of 
+        An interpolation fraction indicating where, for `band` scales, axis ticks should be
+        positioned. A value of `0` places ticks at the left edge of their bands. A value of
         `0.5` places ticks in the middle of their bands.
     domain : boolean
-        A boolean flag indicating if the domain (the axis baseline) should be included as 
+        A boolean flag indicating if the domain (the axis baseline) should be included as
         part of the axis.  __Default value:__ `true`
     domainColor : string
         Color of axis domain line.  __Default value:__  (none, using Vega default).
     domainWidth : float
         Stroke width of axis domain line  __Default value:__  (none, using Vega default).
     grid : boolean
-        A boolean flag indicating if grid lines should be included as part of the axis  
-        __Default value:__ `true` for [continuous scales](scale.html#continuous) that are 
+        A boolean flag indicating if grid lines should be included as part of the axis
+        __Default value:__ `true` for [continuous scales](scale.html#continuous) that are
         not binned; otherwise, `false`.
     gridColor : string
         Color of gridlines.
     gridDash : List(float)
         The offset (in pixels) into which to begin drawing with the grid dash array.
     gridOpacity : float
-        The stroke opacity of grid (value between [0,1])  __Default value:__ (`1` by 
+        The stroke opacity of grid (value between [0,1])  __Default value:__ (`1` by
         default)
     gridWidth : float
         The grid width, in pixels.
     labelAngle : float
-        The rotation angle of the axis labels.  __Default value:__ `-90` for nominal and 
+        The rotation angle of the axis labels.  __Default value:__ `-90` for nominal and
         ordinal fields; `0` otherwise.
     labelBound : anyOf(boolean, float)
-        Indicates if labels should be hidden if they exceed the axis range. If `false `(the 
-        default) no bounds overlap analysis is performed. If `true`, labels will be hidden 
+        Indicates if labels should be hidden if they exceed the axis range. If `false `(the
+        default) no bounds overlap analysis is performed. If `true`, labels will be hidden
         if they exceed the axis range by more than 1 pixel. If this property is a number, it
          specifies the pixel tolerance: the maximum amount by which a label bounding box may
          exceed the axis range.  __Default value:__ `false`.
     labelColor : string
         The color of the tick label, can be in hex color code or regular color name.
     labelFlush : anyOf(boolean, float)
-        Indicates if the first and last axis labels should be aligned flush with the scale 
-        range. Flush alignment for a horizontal axis will left-align the first label and 
-        right-align the last label. For vertical axes, bottom and top text baselines are 
-        applied instead. If this property is a number, it also indicates the number of 
-        pixels by which to offset the first and last labels; for example, a value of 2 will 
-        flush-align the first and last labels and also push them 2 pixels outward from the 
-        center of the axis. The additional adjustment can sometimes help the labels better 
+        Indicates if the first and last axis labels should be aligned flush with the scale
+        range. Flush alignment for a horizontal axis will left-align the first label and
+        right-align the last label. For vertical axes, bottom and top text baselines are
+        applied instead. If this property is a number, it also indicates the number of
+        pixels by which to offset the first and last labels; for example, a value of 2 will
+        flush-align the first and last labels and also push them 2 pixels outward from the
+        center of the axis. The additional adjustment can sometimes help the labels better
         visually group with corresponding axis ticks.  __Default value:__ `true` for axis of
          a continuous x-scale. Otherwise, `false`.
     labelFont : string
@@ -5964,29 +5964,29 @@ class VgAxisConfig(VegaLiteSchema):
     labelLimit : float
         Maximum allowed pixel width of axis tick labels.
     labelOverlap : anyOf(boolean, enum('parity'), enum('greedy'))
-        The strategy to use for resolving overlap of axis labels. If `false` (the default), 
-        no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of 
-        removing every other label is used (this works well for standard linear axes). If 
-        set to `"greedy"`, a linear scan of the labels is performed, removing any labels 
-        that overlaps with the last visible label (this often works better for log-scaled 
-        axes).  __Default value:__ `true` for non-nominal fields with non-log scales; 
+        The strategy to use for resolving overlap of axis labels. If `false` (the default),
+        no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of
+        removing every other label is used (this works well for standard linear axes). If
+        set to `"greedy"`, a linear scan of the labels is performed, removing any labels
+        that overlaps with the last visible label (this often works better for log-scaled
+        axes).  __Default value:__ `true` for non-nominal fields with non-log scales;
         `"greedy"` for log scales; otherwise `false`.
     labelPadding : float
         The padding, in pixels, between axis and text labels.
     labels : boolean
-        A boolean flag indicating if labels should be included as part of the axis.  
+        A boolean flag indicating if labels should be included as part of the axis.
         __Default value:__  `true`.
     maxExtent : float
-        The maximum extent in pixels that axis ticks and labels should use. This determines 
+        The maximum extent in pixels that axis ticks and labels should use. This determines
         a maximum offset value for axis titles.  __Default value:__ `undefined`.
     minExtent : float
-        The minimum extent in pixels that axis ticks and labels should use. This determines 
-        a minimum offset value for axis titles.  __Default value:__ `30` for y-axis; 
+        The minimum extent in pixels that axis ticks and labels should use. This determines
+        a minimum offset value for axis titles.  __Default value:__ `30` for y-axis;
         `undefined` for x-axis.
     tickColor : string
         The color of the axis's tick.
     tickRound : boolean
-        Boolean flag indicating if pixel position values should be rounded to the nearest 
+        Boolean flag indicating if pixel position values should be rounded to the nearest
         integer.
     tickSize : float
         The size in pixels of axis ticks.
@@ -6007,13 +6007,13 @@ class VgAxisConfig(VegaLiteSchema):
     titleFontSize : float
         Font size of the title.
     titleFontWeight : FontWeight
-        Font weight of the title. This can be either a string (e.g `"bold"`, `"normal"`) or 
-        a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = 
+        Font weight of the title. This can be either a string (e.g `"bold"`, `"normal"`) or
+        a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` =
         `700`).
     titleLimit : float
         Maximum allowed pixel width of axis titles.
     titleMaxLength : float
-        Max length for axis title if the title is automatically generated from the field's 
+        Max length for axis title if the title is automatically generated from the field's
         description.
     titlePadding : float
         The padding, in pixels, between title and axis.
@@ -6058,7 +6058,7 @@ class VgAxisConfig(VegaLiteSchema):
 
 class VgBinding(VegaLiteSchema):
     """VgBinding schema wrapper
-    
+
     anyOf(VgCheckboxBinding, VgRadioBinding, VgSelectBinding, VgRangeBinding, VgGenericBinding)
     """
     _schema = {'$ref': '#/definitions/VgBinding'}
@@ -6070,15 +6070,15 @@ class VgBinding(VegaLiteSchema):
 
 class VgCheckboxBinding(VegaLiteSchema):
     """VgCheckboxBinding schema wrapper
-    
+
     Mapping(required=[input])
-    
+
     Attributes
     ----------
     input : enum('checkbox')
-    
+
     element : string
-    
+
     """
     _schema = {'$ref': '#/definitions/VgCheckboxBinding'}
     _rootschema = Root._schema
@@ -6089,7 +6089,7 @@ class VgCheckboxBinding(VegaLiteSchema):
 
 class VgEventStream(VegaLiteSchema):
     """VgEventStream schema wrapper
-    
+
     Mapping(required=[])
     """
     _schema = {'$ref': '#/definitions/VgEventStream'}
@@ -6101,15 +6101,15 @@ class VgEventStream(VegaLiteSchema):
 
 class VgGenericBinding(VegaLiteSchema):
     """VgGenericBinding schema wrapper
-    
+
     Mapping(required=[input])
-    
+
     Attributes
     ----------
     input : string
-    
+
     element : string
-    
+
     """
     _schema = {'$ref': '#/definitions/VgGenericBinding'}
     _rootschema = Root._schema
@@ -6120,9 +6120,9 @@ class VgGenericBinding(VegaLiteSchema):
 
 class VgMarkConfig(VegaLiteSchema):
     """VgMarkConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     align : HorizontalAlign
@@ -6130,23 +6130,23 @@ class VgMarkConfig(VegaLiteSchema):
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.  
+        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
         __Default value:__ `"middle"`
-    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress', 
-    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop', 
-    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize', 
-    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize', 
+    cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
+    'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
+    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
+    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor 
+        The mouse cursor used over the mark. Any valid [CSS cursor
         type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
     dx : float
-        The horizontal offset, in pixels, between the text label and its anchor point. The 
+        The horizontal offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     dy : float
-        The vertical offset, in pixels, between the text label and its anchor point. The 
+        The vertical offset, in pixels, between the text label and its anchor point. The
         offset is applied after rotation by the _angle_ property.
     fill : string
-        Default Fill Color.  This has higher precedence than config.color  __Default 
+        Default Fill Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     fillOpacity : float
         The fill opacity (value between [0,1]).  __Default value:__ `1`
@@ -6157,54 +6157,54 @@ class VgMarkConfig(VegaLiteSchema):
     fontStyle : FontStyle
         The font style (e.g., `"italic"`).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number 
+        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
         (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
-        The line interpolation method to use for line and area marks. One of the following: 
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`: 
-        close the linear segments to form a polygon. - `"step"`: alternate between 
-        horizontal and vertical segments, as in a step function. - `"step-before"`: 
-        alternate between vertical and horizontal segments, as in a step function. - 
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step 
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. - 
-        `"basis-open"`: an open B-spline; may not intersect the start or end. - 
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal 
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open 
-        Cardinal spline; may not intersect the start or end, but will intersect other 
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. - 
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten 
+        The line interpolation method to use for line and area marks. One of the following:
+        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
+        close the linear segments to form a polygon. - `"step"`: alternate between
+        horizontal and vertical segments, as in a step function. - `"step-before"`:
+        alternate between vertical and horizontal segments, as in a step function. -
+        `"step-after"`: alternate between horizontal and vertical segments, as in a step
+        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
+        `"basis-open"`: an open B-spline; may not intersect the start or end. -
+        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
+        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
+        Cardinal spline; may not intersect the start or end, but will intersect other
+        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
+        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
         the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
     limit : float
-        The maximum length of the text mark in pixels (default 0, indicating no limit). The 
+        The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for 
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered 
+        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
+        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
         `bar` charts and `1` otherwise.
     orient : Orient
-        The orientation of a non-stacked bar, tick, area, and line charts. The value is 
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines 
-        whether the size of the bar and tick should be applied to x or y dimension. - For 
-        area, this property determines the orient property of the Vega output. - For line, 
-        this property determines the sort order of the points in the line if 
-        `config.sortLineBy` is not specified. For stacked charts, this is always determined 
-        by the orientation of the stack; therefore explicitly specified value will be 
+        The orientation of a non-stacked bar, tick, area, and line charts. The value is
+        either horizontal (default) or vertical. - For bar, rule and tick, this determines
+        whether the size of the bar and tick should be applied to x or y dimension. - For
+        area, this property determines the orient property of the Vega output. - For line,
+        this property determines the sort order of the points in the line if
+        `config.sortLineBy` is not specified. For stacked charts, this is always determined
+        by the orientation of the stack; therefore explicitly specified value will be
         ignored.
     radius : float
-        Polar coordinate radial offset, in pixels, of the text label from the origin 
+        Polar coordinate radial offset, in pixels, of the text label from the origin
         determined by the `x` and `y` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`, 
+        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
         `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
           __Default value:__ `"circle"`
     size : float
-        The pixel area each the point/circle/square. For example: in the case of circles, 
-        the radius is determined in part by the square root of the size value.  __Default 
+        The pixel area each the point/circle/square. For example: in the case of circles,
+        the radius is determined in part by the square root of the size value.  __Default
         value:__ `30`
     stroke : string
-        Default Stroke Color.  This has higher precedence than config.color  __Default 
+        Default Stroke Color.  This has higher precedence than config.color  __Default
         value:__ (None)
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
@@ -6215,14 +6215,14 @@ class VgMarkConfig(VegaLiteSchema):
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
-        Depending on the interpolation type, sets the tension parameter (for line and area 
+        Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
         Placeholder text if the `text` channel is not specified
     theta : float
-        Polar coordinate angle, in radians, of the text label from the origin determined by 
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc` 
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with 
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
+        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
         `0` indicating "north".
     """
     _schema = {'$ref': '#/definitions/VgMarkConfig'}
@@ -6248,9 +6248,9 @@ class VgMarkConfig(VegaLiteSchema):
 
 class VgProjectionType(VegaLiteSchema):
     """VgProjectionType schema wrapper
-    
-    enum('albers', 'albersUsa', 'azimuthalEqualArea', 'azimuthalEquidistant', 'conicConformal', 
-    'conicEqualArea', 'conicEquidistant', 'equirectangular', 'gnomonic', 'mercator', 
+
+    enum('albers', 'albersUsa', 'azimuthalEqualArea', 'azimuthalEquidistant', 'conicConformal',
+    'conicEqualArea', 'conicEquidistant', 'equirectangular', 'gnomonic', 'mercator',
     'orthographic', 'stereographic', 'transverseMercator')
     """
     _schema = {'$ref': '#/definitions/VgProjectionType'}
@@ -6262,17 +6262,17 @@ class VgProjectionType(VegaLiteSchema):
 
 class VgRadioBinding(VegaLiteSchema):
     """VgRadioBinding schema wrapper
-    
+
     Mapping(required=[input, options])
-    
+
     Attributes
     ----------
     input : enum('radio')
-    
+
     options : List(string)
-    
+
     element : string
-    
+
     """
     _schema = {'$ref': '#/definitions/VgRadioBinding'}
     _rootschema = Root._schema
@@ -6283,21 +6283,21 @@ class VgRadioBinding(VegaLiteSchema):
 
 class VgRangeBinding(VegaLiteSchema):
     """VgRangeBinding schema wrapper
-    
+
     Mapping(required=[input])
-    
+
     Attributes
     ----------
     input : enum('range')
-    
+
     element : string
-    
+
     max : float
-    
+
     min : float
-    
+
     step : float
-    
+
     """
     _schema = {'$ref': '#/definitions/VgRangeBinding'}
     _rootschema = Root._schema
@@ -6310,17 +6310,17 @@ class VgRangeBinding(VegaLiteSchema):
 
 class VgScheme(VegaLiteSchema):
     """VgScheme schema wrapper
-    
+
     Mapping(required=[scheme])
-    
+
     Attributes
     ----------
     scheme : string
-    
+
     count : float
-    
+
     extent : List(float)
-    
+
     """
     _schema = {'$ref': '#/definitions/VgScheme'}
     _rootschema = Root._schema
@@ -6331,17 +6331,17 @@ class VgScheme(VegaLiteSchema):
 
 class VgSelectBinding(VegaLiteSchema):
     """VgSelectBinding schema wrapper
-    
+
     Mapping(required=[input, options])
-    
+
     Attributes
     ----------
     input : enum('select')
-    
+
     options : List(string)
-    
+
     element : string
-    
+
     """
     _schema = {'$ref': '#/definitions/VgSelectBinding'}
     _rootschema = Root._schema
@@ -6352,16 +6352,16 @@ class VgSelectBinding(VegaLiteSchema):
 
 class VgTitleConfig(VegaLiteSchema):
     """VgTitleConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     anchor : Anchor
         The anchor position for placing the title. One of `"start"`, `"middle"`, or `"end"`.
-         For example, with an orientation of top these anchor positions map to a left-, 
-        center-, or right-aligned title.  __Default value:__ `"middle"` for 
-        [single](spec.html) and [layered](layer.html) views. `"start"` for other composite 
+         For example, with an orientation of top these anchor positions map to a left-,
+        center-, or right-aligned title.  __Default value:__ `"middle"` for
+        [single](spec.html) and [layered](layer.html) views. `"start"` for other composite
         views.  __Note:__ [For now](https://github.com/vega/vega-lite/issues/2875), `anchor`
          is only customizable only for [single](spec.html) and [layered](layer.html) views.
           For other composite views, `anchor` is always `"start"`.
@@ -6376,7 +6376,7 @@ class VgTitleConfig(VegaLiteSchema):
     fontSize : float
         Font size in pixels for title text.  __Default value:__ `10`.
     fontWeight : FontWeight
-        Font weight for title text. This can be either a string (e.g `"bold"`, `"normal"`) 
+        Font weight for title text. This can be either a string (e.g `"bold"`, `"normal"`)
         or a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` =
          `700`).
     limit : float
@@ -6399,9 +6399,9 @@ class VgTitleConfig(VegaLiteSchema):
 
 class ViewConfig(VegaLiteSchema):
     """ViewConfig schema wrapper
-    
+
     Mapping(required=[])
-    
+
     Attributes
     ----------
     clip : boolean
@@ -6411,24 +6411,24 @@ class ViewConfig(VegaLiteSchema):
     fillOpacity : float
         The fill opacity (value between [0,1]).  __Default value:__ (none)
     height : float
-        The default height of the single plot or each plot in a trellis plot when the 
-        visualization has a continuous (non-ordinal) y-scale with `rangeStep` = `null`.  
+        The default height of the single plot or each plot in a trellis plot when the
+        visualization has a continuous (non-ordinal) y-scale with `rangeStep` = `null`.
         __Default value:__ `200`
     stroke : string
         The stroke color.  __Default value:__ (none)
     strokeDash : List(float)
-        An array of alternating stroke, space lengths for creating dashed or dotted lines.  
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
         __Default value:__ (none)
     strokeDashOffset : float
-        The offset (in pixels) into which to begin drawing with the stroke dash array.  
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
         __Default value:__ (none)
     strokeOpacity : float
         The stroke opacity (value between [0,1]).  __Default value:__ (none)
     strokeWidth : float
         The stroke width, in pixels.  __Default value:__ (none)
     width : float
-        The default width of the single plot or each plot in a trellis plot when the 
-        visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with 
+        The default width of the single plot or each plot in a trellis plot when the
+        visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with
         `rangeStep` = `null`.  __Default value:__ `200`
     """
     _schema = {'$ref': '#/definitions/ViewConfig'}
@@ -6441,4 +6441,3 @@ class ViewConfig(VegaLiteSchema):
                                          stroke=stroke, strokeDash=strokeDash,
                                          strokeDashOffset=strokeDashOffset, strokeOpacity=strokeOpacity,
                                          strokeWidth=strokeWidth, width=width, **kwds)
-


### PR DESCRIPTION
There are a series of other small PEP8 violations hanging around the library that could use a little housecleaning, IMHO. If you're open to it, I'd be happy to use `flake8` to tidy up the rest.

Ultimately the library could use flake8 to enforce Python style as part of the tests on TravisCI. In my experience as a package maintainer this has been a positive thing because, as pedantic as PEP8 is, it provides a common foundation that can bring some consistency to a large library and quickly settle subjective debates about style. 