### PR TITLE
Example: world map projections

### DIFF
--- a/altair/vegalite/v2/examples/world_projections.py
+++ b/altair/vegalite/v2/examples/world_projections.py
@@ -1,0 +1,30 @@
+"""
+World Projections
+-----------------
+This example shows a map of the countries of the world using four available
+geographic projections. For more details on the projections available in
+Altair, see https://vega.github.io/vega-lite/docs/projection.html
+"""
+# category: geographic
+
+import altair as alt
+from vega_datasets import data
+
+countries = alt.topo_feature(data.world_110m.url, 'countries')
+
+base = alt.Chart(countries).mark_geoshape(
+    fill='#666666',
+    stroke='white'
+).properties(
+    width=300,
+    height=180
+)
+
+projections = ['equirectangular', 'mercator', 'orthographic', 'gnomonic']
+charts = [base.properties(title=proj, projection={'type': proj})
+          for proj in projections]
+
+alt.vconcat(
+    alt.hconcat(*charts[:2]),
+    alt.hconcat(*charts[2:])
+)


### PR DESCRIPTION
Some world map examples:

![visualization 1](https://user-images.githubusercontent.com/781659/38689167-b78511fa-3e2f-11e8-9c38-474fa7f7cc9b.png)

Note that graticules (lat/long lines) are not yet supported in Vega-Lite; see https://github.com/vega/vega-lite/issues/3337