### PR TITLE
PyFlakes fixes to __init__.py files

### DIFF
--- a/altair/__init__.py
+++ b/altair/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 __version__ = '2.0.0dev'
 
 from .vegalite import *

--- a/altair/expr/__init__.py
+++ b/altair/expr/__init__.py
@@ -1,4 +1,5 @@
 """Tools for creating transform & filter expressions with a python syntax"""
+# flake8: noqa
 from .core import datum, Expression
 from .funcs import *
 from .consts import *

--- a/altair/utils/__init__.py
+++ b/altair/utils/__init__.py
@@ -6,7 +6,9 @@ from .core import (
     update_subtraits,
     update_nested,
     write_file_or_filename,
-    display_traceback
+    display_traceback,
+    SchemaBase,
+    Undefined
 )
 from .plugin_registry import PluginRegistry
 
@@ -20,5 +22,7 @@ __all__ = (
     'update_nested',
     'write_file_or_filename',
     'display_traceback',
+    'SchemaBase',
+    'Undefined',
     'PluginRegistry'
 )

--- a/altair/utils/__init__.py
+++ b/altair/utils/__init__.py
@@ -1,3 +1,24 @@
-from .core import *
-
+from .core import (
+    infer_vegalite_type,
+    sanitize_dataframe,
+    parse_shorthand,
+    use_signature,
+    update_subtraits,
+    update_nested,
+    write_file_or_filename,
+    display_traceback
+)
 from .plugin_registry import PluginRegistry
+
+
+__all__ = (
+    'infer_vegalite_type',
+    'sanitize_dataframe',
+    'parse_shorthand',
+    'use_signature',
+    'update_subtraits',
+    'update_nested',
+    'write_file_or_filename',
+    'display_traceback',
+    'PluginRegistry'
+)

--- a/altair/vega/__init__.py
+++ b/altair/vega/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from .v3 import *

--- a/altair/vega/v2/__init__.py
+++ b/altair/vega/v2/__init__.py
@@ -1,2 +1,3 @@
+# flake8: noqa
 from .display import vega, Vega, renderers
 from .schema import *

--- a/altair/vega/v2/schema/__init__.py
+++ b/altair/vega/v2/schema/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from .core import *
 
 SCHEMA_VERSION = 'v2.6.5'

--- a/altair/vega/v3/__init__.py
+++ b/altair/vega/v3/__init__.py
@@ -1,2 +1,3 @@
+# flake8: noqa
 from .display import vega, Vega, renderers
 from .schema import *

--- a/altair/vega/v3/schema/__init__.py
+++ b/altair/vega/v3/schema/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from .core import *
 
 SCHEMA_VERSION = 'v3.2.1'

--- a/altair/vegalite/__init__.py
+++ b/altair/vegalite/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from .v2 import *

--- a/altair/vegalite/v1/__init__.py
+++ b/altair/vegalite/v1/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from .schema import *
 from .api import *
 

--- a/altair/vegalite/v1/schema/__init__.py
+++ b/altair/vegalite/v1/schema/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from .core import *
 from .channels import *
 SCHEMA_VERSION = 'v1.3.1'

--- a/altair/vegalite/v2/__init__.py
+++ b/altair/vegalite/v2/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from .schema import *
 from .api import *
 

--- a/altair/vegalite/v2/schema/__init__.py
+++ b/altair/vegalite/v2/schema/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from .core import *
 from .channels import *
 SCHEMA_VERSION = 'v2.3.0'


### PR DESCRIPTION
Attached are a variety of fixes to manage PyFlakes violations in ``__init__.py`` files.

My reading of the library is that ``*``'s have been used in autogenerated modules to allow for a changing number of imports. To allow that to continue, I have exempted those files from PyFlakes inspection. If you'd prefer another approach, please let me know.