### PR TITLE
MAINT: use standard form for magics

### DIFF
--- a/altair/__init__.py
+++ b/altair/__init__.py
@@ -2,3 +2,8 @@
 __version__ = '2.0.0dev'
 
 from .vegalite import *
+
+def load_ipython_extension(ipython):
+    from ._magics import vega, vegalite
+    ipython.register_magic_function(vega, 'cell')
+    ipython.register_magic_function(vegalite, 'cell')

--- a/altair/_magics.py
+++ b/altair/_magics.py
@@ -7,7 +7,7 @@ import json
 import warnings
 
 import IPython
-from IPython.core import magic, magic_arguments
+from IPython.core import magic_arguments
 import pandas as pd
 import six
 from toolz import pipe
@@ -118,7 +118,7 @@ def vega(line, cell):
     elif not YAML_AVAILABLE:
         try:
             spec = json.loads(cell)
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             raise ValueError("%%vega: spec is not valid JSON. "
                              "Install pyyaml to parse spec as yaml")
     else:
@@ -163,7 +163,7 @@ def vegalite(line, cell):
     elif not YAML_AVAILABLE:
         try:
             spec = json.loads(cell)
-        except JSONDecodeError:
+        except json.JSONDecodeError:
             raise ValueError("%%vegalite: spec is not valid JSON. "
                              "Install pyyaml to parse spec as yaml")
     else:

