### PR TITLE
Fix for `to_json` and `to_csv` path resolving

### DIFF
--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -1,0 +1,134 @@
+import json
+import os
+import random
+import uuid
+
+import pandas as pd
+from toolz.curried import curry, pipe
+
+from .core import sanitize_dataframe
+
+
+# ==============================================================================
+# Data model transformers
+#
+# A data model transformer is a pure function that takes a dict or DataFrame
+# and returns a transformed version of a dict or DataFrame. The dict objects
+# will be the Data portion of the VegaLite schema. The idea is that user can
+# pipe a sequence of these data transformers together to prepare the data before
+# it hits the renderer.
+#
+# In this version of Altair, renderers only deal with the dict form of a
+# VegaLite spec, after the Data model has been put into a schema compliant
+# form.
+#
+# A data model transformer has the following type signature:
+# DataModelType = Union[dict, pd.DataFrame]
+# DataModelTransformerType = Callable[[DataModelType, KwArgs], DataModelType]
+# ==============================================================================
+
+
+class MaxRowsError(Exception):
+    """Raised when a data model has too many rows."""
+    pass
+
+
+@curry
+def limit_rows(data, max_rows=5000):
+    """Raise MaxRowsError if the data model has more than max_rows."""
+    check_data_type(data)
+    if isinstance(data, pd.DataFrame):
+        values = data
+    elif isinstance(data, dict):
+        if 'values' in data:
+            values = data['values']
+        else:
+            return data
+    if len(values) > max_rows:
+        raise MaxRowsError('The number of rows in your dataset is greater than the max of {}'.format(max_rows))
+    return data
+
+
+@curry
+def sample(data, n=None, frac=None):
+    """Reduce the size of the data model by sampling without replacement."""
+    check_data_type(data)
+    if isinstance(data, pd.DataFrame):
+        return data.sample(n=n, frac=frac)
+    elif isinstance(data, dict):
+        if 'values' in data:
+            values = data['values']
+            n = n if n else int(frac*len(values))
+            values = random.sample(values, n)
+            return {'values': values}
+
+
+@curry
+def to_json(data, prefix='altair-data'):
+    """Write the data model to a .json file and return a url based data model."""
+    check_data_type(data)
+    ext = '.json'
+    filename = _compute_filename(prefix=prefix, ext=ext)
+    if isinstance(data, pd.DataFrame):
+        data = sanitize_dataframe(data)
+        data.to_json(filename, orient='records')
+    elif isinstance(data, dict):
+        if 'values' not in data:
+            raise KeyError('values expected in data dict, but not present.')
+        values = data['values']
+        with open(filename) as f:
+            json.dump(values, f)
+    return {
+        'url': filename,
+        'format': {'type': 'json'}
+    }
+
+
+@curry
+def to_csv(data, prefix='altair-data'):
+    """Write the data model to a .csv file and return a url based data model."""
+    check_data_type(data)
+    ext = '.csv'
+    filename = _compute_filename(prefix=prefix, ext=ext)
+    if isinstance(data, pd.DataFrame):
+        data = sanitize_dataframe(data)
+        data.to_csv(filename)
+        return {
+            'url': filename,
+            'format': {'type': 'csv'}
+        }
+    elif isinstance(data, dict):
+        raise NotImplementedError('to_csv only works with Pandas DataFrame objects.')
+
+
+@curry
+def to_values(data):
+    """Replace a DataFrame by a data model with values."""
+    check_data_type(data)
+    if isinstance(data, pd.DataFrame):
+        data = sanitize_dataframe(data)
+        return {'values': data.to_dict(orient='records')}
+    elif isinstance(data, dict):
+        if 'values' not in data:
+            raise KeyError('values expected in data dict, but not present.')
+        return data
+
+
+def check_data_type(data):
+    """Raise if the data is not a dict or DataFrame."""
+    if not isinstance(data, (dict, pd.DataFrame)):
+        raise TypeError('Expected dict or DataFrame, got: {}'.format(type(data)))
+
+
+# ==============================================================================
+# Private utilities
+# ==============================================================================
+
+
+def _compute_uuid_filename(prefix, ext):
+    return prefix + '-' + str(uuid.uuid4()) + ext
+
+
+def _compute_filename(prefix='altair-data', ext='.csv'):
+    filename = _compute_uuid_filename(prefix, ext)
+    return filename

