### PR TITLE
ENH: add project() method to Chart

### DIFF
--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import warnings
 
 import jsonschema

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -448,6 +448,77 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             setattr(copy, key, val)
         return copy
 
+    def project(self, type='mercator', center=Undefined, clipAngle=Undefined, clipExtent=Undefined,
+                coefficient=Undefined, distance=Undefined, fraction=Undefined, lobes=Undefined,
+                parallel=Undefined, precision=Undefined, radius=Undefined, ratio=Undefined,
+                rotate=Undefined, spacing=Undefined, tilt=Undefined, **kwds):
+        """Add a geographic projection to the chartself.
+
+        This is generally used either with ``mark_geoshape`` or with the
+        ``latitude``/``longitude`` encodings.
+
+        Available projection types are
+        ['albers', 'albersUsa', 'azimuthalEqualArea', 'azimuthalEquidistant',
+         'conicConformal', 'conicEqualArea', 'conicEquidistant', 'equirectangular',
+         'gnomonic', 'mercator', 'orthographic', 'stereographic', 'transverseMercator']
+
+        Attributes
+        ----------
+        type : ProjectionType
+            The cartographic projection to use. This value is case-insensitive, for example
+            `"albers"` and `"Albers"` indicate the same projection type. You can find all valid
+            projection types [in the
+            documentation](https://vega.github.io/vega-lite/docs/projection.html#projection-types).
+              __Default value:__ `mercator`
+        center : List(float)
+            Sets the projection’s center to the specified center, a two-element array of
+            longitude and latitude in degrees.  __Default value:__ `[0, 0]`
+        clipAngle : float
+            Sets the projection’s clipping circle radius to the specified angle in degrees. If
+            `null`, switches to [antimeridian](http://bl.ocks.org/mbostock/3788999) cutting
+            rather than small-circle clipping.
+        clipExtent : List(List(float))
+            Sets the projection’s viewport clip extent to the specified bounds in pixels. The
+            extent bounds are specified as an array `[[x0, y0], [x1, y1]]`, where `x0` is the
+            left-side of the viewport, `y0` is the top, `x1` is the right and `y1` is the
+            bottom. If `null`, no viewport clipping is performed.
+        coefficient : float
+
+        distance : float
+
+        fraction : float
+
+        lobes : float
+
+        parallel : float
+
+        precision : Mapping(required=[length])
+            Sets the threshold for the projection’s [adaptive
+            resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels.
+            This value corresponds to the [Douglas–Peucker
+            distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm).
+             If precision is not specified, returns the projection’s current resampling
+            precision which defaults to `√0.5 ≅ 0.70710…`.
+        radius : float
+
+        ratio : float
+
+        rotate : List(float)
+            Sets the projection’s three-axis rotation to the specified angles, which must be a
+            two- or three-element array of numbers [`lambda`, `phi`, `gamma`] specifying the
+            rotation angles in degrees about each spherical axis. (These correspond to yaw,
+            pitch and roll.)  __Default value:__ `[0, 0, 0]`
+        spacing : float
+
+        tilt : float
+        """
+        projection = core.Projection(center=center, clipAngle=clipAngle, clipExtent=clipExtent,
+                                     coefficient=coefficient, distance=distance, fraction=fraction,
+                                     lobes=lobes, parallel=parallel, precision=precision,
+                                     radius=radius, ratio=ratio, rotate=rotate, spacing=spacing,
+                                     tilt=tilt, type=type, **kwds)
+        return self.properties(projection=projection)
+
     def _add_transform(self, *transforms):
         """Copy the chart and add specified transforms to chart.transform"""
         copy = self.copy()

--- a/altair/vegalite/v2/examples/airports.py
+++ b/altair/vegalite/v2/examples/airports.py
@@ -16,10 +16,9 @@ background = alt.Chart(states).mark_geoshape(
     fill='lightgray',
     stroke='white'
 ).properties(
-    projection={'type': 'albersUsa'},
     width=500,
     height=300
-)
+).project('albersUsa')
 
 # airport positions on background
 points = alt.Chart(airports).mark_circle().encode(

--- a/altair/vegalite/v2/examples/choropleth.py
+++ b/altair/vegalite/v2/examples/choropleth.py
@@ -12,13 +12,14 @@ counties = alt.topo_feature(data.us_10m.url, 'counties')
 unemp_data = data.unemployment.url
 
 
-alt.Chart(counties).mark_geoshape().properties(
-    projection={'type': 'albersUsa'},
-    width=500,
-    height=300
-).encode(
+alt.Chart(counties).mark_geoshape().encode(
     color='rate:Q'
 ).transform_lookup(
     lookup='id',
     from_=alt.LookupData(unemp_data, 'id', ['rate'])
+).project(
+    type='albersUsa'
+).properties(
+    width=500,
+    height=300
 )

--- a/altair/vegalite/v2/examples/choropleth_repeat.py
+++ b/altair/vegalite/v2/examples/choropleth_repeat.py
@@ -14,15 +14,16 @@ pop_eng_hur = data.population_engineers_hurricanes.url
 
 variable_list = ['population', 'engineers', 'hurricanes']
 
-alt.Chart(states).mark_geoshape().properties(
-    projection={'type': 'albersUsa'},
-    width=500,
-    height=300
-).encode(
+alt.Chart(states).mark_geoshape().encode(
     alt.Color(alt.repeat('row'), type='quantitative')
 ).transform_lookup(
     lookup='id',
     from_=alt.LookupData(pop_eng_hur, 'id', variable_list)
+).properties(
+    width=500,
+    height=300
+).project(
+    type='albersUsa'
 ).repeat(
     row=variable_list
 ).resolve_scale(

--- a/altair/vegalite/v2/examples/one_dot_per_zipcode.py
+++ b/altair/vegalite/v2/examples/one_dot_per_zipcode.py
@@ -15,8 +15,9 @@ alt.Chart(zipcodes).mark_circle(size=3).encode(
     longitude='longitude:Q',
     latitude='latitude:Q',
     color='digit:N'
+).project(
+    type='albersUsa'
 ).properties(
-    projection={'type': 'albersUsa'},
     width=650,
     height=400
 ).transform_calculate(

--- a/altair/vegalite/v2/examples/us_state_capitals.py
+++ b/altair/vegalite/v2/examples/us_state_capitals.py
@@ -18,10 +18,9 @@ background = alt.Chart(states).mark_geoshape(
     stroke='white'
 ).properties(
     title='US State Capitols',
-    projection={'type': 'albersUsa'},
     width=700,
     height=400
-)
+).project('albersUsa')
 
 # Points and text
 hover = alt.selection(type='single', on='mouseover', nearest=True,

--- a/altair/vegalite/v2/examples/world_projections.py
+++ b/altair/vegalite/v2/examples/world_projections.py
@@ -21,7 +21,7 @@ base = alt.Chart(countries).mark_geoshape(
 )
 
 projections = ['equirectangular', 'mercator', 'orthographic', 'gnomonic']
-charts = [base.properties(title=proj, projection={'type': proj})
+charts = [base.project(proj).properties(title=proj)
           for proj in projections]
 
 alt.vconcat(


### PR DESCRIPTION
This adds a ``Chart.project`` method.

Before, applying a geographic projection required something like this:
```python
alt.Chart(data).mark_geojson().properties(
    projection=alt.Projection(type='albersUsa', **kwds)
)
```
After this PR, the equivalent is
```python
alt.Chart(data).mark_geojson().project('albersUsa', **kwds)
```