### PR TITLE
Ignore PEP8 errors E711 and E712

### DIFF
--- a/altair/expr/tests/test_expr.py
+++ b/altair/expr/tests/test_expr.py
@@ -71,9 +71,9 @@ def test_expr_consts():
 
 def test_json_reprs():
     """Test JSON representations of special values"""
-    assert repr(datum.xxx == None) == '(datum.xxx === null)'
-    assert repr(datum.xxx == False) == '(datum.xxx === false)'
-    assert repr(datum.xxx == True) == '(datum.xxx === true)'
+    assert repr(datum.xxx == None) == '(datum.xxx === null)'  # noqa: E711
+    assert repr(datum.xxx == False) == '(datum.xxx === false)'  # noqa: E712
+    assert repr(datum.xxx == True) == '(datum.xxx === true)'  # noqa: E712
 
 
 def test_to_dict():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 119
+ignore = E711,E712

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,2 @@
 [flake8]
 max-line-length = 119
-ignore = E711,E712


### PR DESCRIPTION
For reasons described in #705.