--- a/altair/utils/tests/test_data.py
+++ b/altair/utils/tests/test_data.py
@@ -2,7 +2,7 @@ import pytest
 import pandas as pd
 
 
-from altair.vegalite.data import limit_rows, MaxRowsError, sample, pipe, to_values
+from ..data import limit_rows, MaxRowsError, sample, pipe, to_values
 
 
 def _create_dataframe(N):

--- a/altair/vega/data.py
+++ b/altair/vega/data.py
@@ -1,36 +1,9 @@
-import json
-import os
-import random
-import uuid
-
 import pandas as pd
 from toolz.curried import curry, pipe
-
 from ..utils.core import sanitize_dataframe
-
-
-# ==============================================================================
-# Data model transformers
-#
-# A data model transformer is a pure function that takes a dict or DataFrame
-# and returns a transformed version of a dict or DataFrame. The dict objects
-# will be the Data portion of the VegaLite schema. The idea is that user can
-# pipe a sequence of these data transformers together to prepare the data before
-# it hits the renderer.
-#
-# In this version of Altair, renderers only deal with the dict form of a
-# VegaLite spec, after the Data model has been put into a schema compliant
-# form.
-#
-# A data model transformer has the following type signature:
-# DataModelType = Union[dict, pd.DataFrame]
-# DataModelTransformerType = Callable[[DataModelType, KwArgs], DataModelType]
-# ==============================================================================
-
-
-class MaxRowsError(Exception):
-    """Raised when a data model has too many rows."""
-    pass
+from ..utils.data import (
+    MaxRowsError, sample, to_csv, to_json, to_values, check_data_type
+)
 
 
 @curry
@@ -44,90 +17,18 @@ def limit_rows(data, max_rows=5000):
 
 
 @curry
-def sample(data, n=None, frac=None):
-    """Reduce the size of the data model by sampling without replacement."""
-    _check_data_type(data)
-    if isinstance(data, pd.DataFrame):
-        return data.sample(n=n, frac=frac)
-    elif isinstance(data, dict):
-        if 'values' in data:
-            values = data['values']
-            n = n if n else int(frac*len(values))
-            values = random.sample(values, n)
-            return {'values': values}
-
-
-@curry
-def to_json(data, prefix='altair-data'):
-    """Write the data model to a .json file and return a url based data model."""
-    _check_data_type(data)
-    ext = '.json'
-    filename = _compute_filename(prefix=prefix, ext=ext)
-    if isinstance(data, pd.DataFrame):
-        data = sanitize_dataframe(data)
-        data.to_json(filename, orient='records')
-    elif isinstance(data, dict):
-        if 'values' not in data:
-            raise KeyError('values expected in data dict, but not present.')
-        values = data['values']
-        with open(filename) as f:
-            json.dump(values, f)
-    return {
-        'url': filename,
-        'format': {'type': 'json'}
-    }
-
-
-@curry
-def to_csv(data, prefix='altair-data'):
-    """Write the data model to a .csv file and return a url based data model."""
-    _check_data_type(data)
-    ext = '.csv'
-    filename = _compute_filename(prefix=prefix, ext=ext)
-    if isinstance(data, pd.DataFrame):
-        data = sanitize_dataframe(data)
-        data.to_csv(filename)
-        return {
-            'url': filename,
-            'format': {'type': 'csv'}
-        }
-    elif isinstance(data, dict):
-        raise NotImplementedError('to_csv only works with Pandas DataFrame objects.')
-
-
-@curry
-def to_values(data):
-    """Replace a DataFrame by a data model with values."""
-    _check_data_type(data)
-    if isinstance(data, pd.DataFrame):
-        data = sanitize_dataframe(data)
-        return {'values': data.to_dict(orient='records')}
-    elif isinstance(data, dict):
-        if 'values' not in data:
-            raise KeyError('values expected in data dict, but not present.')
-        return data
-
-
-@curry
 def default_data_transformer(data):
     return pipe(data, limit_rows, to_values)
 
 
