### PR TITLE
[HOLD] Add aggregate functions

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -357,8 +357,10 @@ class SchemaBase(object):
         return jsonschema.validate(instance, schema, resolver=resolver)
 
     @classmethod
-    def resolve_references(cls, schema):
+    def resolve_references(cls, schema=None):
         """Resolve references of the schema the context of this object's schema"""
+        if schema is None:
+            schema = cls._schema
         resolver = jsonschema.RefResolver.from_schema(cls._rootschema
                                                       or cls._schema
                                                       or schema)

--- a/altair/vegalite/v1/schema/channels.py
+++ b/altair/vegalite/v1/schema/channels.py
@@ -59,6 +59,7 @@ class Row(core.PositionChannelDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -71,6 +72,9 @@ class Row(core.PositionChannelDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -79,7 +83,7 @@ class Row(core.PositionChannelDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -139,6 +143,7 @@ class Column(core.PositionChannelDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -151,6 +156,9 @@ class Column(core.PositionChannelDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -159,7 +167,7 @@ class Column(core.PositionChannelDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -219,6 +227,7 @@ class X(core.PositionChannelDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -231,6 +240,9 @@ class X(core.PositionChannelDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -239,7 +251,7 @@ class X(core.PositionChannelDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -299,6 +311,7 @@ class Y(core.PositionChannelDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -311,6 +324,9 @@ class Y(core.PositionChannelDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -319,7 +335,7 @@ class Y(core.PositionChannelDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -371,6 +387,7 @@ class X2(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -383,6 +400,9 @@ class X2(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -391,7 +411,7 @@ class X2(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -443,6 +463,7 @@ class Y2(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -455,6 +476,9 @@ class Y2(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -463,7 +487,7 @@ class Y2(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -523,6 +547,7 @@ class Color(core.ChannelDefWithLegend):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -535,6 +560,9 @@ class Color(core.ChannelDefWithLegend):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -543,7 +571,7 @@ class Color(core.ChannelDefWithLegend):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -603,6 +631,7 @@ class Opacity(core.ChannelDefWithLegend):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -615,6 +644,9 @@ class Opacity(core.ChannelDefWithLegend):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -623,7 +655,7 @@ class Opacity(core.ChannelDefWithLegend):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -683,6 +715,7 @@ class Size(core.ChannelDefWithLegend):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -695,6 +728,9 @@ class Size(core.ChannelDefWithLegend):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -703,7 +739,7 @@ class Size(core.ChannelDefWithLegend):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -763,6 +799,7 @@ class Shape(core.ChannelDefWithLegend):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -775,6 +812,9 @@ class Shape(core.ChannelDefWithLegend):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -783,7 +823,7 @@ class Shape(core.ChannelDefWithLegend):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -835,6 +875,7 @@ class Detail(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -847,6 +888,9 @@ class Detail(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -855,7 +899,7 @@ class Detail(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -907,6 +951,7 @@ class Text(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -919,6 +964,9 @@ class Text(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -927,7 +975,7 @@ class Text(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -979,6 +1027,7 @@ class Label(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -991,6 +1040,9 @@ class Label(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -999,7 +1051,7 @@ class Label(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -1055,6 +1107,7 @@ class Path(core.OrderChannelDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -1067,6 +1120,9 @@ class Path(core.OrderChannelDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -1075,7 +1131,7 @@ class Path(core.OrderChannelDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -1131,6 +1187,7 @@ class Order(core.OrderChannelDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -1143,6 +1200,9 @@ class Order(core.OrderChannelDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -1151,7 +1211,7 @@ class Order(core.OrderChannelDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})

--- a/altair/vegalite/v2/__init__.py
+++ b/altair/vegalite/v2/__init__.py
@@ -4,6 +4,9 @@ from .api import *
 
 from . import examples
 
+from . import aggregates
+from .aggregates import *
+
 from ...datasets import (
     list_datasets,
     load_dataset

--- a/altair/vegalite/v2/aggregates.py
+++ b/altair/vegalite/v2/aggregates.py
@@ -1,0 +1,48 @@
+from .schema import core as _schema_core
+from .schema import Undefined
+from altair.utils import core as _utils_core
+
+
+class _AggregateFunction(object):
+    _doc_template = """Altair {aggregate} aggregate
+
+    {aggregate}(field, type='quantitative', **kwargs)
+
+    Parameters
+    ----------
+    field : string
+        the name of the field to be aggregated
+    type : string, default='quantitative'
+        the type of the aggregated field
+    **kwargs :
+        additional parameters are added to the dict
+
+    Returns
+    -------
+    dct : dictionary
+        dictionary with keys "aggregate", "field", and "type"
+    """
+    def __init__(self, aggregate):
+        self.aggregate = aggregate
+        self.__doc__ = self._doc_template.format(aggregate=aggregate)
+
+    def __call__(self, field=Undefined, type='quantitative'):
+        type = _utils_core.INV_TYPECODE_MAP.get(type, type)
+        if field is Undefined and self.aggregate != 'count':
+            raise TypeError("{0}() missing 1 required positional argument: 'field'".format(self.aggregate))
+        if type not in _utils_core.TYPECODE_MAP:
+            valid = list(_utils_core.TYPECODE_MAP) + list(_utils_core.INV_TYPECODE_MAP)
+            raise ValueError("invalid type argument '{0}'; must be one of {1}".format(type, valid))
+        dct = {'aggregate': self.aggregate}
+        if field is not Undefined:
+            dct['field'] = field
+        if type is not Undefined:
+            dct['type'] = type
+        return dct
+
+
+# Define an object for each valid aggregate
+__all__ = _schema_core.Aggregate.resolve_references()['enum']
+
+for aggregate in __all__:
+    globals()[aggregate] = _AggregateFunction(aggregate)

--- a/altair/vegalite/v2/aggregates.py
+++ b/altair/vegalite/v2/aggregates.py
@@ -42,7 +42,8 @@ class _AggregateFunction(object):
 
 
 # Define an object for each valid aggregate
-__all__ = _schema_core.Aggregate.resolve_references()['enum']
+_agg_names = _schema_core.Aggregate.resolve_references()['enum']
+__all__ = ["agg_" + name for name in _agg_names]
 
-for aggregate in __all__:
-    globals()[aggregate] = _AggregateFunction(aggregate)
+for name in _agg_names:
+    globals()["agg_" + name] = _AggregateFunction(name)

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -4,6 +4,9 @@ import jsonschema
 import six
 import pandas as pd
 
+from . import aggregates
+from .aggregates import *
+
 from .schema import core, channels, mixins, Undefined, SCHEMA_URL
 
 from .data import data_transformers, pipe

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -4,9 +4,6 @@ import jsonschema
 import six
 import pandas as pd
 
-from . import aggregates
-from .aggregates import *
-
 from .schema import core, channels, mixins, Undefined, SCHEMA_URL
 
 from .data import data_transformers, pipe

--- a/altair/vegalite/v2/schema/channels.py
+++ b/altair/vegalite/v2/schema/channels.py
@@ -91,6 +91,7 @@ class Color(core.MarkPropFieldDefWithCondition):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -103,6 +104,9 @@ class Color(core.MarkPropFieldDefWithCondition):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -111,7 +115,7 @@ class Color(core.MarkPropFieldDefWithCondition):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -215,6 +219,7 @@ class Column(core.FacetFieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -227,6 +232,9 @@ class Column(core.FacetFieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -235,7 +243,7 @@ class Column(core.FacetFieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -297,6 +305,7 @@ class Detail(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -309,6 +318,9 @@ class Detail(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -317,7 +329,7 @@ class Detail(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -409,6 +421,7 @@ class Fill(core.MarkPropFieldDefWithCondition):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -421,6 +434,9 @@ class Fill(core.MarkPropFieldDefWithCondition):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -429,7 +445,7 @@ class Fill(core.MarkPropFieldDefWithCondition):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -541,6 +557,7 @@ class Href(core.FieldDefWithCondition):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -553,6 +570,9 @@ class Href(core.FieldDefWithCondition):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -561,7 +581,7 @@ class Href(core.FieldDefWithCondition):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -661,6 +681,7 @@ class Key(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -673,6 +694,9 @@ class Key(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -681,7 +705,7 @@ class Key(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -743,6 +767,7 @@ class Latitude(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -755,6 +780,9 @@ class Latitude(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -763,7 +791,7 @@ class Latitude(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -825,6 +853,7 @@ class Latitude2(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -837,6 +866,9 @@ class Latitude2(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -845,7 +877,7 @@ class Latitude2(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -907,6 +939,7 @@ class Longitude(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -919,6 +952,9 @@ class Longitude(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -927,7 +963,7 @@ class Longitude(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -989,6 +1025,7 @@ class Longitude2(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -1001,6 +1038,9 @@ class Longitude2(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -1009,7 +1049,7 @@ class Longitude2(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -1101,6 +1141,7 @@ class Opacity(core.MarkPropFieldDefWithCondition):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -1113,6 +1154,9 @@ class Opacity(core.MarkPropFieldDefWithCondition):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -1121,7 +1165,7 @@ class Opacity(core.MarkPropFieldDefWithCondition):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -1223,6 +1267,7 @@ class Order(core.OrderFieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -1235,6 +1280,9 @@ class Order(core.OrderFieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -1243,7 +1291,7 @@ class Order(core.OrderFieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -1308,6 +1356,7 @@ class Row(core.FacetFieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -1320,6 +1369,9 @@ class Row(core.FacetFieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -1328,7 +1380,7 @@ class Row(core.FacetFieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -1420,6 +1472,7 @@ class Shape(core.MarkPropFieldDefWithCondition):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -1432,6 +1485,9 @@ class Shape(core.MarkPropFieldDefWithCondition):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -1440,7 +1496,7 @@ class Shape(core.MarkPropFieldDefWithCondition):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -1571,6 +1627,7 @@ class Size(core.MarkPropFieldDefWithCondition):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -1583,6 +1640,9 @@ class Size(core.MarkPropFieldDefWithCondition):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -1591,7 +1651,7 @@ class Size(core.MarkPropFieldDefWithCondition):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -1722,6 +1782,7 @@ class Stroke(core.MarkPropFieldDefWithCondition):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -1734,6 +1795,9 @@ class Stroke(core.MarkPropFieldDefWithCondition):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -1742,7 +1806,7 @@ class Stroke(core.MarkPropFieldDefWithCondition):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -1857,6 +1921,7 @@ class Text(core.TextFieldDefWithCondition):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -1869,6 +1934,9 @@ class Text(core.TextFieldDefWithCondition):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -1877,7 +1945,7 @@ class Text(core.TextFieldDefWithCondition):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -1991,6 +2059,7 @@ class Tooltip(core.TextFieldDefWithCondition):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -2003,6 +2072,9 @@ class Tooltip(core.TextFieldDefWithCondition):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -2011,7 +2083,7 @@ class Tooltip(core.TextFieldDefWithCondition):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -2149,6 +2221,7 @@ class X(core.PositionFieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -2161,6 +2234,9 @@ class X(core.PositionFieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -2169,7 +2245,7 @@ class X(core.PositionFieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -2264,6 +2340,7 @@ class X2(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -2276,6 +2353,9 @@ class X2(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -2284,7 +2364,7 @@ class X2(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -2417,6 +2497,7 @@ class Y(core.PositionFieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -2429,6 +2510,9 @@ class Y(core.PositionFieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -2437,7 +2521,7 @@ class Y(core.PositionFieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})
@@ -2532,6 +2616,7 @@ class Y2(core.FieldDef):
         if self.shorthand is Undefined:
             kwds = {}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -2544,6 +2629,9 @@ class Y2(core.FieldDef):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -2552,7 +2640,7 @@ class Y2(core.FieldDef):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {'field': self.shorthand}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined})

--- a/altair/vegalite/v2/tests/test_aggregates.py
+++ b/altair/vegalite/v2/tests/test_aggregates.py
@@ -1,0 +1,21 @@
+from altair.vegalite import v2 as alt
+
+
+def test_all_aggregates():
+    for aggregate in dir(alt.aggregates):
+        if not aggregate.startswith('agg_'):
+            continue
+        aggfunc = getattr(alt, aggregate)
+        print(aggregate)
+        name = aggregate.split('_', 1)[1]
+
+        assert aggfunc('foo') == {'field': 'foo',
+                                  'aggregate': name,
+                                  'type': 'quantitative'}
+        assert aggfunc('foo', 'O') == {'field': 'foo',
+                                       'aggregate': name,
+                                       'type': 'ordinal'}
+
+
+def test_count_aggregate():
+    assert alt.agg_count() == {'aggregate': 'count', 'type': 'quantitative'}

--- a/altair/vegalite/v2/tests/test_api.py
+++ b/altair/vegalite/v2/tests/test_api.py
@@ -84,6 +84,12 @@ def test_chart_infer_types():
     assert dct['encoding']['y']['type'] == 'ordinal'
 
 
+def test_chart_aggregates():
+    chart1 = alt.Chart('foo.csv').mark_point().encode(x='mean(x):Q')
+    chart2 = alt.Chart('foo.csv').mark_point().encode(x=alt.agg_mean('x'))
+    assert chart1.to_dict() == chart2.to_dict()
+
+
 def test_chart_operations():
     data = pd.DataFrame({'x': pd.date_range('2012', periods=10, freq='Y'),
                          'y': range(10),

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -56,6 +56,7 @@ class {classname}(core.{basename}):
         if self.shorthand is Undefined:
             kwds = {{}}
         elif isinstance(self.shorthand, six.string_types):
+            # shorthand is a string: we parse it for forms like "mean(x):Q"
             kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
             type_defined = self._kwds.get('type', Undefined) is not Undefined
             if not (type_defined or 'type' in kwds):
@@ -68,6 +69,9 @@ class {classname}(core.{basename}):
                                      "the type cannot be automacially inferred because "
                                      "the data is not specified as a pandas.DataFrame."
                                      "".format(self.shorthand))
+        elif isinstance(self.shorthand, dict):
+            # shorthand is a dict; comes from something like alt.mean('x')
+            kwds = self.shorthand
         else:
             # shorthand is not a string; we pass the definition to field
             if self.field is not Undefined:
@@ -76,7 +80,7 @@ class {classname}(core.{basename}):
             # field is a RepeatSpec or similar; cannot infer type
             kwds = {{'field': self.shorthand}}
 
-        # set shorthand to Undefined, because it's not part of the schema
+        # set shorthand to Undefined because it's not part of the schema
         self.shorthand = Undefined
         self._kwds.update({{k: v for k, v in kwds.items()
                            if self._kwds.get(k, Undefined) is Undefined}})

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -353,8 +353,10 @@ class SchemaBase(object):
         return jsonschema.validate(instance, schema, resolver=resolver)
 
     @classmethod
-    def resolve_references(cls, schema):
+    def resolve_references(cls, schema=None):
         """Resolve references of the schema the context of this object's schema"""
+        if schema is None:
+            schema = cls._schema
         resolver = jsonschema.RefResolver.from_schema(cls._rootschema
                                                       or cls._schema
                                                       or schema)


### PR DESCRIPTION
Addresses #763.

This adds functions in place of the current string aggregation shortcuts. So instead of
```python
alt.Chart(data).mark_bar().encode(
    x='mean(x):Q'
)
```
you can do
```python
alt.Chart(data).mark_bar().encode(
    x=alt.agg_mean('x')
)
```
or
```python
alt.Chart(data).mark_bar().encode(
    alt.X(alt.agg_mean('x'), **kwds)
)
```
the type defaults to quantitative, because in almost all cases where an aggregation is used it is performed on a field with quantitative type.