### PR TITLE
Cache pip dependencies on TravisCI for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+cache: pip
+
 python:
   - 3.5
   - 3.6


### PR DESCRIPTION
As recommended by the [TravisCI documentation](https://docs.travis-ci.com/user/caching/). 