-# ==============================================================================
-# Private utilities
-# ==============================================================================
-
-
-def _check_data_type(data):
-    """Raise if the data is not a dict or DataFrame."""
-    if not isinstance(data, (dict, pd.DataFrame)):
-        raise TypeError('Expected dict or DataFrame, got: {}'.format(type(data)))
-
-
-def _compute_uuid_filename(prefix, ext):
-    return prefix + '-' + str(uuid.uuid4()) + ext
-
-
-def _compute_filename(prefix='altair-data', ext='.csv'):
-    filename = _compute_uuid_filename(prefix, ext)
-    return filename
+__all__ = (
+    'MaxRowsError',
+    'curry',
+    'default_data_transformer',
+    'limit_rows',
+    'pipe',
+    'sample',
+    'to_csv',
+    'to_json',
+    'to_values'
+)

--- a/altair/vega/v2/__init__.py
+++ b/altair/vega/v2/__init__.py
@@ -1,2 +1,8 @@
 from .display import vega, Vega, renderers
 from .schema import *
+
+from .data import (
+    pipe, curry, limit_rows,
+    sample, to_json, to_csv, to_values,
+    default_data_transformer
+)

--- a/altair/vega/v2/data.py
+++ b/altair/vega/v2/data.py
@@ -1,0 +1,19 @@
+from ..data import (MaxRowsError, curry, default_data_transformer, limit_rows,
+                    pipe, sample, to_csv, to_json, to_values)
+
+
+# ==============================================================================
+# Vega 2 data transformers
+# ==============================================================================
+
+
+__all__ = (
+    'MaxRowsError',
+    'curry',
+    'limit_rows',
+    'pipe',
+    'sample',
+    'to_csv',
+    'to_json',
+    'to_values',
+)

--- a/altair/vega/v3/__init__.py
+++ b/altair/vega/v3/__init__.py
@@ -1,2 +1,8 @@
 from .display import vega, Vega, renderers
 from .schema import *
+
+from .data import (
+    pipe, curry, limit_rows,
+    sample, to_json, to_csv, to_values,
+    default_data_transformer
+)

--- a/altair/vega/v3/data.py
+++ b/altair/vega/v3/data.py
@@ -1,0 +1,19 @@
+from ..data import (MaxRowsError, curry, default_data_transformer, limit_rows,
+                    pipe, sample, to_csv, to_json, to_values)
+
+
+# ==============================================================================
+# Vega 3 data transformers
+# ==============================================================================
+
+
+__all__ = (
+    'MaxRowsError',
+    'curry',
+    'limit_rows',
+    'pipe',
+    'sample',
+    'to_csv',
+    'to_json',
+    'to_values',
+)

--- a/altair/vegalite/data.py
+++ b/altair/vegalite/data.py
@@ -1,117 +1,9 @@
-import json
-import os
-import random
-import uuid
 
-import pandas as pd
 from toolz.curried import curry, pipe
-
 from ..utils.core import sanitize_dataframe