--- a/altair/_magics.py
+++ b/altair/_magics.py
@@ -40,12 +40,12 @@ RENDERERS = {
 TRANSFORMERS = {
   'vega': {
       # Vega doesn't yet have specific data transformers; use vegalite
-      '2': vegalite_v1.data.data_transformers,
-      '3': vegalite_v2.data.data_transformers,
+      '2': vegalite_v1.data_transformers,
+      '3': vegalite_v2.data_transformers,
   },
   'vega-lite': {
-      '1': vegalite_v1.data.data_transformers,
-      '2': vegalite_v2.data.data_transformers,
+      '1': vegalite_v1.data_transformers,
+      '2': vegalite_v2.data_transformers,
   }
 }
 
@@ -75,7 +75,6 @@ def _get_variable(name):
     return ip.user_ns[name]
 
 
-@magic.register_cell_magic
 @magic_arguments.magic_arguments()
 @magic_arguments.argument(
     'data',
@@ -119,7 +118,7 @@ def vega(line, cell):
     elif not YAML_AVAILABLE:
         try:
             spec = json.loads(cell)
-        except json.JSONDecodeError:
+        except JSONDecodeError:
             raise ValueError("%%vega: spec is not valid JSON. "
                              "Install pyyaml to parse spec as yaml")
     else:
@@ -136,7 +135,6 @@ def vega(line, cell):
     return Vega(spec)
 
 
-@magic.register_cell_magic
 @magic_arguments.magic_arguments()
 @magic_arguments.argument(
     'data',
@@ -165,7 +163,7 @@ def vegalite(line, cell):
     elif not YAML_AVAILABLE:
         try:
             spec = json.loads(cell)
-        except json.JSONDecodeError:
+        except JSONDecodeError:
             raise ValueError("%%vegalite: spec is not valid JSON. "
                              "Install pyyaml to parse spec as yaml")
     else:

--- a/altair/tests/test_magics.py
+++ b/altair/tests/test_magics.py
@@ -6,7 +6,7 @@ from altair.vegalite.v2 import VegaLite
 from altair.vega.v3 import Vega
 
 _ipshell = InteractiveShell.instance()
-_ipshell.run_cell('from altair.magics import vega, vegalite')
+_ipshell.run_cell('%load_ext altair')
 
 DATA_RECORDS = [{'amount': 28, 'category': 'A'},
                 {'amount': 55, 'category': 'B'},
@@ -78,7 +78,7 @@ def test_vegalite_magic_data_included():
     result = _ipshell.run_cell('%%vegalite\n' + json.dumps(VEGALITE_SPEC))
     assert isinstance(result.result, VegaLite)
     assert VEGALITE_SPEC == result.result.spec
-    
+
 
 def test_vegalite_magic_json_flag():
     result = _ipshell.run_cell('%%vegalite --json\n'

--- a/notebooks/MagicTest.ipynb
+++ b/notebooks/MagicTest.ipynb
@@ -9,32 +9,102 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "# import os, sys; sys.path.insert(0, os.path.abspath('..'))\n",
-    "from altair.magics import vega, vegalite\n",
+    "%load_ext altair\n",
     "import pandas as pd"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "# For notebook (not jupyterlab) enable the vega and vegalite renderers\n",
-    "import altair as alt\n",
-    "alt.vegalite.v2.renderers.enable('notebook')\n",
-    "alt.vega.v3.renderers.enable('notebook')"
+    "# import altair as alt\n",
+    "# alt.vegalite.v2.renderers.enable('notebook')\n",
+    "# alt.vega.v3.renderers.enable('notebook')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vegalite.v2+json": {
+       "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+       "data": {
+        "values": [
+         {
+          "a": "A",
+          "b": 28
+         },
+         {
+          "a": "B",
+          "b": 55
+         },
+         {
+          "a": "C",
+          "b": 43
+         },
+         {
+          "a": "D",
+          "b": 91
+         },
+         {
+          "a": "E",
+          "b": 81
+         },
+         {
+          "a": "F",
+          "b": 53
+         },
+         {
+          "a": "G",
+          "b": 19
+         },
+         {
+          "a": "H",
+          "b": 87
+         },
+         {
+          "a": "I",
+          "b": 52
+         }
+        ]
+       },
+       "description": "A simple bar chart with embedded data.",
+       "encoding": {
+        "x": {
+         "field": "a",
+         "type": "ordinal"
+        },
+        "y": {
+         "field": "b",
+         "type": "quantitative"
+        }
+       },
+       "mark": "bar"
+      },
+      "text/plain": [
+       "<VegaLite 2 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/display.html\n"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%vegalite\n",
     "{\n",
@@ -57,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,9 +138,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vegalite.v2+json": {
+       "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+       "data": {
+        "values": [
+         {
+          "a": "A",
+          "b": 28
+         },
+         {
+          "a": "B",
+          "b": 55
+         },
+         {
+          "a": "C",
+          "b": 43
+         },
+         {
+          "a": "D",
+          "b": 91
+         },
+         {
+          "a": "E",
+          "b": 81
+         },
+         {
+          "a": "F",
+          "b": 53
+         },
+         {
+          "a": "G",
+          "b": 19
+         },
+         {
+          "a": "H",
+          "b": 87
+         },
+         {
+          "a": "I",
+          "b": 52
+         }
+        ]
+       },
+       "description": "A simple bar chart with embedded data.",
+       "encoding": {
+        "x": {
+         "field": "a",
+         "type": "ordinal"
+        },
+        "y": {
+         "field": "b",
+         "type": "quantitative"
+        }
+       },
+       "mark": "bar"
+      },
+      "text/plain": [
+       "<VegaLite 2 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/display.html\n"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%vegalite vgl_data\n",
     "{\n",
@@ -86,9 +226,195 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vega.v3+json": {
+       "$schema": "https://vega.github.io/schema/vega/v3.0.json",
+       "axes": [
+        {
+         "orient": "bottom",
+         "scale": "xscale"
+        },
+        {
+         "orient": "left",
+         "scale": "yscale"
+        }
+       ],
+       "data": [
+        {
+         "name": "table",
+         "values": [
+          {
+           "amount": 28,
+           "category": "A"
+          },
+          {
+           "amount": 55,
+           "category": "B"
+          },
+          {
+           "amount": 43,
+           "category": "C"
+          },
+          {
+           "amount": 91,
+           "category": "D"
+          },
+          {
+           "amount": 81,
+           "category": "E"
+          },
+          {
+           "amount": 53,
+           "category": "F"
+          },
+          {
+           "amount": 19,
+           "category": "G"
+          },
+          {
+           "amount": 87,
+           "category": "H"
+          }
+         ]
+        }
+       ],
+       "height": 200,
+       "marks": [
+        {
+         "encode": {
+          "enter": {
+           "width": {
+            "band": 1,
+            "scale": "xscale"
+           },
+           "x": {
+            "field": "category",
+            "scale": "xscale"
+           },
+           "y": {
+            "field": "amount",
+            "scale": "yscale"
+           },
+           "y2": {
+            "scale": "yscale",
+            "value": 0
+           }
+          },
+          "hover": {
+           "fill": {
+            "value": "red"
+           }
+          },
+          "update": {
+           "fill": {
+            "value": "steelblue"
+           }
+          }
+         },
+         "from": {
+          "data": "table"
+         },
+         "type": "rect"
+        },
+        {
+         "encode": {
+          "enter": {
+           "align": {
+            "value": "center"
+           },
+           "baseline": {
+            "value": "bottom"
+           },
+           "fill": {
+            "value": "#333"
+           }
+          },
+          "update": {
+           "fillOpacity": [
+            {
+             "test": "datum === tooltip",
+             "value": 0
+            },
+            {
+             "value": 1
+            }
+           ],
+           "text": {
+            "signal": "tooltip.amount"
+           },
+           "x": {
+            "band": 0.5,
+            "scale": "xscale",
+            "signal": "tooltip.category"
+           },
+           "y": {
+            "offset": -2,
+            "scale": "yscale",
+            "signal": "tooltip.amount"
+           }
+          }
+         },
+         "type": "text"
+        }
+       ],
+       "padding": 5,
+       "scales": [
+        {
+         "domain": {
+          "data": "table",
+          "field": "category"
+         },
+         "name": "xscale",
+         "padding": 0.05,
+         "range": "width",
+         "round": true,
+         "type": "band"
+        },
+        {
+         "domain": {
+          "data": "table",
+          "field": "amount"
+         },
+         "name": "yscale",
+         "nice": true,
+         "range": "height"
+        }
+       ],
+       "signals": [
+        {
+         "name": "tooltip",
+         "on": [
+          {
+           "events": "rect:mouseover",
+           "update": "datum"
+          },
+          {
+           "events": "rect:mouseout",
+           "update": "{}"
+          }
+         ],
+         "value": {}
+        }
+       ],
+       "width": 400
+      },
+      "text/plain": [
+       "<Vega 3 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/display.html\n"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%vega\n",
     "{\n",
@@ -190,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,9 +526,195 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vega.v3+json": {
+       "$schema": "https://vega.github.io/schema/vega/v3.0.json",
+       "axes": [
+        {
+         "orient": "bottom",
+         "scale": "xscale"
+        },
+        {
+         "orient": "left",
+         "scale": "yscale"
+        }
+       ],
+       "data": [
+        {
+         "name": "table",
+         "values": [
+          {
+           "amount": 28,
+           "category": "A"
+          },
+          {
+           "amount": 55,
+           "category": "B"
+          },
+          {
+           "amount": 43,
+           "category": "C"
+          },
+          {
+           "amount": 91,
+           "category": "D"
+          },
+          {
+           "amount": 81,
+           "category": "E"
+          },
+          {
+           "amount": 53,
+           "category": "F"
+          },
+          {
+           "amount": 19,
+           "category": "G"
+          },
+          {
+           "amount": 87,
+           "category": "H"
+          }
+         ]
+        }
+       ],
+       "height": 200,
+       "marks": [
+        {
+         "encode": {
+          "enter": {
+           "width": {
+            "band": 1,
+            "scale": "xscale"
+           },
+           "x": {
+            "field": "category",
+            "scale": "xscale"
+           },
+           "y": {
+            "field": "amount",
+            "scale": "yscale"
+           },
+           "y2": {
+            "scale": "yscale",
+            "value": 0
+           }
+          },
+          "hover": {
+           "fill": {
+            "value": "red"
+           }
+          },
+          "update": {
+           "fill": {
+            "value": "steelblue"
+           }
+          }
+         },
+         "from": {
+          "data": "table"
+         },
+         "type": "rect"
+        },
+        {
+         "encode": {
+          "enter": {
+           "align": {
+            "value": "center"
+           },
+           "baseline": {
+            "value": "bottom"
+           },
+           "fill": {
+            "value": "#333"
+           }
+          },
+          "update": {
+           "fillOpacity": [
+            {
+             "test": "datum === tooltip",
+             "value": 0
+            },
+            {
+             "value": 1
+            }
+           ],
+           "text": {
+            "signal": "tooltip.amount"
+           },
+           "x": {
+            "band": 0.5,
+            "scale": "xscale",
+            "signal": "tooltip.category"
+           },
+           "y": {
+            "offset": -2,
+            "scale": "yscale",
+            "signal": "tooltip.amount"
+           }
+          }
+         },
+         "type": "text"
+        }
+       ],
+       "padding": 5,
+       "scales": [
+        {
+         "domain": {
+          "data": "table",
+          "field": "category"
+         },
+         "name": "xscale",
+         "padding": 0.05,
+         "range": "width",
+         "round": true,
+         "type": "band"
+        },
+        {
+         "domain": {
+          "data": "table",
+          "field": "amount"
+         },
+         "name": "yscale",
+         "nice": true,
+         "range": "height"
+        }
+       ],
+       "signals": [
+        {
+         "name": "tooltip",
+         "on": [
+          {
+           "events": "rect:mouseover",
+           "update": "datum"
+          },
+          {
+           "events": "rect:mouseout",
+           "update": "{}"
+          }
+         ],
+         "value": {}
+        }
+       ],
+       "width": 400
+      },
+      "text/plain": [
+       "<Vega 3 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/display.html\n"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%vega table:vg_data\n",
     "{\n",
@@ -288,7 +800,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,9 +809,195 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vega.v3+json": {
+       "$schema": "https://vega.github.io/schema/vega/v3.0.json",
+       "axes": [
+        {
+         "orient": "bottom",
+         "scale": "xscale"
+        },
+        {
+         "orient": "left",
+         "scale": "yscale"
+        }
+       ],
+       "data": [
+        {
+         "name": "table",
+         "values": [
+          {
+           "amount": 28,
+           "category": "A"
+          },
+          {
+           "amount": 55,
+           "category": "B"
+          },
+          {
+           "amount": 43,
+           "category": "C"
+          },
+          {
+           "amount": 91,
+           "category": "D"
+          },
+          {
+           "amount": 81,
+           "category": "E"
+          },
+          {
+           "amount": 53,
+           "category": "F"
+          },
+          {
+           "amount": 19,
+           "category": "G"
+          },
+          {
+           "amount": 87,
+           "category": "H"
+          }
+         ]
+        }
+       ],
+       "height": 200,
+       "marks": [
+        {
+         "encode": {
+          "enter": {
+           "width": {
+            "band": 1,
+            "scale": "xscale"
+           },
+           "x": {
+            "field": "category",
+            "scale": "xscale"
+           },
+           "y": {
+            "field": "amount",
+            "scale": "yscale"
+           },
+           "y2": {
+            "scale": "yscale",
+            "value": 0
+           }
+          },
+          "hover": {
+           "fill": {
+            "value": "red"
+           }
+          },
+          "update": {
+           "fill": {
+            "value": "steelblue"
+           }
+          }
+         },
+         "from": {
+          "data": "table"
+         },
+         "type": "rect"
+        },
+        {
+         "encode": {
+          "enter": {
+           "align": {
+            "value": "center"
+           },
+           "baseline": {
+            "value": "bottom"
+           },
+           "fill": {
+            "value": "#333"
+           }
+          },
+          "update": {
+           "fillOpacity": [
+            {
+             "test": "datum === tooltip",
+             "value": 0
+            },
+            {
+             "value": 1
+            }
+           ],
+           "text": {
+            "signal": "tooltip.amount"
+           },
+           "x": {
+            "band": 0.5,
+            "scale": "xscale",
+            "signal": "tooltip.category"
+           },
+           "y": {
+            "offset": -2,
+            "scale": "yscale",
+            "signal": "tooltip.amount"
+           }
+          }
+         },
+         "type": "text"
+        }
+       ],
+       "padding": 5,
+       "scales": [
+        {
+         "domain": {
+          "data": "table",
+          "field": "category"
+         },
+         "name": "xscale",
+         "padding": 0.05,
+         "range": "width",
+         "round": true,
+         "type": "band"
+        },
+        {
+         "domain": {
+          "data": "table",
+          "field": "amount"
+         },
+         "name": "yscale",
+         "nice": true,
+         "range": "height"
+        }
+       ],
+       "signals": [
+        {
+         "name": "tooltip",
+         "on": [
+          {
+           "events": "rect:mouseover",
+           "update": "datum"
+          },
+          {
+           "events": "rect:mouseout",
+           "update": "{}"
+          }
+         ],
+         "value": {}
+        }
+       ],
+       "width": 400
+      },
+      "text/plain": [
+       "<Vega 3 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/display.html\n"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%vega table\n",
     "{\n",
@@ -385,7 +1083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,9 +1095,1505 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vegalite.v2+json": {
+       "data": {
+        "values": [
+         {
+          "date": "2017-01-01",
+          "price": 0.4967141530112327
+         },
+         {
+          "date": "2017-01-02",
+          "price": 0.358449851840048
+         },
+         {
+          "date": "2017-01-03",
+          "price": 1.0061383899407406
+         },
+         {
+          "date": "2017-01-04",
+          "price": 2.5291682463487657
+         },
+         {
+          "date": "2017-01-05",
+          "price": 2.2950148716254297
+         },
+         {
+          "date": "2017-01-06",
+          "price": 2.060877914676249
+         },
+         {
+          "date": "2017-01-07",
+          "price": 3.6400907301836405
+         },
+         {
+          "date": "2017-01-08",
+          "price": 4.407525459336549
+         },
+         {
+          "date": "2017-01-09",
+          "price": 3.938051073401597
+         },
+         {
+          "date": "2017-01-10",
+          "price": 4.4806111169875615
+         },
+         {
+          "date": "2017-01-11",
+          "price": 4.017193424175099
+         },
+         {
+          "date": "2017-01-12",
+          "price": 3.5514636706048424
+         },
+         {
+          "date": "2017-01-13",
+          "price": 3.7934259421708765
+         },
+         {
+          "date": "2017-01-14",
+          "price": 1.8801456975130786
+         },
+         {
+          "date": "2017-01-15",
+          "price": 0.15522786500004582
+         },
+         {
+          "date": "2017-01-16",
+          "price": -0.4070596642409269
+         },
+         {
+          "date": "2017-01-17",
+          "price": -1.4198907845753506
+         },
+         {
+          "date": "2017-01-18",
+          "price": -1.1056434519800766
+         },
+         {
+          "date": "2017-01-19",
+          "price": -2.0136675275012874
+         },
+         {
+          "date": "2017-01-20",
+          "price": -3.4259712288365787
+         },
+         {
+          "date": "2017-01-21",
+          "price": -1.9603224599150246
+         },
+         {
+          "date": "2017-01-22",
+          "price": -2.1860987604015603
+         },
+         {
+          "date": "2017-01-23",
+          "price": -2.1185705557136365
+         },
+         {
+          "date": "2017-01-24",
+          "price": -3.5433187419270933
+         },
+         {
+          "date": "2017-01-25",
+          "price": -4.087701466452276
+         },
+         {
+          "date": "2017-01-26",
+          "price": -3.9767788767424097
+         },
+         {
+          "date": "2017-01-27",
+          "price": -5.127772454164712
+         },
+         {
+          "date": "2017-01-28",
+          "price": -4.75207443581904
+         },
+         {
+          "date": "2017-01-29",
+          "price": -5.352713125737845
+         },
+         {
+          "date": "2017-01-30",
+          "price": -5.644406875531121
+         },
+         {
+          "date": "2017-01-31",
+          "price": -6.2461134877605184
+         },
+         {
+          "date": "2017-02-01",
+          "price": -4.3938353032515804
+         },
+         {
+          "date": "2017-02-02",
+          "price": -4.407332527989515
+         },
+         {
+          "date": "2017-02-03",
+          "price": -5.4650434569454145
+         },
+         {
+          "date": "2017-02-04",
+          "price": -4.642498544842225
+         },
+         {
+          "date": "2017-02-05",
+          "price": -5.863342194813248
+         },
+         {
+          "date": "2017-02-06",
+          "price": -5.654478599808492
+         },
+         {
+          "date": "2017-02-07",
+          "price": -7.614148723688268
+         },
+         {
+          "date": "2017-02-08",
+          "price": -8.942334772586698
+         },
+         {
+          "date": "2017-02-09",
+          "price": -8.745473536717574
+         },
+         {
+          "date": "2017-02-10",
+          "price": -8.007006956722163
+         },
+         {
+          "date": "2017-02-11",
+          "price": -7.835638675532193
+         },
+         {
+          "date": "2017-02-12",
+          "price": -7.951286957920433
+         },
+         {
+          "date": "2017-02-13",
+          "price": -8.252390653509723
+         },
+         {
+          "date": "2017-02-14",
+          "price": -9.73091264387715
+         },
+         {
+          "date": "2017-02-15",
+          "price": -10.450756852271859
+         },
+         {
+          "date": "2017-02-16",
+          "price": -10.911395623231646
+         },
+         {
+          "date": "2017-02-17",
+          "price": -9.854273397012731
+         },
+         {
+          "date": "2017-02-18",
+          "price": -9.51065510744427
+         },
+         {
+          "date": "2017-02-19",
+          "price": -11.273695262807005
+         },
+         {
+          "date": "2017-02-20",
+          "price": -10.94961129341221
+         },
+         {
+          "date": "2017-02-21",
+          "price": -11.334693573828526
+         },
+         {
+          "date": "2017-02-22",
+          "price": -12.011615574134485
+         },
+         {
+          "date": "2017-02-23",
+          "price": -11.399939285293616
+         },
+         {
+          "date": "2017-02-24",
+          "price": -10.368939762797666
+         },
+         {
+          "date": "2017-02-25",
+          "price": -9.437659643681467
+         },
+         {
+          "date": "2017-02-26",
+          "price": -10.276877166904105
+         },
+         {
+          "date": "2017-02-27",
+          "price": -10.58608954275532
+         },
+         {
+          "date": "2017-02-28",
+          "price": -10.254826111351756
+         },
+         {
+          "date": "2017-03-01",
+          "price": -9.279280984229397
+         },
+         {
+          "date": "2017-03-02",
+          "price": -9.758455222074687
+         },
+         {
+          "date": "2017-03-03",
+          "price": -9.944114198738504
+         },
+         {
+          "date": "2017-03-04",
+          "price": -11.050449172744532
+         },
+         {
+          "date": "2017-03-05",
+          "price": -12.246655796825202
+         },
+         {
+          "date": "2017-03-06",
+          "price": -11.434129974431004
+         },
+         {
+          "date": "2017-03-07",
+          "price": -10.07788994586018
+         },
+         {
+          "date": "2017-03-08",
+          "price": -10.149900067440514
+         },
+         {
+          "date": "2017-03-09",
+          "price": -9.14636716954849
+         },
+         {
+          "date": "2017-03-10",
+          "price": -8.784731144500856
+         },
+         {
+          "date": "2017-03-11",
+          "price": -9.42985089910598
+         },
+         {
+          "date": "2017-03-12",
+          "price": -9.068455293597568
+         },
+         {
+          "date": "2017-03-13",
+          "price": -7.5304187271315985
+         },
+         {
+          "date": "2017-03-14",
+          "price": -7.56624476624155
+         },
+         {
+          "date": "2017-03-15",
+          "price": -6.001601110427544
+         },
+         {
+          "date": "2017-03-16",
+          "price": -8.621346214517288
+         },
+         {
+          "date": "2017-03-17",
+          "price": -7.799443710142064
+         },
+         {
+          "date": "2017-03-18",
+          "price": -7.712396641903894
+         },
+         {
+          "date": "2017-03-19",
+          "price": -8.011403992369761
+         },
+         {
+          "date": "2017-03-20",
+          "price": -7.919643215834259
+         },
+         {
+          "date": "2017-03-21",
+          "price": -9.907212130435152
+         },
+         {
+          "date": "2017-03-22",
+          "price": -10.126884018272664
+         },
+         {
+          "date": "2017-03-23",
+          "price": -9.769771446760917
+         },
+         {
+          "date": "2017-03-24",
+          "price": -8.2918774020194
+         },
+         {
+          "date": "2017-03-25",
+          "price": -8.810147620293048
+         },
+         {
+          "date": "2017-03-26",
+          "price": -9.618641223186236
+         },
+         {
+          "date": "2017-03-27",
+          "price": -10.120398266770772
+         },
+         {
+          "date": "2017-03-28",
+          "price": -9.204996149068698
+         },
+         {
+          "date": "2017-03-29",
+          "price": -8.876245039409014
+         },
+         {
+          "date": "2017-03-30",
+          "price": -9.406005243176052
+         },
+         {
+          "date": "2017-03-31",
+          "price": -8.892737810062696
+         },
+         {
+          "date": "2017-04-01",
+          "price": -8.795660260714657
+         },
+         {
+          "date": "2017-04-02",
+          "price": -7.827015270181768
+         },
+         {
+          "date": "2017-04-03",
+          "price": -8.529068364059121
+         },
+         {
+          "date": "2017-04-04",
+          "price": -8.85673051065689
+         },
+         {
+          "date": "2017-04-05",
+          "price": -9.248838663789048
+         },
+         {
+          "date": "2017-04-06",
+          "price": -10.712353611921166
+         },
+         {
+          "date": "2017-04-07",
+          "price": -10.41623333485659
+         },
+         {
+          "date": "2017-04-08",
+          "price": -10.1551780626767
+         },
+         {
+          "date": "2017-04-09",
+          "price": -10.15006460603424
+         },
+         {
+          "date": "2017-04-10",
+          "price": -10.384651739409387
+         },
+         {
+          "date": "2017-04-11",
+          "price": -11.800022481459802
+         },
+         {
+          "date": "2017-04-12",
+          "price": -12.220667804225162
+         },
+         {
+          "date": "2017-04-13",
+          "price": -12.56338232075193
+         },
+         {
+          "date": "2017-04-14",
+          "price": -13.36565958997355
+         },
+         {
+          "date": "2017-04-15",
+          "price": -13.526945301639559
+         },
+         {
+          "date": "2017-04-16",
+          "price": -13.12289444482502
+         },
+         {
+          "date": "2017-04-17",
+          "price": -11.23670854361449
+         },
+         {
+          "date": "2017-04-18",
+          "price": -11.062130730782652
+         },
+         {
+          "date": "2017-04-19",
+          "price": -10.804580340059887
+         },
+         {
+          "date": "2017-04-20",
+          "price": -10.879026255826055
+         },
+         {
+          "date": "2017-04-21",
+          "price": -12.797797471125097
+         },
+         {
+          "date": "2017-04-22",
+          "price": -12.824311346574314
+         },
+         {
+          "date": "2017-04-23",
+          "price": -12.764081136633287
+         },
+         {
+          "date": "2017-04-24",
+          "price": -10.300839024148
+         },
+         {
+          "date": "2017-04-25",
+          "price": -10.493199988929124
+         },
+         {
+          "date": "2017-04-26",
+          "price": -10.19165264659551
+         },
+         {
+          "date": "2017-04-27",
+          "price": -10.226364416300754
+         },
+         {
+          "date": "2017-04-28",
+          "price": -11.395042453920286
+         },
+         {
+          "date": "2017-04-29",
+          "price": -10.252219639405265
+         },
+         {
+          "date": "2017-04-30",
+          "price": -9.500286606718491
+         },
+         {
+          "date": "2017-05-01",
+          "price": -8.709254659675445
+         },
+         {
+          "date": "2017-05-02",
+          "price": -9.618642114470184
+         },
+         {
+          "date": "2017-05-03",
+          "price": -8.215847803534086
+         },
+         {
+          "date": "2017-05-04",
+          "price": -9.617698866326366
+         },
+         {
+          "date": "2017-05-05",
+          "price": -9.030841772526095
+         },
+         {
+          "date": "2017-05-06",
+          "price": -6.840386146716117
+         },
+         {
+          "date": "2017-05-07",
+          "price": -7.830922471846805
+         },
+         {
+          "date": "2017-05-08",
+          "price": -8.397220201449578
+         },
+         {
+          "date": "2017-05-09",
+          "price": -8.297568836361936
+         },
+         {
+          "date": "2017-05-10",
+          "price": -8.801044490478136
+         },
+         {
+          "date": "2017-05-11",
+          "price": -10.351707921544268
+         },
+         {
+          "date": "2017-05-12",
+          "price": -10.28314494673824
+         },
+         {
+          "date": "2017-05-13",
+          "price": -11.345448660464346
+         },
+         {
+          "date": "2017-05-14",
+          "price": -10.871856229829165
+         },
+         {
+          "date": "2017-05-15",
+          "price": -11.791280464062968
+         },
+         {
+          "date": "2017-05-16",
+          "price": -10.241346059045428
+         },
+         {
+          "date": "2017-05-17",
+          "price": -11.024599351381665
+         },
+         {
+          "date": "2017-05-18",
+          "price": -11.34666086758734
+         },
+         {
+          "date": "2017-05-19",
+          "price": -10.53314365021767
+         },
+         {
+          "date": "2017-05-20",
+          "price": -11.764007966651626
+         },
+         {
+          "date": "2017-05-21",
+          "price": -11.536548032047497
+         },
+         {
+          "date": "2017-05-22",
+          "price": -10.22940527776507
+         },
+         {
+          "date": "2017-05-23",
+          "price": -11.836888512326297
+         },
+         {
+          "date": "2017-05-24",
+          "price": -11.652254653793992
+         },
+         {
+          "date": "2017-05-25",
+          "price": -11.39237185954557
+         },
+         {
+          "date": "2017-05-26",
+          "price": -10.61054898776826
+         },
+         {
+          "date": "2017-05-27",
+          "price": -11.847499698646342
+         },
+         {
+          "date": "2017-05-28",
+          "price": -13.167956311730618
+         },
+         {
+          "date": "2017-05-29",
+          "price": -12.646014746113721
+         },
+         {
+          "date": "2017-05-30",
+          "price": -12.349030072880534
+         },
+         {
+          "date": "2017-05-31",
+          "price": -12.098537222534658
+         },
+         {
+          "date": "2017-06-01",
+          "price": -11.752089013037683
+         },
+         {
+          "date": "2017-06-02",
+          "price": -12.432113734616173
+         },
+         {
+          "date": "2017-06-03",
+          "price": -12.19986003745517
+         },
+         {
+          "date": "2017-06-04",
+          "price": -11.90678756415649
+         },
+         {
+          "date": "2017-06-05",
+          "price": -12.621138982182858
+         },
+         {
+          "date": "2017-06-06",
+          "price": -10.755364471038101
+         },
+         {
+          "date": "2017-06-07",
+          "price": -10.281531550126314
+         },
+         {
+          "date": "2017-06-08",
+          "price": -11.472835047328962
+         },
+         {
+          "date": "2017-06-09",
+          "price": -10.816281438695132
+         },
+         {
+          "date": "2017-06-10",
+          "price": -11.790963108922453
+         },
+         {
+          "date": "2017-06-11",
+          "price": -11.003878505180001
+         },
+         {
+          "date": "2017-06-12",
+          "price": -9.845282926172597
+         },
+         {
+          "date": "2017-06-13",
+          "price": -10.665965244524308
+         },
+         {
+          "date": "2017-06-14",
+          "price": -9.702589115279986
+         },
+         {
+          "date": "2017-06-15",
+          "price": -9.289808188343487
+         },
+         {
+          "date": "2017-06-16",
+          "price": -8.467748028348998
+         },
+         {
+          "date": "2017-06-17",
+          "price": -6.570955045695051
+         },
+         {
+          "date": "2017-06-18",
+          "price": -6.8163431616979215
+         },
+         {
+          "date": "2017-06-19",
+          "price": -7.570079326055411
+         },
+         {
+          "date": "2017-06-20",
+          "price": -8.459593755680935
+         },
+         {
+          "date": "2017-06-21",
+          "price": -9.275404040646373
+         },
+         {
+          "date": "2017-06-22",
+          "price": -9.352505750060477
+         },
+         {
+          "date": "2017-06-23",
+          "price": -9.011353775243833
+         },
+         {
+          "date": "2017-06-24",
+          "price": -8.734662975913814
+         },
+         {
+          "date": "2017-06-25",
+          "price": -7.90747972687779
+         },
+         {
+          "date": "2017-06-26",
+          "price": -7.894477834999884
+         },
+         {
+          "date": "2017-06-27",
+          "price": -6.440943757842566
+         },
+         {
+          "date": "2017-06-28",
+          "price": -6.705600591080523
+         },
+         {
+          "date": "2017-06-29",
+          "price": -3.985431424490904
+         },
+         {
+          "date": "2017-06-30",
+          "price": -3.359764076725898
+         },
+         {
+          "date": "2017-07-01",
+          "price": -4.216921633142181
+         },
+         {
+          "date": "2017-07-02",
+          "price": -5.287814131203293
+         },
+         {
+          "date": "2017-07-03",
+          "price": -4.8053417159601075
+         },
+         {
+          "date": "2017-07-04",
+          "price": -5.028804501285959
+         },
+         {
+          "date": "2017-07-05",
+          "price": -4.3148040071938665
+         },
+         {
+          "date": "2017-07-06",
+          "price": -3.8415663826203215
+         },
+         {
+          "date": "2017-07-07",
+          "price": -3.914395295277194
+         },
+         {
+          "date": "2017-07-08",
+          "price": -4.761189013345599
+         },
+         {
+          "date": "2017-07-09",
+          "price": -6.276036238031464
+         },
+         {
+          "date": "2017-07-10",
+          "price": -6.722551190098486
+         },
+         {
+          "date": "2017-07-11",
+          "price": -5.866152395775013
+         },
+         {
+          "date": "2017-07-12",
+          "price": -5.6520586516448095
+         },
+         {
+          "date": "2017-07-13",
+          "price": -6.897797430356798
+         },
+         {
+          "date": "2017-07-14",
+          "price": -6.724616504505616
+         },
+         {
+          "date": "2017-07-15",
+          "price": -6.33929912477678
+         },
+         {
+          "date": "2017-07-16",
+          "price": -7.2231565609779125
+         },
+         {
+          "date": "2017-07-17",
+          "price": -7.069431455032385
+         },
+         {
+          "date": "2017-07-18",
+          "price": -7.011222736586385
+         },
+         {
+          "date": "2017-07-19",
+          "price": -8.154193034417007
+         },
+         {
+          "date": "2017-07-20",
+          "price": -7.796405674068724
+         },
+         {
+          "date": "2017-07-21",
+          "price": -7.23562114770049
+         },
+         {
+          "date": "2017-07-22",
+          "price": -6.152569904525214
+         },
+         {
+          "date": "2017-07-23",
+          "price": -5.098767852490311
+         },
+         {
+          "date": "2017-07-24",
+          "price": -6.476437220447401
+         },
+         {
+          "date": "2017-07-25",
+          "price": -7.414262260362524
+         },
+         {
+          "date": "2017-07-26",
+          "price": -6.899226993153865
+         },
+         {
+          "date": "2017-07-27",
+          "price": -6.385441042241656
+         },
+         {
+          "date": "2017-07-28",
+          "price": -5.870393355935608
+         },
+         {
+          "date": "2017-07-29",
+          "price": -2.017661865280887
+         },
+         {
+          "date": "2017-07-30",
+          "price": -1.4467713545877199
+         },
+         {
+          "date": "2017-07-31",
+          "price": -0.31120571440712097
+         },
+         {
+          "date": "2017-08-01",
+          "price": 0.6427960490860813
+         },
+         {
+          "date": "2017-08-02",
+          "price": 1.2941873003918793
+         },
+         {
+          "date": "2017-08-03",
+          "price": 0.9789180557515338
+         },
+         {
+          "date": "2017-08-04",
+          "price": 1.7378872762448012
+         },
+         {
+          "date": "2017-08-05",
+          "price": 0.9650620617072294
+         },
+         {
+          "date": "2017-08-06",
+          "price": 0.7282434549672205
+         },
+         {
+          "date": "2017-08-07",
+          "price": 0.24287990713811708
+         },
+         {
+          "date": "2017-08-08",
+          "price": 0.3247540465244396
+         },
+         {
+          "date": "2017-08-09",
+          "price": 2.6394126131979485
+         },
+         {
+          "date": "2017-08-10",
+          "price": 0.7721474206062005
+         },
+         {
+          "date": "2017-08-11",
+          "price": 1.4584076109807138
+         },
+         {
+          "date": "2017-08-12",
+          "price": -0.15430826020893784
+         },
+         {
+          "date": "2017-08-13",
+          "price": -0.6262401259983713
+         },
+         {
+          "date": "2017-08-14",
+          "price": 0.46271047096899476
+         },
+         {
+          "date": "2017-08-15",
+          "price": 0.5269904900644575
+         },
+         {
+          "date": "2017-08-16",
+          "price": -0.5507542878648486
+         },
+         {
+          "date": "2017-08-17",
+          "price": -1.266057997124817
+         },
+         {
+          "date": "2017-08-18",
+          "price": -0.5864602481901411
+         },
+         {
+          "date": "2017-08-19",
+          "price": -1.3168268799072778
+         },
+         {
+          "date": "2017-08-20",
+          "price": -1.100368290325303
+         },
+         {
+          "date": "2017-08-21",
+          "price": -1.054796450421489
+         },
+         {
+          "date": "2017-08-22",
+          "price": -1.7063967980273063
+         },
+         {
+          "date": "2017-08-23",
+          "price": 0.4375472912980194
+         },
+         {
+          "date": "2017-08-24",
+          "price": 1.0714663136160305
+         },
+         {
+          "date": "2017-08-25",
+          "price": -0.9536762730415766
+         },
+         {
+          "date": "2017-08-26",
+          "price": -0.767221958272149
+         },
+         {
+          "date": "2017-08-27",
+          "price": -1.4290084230405369
+         },
+         {
+          "date": "2017-08-28",
+          "price": -0.5765750882443129
+         },
+         {
+          "date": "2017-08-29",
+          "price": -1.3690958266770137
+         },
+         {
+          "date": "2017-08-30",
+          "price": -1.4838322681439127
+         },
+         {
+          "date": "2017-08-31",
+          "price": -0.9788449891634555
+         },
+         {
+          "date": "2017-09-01",
+          "price": -0.11308979499333405
+         },
+         {
+          "date": "2017-09-02",
+          "price": -1.3133862020491103
+         },
+         {
+          "date": "2017-09-03",
+          "price": -1.6478874378900588
+         },
+         {
+          "date": "2017-09-04",
+          "price": -2.122832749051015
+         },
+         {
+          "date": "2017-09-05",
+          "price": -2.7761619816247265
+         },
+         {
+          "date": "2017-09-06",
+          "price": -1.0107077413436296
+         },
+         {
+          "date": "2017-09-07",
+          "price": -0.6057260303826741
+         },
+         {
+          "date": "2017-09-08",
+          "price": -1.8666099847177193
+         },
+         {
+          "date": "2017-09-09",
+          "price": -0.9487480376629432
+         },
+         {
+          "date": "2017-09-10",
+          "price": 1.1734081593496901
+         },
+         {
+          "date": "2017-09-11",
+          "price": 2.205873419900837
+         },
+         {
+          "date": "2017-09-12",
+          "price": 0.6865034539468238
+         },
+         {
+          "date": "2017-09-13",
+          "price": 0.2022693810805724
+         },
+         {
+          "date": "2017-09-14",
+          "price": 1.4691805302671952
+         },
+         {
+          "date": "2017-09-15",
+          "price": 0.7615110646484144
+         },
+         {
+          "date": "2017-09-16",
+          "price": 1.2053304927946429
+         },
+         {
+          "date": "2017-09-17",
+          "price": 1.9799645462239797
+         },
+         {
+          "date": "2017-09-18",
+          "price": 1.0530340746458968
+         },
+         {
+          "date": "2017-09-19",
+          "price": 0.9935087185840967
+         },
+         {
+          "date": "2017-09-20",
+          "price": -2.2477586214849756
+         },
+         {
+          "date": "2017-09-21",
+          "price": -3.2721462628192652
+         },
+         {
+          "date": "2017-09-22",
+          "price": -3.5247144142124256
+         },
+         {
+          "date": "2017-09-23",
+          "price": -4.772497596177275
+         },
+         {
+          "date": "2017-09-24",
+          "price": -3.14008629224564
+         },
+         {
+          "date": "2017-09-25",
+          "price": -4.570227670206273
+         },
+         {
+          "date": "2017-09-26",
+          "price": -5.010272156903256
+         },
+         {
+          "date": "2017-09-27",
+          "price": -4.879531579617165
+         },
+         {
+          "date": "2017-09-28",
+          "price": -3.4382582905510493
+         },
+         {
+          "date": "2017-09-29",
+          "price": -4.874120441730488
+         },
+         {
+          "date": "2017-09-30",
+          "price": -3.7109566895755286
+         },
+         {
+          "date": "2017-10-01",
+          "price": -3.7007236285559415
+         },
+         {
+          "date": "2017-10-02",
+          "price": -4.682232279603893
+         },
+         {
+          "date": "2017-10-03",
+          "price": -4.2201288053406225
+         },
+         {
+          "date": "2017-10-04",
+          "price": -4.0210691097671525
+         },
+         {
+          "date": "2017-10-05",
+          "price": -4.6212859869259475
+         },
+         {
+          "date": "2017-10-06",
+          "price": -4.551483901935929
+         },
+         {
+          "date": "2017-10-07",
+          "price": -4.936797498797689
+         },
+         {
+          "date": "2017-10-08",
+          "price": -4.823280153546441
+         },
+         {
+          "date": "2017-10-09",
+          "price": -4.1611494790253944
+         },
+         {
+          "date": "2017-10-10",
+          "price": -2.5751326628800424
+         },
+         {
+          "date": "2017-10-11",
+          "price": -3.8129481617068914
+         },
+         {
+          "date": "2017-10-12",
+          "price": -1.6799147870506248
+         },
+         {
+          "date": "2017-10-13",
+          "price": -3.632002586573127
+         },
+         {
+          "date": "2017-10-14",
+          "price": -3.78378768160871
+         },
+         {
+          "date": "2017-10-15",
+          "price": -3.1954704751241336
+         },
+         {
+          "date": "2017-10-16",
+          "price": -2.914478607389101
+         },
+         {
+          "date": "2017-10-17",
+          "price": -3.537178127209695
+         },
+         {
+          "date": "2017-10-18",
+          "price": -3.7453003775669704
+         },
+         {
+          "date": "2017-10-19",
+          "price": -4.238301312225803
+         },
+         {
+          "date": "2017-10-20",
+          "price": -4.827666069170014
+         },
+         {
+          "date": "2017-10-21",
+          "price": -3.97806397214899
+         },
+         {
+          "date": "2017-10-22",
+          "price": -3.6210484861839425
+         },
+         {
+          "date": "2017-10-23",
+          "price": -4.313958081444596
+         },
+         {
+          "date": "2017-10-24",
+          "price": -3.4143582060113458
+         },
+         {
+          "date": "2017-10-25",
+          "price": -3.1070586851347364
+         },
+         {
+          "date": "2017-10-26",
+          "price": -2.2941965662957764
+         },
+         {
+          "date": "2017-10-27",
+          "price": -1.6645677243721642
+         },
+         {
+          "date": "2017-10-28",
+          "price": -2.4935627352942364
+         },
+         {
+          "date": "2017-10-29",
+          "price": -3.0537437754912062
+         },
+         {
+          "date": "2017-10-30",
+          "price": -2.3064501703679445
+         },
+         {
+          "date": "2017-10-31",
+          "price": -1.6960799049344797
+         },
+         {
+          "date": "2017-11-01",
+          "price": -1.7169814988986278
+         },
+         {
+          "date": "2017-11-02",
+          "price": -1.5996541155898458
+         },
+         {
+          "date": "2017-11-03",
+          "price": -0.3219892198014209
+         },
+         {
+          "date": "2017-11-04",
+          "price": -0.9135606086372509
+         },
+         {
+          "date": "2017-11-05",
+          "price": -0.36646322746721294
+         },
+         {
+          "date": "2017-11-06",
+          "price": -0.568655879901107
+         },
+         {
+          "date": "2017-11-07",
+          "price": -0.7863370831283273
+         },
+         {
+          "date": "2017-11-08",
+          "price": 0.3124397688588628
+         },
+         {
+          "date": "2017-11-09",
+          "price": 1.1378561178468927
+         },
+         {
+          "date": "2017-11-10",
+          "price": 1.951365753847531
+         },
+         {
+          "date": "2017-11-11",
+          "price": 3.25684456100186
+         },
+         {
+          "date": "2017-11-12",
+          "price": 3.277848402634619
+         },
+         {
+          "date": "2017-11-13",
+          "price": 3.959801373929583
+         },
+         {
+          "date": "2017-11-14",
+          "price": 3.649534617336127
+         },
+         {
+          "date": "2017-11-15",
+          "price": 3.973700969824569
+         },
+         {
+          "date": "2017-11-16",
+          "price": 3.8435579154568846
+         },
+         {
+          "date": "2017-11-17",
+          "price": 3.940553880449603
+         },
+         {
+          "date": "2017-11-18",
+          "price": 4.535710905886517
+         },
+         {
+          "date": "2017-11-19",
+          "price": 3.717490222653044
+         },
+         {
+          "date": "2017-11-20",
+          "price": 5.809877498338505
+         },
+         {
+          "date": "2017-11-21",
+          "price": 4.803860116838803
+         },
+         {
+          "date": "2017-11-22",
+          "price": 3.5896715040510707
+         },
+         {
+          "date": "2017-11-23",
+          "price": 4.747782377551139
+         },
+         {
+          "date": "2017-11-24",
+          "price": 5.539445071514074
+         },
+         {
+          "date": "2017-11-25",
+          "price": 6.1635648885662295
+         },
+         {
+          "date": "2017-11-26",
+          "price": 6.7919103978305095
+         },
+         {
+          "date": "2017-11-27",
+          "price": 6.779663624983595
+         },
+         {
+          "date": "2017-11-28",
+          "price": 5.882409253497763
+         },
+         {
+          "date": "2017-11-29",
+          "price": 5.95821381169149
+         },
+         {
+          "date": "2017-11-30",
+          "price": 5.281052100179378
+         },
+         {
+          "date": "2017-12-01",
+          "price": 6.256171833597129
+         },
+         {
+          "date": "2017-12-02",
+          "price": 6.109114452094991
+         },
+         {
+          "date": "2017-12-03",
+          "price": 5.283617255302479
+         },
+         {
+          "date": "2017-12-04",
+          "price": 4.962231413649485
+         },
+         {
+          "date": "2017-12-05",
+          "price": 5.37516286792511
+         },
+         {
+          "date": "2017-12-06",
+          "price": 4.811438315121135
+         },
+         {
+          "date": "2017-12-07",
+          "price": 3.989217919554704
+         },
+         {
+          "date": "2017-12-08",
+          "price": 4.232905131046616
+         },
+         {
+          "date": "2017-12-09",
+          "price": 4.477871702155339
+         },
+         {
+          "date": "2017-12-10",
+          "price": 3.970928526784209
+         },
+         {
+          "date": "2017-12-11",
+          "price": 3.499890221165886
+         },
+         {
+          "date": "2017-12-12",
+          "price": 3.7319401585235226
+         },
+         {
+          "date": "2017-12-13",
+          "price": 2.2838558170261987
+         },
+         {
+          "date": "2017-12-14",
+          "price": 0.8763920426496434
+         },
+         {
+          "date": "2017-12-15",
+          "price": 0.15794782139720742
+         },
+         {
+          "date": "2017-12-16",
+          "price": -0.05549933031463983
+         },
+         {
+          "date": "2017-12-17",
+          "price": 0.25540823528336476
+         },
+         {
+          "date": "2017-12-18",
+          "price": 1.7307644522329166
+         },
+         {
+          "date": "2017-12-19",
+          "price": 2.588424075434936
+         },
+         {
+          "date": "2017-12-20",
+          "price": 2.4284855454715086
+         },
+         {
+          "date": "2017-12-21",
+          "price": 2.4094693375688196
+         },
+         {
+          "date": "2017-12-22",
+          "price": 1.4069399729310108
+         },
+         {
+          "date": "2017-12-23",
+          "price": 1.3884268369386208
+         },
+         {
+          "date": "2017-12-24",
+          "price": 1.0997681980184826
+         },
+         {
+          "date": "2017-12-25",
+          "price": 1.4224867583565721
+         },
+         {
+          "date": "2017-12-26",
+          "price": 0.5952558148042492
+         },
+         {
+          "date": "2017-12-27",
+          "price": 1.1146023290454214
+         },
+         {
+          "date": "2017-12-28",
+          "price": 2.6473412420479994
+         },
+         {
+          "date": "2017-12-29",
+          "price": 2.5385810935911417
+         },
+         {
+          "date": "2017-12-30",
+          "price": 2.940292815690083
+         },
+         {
+          "date": "2017-12-31",
+          "price": 3.6304368074011952
+         }
+        ]
+       },
+       "encoding": {
+        "x": {
+         "axis": {
+          "format": "%b %d"
+         },
+         "field": "date",
+         "type": "temporal"
+        },
+        "y": {
+         "field": "price",
+         "type": "quantitative"
+        }
+       },
+       "mark": "line",
+       "width": 600
+      },
+      "text/plain": [
+       "<VegaLite 2 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/display.html\n"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%vegalite ts_data\n",
     "{\n",
@@ -429,7 +2623,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This changes things so users can use ``%load_ext altair`` in order to get the ``%%vega`` and ``%vegalite`` magics.