### PR TITLE
Typing is in requirements.txt but not setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ INSTALL_REQUIRES    = ['entrypoints',
                        'pytest',
                        'six',
                        'toolz',
+                       'typing',
                        'vega_datasets']
 VERSION             = version('altair/__init__.py')
 


### PR DESCRIPTION
One of my colleagues installed Altair's new release candidate in Python 2.7 today. He had to install typing himself manually afterwards. I suspect this is because it was not added to setup.py. 