-
-
-# ==============================================================================
-# Data model transformers
-#
-# A data model transformer is a pure function that takes a dict or DataFrame
-# and returns a transformed version of a dict or DataFrame. The dict objects
-# will be the Data portion of the VegaLite schema. The idea is that user can
-# pipe a sequence of these data transformers together to prepare the data before
-# it hits the renderer.
-#
-# In this version of Altair, renderers only deal with the dict form of a
-# VegaLite spec, after the Data model has been put into a schema compliant
-# form.
-#
-# A data model transformer has the following type signature:
-# DataModelType = Union[dict, pd.DataFrame]
-# DataModelTransformerType = Callable[[DataModelType, KwArgs], DataModelType]
-# ==============================================================================
-
-
-class MaxRowsError(Exception):
-    """Raised when a data model has too many rows."""
-    pass
-
-
-@curry
-def limit_rows(data, max_rows=5000):
-    """Raise MaxRowsError if the data model has more than max_rows."""
-    _check_data_type(data)
-    if isinstance(data, pd.DataFrame):
-        values = data
-    elif isinstance(data, dict):
-        if 'values' in data:
-            values = data['values']
-        else:
-            return data
-    if len(values) > max_rows:
-        raise MaxRowsError('The number of rows in your dataset is greater than the max of {}'.format(max_rows))
-    return data
-
-
-@curry
-def sample(data, n=None, frac=None):
-    """Reduce the size of the data model by sampling without replacement."""
-    _check_data_type(data)
-    if isinstance(data, pd.DataFrame):
-        return data.sample(n=n, frac=frac)
-    elif isinstance(data, dict):
-        if 'values' in data:
-            values = data['values']
-            n = n if n else int(frac*len(values))
-            values = random.sample(values, n)
-            return {'values': values}
-
-
-@curry
-def to_json(data, prefix='altair-data'):
-    """Write the data model to a .json file and return a url based data model."""
-    _check_data_type(data)
-    ext = '.json'
-    filename = _compute_filename(prefix=prefix, ext=ext)
-    if isinstance(data, pd.DataFrame):
-        data = sanitize_dataframe(data)
-        data.to_json(filename, orient='records')
-    elif isinstance(data, dict):
-        if 'values' not in data:
-            raise KeyError('values expected in data dict, but not present.')
-        values = data['values']
-        with open(filename) as f:
-            json.dump(values, f)
-    return {
-        'url': filename,
-        'format': {'type': 'json'}
-    }
-
-
-@curry
-def to_csv(data, prefix='altair-data'):
-    """Write the data model to a .csv file and return a url based data model."""
-    _check_data_type(data)
-    ext = '.csv'
-    filename = _compute_filename(prefix=prefix, ext=ext)
-    if isinstance(data, pd.DataFrame):
-        data = sanitize_dataframe(data)
-        data.to_csv(filename)
-        return {
-            'url': filename,
-            'format': {'type': 'csv'}
-        }
-    elif isinstance(data, dict):
-        raise NotImplementedError('to_csv only works with Pandas DataFrame objects.')
-
-
-@curry
-def to_values(data):
-    """Replace a DataFrame by a data model with values."""
-    _check_data_type(data)
-    if isinstance(data, pd.DataFrame):
-        data = sanitize_dataframe(data)
-        return {'values': data.to_dict(orient='records')}
-    elif isinstance(data, dict):
-        if 'values' not in data:
-            raise KeyError('values expected in data dict, but not present.')
-        return data
+from ..utils.data import (
+    MaxRowsError, limit_rows, sample, to_csv, to_json, to_values, check_data_type
+)
 
 
 @curry
@@ -119,21 +11,14 @@ def default_data_transformer(data):
     return pipe(data, limit_rows, to_values)
 
 
-# ==============================================================================
-# Private utilities
-# ==============================================================================
-
-
-def _check_data_type(data):
-    """Raise if the data is not a dict or DataFrame."""
-    if not isinstance(data, (dict, pd.DataFrame)):
-        raise TypeError('Expected dict or DataFrame, got: {}'.format(type(data)))
-
-
-def _compute_uuid_filename(prefix, ext):
-    return prefix + '-' + str(uuid.uuid4()) + ext
-
-
-def _compute_filename(prefix='altair-data', ext='.csv'):
-    filename = _compute_uuid_filename(prefix, ext)
-    return filename
+__all__ = (
+    'MaxRowsError',
+    'curry',
+    'default_data_transformer',
+    'limit_rows',
+    'pipe',
+    'sample',
+    'to_csv',
+    'to_json',
+    'to_values'
+)

--- a/altair/vegalite/data.py
+++ b/altair/vegalite/data.py
@@ -64,13 +64,11 @@ def sample(data, n=None, frac=None):
 
 
 @curry
-def to_json(data, filename=None, prefix='altair-data', base_url='/', nbserver_cwd='~'):
+def to_json(data, prefix='altair-data'):
     """Write the data model to a .json file and return a url based data model."""
     _check_data_type(data)
     ext = '.json'
-    filename, url = _compute_filename_and_url(filename=filename, prefix=prefix,
-                                         base_url=base_url, nbserver_cwd=nbserver_cwd,
-                                         ext=ext)
+    filename = _compute_filename(prefix=prefix, ext=ext)
     if isinstance(data, pd.DataFrame):
         data = sanitize_dataframe(data)
         data.to_json(filename, orient='records')
