### PR TITLE
Add support for generating vega spec in headless

### DIFF
--- a/altair/utils/headless.py
+++ b/altair/utils/headless.py
@@ -208,3 +208,4 @@ def spec_to_mimebundle(spec, format, mode,
         return {'image/svg+xml': render}
     elif format == 'vega':
         return {'application/vnd.vega.v{}+json'.format(vega_version[0]): render}
+    raise ValueError("format must be 'png', 'svg', or 'vega'")

--- a/altair/utils/headless.py
+++ b/altair/utils/headless.py
@@ -106,45 +106,7 @@ EXTRACT_CODE = {
         """}
 
 
-def spec_to_image_mimebundle(spec, format, mode,
-                             vega_version,
-                             vegaembed_version,
-                             vegalite_version=None,
-                             driver_timeout=10,
-                             webdriver='chrome'):
-    """Convert a vega/vega-lite specification to a PNG/SVG image/Vega spec
-
-    Parameters
-    ----------
-    spec : dict
-        a dictionary representing a vega-lite plot spec
-    format : string {'png' | 'svg' | 'vega'}
-        the file format to be saved.
-    mode : string {'vega' | 'vega-lite'}
-        The rendering mode.
-    vega_version : string
-        For html output, the version of vega.js to use
-    vegalite_version : string
-        For html output, the version of vegalite.js to use
-    vegaembed_version : string
-        For html output, the version of vegaembed.js to use
-    driver_timeout : int (optional)
-        the number of seconds to wait for page load before raising an
-        error (default: 10)
-    webdriver : string {'chrome' | 'firefox'}
-        Webdriver to use.
-
-    Returns
-    -------
-    output : dict
-        a mime-bundle representing the image
-
-    Note
-    ----
-    This requires the pillow and selenium Python modules to be installed.
-    Additionally it requires either chromedriver (if webdriver=='chrome') or
-    geckodriver (if webdriver=='firefox')
-    """
+def compile_spec(spec, format, mode, vega_version, vegaembed_version, vegalite_version, driver_timeout, webdriver):
     # TODO: allow package versions to be specified
     # TODO: detect & use local Jupyter caches of JS packages?
     if format not in ['png', 'svg', 'vega']:
@@ -193,11 +155,53 @@ def spec_to_image_mimebundle(spec, format, mode,
             if not online:
                 raise ValueError("Internet connection required for saving "
                                  "chart as {0}".format(format))
-            render = driver.execute_async_script(EXTRACT_CODE[format],
-                                                 spec, mode)
+            return driver.execute_async_script(EXTRACT_CODE[format],
+                                               spec, mode)
     finally:
         driver.close()
 
+
+def spec_to_mimebundle(spec, format, mode,
+                       vega_version,
+                       vegaembed_version,
+                       vegalite_version=None,
+                       driver_timeout=10,
+                       webdriver='chrome'):
+    """Convert a vega/vega-lite specification to a PNG/SVG image/Vega spec
+
+    Parameters
+    ----------
+    spec : dict
+        a dictionary representing a vega-lite plot spec
+    format : string {'png' | 'svg' | 'vega'}
+        the file format to be saved.
+    mode : string {'vega' | 'vega-lite'}
+        The rendering mode.
+    vega_version : string
+        For html output, the version of vega.js to use
+    vegalite_version : string
+        For html output, the version of vegalite.js to use
+    vegaembed_version : string
+        For html output, the version of vegaembed.js to use
+    driver_timeout : int (optional)
+        the number of seconds to wait for page load before raising an
+        error (default: 10)
+    webdriver : string {'chrome' | 'firefox'}
+        Webdriver to use.
+
+    Returns
+    -------
+    output : dict
+        a mime-bundle representing the image
+
+    Note
+    ----
+    This requires the pillow and selenium Python modules to be installed.
+    Additionally it requires either chromedriver (if webdriver=='chrome') or
+    geckodriver (if webdriver=='firefox')
+    """
+
+    render = compile_spec(spec, format, mode, vega_version, vegaembed_version, vegalite_version, driver_timeout, webdriver)
     if format == 'png':
         return {'image/png': base64.decodebytes(render.split(',', 1)[1].encode())}
     elif format == 'svg':

--- a/altair/utils/headless.py
+++ b/altair/utils/headless.py
@@ -110,7 +110,7 @@ def compile_spec(spec, format, mode, vega_version, vegaembed_version, vegalite_v
     # TODO: allow package versions to be specified
     # TODO: detect & use local Jupyter caches of JS packages?
     if format not in ['png', 'svg', 'vega']:
-        raise NotImplementedError("format must be 'svg' and 'png'")
+        raise NotImplementedError("format must be 'svg', 'png' or 'vega'")
     if mode not in ['vega', 'vega-lite']:
         raise ValueError("mode must be 'vega' or 'vega-lite'")
 

--- a/altair/utils/headless.py
+++ b/altair/utils/headless.py
@@ -90,6 +90,19 @@ EXTRACT_CODE = {
             .toSVG()
             .then(done)
             .catch(function(err) { console.error(err); });
+        """,
+'vega': """
+        var spec = arguments[0];
+        var mode = arguments[1];
+        var done = arguments[2];
+
+        if(mode === 'vega-lite'){
+          // compile vega-lite to vega
+          const compiled = vl.compile(spec);
+          spec = compiled.spec;
+        }
+
+        done(spec);
         """}
 
 
@@ -99,13 +112,13 @@ def spec_to_image_mimebundle(spec, format, mode,
                              vegalite_version=None,
                              driver_timeout=10,
                              webdriver='chrome'):
-    """Conver a vega/vega-lite specification to a PNG/SVG image
+    """Convert a vega/vega-lite specification to a PNG/SVG image/Vega spec
 
     Parameters
     ----------
     spec : dict
         a dictionary representing a vega-lite plot spec
-    format : string {'png' | 'svg'}
+    format : string {'png' | 'svg' | 'vega'}
         the file format to be saved.
     mode : string {'vega' | 'vega-lite'}
         The rendering mode.
@@ -134,7 +147,7 @@ def spec_to_image_mimebundle(spec, format, mode,
     """
     # TODO: allow package versions to be specified
     # TODO: detect & use local Jupyter caches of JS packages?
-    if format not in ['png', 'svg']:
+    if format not in ['png', 'svg', 'vega']:
         raise NotImplementedError("format must be 'svg' and 'png'")
     if mode not in ['vega', 'vega-lite']:
         raise ValueError("mode must be 'vega' or 'vega-lite'")
@@ -189,3 +202,5 @@ def spec_to_image_mimebundle(spec, format, mode,
         return {'image/png': base64.decodebytes(render.split(',', 1)[1].encode())}
     elif format == 'svg':
         return {'image/svg+xml': render}
+    elif format == 'vega':
+        return {'application/vnd.vega.v{}+json'.format(vega_version[0]): render}

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -84,10 +84,10 @@ def save(chart, fp, vega_version, vegaembed_version,
         write_file_or_filename(fp, mimebundle['text/html'], mode='w')
     elif format in ['png', 'svg']:
         mimebundle = spec_to_mimebundle(spec=spec, format=format, mode=mode,
-                                              vega_version=vega_version,
-                                              vegalite_version=vegalite_version,
-                                              vegaembed_version=vegaembed_version,
-                                              webdriver=webdriver)
+                                        vega_version=vega_version,
+                                        vegalite_version=vegalite_version,
+                                        vegaembed_version=vegaembed_version,
+                                        webdriver=webdriver)
         if format == 'png':
             write_file_or_filename(fp, mimebundle['image/png'], mode='wb')
         else:

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -3,7 +3,7 @@ import json
 import six
 
 from .core import write_file_or_filename
-from .headless import spec_to_image_mimebundle
+from .headless import spec_to_mimebundle
 from .html import spec_to_html_mimebundle
 
 
@@ -83,7 +83,7 @@ def save(chart, fp, vega_version, vegaembed_version,
                                              json_kwds=json_kwds)
         write_file_or_filename(fp, mimebundle['text/html'], mode='w')
     elif format in ['png', 'svg']:
-        mimebundle = spec_to_image_mimebundle(spec=spec, format=format, mode=mode,
+        mimebundle = spec_to_mimebundle(spec=spec, format=format, mode=mode,
                                               vega_version=vega_version,
                                               vegalite_version=vegalite_version,
                                               vegaembed_version=vegaembed_version,

--- a/altair/utils/tests/test_headless.py
+++ b/altair/utils/tests/test_headless.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     selenium = None
 
-from ..headless import spec_to_image_mimebundle
+from ..headless import spec_to_mimebundle
 
 
 # example from https://vega.github.io/editor/#/examples/vega-lite/bar
@@ -158,8 +158,8 @@ VEGALITE_VERSION = '2.3.1'
 VEGA_VERSION = '3.3.1'
 
 @pytest.mark.skipif('not selenium')
-def test_spec_to_image_mimebundle():
-    assert spec_to_image_mimebundle(
+def test_spec_to_mimebundle():
+    assert spec_to_mimebundle(
         spec=VEGA_LITE_SPEC,
         format='vega',
         mode='vega-lite',

--- a/altair/utils/tests/test_headless.py
+++ b/altair/utils/tests/test_headless.py
@@ -1,0 +1,169 @@
+import pytest
+import json
+
+try:
+    import selenium
+except ImportError:
+    selenium = None
+
+from ..headless import spec_to_image_mimebundle
+
+
+# example from https://vega.github.io/editor/#/examples/vega-lite/bar
+VEGA_LITE_SPEC = json.loads(
+    """
+        {
+    "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+    "description": "A simple bar chart with embedded data.",
+    "data": {
+        "values": [
+        {"a": "A","b": 28}, {"a": "B","b": 55}, {"a": "C","b": 43},
+        {"a": "D","b": 91}, {"a": "E","b": 81}, {"a": "F","b": 53},
+        {"a": "G","b": 19}, {"a": "H","b": 87}, {"a": "I","b": 52}
+        ]
+    },
+    "mark": "bar",
+    "encoding": {
+        "x": {"field": "a", "type": "ordinal"},
+        "y": {"field": "b", "type": "quantitative"}
+    }
+    }
+    """
+)
+
+VEGA_SPEC = json.loads(
+    """
+    {
+    "$schema": "https://vega.github.io/schema/vega/v3.0.json",
+    "description": "A simple bar chart with embedded data.",
+    "autosize": "pad",
+    "padding": 5,
+    "height": 200,
+    "style": "cell",
+    "data": [
+        {
+        "name": "source_0",
+        "values": [
+            {"a": "A", "b": 28},
+            {"a": "B", "b": 55},
+            {"a": "C", "b": 43},
+            {"a": "D", "b": 91},
+            {"a": "E", "b": 81},
+            {"a": "F", "b": 53},
+            {"a": "G", "b": 19},
+            {"a": "H", "b": 87},
+            {"a": "I", "b": 52}
+        ]
+        },
+        {
+        "name": "data_0",
+        "source": "source_0",
+        "transform": [
+            {"type": "formula", "expr": "toNumber(datum[\\"b\\"])", "as": "b"},
+            {
+            "type": "filter",
+            "expr": "datum[\\"b\\"] !== null && !isNaN(datum[\\"b\\"])"
+            }
+        ]
+        }
+    ],
+    "signals": [
+        {"name": "x_step", "value": 21},
+        {
+        "name": "width",
+        "update": "bandspace(domain('x').length, 0.1, 0.05) * x_step"
+        }
+    ],
+    "marks": [
+        {
+        "name": "marks",
+        "type": "rect",
+        "style": ["bar"],
+        "from": {"data": "data_0"},
+        "encode": {
+            "update": {
+            "fill": {"value": "#4c78a8"},
+            "x": {"scale": "x", "field": "a"},
+            "width": {"scale": "x", "band": true},
+            "y": {"scale": "y", "field": "b"},
+            "y2": {"scale": "y", "value": 0}
+            }
+        }
+        }
+    ],
+    "scales": [
+        {
+        "name": "x",
+        "type": "band",
+        "domain": {"data": "data_0", "field": "a", "sort": true},
+        "range": {"step": {"signal": "x_step"}},
+        "paddingInner": 0.1,
+        "paddingOuter": 0.05
+        },
+        {
+        "name": "y",
+        "type": "linear",
+        "domain": {"data": "data_0", "field": "b"},
+        "range": [{"signal": "height"}, 0],
+        "nice": true,
+        "zero": true
+        }
+    ],
+    "axes": [
+        {
+        "scale": "x",
+        "orient": "bottom",
+        "title": "a",
+        "labelOverlap": true,
+        "encode": {
+            "labels": {
+            "update": {
+                "angle": {"value": 270},
+                "align": {"value": "right"},
+                "baseline": {"value": "middle"}
+            }
+            }
+        },
+        "zindex": 1
+        },
+        {
+        "scale": "y",
+        "orient": "left",
+        "title": "b",
+        "labelOverlap": true,
+        "tickCount": {"signal": "ceil(height/40)"},
+        "zindex": 1
+        },
+        {
+        "scale": "y",
+        "orient": "left",
+        "grid": true,
+        "tickCount": {"signal": "ceil(height/40)"},
+        "gridScale": "x",
+        "domain": false,
+        "labels": false,
+        "maxExtent": 0,
+        "minExtent": 0,
+        "ticks": false,
+        "zindex": 0
+        }
+    ],
+    "config": {"axisY": {"minExtent": 30}}
+    }
+    """
+)
+
+VEGAEMBED_VERSION = '3.7.0'
+VEGALITE_VERSION = '2.3.1'
+VEGA_VERSION = '3.3.1'
+
+@pytest.mark.skipif('not selenium')
+def test_spec_to_image_mimebundle():
+    assert spec_to_image_mimebundle(
+        spec=VEGA_LITE_SPEC,
+        format='vega',
+        mode='vega-lite',
+        vega_version=VEGA_VERSION,
+        vegalite_version=VEGALITE_VERSION,
+        vegaembed_version=VEGAEMBED_VERSION
+    ) == {'application/vnd.vega.v3+json': VEGA_SPEC}

--- a/altair/vegalite/v1/display.py
+++ b/altair/vegalite/v1/display.py
@@ -61,7 +61,7 @@ def json_renderer(spec):
 
 
 def png_renderer(spec):
-    return headless.spec_to_image_mimebundle(spec, format='png',
+    return headless.spec_to_mimebundle(spec, format='png',
                                              mode='vega-lite',
                                              vega_version=VEGA_VERSION,
                                              vegaembed_version=VEGAEMBED_VERSION,
@@ -69,7 +69,7 @@ def png_renderer(spec):
 
 
 def svg_renderer(spec):
-    return headless.spec_to_image_mimebundle(spec, format='svg',
+    return headless.spec_to_mimebundle(spec, format='svg',
                                              mode='vega-lite',
                                              vega_version=VEGA_VERSION,
                                              vegaembed_version=VEGAEMBED_VERSION,

--- a/altair/vegalite/v1/display.py
+++ b/altair/vegalite/v1/display.py
@@ -62,18 +62,18 @@ def json_renderer(spec):
 
 def png_renderer(spec):
     return headless.spec_to_mimebundle(spec, format='png',
-                                             mode='vega-lite',
-                                             vega_version=VEGA_VERSION,
-                                             vegaembed_version=VEGAEMBED_VERSION,
-                                             vegalite_version=VEGALITE_VERSION)
+                                       mode='vega-lite',
+                                       vega_version=VEGA_VERSION,
+                                       vegaembed_version=VEGAEMBED_VERSION,
+                                       vegalite_version=VEGALITE_VERSION)
 
 
 def svg_renderer(spec):
     return headless.spec_to_mimebundle(spec, format='svg',
-                                             mode='vega-lite',
-                                             vega_version=VEGA_VERSION,
-                                             vegaembed_version=VEGAEMBED_VERSION,
-                                             vegalite_version=VEGALITE_VERSION)
+                                       mode='vega-lite',
+                                       vega_version=VEGA_VERSION,
+                                       vegaembed_version=VEGAEMBED_VERSION,
+                                       vegalite_version=VEGALITE_VERSION)
 
 
 def colab_renderer(spec):

--- a/altair/vegalite/v2/display.py
+++ b/altair/vegalite/v2/display.py
@@ -63,18 +63,18 @@ def json_renderer(spec):
 
 def png_renderer(spec):
     return headless.spec_to_mimebundle(spec, format='png',
-                                             mode='vega-lite',
-                                             vega_version=VEGA_VERSION,
-                                             vegaembed_version=VEGAEMBED_VERSION,
-                                             vegalite_version=VEGALITE_VERSION)
+                                       mode='vega-lite',
+                                       vega_version=VEGA_VERSION,
+                                       vegaembed_version=VEGAEMBED_VERSION,
+                                       vegalite_version=VEGALITE_VERSION)
 
 
 def svg_renderer(spec):
     return headless.spec_to_mimebundle(spec, format='svg',
-                                             mode='vega-lite',
-                                             vega_version=VEGA_VERSION,
-                                             vegaembed_version=VEGAEMBED_VERSION,
-                                             vegalite_version=VEGALITE_VERSION)
+                                       mode='vega-lite',
+                                       vega_version=VEGA_VERSION,
+                                       vegaembed_version=VEGAEMBED_VERSION,
+                                       vegalite_version=VEGALITE_VERSION)
 
 def colab_renderer(spec):
     return html.spec_to_html_mimebundle(spec, mode='vega-lite',

--- a/altair/vegalite/v2/display.py
+++ b/altair/vegalite/v2/display.py
@@ -62,7 +62,7 @@ def json_renderer(spec):
 
 
 def png_renderer(spec):
-    return headless.spec_to_image_mimebundle(spec, format='png',
+    return headless.spec_to_mimebundle(spec, format='png',
                                              mode='vega-lite',
                                              vega_version=VEGA_VERSION,
                                              vegaembed_version=VEGAEMBED_VERSION,
@@ -70,7 +70,7 @@ def png_renderer(spec):
 
 
 def svg_renderer(spec):
-    return headless.spec_to_image_mimebundle(spec, format='svg',
+    return headless.spec_to_mimebundle(spec, format='svg',
                                              mode='vega-lite',
                                              vega_version=VEGA_VERSION,
                                              vegaembed_version=VEGAEMBED_VERSION,


### PR DESCRIPTION
This closes #441 by adding support for generating Vega spec's from vega
lite specs. It does this by using a headless browser (either chrome
or firefox) and loading a hosted version of the vega lite JS API.

To test this code install seleneium (`pip install selenium`) and
chromedriver (`brew cask install chromedriver`).

I implemented this with minimal changes to the existing API by adding
the `vega` format to the `spec_to_image_mimebundle` function. So it will
return a dictionary mapping the correct vega mimetype (as defined in
https://altair-viz.github.io/user_guide/display_frontends.html#renderer-api)
to the vega spec. It doesn't really make much sense to render vega to vega,
but this is currently supported as a no-op.