### PR TITLE
DOC: eps replaced with svg

### DIFF
--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -21,7 +21,7 @@ def save(chart, fp, vega_version, vegaembed_version,
     fp : string filename or file-like object
         file in which to write the chart.
     format : string (optional)
-        the format to write: one of ['json', 'html', 'png', 'eps'].
+        the format to write: one of ['json', 'html', 'png', 'svg'].
         If not specified, the format will be determined from the filename.
     mode : string (optional)
         Either 'vega' or 'vegalite'. If not specified, then infer the mode from
@@ -51,7 +51,7 @@ def save(chart, fp, vega_version, vegaembed_version,
             format = fp.split('.')[-1]
         else:
             raise ValueError("must specify file format: "
-                             "['png', 'eps', 'html', 'json']")
+                             "['png', 'svg', 'html', 'json']")
 
     spec = chart.to_dict()
 

--- a/altair/vegalite/v1/api.py
+++ b/altair/vegalite/v1/api.py
@@ -108,7 +108,7 @@ class TopLevelMixin(object):
         fp : string filename or file-like object
             file in which to write the chart.
         format : string (optional)
-            the format to write: one of ['json', 'html', 'png', 'eps'].
+            the format to write: one of ['json', 'html', 'png', 'svg'].
             If not specified, the format will be determined from the filename.
         **kwargs :
             Additional keyword arguments are passed to the output method
@@ -130,7 +130,7 @@ class TopLevelMixin(object):
         fp : string filename or file-like object
             file in which to write the chart.
         format : string (optional)
-            the format to write: one of ['json', 'html', 'png', 'eps'].
+            the format to write: one of ['json', 'html', 'png', 'svg'].
             If not specified, the format will be determined from the filename.
         **kwargs :
             Additional keyword arguments are passed to the output method

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -361,7 +361,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         fp : string filename or file-like object
             file in which to write the chart.
         format : string (optional)
-            the format to write: one of ['json', 'html', 'png', 'eps'].
+            the format to write: one of ['json', 'html', 'png', 'svg'].
             If not specified, the format will be determined from the filename.
         **kwargs :
             Additional keyword arguments are passed to the output method
@@ -383,7 +383,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         fp : string filename or file-like object
             file in which to write the chart.
         format : string (optional)
-            the format to write: one of ['json', 'html', 'png', 'eps'].
+            the format to write: one of ['json', 'html', 'png', 'svg'].
             If not specified, the format will be determined from the filename.
         **kwargs :
             Additional keyword arguments are passed to the output method


### PR DESCRIPTION
Per @jakevdp's request, to fix when he types 'eps' instead of 'svg'. 'eps' is removed with this pull request and replaced with 'svg'.

Fixes #722.