@@ -81,24 +79,22 @@ def to_json(data, filename=None, prefix='altair-data', base_url='/', nbserver_cw
         with open(filename) as f:
             json.dump(values, f)
     return {
-        'url': url,
+        'url': filename,
         'format': {'type': 'json'}
     }
 
 
 @curry
-def to_csv(data, filename=None, prefix='altair-data', base_url='/', nbserver_cwd='~'):
+def to_csv(data, prefix='altair-data'):
     """Write the data model to a .csv file and return a url based data model."""
     _check_data_type(data)
     ext = '.csv'
-    filename, url = _compute_filename_and_url(filename=filename, prefix=prefix,
-                                         base_url=base_url, nbserver_cwd=nbserver_cwd,
-                                         ext=ext)
+    filename = _compute_filename(prefix=prefix, ext=ext)
     if isinstance(data, pd.DataFrame):
         data = sanitize_dataframe(data)
         data.to_csv(filename)
         return {
-            'url': url,
+            'url': filename,
             'format': {'type': 'csv'}
         }
     elif isinstance(data, dict):
@@ -134,40 +130,10 @@ def _check_data_type(data):
         raise TypeError('Expected dict or DataFrame, got: {}'.format(type(data)))
 
 
-def _url_path_join(*pieces):
-    """Join components of url into a relative url
-    Use to prevent double slash when joining subpath. This will leave the
-    initial and final / in place
-    """
-    initial = pieces[0].startswith('/')
-    final = pieces[-1].endswith('/')
-    stripped = [s.strip('/') for s in pieces]
-    result = '/'.join(s for s in stripped if s)
-    if initial: result = '/' + result
-    if final: result = result + '/'
-    if result == '//': result = '/'
-    return result
-
-
-def _compute_nbserver_url(filename, base_url='/', nbserver_cwd='~'):
-    nbserver_cwd = os.path.expanduser(nbserver_cwd)
-    here = os.getcwd()
-    rel_path = os.path.relpath(here, nbserver_cwd)
-    return _url_path_join(base_url, '/files/', rel_path, filename)
-
-
 def _compute_uuid_filename(prefix, ext):
     return prefix + '-' + str(uuid.uuid4()) + ext
 
 
-def _compute_filename_and_url(filename=None, prefix='altair',
-                         base_url='/', nbserver_cwd='~',
-                         ext='.csv'):
-
-    if filename is None:
-        filename = _compute_uuid_filename(prefix, ext)
-    else:
-        if not filename.endswith(ext):
-            filename = filename + ext
-    url = _compute_nbserver_url(filename, base_url=base_url, nbserver_cwd=nbserver_cwd)
-    return filename, url
+def _compute_filename(prefix='altair-data', ext='.csv'):
+    filename = _compute_uuid_filename(prefix, ext)
+    return filename

--- a/altair/vegalite/v1/data.py
+++ b/altair/vegalite/v1/data.py
@@ -16,3 +16,17 @@ data_transformers.register('default', default_data_transformer)
 data_transformers.register('json', to_json)
 data_transformers.register('csv', to_csv)
 data_transformers.enable('default')
+
+
+__all__ = (
+    'MaxRowsError',
+    'curry',
+    'default_data_transformer',
+    'limit_rows',
+    'pipe',
+    'sample',
+    'to_csv',
+    'to_json',
+    'to_values',
+    'data_transformers'
+)

--- a/altair/vegalite/v2/data.py
+++ b/altair/vegalite/v2/data.py
@@ -16,3 +16,17 @@ data_transformers.register('default', default_data_transformer)
 data_transformers.register('json', to_json)
 data_transformers.register('csv', to_csv)
 data_transformers.enable('default')
+
+
+__all__ = (
+    'MaxRowsError',
+    'curry',
+    'default_data_transformer',
+    'limit_rows',
+    'pipe',
+    'sample',
+    'to_csv',
+    'to_json',
+    'to_values',
+    'data_transformers'
+)

--- a/doc/user_guide/display.rst
+++ b/doc/user_guide/display.rst
@@ -270,11 +270,11 @@ Randomly sample a DataFrame (without replacement) before visualizing::
 
 Convert a Dataframe to a separate ``.json`` file before visualization::
 
-    to_json(data, filename=None, prefix='altair-data', base_url='/', nbserver_cwd='~'):
+    to_json(data, prefix='altair-data'):
 
 Convert a Dataframe to a separate ``.csv`` file before visualiztion::
 
-    to_csv(data, filename=None, prefix='altair-data', base_url='/', nbserver_cwd='~'):
+    to_csv(data, prefix='altair-data'):
 
 Convert a Dataframe to inline JSON values before visualization::
 


### PR DESCRIPTION
This PR in combination with JupyterLab master (which should be released this week) fixed the path resolution issues of `to_json` and `to_csv`. Things should "just work" now with no extra path hacking in JupyterLab. All paths used by these data transformers are relative to the notebook. Other renderers such as ipyvega should now use this same approach. The key is that the notebook servers baseURL + `/files` + path of the notebook needs to be prefixed to the relative filename.

@jakevdp 