### PR TITLE
DOC: convert markdown docstrings to RST

### DIFF
--- a/altair/sphinxext/schematable.py
+++ b/altair/sphinxext/schematable.py
@@ -35,13 +35,12 @@ def type_description(schema):
 
 def iter_properties(cls):
     """Iterate over (property, type, description)"""
-    import m2r  # convert markdown to rst
     schema = cls.resolve_references(cls._schema)
     properties = schema.get('properties', {})
     for prop, propschema in properties.items():
         yield (prop,
                type_description(propschema),
-               m2r.convert(propschema.get('description', ' ')))
+               propschema.get('description', ' '))
 
 
 def build_rst_table(rows, titles):

--- a/altair/vega/v2/schema/core.py
+++ b/altair/vega/v2/schema/core.py
@@ -993,7 +993,7 @@ class pieTransform(VegaSchema):
     output : Mapping(required=[])
         Rename the output data fields
     sort : oneOf(boolean, signal)
-         If true, will sort the data prior to computing angles.
+        If true, will sort the data prior to computing angles.
     startAngle : oneOf(float, signal)
 
     """

--- a/altair/vegalite/v1/schema/channels.py
+++ b/altair/vegalite/v1/schema/channels.py
@@ -20,12 +20,12 @@ class Row(core.PositionChannelDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     axis : Axis
 
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -34,14 +34,15 @@ class Row(core.PositionChannelDef):
     sort : anyOf(SortOrder, SortField)
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -100,12 +101,12 @@ class Column(core.PositionChannelDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     axis : Axis
 
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -114,14 +115,15 @@ class Column(core.PositionChannelDef):
     sort : anyOf(SortOrder, SortField)
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -180,12 +182,12 @@ class X(core.PositionChannelDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     axis : Axis
 
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -194,14 +196,15 @@ class X(core.PositionChannelDef):
     sort : anyOf(SortOrder, SortField)
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -260,12 +263,12 @@ class Y(core.PositionChannelDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     axis : Axis
 
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -274,14 +277,15 @@ class Y(core.PositionChannelDef):
     sort : anyOf(SortOrder, SortField)
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -340,22 +344,23 @@ class X2(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -412,22 +417,23 @@ class Y2(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -484,10 +490,10 @@ class Color(core.ChannelDefWithLegend):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -498,14 +504,15 @@ class Color(core.ChannelDefWithLegend):
     sort : anyOf(SortOrder, SortField)
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -564,10 +571,10 @@ class Opacity(core.ChannelDefWithLegend):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -578,14 +585,15 @@ class Opacity(core.ChannelDefWithLegend):
     sort : anyOf(SortOrder, SortField)
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -644,10 +652,10 @@ class Size(core.ChannelDefWithLegend):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -658,14 +666,15 @@ class Size(core.ChannelDefWithLegend):
     sort : anyOf(SortOrder, SortField)
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -724,10 +733,10 @@ class Shape(core.ChannelDefWithLegend):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -738,14 +747,15 @@ class Shape(core.ChannelDefWithLegend):
     sort : anyOf(SortOrder, SortField)
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -804,22 +814,23 @@ class Detail(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -876,22 +887,23 @@ class Text(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -948,22 +960,23 @@ class Label(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -1020,24 +1033,25 @@ class Path(core.OrderChannelDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     sort : SortOrder
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -1096,24 +1110,25 @@ class Order(core.OrderChannelDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     sort : SortOrder
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """

--- a/altair/vegalite/v1/schema/core.py
+++ b/altair/vegalite/v1/schema/core.py
@@ -37,19 +37,20 @@ class ExtendedUnitSpec(VegaLiteSchema):
     Mapping(required=[mark])
     Schema for a unit Vega-Lite specification, with the syntactic sugar extensions:
 
-    - `row` and `column` are included in the encoding.
 
-    - (Future) label, box plot
+    *
+      ``row`` and ``column`` are included in the encoding.
 
-
+    *
+      (Future) label, box plot
 
     Note: the spec could contain facet.
 
     Attributes
     ----------
     mark : Mark
-        The mark type.  One of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`,
-        `"area"`, `"point"`, `"rule"`, and `"text"`.
+        The mark type.  One of ``"bar"``, ``"circle"``, ``"square"``, ``"tick"``,
+        ``"line"``,  ``"area"``, ``"point"``, ``"rule"``, and ``"text"``.
     config : Config
         Configuration object
     data : Data
@@ -101,8 +102,8 @@ class Encoding(VegaLiteSchema):
     ----------
     color : ChannelDefWithLegend
         Color of the marks – either fill or stroke color based on mark type.  (By default,
-        fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /  stroke color
-         for `line` and `point`.)
+        fill color for ``area``, ``bar``, ``tick``, ``text``, ``circle``, and ``square`` /
+        stroke color for ``line`` and ``point``.)
     column : PositionChannelDef
         Horizontal facets for trellis plots.
     detail : anyOf(FieldDef, List(FieldDef))
@@ -119,25 +120,26 @@ class Encoding(VegaLiteSchema):
     row : PositionChannelDef
         Vertical facets for trellis plots.
     shape : ChannelDefWithLegend
-        The symbol's shape (only for `point` marks). The supported values are  `"circle"`
-        (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,  or
-        `"triangle-down"`, or else a custom SVG path string.
+        The symbol's shape (only for ``point`` marks). The supported values are
+        ``"circle"`` (default), ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``,
+          or ``"triangle-down"``, or else a custom SVG path string.
     size : ChannelDefWithLegend
-        Size of the mark.  - For `point`, `square` and `circle`  – the symbol size, or pixel
-         area of the mark.  - For `bar` and `tick` – the bar and tick's size.  - For `text`
-        – the text's font size.  - Size is currently unsupported for `line` and `area`.
+        Size of the mark.   * For ``point``, ``square`` and ``circle``  – the symbol size,
+        or pixel area of the mark.   *    For ``bar`` and ``tick`` – the bar and tick's
+        size.  *    For ``text`` – the text's font size.  *    Size is currently unsupported
+         for ``line`` and ``area``.
     text : FieldDef
-        Text of the `text` mark.
+        Text of the ``text`` mark.
     x : PositionChannelDef
-        X coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`
-        (or to width and height for `bar` and `area` marks).
+        X coordinates for ``point``, ``circle``, ``square``,  ``line``, ``rule``, ``text``,
+        and ``tick``  (or to width and height for ``bar`` and ``area`` marks).
     x2 : FieldDef
-        X2 coordinates for ranged `bar`, `rule`, `area`
+        X2 coordinates for ranged ``bar``, ``rule``, ``area``
     y : PositionChannelDef
-        Y coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`
-        (or to width and height for `bar` and `area` marks).
+        Y coordinates for ``point``, ``circle``, ``square``,  ``line``, ``rule``, ``text``,
+        and ``tick``  (or to width and height for ``bar`` and ``area`` marks).
     y2 : FieldDef
-        Y2 coordinates for ranged `bar`, `rule`, `area`
+        Y2 coordinates for ranged ``bar``, ``rule``, ``area``
     """
     _schema = {'$ref': '#/definitions/Encoding'}
     _rootschema = Root._schema
@@ -159,12 +161,12 @@ class PositionChannelDef(VegaLiteSchema):
     Attributes
     ----------
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     axis : Axis
 
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -173,14 +175,15 @@ class PositionChannelDef(VegaLiteSchema):
     sort : anyOf(SortOrder, SortField)
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -227,7 +230,7 @@ class DateTime(VegaLiteSchema):
 
     If both month and quarter are provided, month has higher precedence.
 
-    `day` cannot be combined with other date.
+    ``day`` cannot be combined with other date.
 
     We accept string for month and day names.
 
@@ -236,11 +239,11 @@ class DateTime(VegaLiteSchema):
     date : float
         Integer value representing the date from 1-31.
     day : anyOf(string, float)
-        Value representing the day of week.  This can be one of: (1) integer value -- `1`
-        represents Monday; (2) case-insensitive day name (e.g., `"Monday"`);  (3)
-        case-insensitive, 3-character short day name (e.g., `"Mon"`).   <br/> **Warning:** A
-         DateTime definition object with `day`** should not be combined with `year`,
-        `quarter`, `month`, or `date`.
+        Value representing the day of week.  This can be one of: (1) integer value -- ``1``
+        represents Monday; (2) case-insensitive day name (e.g., ``"Monday"`` );  (3)
+        case-insensitive, 3-character short day name (e.g., ``"Mon"`` ).   :raw-html:`<br/>`
+         **Warning:** A DateTime definition object with ``day`` ** should not be combined
+        with ``year``, ``quarter``, ``month``, or ``date``.
     hours : float
         Integer value representing the hour of day from 0-23.
     milliseconds : float
@@ -248,9 +251,9 @@ class DateTime(VegaLiteSchema):
     minutes : float
         Integer value representing minute segment of a time from 0-59.
     month : anyOf(string, float)
-        One of: (1) integer value representing the month from `1`-`12`. `1` represents
-        January;  (2) case-insensitive month name (e.g., `"January"`);  (3)
-        case-insensitive, 3-character short month name (e.g., `"Jan"`).
+        One of: (1) integer value representing the month from ``1`` - ``12``. ``1``
+        represents January;  (2) case-insensitive month name (e.g., ``"January"`` );  (3)
+        case-insensitive, 3-character short month name (e.g., ``"Jan"`` ).
     quarter : float
         Integer value representing the quarter of the year (from 1-4).
     seconds : float
@@ -296,14 +299,14 @@ class Scale(VegaLiteSchema):
         only, the nice value should be a string indicating the desired time interval.
     padding : float
         Applies spacing among ordinal elements in the scale range. The actual effect depends
-         on how the scale is configured. If the __points__ parameter is `true`, the padding
-        value is interpreted as a multiple of the spacing between points. A reasonable value
-         is 1.0, such that the first and last point will be offset from the minimum and
-        maximum value by half the distance between points. Otherwise, padding is typically
-        in the range [0, 1] and corresponds to the fraction of space in the range interval
-        to allocate to padding. A value of 0.5 means that the range band width will be equal
-         to the padding width. For more, see the [D3 ordinal scale
-        documentation](https://github.com/mbostock/d3/wiki/Ordinal-Scales).
+         on how the scale is configured. If the **points** parameter is ``true``, the
+        padding value is interpreted as a multiple of the spacing between points. A
+        reasonable value is 1.0, such that the first and last point will be offset from the
+        minimum and maximum value by half the distance between points. Otherwise, padding is
+         typically in the range [0, 1] and corresponds to the fraction of space in the range
+         interval to allocate to padding. A value of 0.5 means that the range band width
+        will be equal to the padding width. For more, see the `D3 ordinal scale
+        documentation <https://github.com/mbostock/d3/wiki/Ordinal-Scales>`_.
     range : anyOf(List(string), List(float), string)
         The range of the scale, representing the set of visual values. For numeric values,
         the range can take the form of a two-element array with minimum and maximum values.
@@ -319,13 +322,14 @@ class Scale(VegaLiteSchema):
     useRawDomain : boolean
         Uses the source data range as scale domain instead of aggregated data for aggregate
         axis.  This property only works with aggregate functions that produce values within
-        the raw data domain (`"mean"`, `"average"`, `"stdev"`, `"stdevp"`, `"median"`,
-        `"q1"`, `"q3"`, `"min"`, `"max"`). For other aggregations that produce values
-        outside of the raw data domain (e.g. `"count"`, `"sum"`), this property is ignored.
+        the raw data domain ( ``"mean"``, ``"average"``, ``"stdev"``, ``"stdevp"``,
+        ``"median"``, ``"q1"``, ``"q3"``, ``"min"``, ``"max"`` ). For other aggregations
+        that produce values outside of the raw data domain (e.g. ``"count"``, ``"sum"`` ),
+        this property is ignored.
     zero : boolean
-        If `true`, ensures that a zero baseline value is included in the scale domain.
-        Default value: `true` for `x` and `y` channel if the quantitative field is not
-        binned  and no custom `domain` is provided; `false` otherwise.
+        If ``true``, ensures that a zero baseline value is included in the scale domain.
+        Default value: ``true`` for ``x`` and ``y`` channel if the quantitative field is not
+         binned  and no custom ``domain`` is provided; ``false`` otherwise.
     """
     _schema = {'$ref': '#/definitions/Scale'}
     _rootschema = Root._schema
@@ -498,22 +502,23 @@ class FieldDef(VegaLiteSchema):
     Attributes
     ----------
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -534,10 +539,10 @@ class ChannelDefWithLegend(VegaLiteSchema):
     Attributes
     ----------
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
@@ -548,14 +553,15 @@ class ChannelDefWithLegend(VegaLiteSchema):
     sort : anyOf(SortOrder, SortField)
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -591,24 +597,25 @@ class OrderChannelDef(VegaLiteSchema):
     Attributes
     ----------
     aggregate : AggregateOp
-        Aggregation function for the field  (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).
+        Aggregation function for the field  (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).
     bin : anyOf(Bin, boolean)
-        Flag for binning a `quantitative` field, or a bin property object  for binning
+        Flag for binning a ``quantitative`` field, or a bin property object  for binning
         parameters.
     field : string
         Name of the field from which to pull a data value.
     sort : SortOrder
 
     timeUnit : TimeUnit
-        Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).
+        Time unit for a ``temporal`` field  (e.g., ``year``, ``yearmonth``, ``month``,
+        ``hour`` ).
     title : string
         Title for axis or legend.
     type : Type
-        The encoded field's type of measurement. This can be either a full type  name
-        (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`)  or an initial
-        character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case
-        insensitive.
+        The encoded field's type of measurement. This can be either a full type  name (
+        ``"quantitative"``, ``"temporal"``, ``"ordinal"``,  and ``"nominal"`` )  or an
+        initial character of the type name ( ``"Q"``, ``"T"``, ``"O"``, ``"N"`` ).  This
+        property is case insensitive.
     value : anyOf(string, float, boolean)
         A constant value in visual domain.
     """
@@ -653,34 +660,33 @@ class DataFormat(VegaLiteSchema):
     ----------
     feature : string
         The name of the TopoJSON object set to convert to a GeoJSON feature collection.  For
-         example, in a map of the world, there may be an object set named `"countries"`.
+         example, in a map of the world, there may be an object set named ``"countries"``.
         Using the feature property, we can extract this set and generate a GeoJSON feature
         object for each country.
     mesh : string
-        The name of the TopoJSON object set to convert to a mesh.  Similar to the `feature`
-        option, `mesh` extracts a named TopoJSON object set.  Unlike the `feature` option,
-        the corresponding geo data is returned as a single, unified mesh instance, not as
-        individual GeoJSON features.  Extracting a mesh is useful for more efficiently
-        drawing borders or other geographic elements that you do not need to associate with
-        specific regions such as individual countries, states or counties.
+        The name of the TopoJSON object set to convert to a mesh.  Similar to the
+        ``feature`` option, ``mesh`` extracts a named TopoJSON object set.  Unlike the
+        ``feature`` option, the corresponding geo data is returned as a single, unified mesh
+         instance, not as individual GeoJSON features.  Extracting a mesh is useful for more
+         efficiently drawing borders or other geographic elements that you do not need to
+        associate with specific regions such as individual countries, states or counties.
     parse : Mapping(required=[])
         A collection of parsing instructions can be used to define the data types of
         string-valued attributes in the JSON file. Each instruction is a name-value pair,
         where the name is the name of the attribute, and the value is the desired data type
-        (one of `"number"`, `"boolean"` or `"date"`). For example, `"parse":
-        {"modified_on":"date"}` ensures that the `modified_on` value in each row of the
-        input data is parsed as a Date value. (See Datalib's [`dl.read.types`
-        method](https://github.com/vega/datalib/wiki/Import#dl_read_types) for more
-        information.)
+        (one of ``"number"``, ``"boolean"`` or ``"date"`` ). For example, ``"parse":
+        {"modified_on":"date"}`` ensures that the ``modified_on`` value in each row of the
+        input data is parsed as a Date value. (See Datalib's ` ``dl.read.types`` method
+        <https://github.com/vega/datalib/wiki/Import#dl_read_types>`_ for more information.)
     property : string
         JSON only) The JSON property containing the desired data.  This parameter can be
         used when the loaded JSON file may have surrounding structure or meta-data.  For
-        example `"property": "values.features"` is equivalent to retrieving
-        `json.values.features`  from the loaded JSON object.
+        example ``"property": "values.features"`` is equivalent to retrieving
+        ``json.values.features``  from the loaded JSON object.
     type : DataFormatType
-        Type of input data: `"json"`, `"csv"`, `"tsv"`.  The default format type is
-        determined by the extension of the file url.  If no extension is detected, `"json"`
-        will be used by default.
+        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``.  The default format type is
+        determined by the extension of the file url.  If no extension is detected,
+        ``"json"`` will be used by default.
     """
     _schema = {'$ref': '#/definitions/DataFormat'}
     _rootschema = Root._schema
@@ -715,13 +721,13 @@ class Transform(VegaLiteSchema):
         before filter.
     filter : anyOf(EqualFilter, RangeFilter, OneOfFilter, List(anyOf(EqualFilter, RangeFilter,
     OneOfFilter, string)), string)
-        A string containing the filter Vega expression. Use `datum` to refer to the current
-        data object.
+        A string containing the filter Vega expression. Use ``datum`` to refer to the
+        current data object.
     filterInvalid : boolean
-        Whether to filter invalid values (`null` and `NaN`) from the data. By default
-        (`undefined`), only quantitative and temporal fields are filtered. If set to `true`,
-         all data items with null values are filtered. If `false`, all data items are
-        included.
+        Whether to filter invalid values ( ``null`` and ``NaN`` ) from the data. By default
+        ( ``undefined`` ), only quantitative and temporal fields are filtered. If set to
+        ``true``, all data items with null values are filtered. If ``false``, all data items
+         are included.
     """
     _schema = {'$ref': '#/definitions/Transform'}
     _rootschema = Root._schema
@@ -784,7 +790,7 @@ class OneOfFilter(VegaLiteSchema):
     field : string
         Field to be filtered
     oneOf : List(anyOf(DateTime, anyOf(string, float, boolean)))
-        A set of values that the `field`'s value should be a member of,  for a data item
+        A set of values that the ``field`` 's value should be a member of,  for a data item
         included in the filtered data.
     timeUnit : TimeUnit
         time unit for the field to be filtered.
@@ -805,7 +811,7 @@ class Formula(VegaLiteSchema):
     Attributes
     ----------
     expr : string
-        A string containing an expression for the formula. Use the variable `datum` to to
+        A string containing an expression for the formula. Use the variable ``datum`` to to
         refer to the current data object.
     field : string
         The field in which to store the computed formula value.
@@ -828,7 +834,7 @@ class Config(VegaLiteSchema):
         Axis Config
     background : string
         CSS color property to use as background of visualization. Default is
-        `"transparent"`.
+        ``"transparent"``.
     cell : CellConfig
         Cell Config
     countTitle : string
@@ -918,7 +924,7 @@ class MarkConfig(VegaLiteSchema):
     applyColorToBackground : boolean
         Apply color field to background color instead of the text.
     barSize : float
-        The size of the bars.  If unspecified, the default size is  `bandSize-1`,  which
+        The size of the bars.  If unspecified, the default size is  ``bandSize-1``,  which
         provides 1 pixel offset between bars.
     barThinSize : float
         The size of the bars on continuous scales.
@@ -961,13 +967,13 @@ class MarkConfig(VegaLiteSchema):
 
     orient : Orient
         The orientation of a non-stacked bar, tick, area, and line charts.  The value is
-        either horizontal (default) or vertical.  - For bar, rule and tick, this determines
-        whether the size of the bar and tick  should be applied to x or y dimension.  - For
-        area, this property determines the orient property of the Vega output.  - For line,
-        this property determines the sort order of the points in the line  if
-        `config.sortLineBy` is not specified.  For stacked charts, this is always determined
-         by the orientation of the stack;  therefore explicitly specified value will be
-        ignored.
+        either horizontal (default) or vertical.   * For bar, rule and tick, this determines
+         whether the size of the bar and tick  should be applied to x or y dimension.   *
+            For area, this property determines the orient property of the Vega output.  *
+            For line, this property determines the sort order of the points in the line  if
+        ``config.sortLineBy`` is not specified.  For stacked charts, this is always
+        determined by the orientation of the stack;  therefore explicitly specified value
+        will be ignored.
     radius : float
         Polar coordinate radial offset, in pixels, of the text label from the origin
         determined by the x and y properties.
@@ -1177,8 +1183,8 @@ class ScaleConfig(VegaLiteSchema):
     Attributes
     ----------
     bandSize : anyOf(BandSize, float)
-        Default band size for (1) `y` ordinal scale,  and (2) `x` ordinal scale when the
-        mark is not `text`.
+        Default band size for (1) ``y`` ordinal scale,  and (2) ``x`` ordinal scale when the
+         mark is not ``text``.
     barSizeRange : List(float)
         Default range for bar size scale
     fontSizeRange : List(float)
@@ -1188,13 +1194,13 @@ class ScaleConfig(VegaLiteSchema):
     opacity : List(float)
         Default range for opacity.
     padding : float
-        Default padding for `x` and `y` ordinal scales.
+        Default padding for ``x`` and ``y`` ordinal scales.
     pointSizeRange : List(float)
         Default range for bar size scale
     round : boolean
         If true, rounds numeric output values to integers.  This can be helpful for snapping
-         to the pixel grid.  (Only available for `x`, `y`, `size`, `row`, and `column`
-        scales.)
+         to the pixel grid.  (Only available for ``x``, ``y``, ``size``, ``row``, and
+        ``column`` scales.)
     ruleSizeRange : List(float)
         Default range for rule stroke widths
     sequentialColorRange : anyOf(List(string), string)
@@ -1202,15 +1208,16 @@ class ScaleConfig(VegaLiteSchema):
     shapeRange : anyOf(List(string), string)
         Default range for shape
     textBandWidth : float
-        Default band width for `x` ordinal scale when is mark is `text`.
+        Default band width for ``x`` ordinal scale when is mark is ``text``.
     tickSizeRange : List(float)
         Default range for tick spans
     useRawDomain : boolean
         Uses the source data range as scale domain instead of aggregated data for aggregate
         axis.  This property only works with aggregate functions that produce values within
-        the raw data domain (`"mean"`, `"average"`, `"stdev"`, `"stdevp"`, `"median"`,
-        `"q1"`, `"q3"`, `"min"`, `"max"`). For other aggregations that produce values
-        outside of the raw data domain (e.g. `"count"`, `"sum"`), this property is ignored.
+        the raw data domain ( ``"mean"``, ``"average"``, ``"stdev"``, ``"stdevp"``,
+        ``"median"``, ``"q1"``, ``"q3"``, ``"min"``, ``"max"`` ). For other aggregations
+        that produce values outside of the raw data domain (e.g. ``"count"``, ``"sum"`` ),
+        this property is ignored.
     """
     _schema = {'$ref': '#/definitions/ScaleConfig'}
     _rootschema = Root._schema
@@ -1244,9 +1251,9 @@ class AxisConfig(VegaLiteSchema):
     characterWidth : float
         Character width for automatically determining title max length.
     grid : boolean
-        A flag indicate if gridlines should be created in addition to ticks. If `grid` is
-        unspecified, the default value is `true` for ROW and COL. For X and Y, the default
-        value is `true` for quantitative and time fields and `false` otherwise.
+        A flag indicate if gridlines should be created in addition to ticks. If ``grid`` is
+        unspecified, the default value is ``true`` for ROW and COL. For X and Y, the default
+         value is ``true`` for quantitative and time fields and ``false`` otherwise.
     gridColor : string
         Color of gridlines.
     gridDash : List(float)
@@ -1558,8 +1565,8 @@ class UnitSpec(VegaLiteSchema):
     Attributes
     ----------
     mark : Mark
-        The mark type.  One of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`,
-        `"area"`, `"point"`, `"rule"`, and `"text"`.
+        The mark type.  One of ``"bar"``, ``"circle"``, ``"square"``, ``"tick"``,
+        ``"line"``,  ``"area"``, ``"point"``, ``"rule"``, and ``"text"``.
     config : Config
         Configuration object
     data : Data
@@ -1598,8 +1605,8 @@ class UnitEncoding(VegaLiteSchema):
     ----------
     color : ChannelDefWithLegend
         Color of the marks – either fill or stroke color based on mark type.  (By default,
-        fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /  stroke color
-         for `line` and `point`.)
+        fill color for ``area``, ``bar``, ``tick``, ``text``, ``circle``, and ``square`` /
+        stroke color for ``line`` and ``point``.)
     detail : anyOf(FieldDef, List(FieldDef))
         Additional levels of detail for grouping data in aggregate views and  in line and
         area marks without mapping data to a specific visual channel.
@@ -1612,25 +1619,26 @@ class UnitEncoding(VegaLiteSchema):
     path : anyOf(OrderChannelDef, List(OrderChannelDef))
         Order of data points in line marks.
     shape : ChannelDefWithLegend
-        The symbol's shape (only for `point` marks). The supported values are  `"circle"`
-        (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,  or
-        `"triangle-down"`, or else a custom SVG path string.
+        The symbol's shape (only for ``point`` marks). The supported values are
+        ``"circle"`` (default), ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``,
+          or ``"triangle-down"``, or else a custom SVG path string.
     size : ChannelDefWithLegend
-        Size of the mark.  - For `point`, `square` and `circle`  – the symbol size, or pixel
-         area of the mark.  - For `bar` and `tick` – the bar and tick's size.  - For `text`
-        – the text's font size.  - Size is currently unsupported for `line` and `area`.
+        Size of the mark.   * For ``point``, ``square`` and ``circle``  – the symbol size,
+        or pixel area of the mark.   *    For ``bar`` and ``tick`` – the bar and tick's
+        size.  *    For ``text`` – the text's font size.  *    Size is currently unsupported
+         for ``line`` and ``area``.
     text : FieldDef
-        Text of the `text` mark.
+        Text of the ``text`` mark.
     x : PositionChannelDef
-        X coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`
-        (or to width and height for `bar` and `area` marks).
+        X coordinates for ``point``, ``circle``, ``square``,  ``line``, ``rule``, ``text``,
+        and ``tick``  (or to width and height for ``bar`` and ``area`` marks).
     x2 : FieldDef
-        X2 coordinates for ranged `bar`, `rule`, `area`
+        X2 coordinates for ranged ``bar``, ``rule``, ``area``
     y : PositionChannelDef
-        Y coordinates for `point`, `circle`, `square`,  `line`, `rule`, `text`, and `tick`
-        (or to width and height for `bar` and `area` marks).
+        Y coordinates for ``point``, ``circle``, ``square``,  ``line``, ``rule``, ``text``,
+        and ``tick``  (or to width and height for ``bar`` and ``area`` marks).
     y2 : FieldDef
-        Y2 coordinates for ranged `bar`, `rule`, `area`
+        Y2 coordinates for ranged ``bar``, ``rule``, ``area``
     """
     _schema = {'$ref': '#/definitions/UnitEncoding'}
     _rootschema = Root._schema

--- a/altair/vegalite/v2/schema/channels.py
+++ b/altair/vegalite/v2/schema/channels.py
@@ -14,7 +14,7 @@ class Color(core.MarkPropFieldDefWithCondition):
     """Color schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -26,70 +26,70 @@ class Color(core.MarkPropFieldDefWithCondition):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding
-        channel will be removed.  __Default value:__ If undefined, default [legend
-        properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
+        An object defining properties of the legend. If ``null``, the legend for the
+        encoding channel will be removed.  **Default value:** If undefined, default `legend
+        properties <https://vega.github.io/vega-lite/docs/legend.html>`_ are applied.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -185,48 +185,48 @@ class Column(core.FacetFieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     header : Header
         An object defining properties of a facet's header.
     sort : SortOrder
-        Sort order for a facet field. This can be `"ascending"`, `"descending"`.
+        Sort order for a facet field. This can be ``"ascending"``, ``"descending"``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -284,44 +284,44 @@ class Detail(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -370,7 +370,7 @@ class Fill(core.MarkPropFieldDefWithCondition):
     """Fill schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -382,70 +382,70 @@ class Fill(core.MarkPropFieldDefWithCondition):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding
-        channel will be removed.  __Default value:__ If undefined, default [legend
-        properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
+        An object defining properties of the legend. If ``null``, the legend for the
+        encoding channel will be removed.  **Default value:** If undefined, default `legend
+        properties <https://vega.github.io/vega-lite/docs/legend.html>`_ are applied.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -535,7 +535,7 @@ class Href(core.FieldDefWithCondition):
     """Href schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -547,49 +547,49 @@ class Href(core.FieldDefWithCondition):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -684,44 +684,44 @@ class Key(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -777,44 +777,44 @@ class Latitude(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -870,44 +870,44 @@ class Latitude2(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -963,44 +963,44 @@ class Longitude(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -1056,44 +1056,44 @@ class Longitude2(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -1142,7 +1142,7 @@ class Opacity(core.MarkPropFieldDefWithCondition):
     """Opacity schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -1154,70 +1154,70 @@ class Opacity(core.MarkPropFieldDefWithCondition):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding
-        channel will be removed.  __Default value:__ If undefined, default [legend
-        properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
+        An object defining properties of the legend. If ``null``, the legend for the
+        encoding channel will be removed.  **Default value:** If undefined, default `legend
+        properties <https://vega.github.io/vega-lite/docs/legend.html>`_ are applied.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -1313,46 +1313,46 @@ class Order(core.OrderFieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     sort : SortOrder
-        The sort order. One of `"ascending"` (default) or `"descending"`.
+        The sort order. One of ``"ascending"`` (default) or ``"descending"``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -1407,48 +1407,48 @@ class Row(core.FacetFieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     header : Header
         An object defining properties of a facet's header.
     sort : SortOrder
-        Sort order for a facet field. This can be `"ascending"`, `"descending"`.
+        Sort order for a facet field. This can be ``"ascending"``, ``"descending"``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -1499,7 +1499,7 @@ class Shape(core.MarkPropFieldDefWithCondition):
     """Shape schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -1511,70 +1511,70 @@ class Shape(core.MarkPropFieldDefWithCondition):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding
-        channel will be removed.  __Default value:__ If undefined, default [legend
-        properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
+        An object defining properties of the legend. If ``null``, the legend for the
+        encoding channel will be removed.  **Default value:** If undefined, default `legend
+        properties <https://vega.github.io/vega-lite/docs/legend.html>`_ are applied.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -1664,7 +1664,7 @@ class Size(core.MarkPropFieldDefWithCondition):
     """Size schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -1676,70 +1676,70 @@ class Size(core.MarkPropFieldDefWithCondition):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding
-        channel will be removed.  __Default value:__ If undefined, default [legend
-        properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
+        An object defining properties of the legend. If ``null``, the legend for the
+        encoding channel will be removed.  **Default value:** If undefined, default `legend
+        properties <https://vega.github.io/vega-lite/docs/legend.html>`_ are applied.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -1829,7 +1829,7 @@ class Stroke(core.MarkPropFieldDefWithCondition):
     """Stroke schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -1841,70 +1841,70 @@ class Stroke(core.MarkPropFieldDefWithCondition):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding
-        channel will be removed.  __Default value:__ If undefined, default [legend
-        properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
+        An object defining properties of the legend. If ``null``, the legend for the
+        encoding channel will be removed.  **Default value:** If undefined, default `legend
+        properties <https://vega.github.io/vega-lite/docs/legend.html>`_ are applied.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -1994,7 +1994,7 @@ class Text(core.TextFieldDefWithCondition):
     """Text schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -2006,52 +2006,52 @@ class Text(core.TextFieldDefWithCondition):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     format : string
-        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`_ for a
         text field. If not defined, this will be determined automatically.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -2140,7 +2140,7 @@ class Tooltip(core.TextFieldDefWithCondition):
     """Tooltip schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -2152,52 +2152,52 @@ class Tooltip(core.TextFieldDefWithCondition):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     format : string
-        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`_ for a
         text field. If not defined, this will be determined automatically.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -2292,84 +2292,84 @@ class X(core.PositionFieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     axis : anyOf(Axis, None)
-        An object defining properties of axis's gridlines, ticks and labels. If `null`, the
-        axis for the encoding channel will be removed.  __Default value:__ If undefined,
-        default [axis properties](https://vega.github.io/vega-lite/docs/axis.html) are
+        An object defining properties of axis's gridlines, ticks and labels. If ``null``,
+        the axis for the encoding channel will be removed.  **Default value:** If undefined,
+         default `axis properties <https://vega.github.io/vega-lite/docs/axis.html>`_ are
         applied.
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     stack : anyOf(StackOffset, None)
-        Type of stacking offset if the field should be stacked. `stack` is only applicable
-        for `x` and `y` channels with continuous domains. For example, `stack` of `y` can be
-         used to customize stacking for a vertical bar chart.  `stack` can be one of the
-        following values: - `"zero"`: stacking with baseline offset at zero value of the
-        scale (for creating typical stacked
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and
-        [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart). -
-        `"normalize"` - stacking with normalized domain (for creating [normalized stacked
-        bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized).
-        <br/> -`"center"` - stacking with center baseline (for
-        [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)). -
-        `null` - No-stacking. This will produce layered
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area
-        chart.  __Default value:__ `zero` for plots with all of the following conditions are
-         true: (1) the mark is `bar` or `area`; (2) the stacked measure channel (x or y) has
-         a linear scale; (3) At least one of non-position channels mapped to an unaggregated
-         field that is different from x and y.  Otherwise, `null` by default.
+        Type of stacking offset if the field should be stacked. ``stack`` is only applicable
+         for ``x`` and ``y`` channels with continuous domains. For example, ``stack`` of
+        ``y`` can be used to customize stacking for a vertical bar chart.  ``stack`` can be
+        one of the following values:   * `"zero"`: stacking with baseline offset at zero
+        value of the scale (for creating typical stacked
+        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and `area
+        <https://vega.github.io/vega-lite/docs/stack.html#area>`_ chart). * ``"normalize"``
+        - stacking with normalized domain (for creating `normalized stacked bar and area
+        charts <https://vega.github.io/vega-lite/docs/stack.html#normalized>`_.
+        :raw-html:`<br/>`   - ``"center"`` - stacking with center baseline (for `streamgraph
+         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`_ ). * ``null`` -
+        No-stacking. This will produce layered `bar
+        <https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart>`_ and area
+        chart.  **Default value:** ``zero`` for plots with all of the following conditions
+        are true: (1) the mark is ``bar`` or ``area`` ; (2) the stacked measure channel (x
+        or y) has a linear scale; (3) At least one of non-position channels mapped to an
+        unaggregated field that is different from x and y.  Otherwise, ``null`` by default.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -2425,8 +2425,8 @@ class XValue(core.ValueDef):
     Attributes
     ----------
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
-        between `0` to `1` for opacity).
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
     """
     _class_is_valid_at_instantiation = False
 
@@ -2460,44 +2460,44 @@ class X2(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -2551,8 +2551,8 @@ class X2Value(core.ValueDef):
     Attributes
     ----------
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
-        between `0` to `1` for opacity).
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
     """
     _class_is_valid_at_instantiation = False
 
@@ -2585,84 +2585,84 @@ class Y(core.PositionFieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     axis : anyOf(Axis, None)
-        An object defining properties of axis's gridlines, ticks and labels. If `null`, the
-        axis for the encoding channel will be removed.  __Default value:__ If undefined,
-        default [axis properties](https://vega.github.io/vega-lite/docs/axis.html) are
+        An object defining properties of axis's gridlines, ticks and labels. If ``null``,
+        the axis for the encoding channel will be removed.  **Default value:** If undefined,
+         default `axis properties <https://vega.github.io/vega-lite/docs/axis.html>`_ are
         applied.
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     stack : anyOf(StackOffset, None)
-        Type of stacking offset if the field should be stacked. `stack` is only applicable
-        for `x` and `y` channels with continuous domains. For example, `stack` of `y` can be
-         used to customize stacking for a vertical bar chart.  `stack` can be one of the
-        following values: - `"zero"`: stacking with baseline offset at zero value of the
-        scale (for creating typical stacked
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and
-        [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart). -
-        `"normalize"` - stacking with normalized domain (for creating [normalized stacked
-        bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized).
-        <br/> -`"center"` - stacking with center baseline (for
-        [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)). -
-        `null` - No-stacking. This will produce layered
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area
-        chart.  __Default value:__ `zero` for plots with all of the following conditions are
-         true: (1) the mark is `bar` or `area`; (2) the stacked measure channel (x or y) has
-         a linear scale; (3) At least one of non-position channels mapped to an unaggregated
-         field that is different from x and y.  Otherwise, `null` by default.
+        Type of stacking offset if the field should be stacked. ``stack`` is only applicable
+         for ``x`` and ``y`` channels with continuous domains. For example, ``stack`` of
+        ``y`` can be used to customize stacking for a vertical bar chart.  ``stack`` can be
+        one of the following values:   * `"zero"`: stacking with baseline offset at zero
+        value of the scale (for creating typical stacked
+        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and `area
+        <https://vega.github.io/vega-lite/docs/stack.html#area>`_ chart). * ``"normalize"``
+        - stacking with normalized domain (for creating `normalized stacked bar and area
+        charts <https://vega.github.io/vega-lite/docs/stack.html#normalized>`_.
+        :raw-html:`<br/>`   - ``"center"`` - stacking with center baseline (for `streamgraph
+         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`_ ). * ``null`` -
+        No-stacking. This will produce layered `bar
+        <https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart>`_ and area
+        chart.  **Default value:** ``zero`` for plots with all of the following conditions
+        are true: (1) the mark is ``bar`` or ``area`` ; (2) the stacked measure channel (x
+        or y) has a linear scale; (3) At least one of non-position channels mapped to an
+        unaggregated field that is different from x and y.  Otherwise, ``null`` by default.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -2718,8 +2718,8 @@ class YValue(core.ValueDef):
     Attributes
     ----------
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
-        between `0` to `1` for opacity).
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
     """
     _class_is_valid_at_instantiation = False
 
@@ -2753,44 +2753,44 @@ class Y2(core.FieldDef):
     shorthand : string
         shorthand for field, aggregate, and type
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     """
     _class_is_valid_at_instantiation = False
 
@@ -2844,8 +2844,8 @@ class Y2Value(core.ValueDef):
     Attributes
     ----------
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
-        between `0` to `1` for opacity).
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
     """
     _class_is_valid_at_instantiation = False
 

--- a/altair/vegalite/v2/schema/core.py
+++ b/altair/vegalite/v2/schema/core.py
@@ -89,12 +89,11 @@ class AggregatedFieldDef(VegaLiteSchema):
     ----------
     op : AggregateOp
         The aggregation operations to apply to the fields, such as sum, average or count.
-        See the [full list of supported aggregation
-        operations](https://vega.github.io/vega-lite/docs/aggregate.html#ops) for more
-        information.
+        See the `full list of supported aggregation operations
+        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`_ for more information.
     field : string
         The data field for which to compute aggregate function. This is required for all
-        aggregation operations except `"count"`.
+        aggregation operations except ``"count"``.
     as : string
         The output field names to use for each aggregated field.
     """
@@ -137,129 +136,133 @@ class AreaConfig(VegaLiteSchema):
     Attributes
     ----------
     align : HorizontalAlign
-        The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
-        __Default value:__ `"middle"`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+        **Default value:** ``"middle"``
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
-        and will override `color`.  __Default value:__ <span style="color:
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
-        [style config](mark.html#style-config).
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.  **Default value:** :raw-html:`<span
+        style="color: #4682b4;">&#9632;</span>` ``"#4682b4"``  **Note:** This property
+        cannot be used in a `style config <mark.html#style-config>`_.
     cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
     'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
     'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
     'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor
-        type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`_ can be used.
     dx : float
         The horizontal offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     dy : float
         The vertical offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     fill : string
-        Default Fill Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Fill Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     fillOpacity : float
-        The fill opacity (value between [0,1]).  __Default value:__ `1`
+        The fill opacity (value between [0,1]).  **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.
-        __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
-         This property cannot be used in a [style config](mark.html#style-config).
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.  **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and
+        ``area`` marks.  **Note:** This property cannot be used in a `style config
+        <mark.html#style-config>`_.
     font : string
-        The typeface to set the text in (e.g., `"Helvetica Neue"`).
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : float
         The font size, in pixels.
     fontStyle : FontStyle
-        The font style (e.g., `"italic"`).
+        The font style (e.g., ``"italic"`` ).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
-        (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
         The line interpolation method to use for line and area marks. One of the following:
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
-        close the linear segments to form a polygon. - `"step"`: alternate between
-        horizontal and vertical segments, as in a step function. - `"step-before"`:
-        alternate between vertical and horizontal segments, as in a step function. -
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
-        `"basis-open"`: an open B-spline; may not intersect the start or end. -
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
-        Cardinal spline; may not intersect the start or end, but will intersect other
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
-        the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+           * ``"linear"`` : piecewise linear segments, as in a polyline. *
+        ``"linear-closed"`` : close the linear segments to form a polygon. * ``"step"`` :
+        alternate between horizontal and vertical segments, as in a step function. *
+        ``"step-before"`` : alternate between vertical and horizontal segments, as in a step
+         function. * ``"step-after"`` : alternate between horizontal and vertical segments,
+        as in a step function. * ``"basis"`` : a B-spline, with control point duplication on
+         the ends. * ``"basis-open"`` : an open B-spline; may not intersect the start or
+        end. * ``"basis-closed"`` : a closed B-spline, as in a loop. * ``"cardinal"`` : a
+        Cardinal spline, with control point duplication on the ends. * ``"cardinal-open"`` :
+         an open Cardinal spline; may not intersect the start or end, but will intersect
+        other control points. * ``"cardinal-closed"`` : a closed Cardinal spline, as in a
+        loop. * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+        straighten the spline. * ``"monotone"`` : cubic interpolation that preserves
+        monotonicity in y.
     limit : float
         The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     line : anyOf(boolean, MarkProperties)
         A flag for overlaying line on top of area marks, or an object defining the
-        properties of the overlayed lines.  - If this value is an empty object (`{}`) or
-        `true`, lines with default properties will be used.  - If this value is `false`, no
-        lines would be automatically added to area marks.  __Default value:__ `false`.
+        properties of the overlayed lines.   *    If this value is an empty object ( ``{}``
+        ) or ``true``, lines with default properties will be used.  *    If this value is
+        ``false``, no lines would be automatically added to area marks.  **Default value:**
+        ``false``.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
-        `bar` charts and `1` otherwise.
+        The overall opacity (value between [0,1]).  **Default value:** ``0.7`` for
+        non-aggregate plots with ``point``, ``tick``, ``circle``, or ``square`` marks or
+        layered ``bar`` charts and ``1`` otherwise.
     orient : Orient
         The orientation of a non-stacked bar, tick, area, and line charts. The value is
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines
-        whether the size of the bar and tick should be applied to x or y dimension. - For
-        area, this property determines the orient property of the Vega output. - For line
+        either horizontal (default) or vertical.   * For bar, rule and tick, this determines
+         whether the size of the bar and tick   should be applied to x or y dimension. * For
+         area, this property determines the orient property of the Vega output. * For line
         and trail marks, this property determines the sort order of the points in the line
-        if `config.sortLineBy` is not specified. For stacked charts, this is always
-        determined by the orientation of the stack; therefore explicitly specified value
+           if ``config.sortLineBy`` is not specified.   For stacked charts, this is always
+        determined by the orientation of the stack;   therefore explicitly specified value
         will be ignored.
     point : anyOf(boolean, MarkProperties, enum('transparent'))
         A flag for overlaying points on top of line or area marks, or an object defining the
-         properties of the overlayed points.  - If this property is `"transparent"`,
-        transparent points will be used (for enhancing tooltips and selections).  - If this
-        property is an empty object (`{}`) or `true`, filled points with default properties
-        will be used.  - If this property is `false`, no points would be automatically added
-         to line or area marks.  __Default value:__ `false`.
+         properties of the overlayed points.   *    If this property is ``"transparent"``,
+        transparent points will be used (for enhancing tooltips and selections).  *    If
+        this property is an empty object ( ``{}`` ) or ``true``, filled points with default
+        properties will be used.  *    If this property is ``false``, no points would be
+        automatically added to line or area marks.  **Default value:** ``false``.
     radius : float
         Polar coordinate radial offset, in pixels, of the text label from the origin
-        determined by the `x` and `y` properties.
+        determined by the ``x`` and ``y`` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
-          __Default value:__ `"circle"`
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.  **Default value:** ``"circle"``
     size : float
         The pixel area each the point/circle/square. For example: in the case of circles,
-        the radius is determined in part by the square root of the size value.  __Default
-        value:__ `30`
+        the radius is determined in part by the square root of the size value.  **Default
+        value:** ``30``
     stroke : string
-        Default Stroke Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Stroke Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     strokeCap : enum('butt', 'round', 'square')
-        The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
-        __Default value:__ `"square"`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.  **Default value:** ``"square"``
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : float
         The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeOpacity : float
-        The stroke opacity (value between [0,1]).  __Default value:__ `1`
+        The stroke opacity (value between [0,1]).  **Default value:** ``1``
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
         Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
-        Placeholder text if the `text` channel is not specified
+        Placeholder text if the ``text`` channel is not specified
     theta : float
         Polar coordinate angle, in radians, of the text label from the origin determined by
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
-        `0` indicating "north".
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
     """
     _schema = {'$ref': '#/definitions/AreaConfig'}
     _rootschema = Root._schema
@@ -292,19 +295,19 @@ class AutoSizeParams(VegaLiteSchema):
     Attributes
     ----------
     contains : enum('content', 'padding')
-        Determines how size calculation should be performed, one of `"content"` or
-        `"padding"`. The default setting (`"content"`) interprets the width and height
-        settings as the data rectangle (plotting) dimensions, to which padding is then
-        added. In contrast, the `"padding"` setting includes the padding within the view
+        Determines how size calculation should be performed, one of ``"content"`` or
+        ``"padding"``. The default setting ( ``"content"`` ) interprets the width and height
+         settings as the data rectangle (plotting) dimensions, to which padding is then
+        added. In contrast, the ``"padding"`` setting includes the padding within the view
         size calculations, such that the width and height settings indicate the **total**
-        intended size of the view.  __Default value__: `"content"`
+        intended size of the view.  **Default value** : ``"content"``
     resize : boolean
         A boolean flag indicating if autosize layout should be re-calculated on every view
-        update.  __Default value__: `false`
+        update.  **Default value** : ``false``
     type : AutosizeType
-        The sizing format type. One of `"pad"`, `"fit"` or `"none"`. See the [autosize
-        type](https://vega.github.io/vega-lite/docs/size.html#autosize) documentation for
-        descriptions of each.  __Default value__: `"pad"`
+        The sizing format type. One of ``"pad"``, ``"fit"`` or ``"none"``. See the `autosize
+         type <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ documentation for
+         descriptions of each.  **Default value** : ``"pad"``
     """
     _schema = {'$ref': '#/definitions/AutoSizeParams'}
     _rootschema = Root._schema
@@ -334,28 +337,28 @@ class Axis(VegaLiteSchema):
     ----------
     domain : boolean
         A boolean flag indicating if the domain (the axis baseline) should be included as
-        part of the axis.  __Default value:__ `true`
+        part of the axis.  **Default value:** ``true``
     format : string
-        The formatting pattern for labels. This is D3's [number format
-        pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and
-        D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for
-        time field.  See the [format documentation](format.html) for more information.
-        __Default value:__  derived from [numberFormat](config.html#format) config for
-        quantitative fields and from [timeFormat](config.html#format) config for temporal
+        The formatting pattern for labels. This is D3's `number format pattern
+        <https://github.com/d3/d3-format#locale_format>`_ for quantitative fields and D3's
+        `time format pattern <https://github.com/d3/d3-time-format#locale_format>`_ for time
+         field.  See the `format documentation <format.html>`_ for more information.
+        **Default value:**  derived from `numberFormat <config.html#format>`_ config for
+        quantitative fields and from `timeFormat <config.html#format>`_ config for temporal
         fields.
     grid : boolean
         A boolean flag indicating if grid lines should be included as part of the axis
-        __Default value:__ `true` for [continuous scales](scale.html#continuous) that are
-        not binned; otherwise, `false`.
+        **Default value:** ``true`` for `continuous scales <scale.html#continuous>`_ that
+        are not binned; otherwise, ``false``.
     labelAngle : float
-        The rotation angle of the axis labels.  __Default value:__ `-90` for nominal and
-        ordinal fields; `0` otherwise.
+        The rotation angle of the axis labels.  **Default value:** ``-90`` for nominal and
+        ordinal fields; ``0`` otherwise.
     labelBound : anyOf(boolean, float)
-        Indicates if labels should be hidden if they exceed the axis range. If `false `(the
-        default) no bounds overlap analysis is performed. If `true`, labels will be hidden
-        if they exceed the axis range by more than 1 pixel. If this property is a number, it
-         specifies the pixel tolerance: the maximum amount by which a label bounding box may
-         exceed the axis range.  __Default value:__ `false`.
+        Indicates if labels should be hidden if they exceed the axis range. If ``false``
+        (the default) no bounds overlap analysis is performed. If ``true``, labels will be
+        hidden if they exceed the axis range by more than 1 pixel. If this property is a
+        number, it specifies the pixel tolerance: the maximum amount by which a label
+        bounding box may exceed the axis range.  **Default value:** ``false``.
     labelFlush : anyOf(boolean, float)
         Indicates if the first and last axis labels should be aligned flush with the scale
         range. Flush alignment for a horizontal axis will left-align the first label and
@@ -364,41 +367,41 @@ class Axis(VegaLiteSchema):
         pixels by which to offset the first and last labels; for example, a value of 2 will
         flush-align the first and last labels and also push them 2 pixels outward from the
         center of the axis. The additional adjustment can sometimes help the labels better
-        visually group with corresponding axis ticks.  __Default value:__ `true` for axis of
-         a continuous x-scale. Otherwise, `false`.
+        visually group with corresponding axis ticks.  **Default value:** ``true`` for axis
+        of a continuous x-scale. Otherwise, ``false``.
     labelOverlap : anyOf(boolean, enum('parity'), enum('greedy'))
-        The strategy to use for resolving overlap of axis labels. If `false` (the default),
-        no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of
-        removing every other label is used (this works well for standard linear axes). If
-        set to `"greedy"`, a linear scan of the labels is performed, removing any labels
-        that overlaps with the last visible label (this often works better for log-scaled
-        axes).  __Default value:__ `true` for non-nominal fields with non-log scales;
-        `"greedy"` for log scales; otherwise `false`.
+        The strategy to use for resolving overlap of axis labels. If ``false`` (the
+        default), no overlap reduction is attempted. If set to ``true`` or ``"parity"``, a
+        strategy of removing every other label is used (this works well for standard linear
+        axes). If set to ``"greedy"``, a linear scan of the labels is performed, removing
+        any labels that overlaps with the last visible label (this often works better for
+        log-scaled axes).  **Default value:** ``true`` for non-nominal fields with non-log
+        scales; ``"greedy"`` for log scales; otherwise ``false``.
     labelPadding : float
         The padding, in pixels, between axis and text labels.
     labels : boolean
         A boolean flag indicating if labels should be included as part of the axis.
-        __Default value:__  `true`.
+        **Default value:**  ``true``.
     maxExtent : float
         The maximum extent in pixels that axis ticks and labels should use. This determines
-        a maximum offset value for axis titles.  __Default value:__ `undefined`.
+        a maximum offset value for axis titles.  **Default value:** ``undefined``.
     minExtent : float
         The minimum extent in pixels that axis ticks and labels should use. This determines
-        a minimum offset value for axis titles.  __Default value:__ `30` for y-axis;
-        `undefined` for x-axis.
+        a minimum offset value for axis titles.  **Default value:** ``30`` for y-axis;
+        ``undefined`` for x-axis.
     offset : float
         The offset, in pixels, by which to displace the axis from the edge of the enclosing
-        group or data rectangle.  __Default value:__ derived from the [axis
-        config](config.html#facet-scale-config)'s `offset` (`0` by default)
+        group or data rectangle.  **Default value:** derived from the `axis config
+        <config.html#facet-scale-config>`_ 's ``offset`` ( ``0`` by default)
     orient : AxisOrient
-        The orientation of the axis. One of `"top"`, `"bottom"`, `"left"` or `"right"`. The
-        orientation can be used to further specialize the axis type (e.g., a y axis oriented
-         for the right edge of the chart).  __Default value:__ `"bottom"` for x-axes and
-        `"left"` for y-axes.
+        The orientation of the axis. One of ``"top"``, ``"bottom"``, ``"left"`` or
+        ``"right"``. The orientation can be used to further specialize the axis type (e.g.,
+        a y axis oriented for the right edge of the chart).  **Default value:** ``"bottom"``
+         for x-axes and ``"left"`` for y-axes.
     position : float
         The anchor position of the axis in pixels. For x-axis with top or bottom
         orientation, this sets the axis group x coordinate. For y-axis with left or right
-        orientation, this sets the axis group y coordinate.  __Default value__: `0`
+        orientation, this sets the axis group y coordinate.  **Default value** : ``0``
     tickCount : float
         A desired number of ticks, for axes visualizing quantitative scales. The resulting
         number may be different so that values are "nice" (multiples of 2, 5, 10) and lie
@@ -408,17 +411,17 @@ class Axis(VegaLiteSchema):
     ticks : boolean
         Boolean value that determines whether the axis should include ticks.
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     titleMaxLength : float
         Max length for axis title if the title is automatically generated from the field's
         description.
@@ -428,9 +431,9 @@ class Axis(VegaLiteSchema):
         Explicitly set the visible axis tick values.
     zindex : float
         A non-positive integer indicating z-index of the axis. If zindex is 0, axes should
-        be drawn behind all chart elements. To put them in front, use `"zindex = 1"`.
-        __Default value:__ `1` (in front of the marks) for actual axis and `0` (behind the
-        marks) for grids.
+        be drawn behind all chart elements. To put them in front, use ``"zindex = 1"``.
+        **Default value:** ``1`` (in front of the marks) for actual axis and ``0`` (behind
+        the marks) for grids.
     """
     _schema = {'$ref': '#/definitions/Axis'}
     _rootschema = Root._schema
@@ -459,38 +462,38 @@ class AxisConfig(VegaLiteSchema):
     Attributes
     ----------
     bandPosition : float
-        An interpolation fraction indicating where, for `band` scales, axis ticks should be
-        positioned. A value of `0` places ticks at the left edge of their bands. A value of
-        `0.5` places ticks in the middle of their bands.
+        An interpolation fraction indicating where, for ``band`` scales, axis ticks should
+        be positioned. A value of ``0`` places ticks at the left edge of their bands. A
+        value of ``0.5`` places ticks in the middle of their bands.
     domain : boolean
         A boolean flag indicating if the domain (the axis baseline) should be included as
-        part of the axis.  __Default value:__ `true`
+        part of the axis.  **Default value:** ``true``
     domainColor : string
-        Color of axis domain line.  __Default value:__  (none, using Vega default).
+        Color of axis domain line.  **Default value:**  (none, using Vega default).
     domainWidth : float
-        Stroke width of axis domain line  __Default value:__  (none, using Vega default).
+        Stroke width of axis domain line  **Default value:**  (none, using Vega default).
     grid : boolean
         A boolean flag indicating if grid lines should be included as part of the axis
-        __Default value:__ `true` for [continuous scales](scale.html#continuous) that are
-        not binned; otherwise, `false`.
+        **Default value:** ``true`` for `continuous scales <scale.html#continuous>`_ that
+        are not binned; otherwise, ``false``.
     gridColor : string
         Color of gridlines.
     gridDash : List(float)
         The offset (in pixels) into which to begin drawing with the grid dash array.
     gridOpacity : float
-        The stroke opacity of grid (value between [0,1])  __Default value:__ (`1` by
+        The stroke opacity of grid (value between [0,1])  **Default value:** ( ``1`` by
         default)
     gridWidth : float
         The grid width, in pixels.
     labelAngle : float
-        The rotation angle of the axis labels.  __Default value:__ `-90` for nominal and
-        ordinal fields; `0` otherwise.
+        The rotation angle of the axis labels.  **Default value:** ``-90`` for nominal and
+        ordinal fields; ``0`` otherwise.
     labelBound : anyOf(boolean, float)
-        Indicates if labels should be hidden if they exceed the axis range. If `false `(the
-        default) no bounds overlap analysis is performed. If `true`, labels will be hidden
-        if they exceed the axis range by more than 1 pixel. If this property is a number, it
-         specifies the pixel tolerance: the maximum amount by which a label bounding box may
-         exceed the axis range.  __Default value:__ `false`.
+        Indicates if labels should be hidden if they exceed the axis range. If ``false``
+        (the default) no bounds overlap analysis is performed. If ``true``, labels will be
+        hidden if they exceed the axis range by more than 1 pixel. If this property is a
+        number, it specifies the pixel tolerance: the maximum amount by which a label
+        bounding box may exceed the axis range.  **Default value:** ``false``.
     labelColor : string
         The color of the tick label, can be in hex color code or regular color name.
     labelFlush : anyOf(boolean, float)
@@ -501,8 +504,8 @@ class AxisConfig(VegaLiteSchema):
         pixels by which to offset the first and last labels; for example, a value of 2 will
         flush-align the first and last labels and also push them 2 pixels outward from the
         center of the axis. The additional adjustment can sometimes help the labels better
-        visually group with corresponding axis ticks.  __Default value:__ `true` for axis of
-         a continuous x-scale. Otherwise, `false`.
+        visually group with corresponding axis ticks.  **Default value:** ``true`` for axis
+        of a continuous x-scale. Otherwise, ``false``.
     labelFont : string
         The font of the tick label.
     labelFontSize : float
@@ -510,28 +513,28 @@ class AxisConfig(VegaLiteSchema):
     labelLimit : float
         Maximum allowed pixel width of axis tick labels.
     labelOverlap : anyOf(boolean, enum('parity'), enum('greedy'))
-        The strategy to use for resolving overlap of axis labels. If `false` (the default),
-        no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of
-        removing every other label is used (this works well for standard linear axes). If
-        set to `"greedy"`, a linear scan of the labels is performed, removing any labels
-        that overlaps with the last visible label (this often works better for log-scaled
-        axes).  __Default value:__ `true` for non-nominal fields with non-log scales;
-        `"greedy"` for log scales; otherwise `false`.
+        The strategy to use for resolving overlap of axis labels. If ``false`` (the
+        default), no overlap reduction is attempted. If set to ``true`` or ``"parity"``, a
+        strategy of removing every other label is used (this works well for standard linear
+        axes). If set to ``"greedy"``, a linear scan of the labels is performed, removing
+        any labels that overlaps with the last visible label (this often works better for
+        log-scaled axes).  **Default value:** ``true`` for non-nominal fields with non-log
+        scales; ``"greedy"`` for log scales; otherwise ``false``.
     labelPadding : float
         The padding, in pixels, between axis and text labels.
     labels : boolean
         A boolean flag indicating if labels should be included as part of the axis.
-        __Default value:__  `true`.
+        **Default value:**  ``true``.
     maxExtent : float
         The maximum extent in pixels that axis ticks and labels should use. This determines
-        a maximum offset value for axis titles.  __Default value:__ `undefined`.
+        a maximum offset value for axis titles.  **Default value:** ``undefined``.
     minExtent : float
         The minimum extent in pixels that axis ticks and labels should use. This determines
-        a minimum offset value for axis titles.  __Default value:__ `30` for y-axis;
-        `undefined` for x-axis.
+        a minimum offset value for axis titles.  **Default value:** ``30`` for y-axis;
+        ``undefined`` for x-axis.
     shortTimeLabels : boolean
-        Whether month names and weekday names should be abbreviated.  __Default value:__
-        `false`
+        Whether month names and weekday names should be abbreviated.  **Default value:**
+        ``false``
     tickColor : string
         The color of the axis's tick.
     tickRound : boolean
@@ -552,13 +555,13 @@ class AxisConfig(VegaLiteSchema):
     titleColor : string
         Color of the title, can be in hex color code or regular color name.
     titleFont : string
-        Font of the title. (e.g., `"Helvetica Neue"`).
+        Font of the title. (e.g., ``"Helvetica Neue"`` ).
     titleFontSize : float
         Font size of the title.
     titleFontWeight : FontWeight
-        Font weight of the title. This can be either a string (e.g `"bold"`, `"normal"`) or
-        a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` =
-        `700`).
+        Font weight of the title. This can be either a string (e.g ``"bold"``, ``"normal"``
+        ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400``
+         and ``"bold"`` = ``700`` ).
     titleLimit : float
         Maximum allowed pixel width of axis titles.
     titleMaxLength : float
@@ -644,126 +647,129 @@ class BarConfig(VegaLiteSchema):
     Attributes
     ----------
     align : HorizontalAlign
-        The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
-        __Default value:__ `"middle"`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+        **Default value:** ``"middle"``
     binSpacing : float
         Offset between bars for binned field.  Ideal value for this is either 0 (Preferred
-        by statisticians) or 1 (Vega-Lite Default, D3 example style).  __Default value:__
-        `1`
+        by statisticians) or 1 (Vega-Lite Default, D3 example style).  **Default value:**
+        ``1``
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
-        and will override `color`.  __Default value:__ <span style="color:
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
-        [style config](mark.html#style-config).
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.  **Default value:** :raw-html:`<span
+        style="color: #4682b4;">&#9632;</span>` ``"#4682b4"``  **Note:** This property
+        cannot be used in a `style config <mark.html#style-config>`_.
     continuousBandSize : float
-        The default size of the bars on continuous scales.  __Default value:__ `5`
+        The default size of the bars on continuous scales.  **Default value:** ``5``
     cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
     'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
     'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
     'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor
-        type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`_ can be used.
     discreteBandSize : float
-        The size of the bars.  If unspecified, the default size is  `bandSize-1`, which
+        The size of the bars.  If unspecified, the default size is  ``bandSize-1``, which
         provides 1 pixel offset between bars.
     dx : float
         The horizontal offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     dy : float
         The vertical offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     fill : string
-        Default Fill Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Fill Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     fillOpacity : float
-        The fill opacity (value between [0,1]).  __Default value:__ `1`
+        The fill opacity (value between [0,1]).  **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.
-        __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
-         This property cannot be used in a [style config](mark.html#style-config).
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.  **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and
+        ``area`` marks.  **Note:** This property cannot be used in a `style config
+        <mark.html#style-config>`_.
     font : string
-        The typeface to set the text in (e.g., `"Helvetica Neue"`).
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : float
         The font size, in pixels.
     fontStyle : FontStyle
-        The font style (e.g., `"italic"`).
+        The font style (e.g., ``"italic"`` ).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
-        (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
         The line interpolation method to use for line and area marks. One of the following:
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
-        close the linear segments to form a polygon. - `"step"`: alternate between
-        horizontal and vertical segments, as in a step function. - `"step-before"`:
-        alternate between vertical and horizontal segments, as in a step function. -
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
-        `"basis-open"`: an open B-spline; may not intersect the start or end. -
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
-        Cardinal spline; may not intersect the start or end, but will intersect other
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
-        the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+           * ``"linear"`` : piecewise linear segments, as in a polyline. *
+        ``"linear-closed"`` : close the linear segments to form a polygon. * ``"step"`` :
+        alternate between horizontal and vertical segments, as in a step function. *
+        ``"step-before"`` : alternate between vertical and horizontal segments, as in a step
+         function. * ``"step-after"`` : alternate between horizontal and vertical segments,
+        as in a step function. * ``"basis"`` : a B-spline, with control point duplication on
+         the ends. * ``"basis-open"`` : an open B-spline; may not intersect the start or
+        end. * ``"basis-closed"`` : a closed B-spline, as in a loop. * ``"cardinal"`` : a
+        Cardinal spline, with control point duplication on the ends. * ``"cardinal-open"`` :
+         an open Cardinal spline; may not intersect the start or end, but will intersect
+        other control points. * ``"cardinal-closed"`` : a closed Cardinal spline, as in a
+        loop. * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+        straighten the spline. * ``"monotone"`` : cubic interpolation that preserves
+        monotonicity in y.
     limit : float
         The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
-        `bar` charts and `1` otherwise.
+        The overall opacity (value between [0,1]).  **Default value:** ``0.7`` for
+        non-aggregate plots with ``point``, ``tick``, ``circle``, or ``square`` marks or
+        layered ``bar`` charts and ``1`` otherwise.
     orient : Orient
         The orientation of a non-stacked bar, tick, area, and line charts. The value is
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines
-        whether the size of the bar and tick should be applied to x or y dimension. - For
-        area, this property determines the orient property of the Vega output. - For line
+        either horizontal (default) or vertical.   * For bar, rule and tick, this determines
+         whether the size of the bar and tick   should be applied to x or y dimension. * For
+         area, this property determines the orient property of the Vega output. * For line
         and trail marks, this property determines the sort order of the points in the line
-        if `config.sortLineBy` is not specified. For stacked charts, this is always
-        determined by the orientation of the stack; therefore explicitly specified value
+           if ``config.sortLineBy`` is not specified.   For stacked charts, this is always
+        determined by the orientation of the stack;   therefore explicitly specified value
         will be ignored.
     radius : float
         Polar coordinate radial offset, in pixels, of the text label from the origin
-        determined by the `x` and `y` properties.
+        determined by the ``x`` and ``y`` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
-          __Default value:__ `"circle"`
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.  **Default value:** ``"circle"``
     size : float
         The pixel area each the point/circle/square. For example: in the case of circles,
-        the radius is determined in part by the square root of the size value.  __Default
-        value:__ `30`
+        the radius is determined in part by the square root of the size value.  **Default
+        value:** ``30``
     stroke : string
-        Default Stroke Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Stroke Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     strokeCap : enum('butt', 'round', 'square')
-        The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
-        __Default value:__ `"square"`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.  **Default value:** ``"square"``
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : float
         The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeOpacity : float
-        The stroke opacity (value between [0,1]).  __Default value:__ `1`
+        The stroke opacity (value between [0,1]).  **Default value:** ``1``
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
         Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
-        Placeholder text if the `text` channel is not specified
+        Placeholder text if the ``text`` channel is not specified
     theta : float
         Polar coordinate angle, in radians, of the text label from the origin determined by
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
-        `0` indicating "north".
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
     """
     _schema = {'$ref': '#/definitions/BarConfig'}
     _rootschema = Root._schema
@@ -813,25 +819,25 @@ class BinParams(VegaLiteSchema):
     ----------
     base : float
         The number base to use for automatic bin determination (default is base 10).
-        __Default value:__ `10`
+        **Default value:** ``10``
     divide : List(float)
         Scale factors indicating allowable subdivisions. The default value is [5, 2], which
         indicates that for base 10 numbers (the default base), the method may consider
         dividing bin sizes by 5 and/or 2. For example, for an initial step size of 10, the
         method can check if bin sizes of 2 (= 10/5), 5 (= 10/2), or 1 (= 10/(5*2)) might
-        also satisfy the given constraints.  __Default value:__ `[5, 2]`
+        also satisfy the given constraints.  **Default value:** ``[5, 2]``
     extent : List(float)
-        A two-element (`[min, max]`) array indicating the range of desired bin values.
+        A two-element ( ``[min, max]`` ) array indicating the range of desired bin values.
     maxbins : float
-        Maximum number of bins.  __Default value:__ `6` for `row`, `column` and `shape`
-        channels; `10` for other channels
+        Maximum number of bins.  **Default value:** ``6`` for ``row``, ``column`` and
+        ``shape`` channels; ``10`` for other channels
     minstep : float
         A minimum allowable step size (particularly useful for integer values).
     nice : boolean
         If true (the default), attempts to make the bin boundaries use human-friendly
         boundaries, such as multiples of ten.
     step : float
-        An exact step size to use between bins.  __Note:__ If provided, options such as
+        An exact step size to use between bins.  **Note:** If provided, options such as
         maxbins will be ignored.
     steps : List(float)
         An array of allowable step sizes to choose from.
@@ -853,7 +859,7 @@ class BinTransform(VegaLiteSchema):
     Attributes
     ----------
     bin : anyOf(boolean, BinParams)
-        An object indicating bin properties, or simply `true` for using default bin
+        An object indicating bin properties, or simply ``true`` for using default bin
         parameters.
     field : string
         The data field to bin.
@@ -875,12 +881,12 @@ class BrushConfig(VegaLiteSchema):
     Attributes
     ----------
     fill : string
-        The fill color of the interval mark.  __Default value:__ `#333333`
+        The fill color of the interval mark.  **Default value:** ``#333333``
     fillOpacity : float
-        The fill opacity of the interval mark (a value between 0 and 1).  __Default value:__
-         `0.125`
+        The fill opacity of the interval mark (a value between 0 and 1).  **Default value:**
+         ``0.125``
     stroke : string
-        The stroke color of the interval mark.  __Default value:__ `#ffffff`
+        The stroke color of the interval mark.  **Default value:** ``#ffffff``
     strokeDash : List(float)
         An array of alternating stroke and space lengths, for creating dashed or dotted
         lines.
@@ -909,8 +915,8 @@ class CalculateTransform(VegaLiteSchema):
     Attributes
     ----------
     calculate : string
-        A [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string.
-        Use the variable `datum` to refer to the current data object.
+        A `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`_
+        string. Use the variable ``datum`` to refer to the current data object.
     as : string
         The field for storing the computed formula value.
     """
@@ -929,9 +935,10 @@ class CompositeUnitSpec(VegaLiteSchema):
     Attributes
     ----------
     mark : AnyMark
-        A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
-         `"line"`, `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark
-        definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``, ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and
+        ``"text"`` ) or a `mark definition object
+        <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`_.
     data : Data
         An object describing the data source
     description : string
@@ -939,30 +946,30 @@ class CompositeUnitSpec(VegaLiteSchema):
     encoding : Encoding
         A key-value mapping between encoding channels and definition of fields.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its y-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
-        For y-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to
-        y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
-        __Note__: For plots with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the height of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The height of a visualization.  **Default value:**   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its y-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the height will be
+        the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For y-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the height is `determined by the range step, paddings, and the
+        cardinality of the field mapped to y-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_. Otherwise, if the
+        ``rangeStep`` is ``null``, the height will be the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``y`` channel, the ``height`` will be the value of ``rangeStep``.  **Note** : For
+         plots with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        height of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     name : string
         Name of the visualization for later reference.
     projection : Projection
         An object defining properties of geographic projection, which will be applied to
-        `shape` path for `"geoshape"` marks and to `latitude` and `"longitude"` channels for
-         other marks.
+        ``shape`` path for ``"geoshape"`` marks and to ``latitude`` and ``"longitude"``
+        channels for other marks.
     selection : Mapping(required=[])
         A key-value mapping between selection names and definitions.
     title : anyOf(string, TitleParams)
@@ -970,27 +977,28 @@ class CompositeUnitSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the
-        following rules:  - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its x-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
-        be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the width is [determined by the range step, paddings, and the
-        cardinality of the field mapped to
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
-        the `rangeStep` is `null`, the width will be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-        no field is mapped to `x` channel, the `width` will be the value of
-        [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
-        with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the width of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The width of a visualization.  **Default value:** This will be determined by the
+        following rules:   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its x-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the width will be
+        the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For x-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the width is `determined by the range step, paddings, and the
+        cardinality of the field mapped to x-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_.   Otherwise, if the
+        ``rangeStep`` is ``null``, the width will be the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``x`` channel, the ``width`` will be the value of `
+        ``config.scale.textXRangeStep``
+        <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`_ for
+        ``text`` mark and the value of ``rangeStep`` for other marks.  **Note:** For plots
+        with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        width of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     """
     _schema = {'$ref': '#/definitions/CompositeUnitSpec'}
     _rootschema = Root._schema
@@ -1062,44 +1070,44 @@ class ConditionalPredicateFieldDef(VegaLiteSchema):
     test : LogicalOperandPredicate
 
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/ConditionalPredicate<FieldDef>'}
     _rootschema = Root._schema
@@ -1121,65 +1129,65 @@ class ConditionalPredicateMarkPropFieldDef(VegaLiteSchema):
     test : LogicalOperandPredicate
 
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding
-        channel will be removed.  __Default value:__ If undefined, default [legend
-        properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
+        An object defining properties of the legend. If ``null``, the legend for the
+        encoding channel will be removed.  **Default value:** If undefined, default `legend
+        properties <https://vega.github.io/vega-lite/docs/legend.html>`_ are applied.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/ConditionalPredicate<MarkPropFieldDef>'}
     _rootschema = Root._schema
@@ -1205,47 +1213,47 @@ class ConditionalPredicateTextFieldDef(VegaLiteSchema):
     test : LogicalOperandPredicate
 
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     format : string
-        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`_ for a
         text field. If not defined, this will be determined automatically.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/ConditionalPredicate<TextFieldDef>'}
     _rootschema = Root._schema
@@ -1268,8 +1276,8 @@ class ConditionalPredicateValueDef(VegaLiteSchema):
     test : LogicalOperandPredicate
 
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
-        between `0` to `1` for opacity).
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
     """
     _schema = {'$ref': '#/definitions/ConditionalPredicate<ValueDef>'}
     _rootschema = Root._schema
@@ -1286,48 +1294,48 @@ class ConditionalSelectionFieldDef(VegaLiteSchema):
     Attributes
     ----------
     selection : SelectionOperand
-        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a
-        series of [composed
-        selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
+        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`_, or a
+        series of `composed selections
+        <https://vega.github.io/vega-lite/docs/selection.html#compose>`_.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/ConditionalSelection<FieldDef>'}
     _rootschema = Root._schema
@@ -1347,69 +1355,69 @@ class ConditionalSelectionMarkPropFieldDef(VegaLiteSchema):
     Attributes
     ----------
     selection : SelectionOperand
-        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a
-        series of [composed
-        selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
+        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`_, or a
+        series of `composed selections
+        <https://vega.github.io/vega-lite/docs/selection.html#compose>`_.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding
-        channel will be removed.  __Default value:__ If undefined, default [legend
-        properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
+        An object defining properties of the legend. If ``null``, the legend for the
+        encoding channel will be removed.  **Default value:** If undefined, default `legend
+        properties <https://vega.github.io/vega-lite/docs/legend.html>`_ are applied.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/ConditionalSelection<MarkPropFieldDef>'}
     _rootschema = Root._schema
@@ -1433,51 +1441,51 @@ class ConditionalSelectionTextFieldDef(VegaLiteSchema):
     Attributes
     ----------
     selection : SelectionOperand
-        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a
-        series of [composed
-        selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
+        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`_, or a
+        series of `composed selections
+        <https://vega.github.io/vega-lite/docs/selection.html#compose>`_.
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     format : string
-        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`_ for a
         text field. If not defined, this will be determined automatically.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/ConditionalSelection<TextFieldDef>'}
     _rootschema = Root._schema
@@ -1498,12 +1506,12 @@ class ConditionalSelectionValueDef(VegaLiteSchema):
     Attributes
     ----------
     selection : SelectionOperand
-        A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a
-        series of [composed
-        selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
+        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`_, or a
+        series of `composed selections
+        <https://vega.github.io/vega-lite/docs/selection.html#compose>`_.
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
-        between `0` to `1` for opacity).
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
     """
     _schema = {'$ref': '#/definitions/ConditionalSelection<ValueDef>'}
     _rootschema = Root._schema
@@ -1523,13 +1531,14 @@ class Config(VegaLiteSchema):
         Area-Specific Config
     autosize : anyOf(AutosizeType, AutoSizeParams)
         Sets how the visualization size should be determined. If a string, should be one of
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
-        content sizing and automatic resizing. `"fit"` is only supported for single and
-        layered views that don't use `rangeStep`.  __Default value__: `pad`
+        ``"pad"``, ``"fit"`` or ``"none"``. Object values can additionally specify
+        parameters for content sizing and automatic resizing. ``"fit"`` is only supported
+        for single and layered views that don't use ``rangeStep``.  **Default value** :
+        ``pad``
     axis : AxisConfig
-        Axis configuration, which determines default properties for all `x` and `y`
-        [axes](axis.html). For a full list of axis configuration options, please see the
-        [corresponding section of the axis documentation](axis.html#config).
+        Axis configuration, which determines default properties for all ``x`` and ``y``
+        `axes <axis.html>`_. For a full list of axis configuration options, please see the
+        `corresponding section of the axis documentation <axis.html#config>`_.
     axisBand : VgAxisConfig
         Specific axis config for axes with "band" scales.
     axisBottom : VgAxisConfig
@@ -1545,69 +1554,69 @@ class Config(VegaLiteSchema):
     axisY : VgAxisConfig
         Y-axis specific config.
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__
+        CSS color property to use as the background of visualization.  **Default value:**
         none (transparent)
     bar : BarConfig
         Bar-Specific Config
     circle : MarkConfig
         Circle-Specific Config
     countTitle : string
-        Default axis and legend title for count fields.  __Default value:__ `'Number of
-        Records'`.
+        Default axis and legend title for count fields.  **Default value:** ``'Number of
+        Records'``.
     datasets : Datasets
         A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
-         primitive values are ingested as objects with a `data` property.
+         primitive values are ingested as objects with a ``data`` property.
     fieldTitle : enum('verbal', 'functional', 'plain')
         Defines how Vega-Lite generates title for fields.  There are three possible styles:
-        - `"verbal"` (Default) - displays function in a verbal style (e.g., "Sum of field",
-        "Year-month of date", "field (binned)"). - `"function"` - displays function using
-        parentheses and capitalized texts (e.g., "SUM(field)", "YEARMONTH(date)",
-        "BIN(field)"). - `"plain"` - displays only the field name without functions (e.g.,
-        "field", "date", "field").
+           * ``"verbal"`` (Default) - displays function in a verbal style (e.g., "Sum of
+        field", "Year-month of date", "field (binned)"). * ``"function"`` - displays
+        function using parentheses and capitalized texts (e.g., "SUM(field)",
+        "YEARMONTH(date)", "BIN(field)"). * ``"plain"`` - displays only the field name
+        without functions (e.g., "field", "date", "field").
     geoshape : MarkConfig
         Geoshape-Specific Config
     invalidValues : enum('filter', None)
-        Defines how Vega-Lite should handle invalid values (`null` and `NaN`). - If set to
-        `"filter"` (default), all data items with null values will be skipped (for line,
-        trail, and area marks) or filtered (for other marks). - If `null`, all data items
-        are included. In this case, invalid values will be interpreted as zeroes.
+        Defines how Vega-Lite should handle invalid values ( ``null`` and ``NaN`` ).   * If
+        set to ``"filter"`` (default), all data items with null values will be skipped (for
+        line, trail, and area marks) or filtered (for other marks). * If ``null``, all data
+        items are included. In this case, invalid values will be interpreted as zeroes.
     legend : LegendConfig
-        Legend configuration, which determines default properties for all
-        [legends](legend.html). For a full list of legend configuration options, please see
-        the [corresponding section of in the legend documentation](legend.html#config).
+        Legend configuration, which determines default properties for all `legends
+        <legend.html>`_. For a full list of legend configuration options, please see the
+        `corresponding section of in the legend documentation <legend.html#config>`_.
     line : LineConfig
         Line-Specific Config
     mark : MarkConfig
         Mark Config
     numberFormat : string
         D3 Number format for axis labels and text tables. For example "s" for SI units. Use
-        [D3's number format pattern](https://github.com/d3/d3-format#locale_format).
+        `D3's number format pattern <https://github.com/d3/d3-format#locale_format>`_.
     padding : Padding
         The default visualization padding, in pixels, from the edge of the visualization
         canvas to the data rectangle.  If a number, specifies padding for all sides. If an
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default
-        value__: `5`
+        object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.  **Default
+        value** : ``5``
     point : MarkConfig
         Point-Specific Config
     projection : ProjectionConfig
-        Projection configuration, which determines default properties for all
-        [projections](projection.html). For a full list of projection configuration options,
-         please see the [corresponding section of the projection
-        documentation](projection.html#config).
+        Projection configuration, which determines default properties for all `projections
+        <projection.html>`_. For a full list of projection configuration options, please see
+         the `corresponding section of the projection documentation
+        <projection.html#config>`_.
     range : RangeConfig
         An object hash that defines default range arrays or schemes for using with scales.
-        For a full list of scale range configuration options, please see the [corresponding
-        section of the scale documentation](scale.html#config).
+        For a full list of scale range configuration options, please see the `corresponding
+        section of the scale documentation <scale.html#config>`_.
     rect : MarkConfig
         Rect-Specific Config
     rule : MarkConfig
         Rule-Specific Config
     scale : ScaleConfig
-        Scale configuration determines default properties for all [scales](scale.html). For
-        a full list of scale configuration options, please see the [corresponding section of
-         the scale documentation](scale.html#config).
+        Scale configuration determines default properties for all `scales <scale.html>`_.
+        For a full list of scale configuration options, please see the `corresponding
+        section of the scale documentation <scale.html#config>`_.
     selection : SelectionConfig
         An object hash for defining default properties for each type of selections.
     square : MarkConfig
@@ -1616,25 +1625,25 @@ class Config(VegaLiteSchema):
         Default stack offset for stackable mark.
     style : StyleConfigIndex
         An object hash that defines key-value mappings to determine default properties for
-        marks with a given [style](mark.html#mark-def).  The keys represent styles names;
-        the values have to be valid [mark configuration objects](mark.html#config).
+        marks with a given `style <mark.html#mark-def>`_.  The keys represent styles names;
+        the values have to be valid `mark configuration objects <mark.html#config>`_.
     text : TextConfig
         Text-Specific Config
     tick : TickConfig
         Tick-Specific Config
     timeFormat : string
         Default datetime format for axis and legend labels. The format can be set directly
-        on each axis and legend. Use [D3's time format
-        pattern](https://github.com/d3/d3-time-format#locale_format).  __Default value:__
-        `'%b %d, %Y'`.
+        on each axis and legend. Use `D3's time format pattern
+        <https://github.com/d3/d3-time-format#locale_format>`_.  **Default value:** ``'%b
+        %d, %Y'``.
     title : VgTitleConfig
-        Title configuration, which determines default properties for all
-        [titles](title.html). For a full list of title configuration options, please see the
-         [corresponding section of the title documentation](title.html#config).
+        Title configuration, which determines default properties for all `titles
+        <title.html>`_. For a full list of title configuration options, please see the
+        `corresponding section of the title documentation <title.html#config>`_.
     trail : LineConfig
         Trail-Specific Config
     view : ViewConfig
-        Default properties for [single view plots](spec.html#single).
+        Default properties for `single view plots <spec.html#single>`_.
     """
     _schema = {'$ref': '#/definitions/Config'}
     _rootschema = Root._schema
@@ -1673,18 +1682,20 @@ class CsvDataFormat(VegaLiteSchema):
         If set to auto (the default), perform automatic type inference to determine the
         desired data types. Alternatively, a parsing directive object can be provided for
         explicit data types. Each property of the object corresponds to a field name, and
-        the value to the desired data type (one of `"number"`, `"boolean"` or `"date"`). For
-         example, `"parse": {"modified_on": "date"}` parses the `modified_on` field in each
-        input record a Date value.  For `"date"`, we parse data based using Javascript's
-        [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).
-         For Specific date formats can be provided (e.g., `{foo: 'date:"%m%d%Y"'}`), using
-        the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC
-         date format parsing is supported similarly (e.g., `{foo: 'utc:"%m%d%Y"'}`). See
-        more about [UTC time](timeunit.html#utc)
+        the value to the desired data type (one of ``"number"``, ``"boolean"`` or ``"date"``
+         ). For example, ``"parse": {"modified_on": "date"}`` parses the ``modified_on``
+        field in each input record a Date value.  For ``"date"``, we parse data based using
+        Javascript's ` ``Date.parse()``
+        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse>`_.
+         For Specific date formats can be provided (e.g., ``{foo: 'date:"%m%d%Y"'}`` ),
+        using the `d3-time-format syntax
+        <https://github.com/d3/d3-time-format#locale_format>`_. UTC date format parsing is
+        supported similarly (e.g., ``{foo: 'utc:"%m%d%Y"'}`` ). See more about `UTC time
+        <timeunit.html#utc>`_
     type : enum('csv', 'tsv')
-        Type of input data: `"json"`, `"csv"`, `"tsv"`. The default format type is
-        determined by the extension of the file URL. If no extension is detected, `"json"`
-        will be used by default.
+        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``. The default format type is
+        determined by the extension of the file URL. If no extension is detected, ``"json"``
+         will be used by default.
     """
     _schema = {'$ref': '#/definitions/CsvDataFormat'}
     _rootschema = Root._schema
@@ -1735,7 +1746,7 @@ class DateTime(VegaLiteSchema):
     Mapping(required=[])
     Object for defining datetime in Vega-Lite Filter.
     If both month and quarter are provided, month has higher precedence.
-    `day` cannot be combined with other date.
+    ``day`` cannot be combined with other date.
     We accept string for month and day names.
 
     Attributes
@@ -1743,11 +1754,11 @@ class DateTime(VegaLiteSchema):
     date : float
         Integer value representing the date from 1-31.
     day : anyOf(Day, string)
-        Value representing the day of a week.  This can be one of: (1) integer value -- `1`
-        represents Monday; (2) case-insensitive day name (e.g., `"Monday"`);  (3)
-        case-insensitive, 3-character short day name (e.g., `"Mon"`).   <br/> **Warning:** A
-         DateTime definition object with `day`** should not be combined with `year`,
-        `quarter`, `month`, or `date`.
+        Value representing the day of a week.  This can be one of: (1) integer value --
+        ``1`` represents Monday; (2) case-insensitive day name (e.g., ``"Monday"`` );  (3)
+        case-insensitive, 3-character short day name (e.g., ``"Mon"`` ).   :raw-html:`<br/>`
+         **Warning:** A DateTime definition object with ``day`` ** should not be combined
+        with ``year``, ``quarter``, ``month``, or ``date``.
     hours : float
         Integer value representing the hour of a day from 0-23.
     milliseconds : float
@@ -1755,9 +1766,9 @@ class DateTime(VegaLiteSchema):
     minutes : float
         Integer value representing the minute segment of time from 0-59.
     month : anyOf(Month, string)
-        One of: (1) integer value representing the month from `1`-`12`. `1` represents
-        January;  (2) case-insensitive month name (e.g., `"January"`);  (3)
-        case-insensitive, 3-character short month name (e.g., `"Jan"`).
+        One of: (1) integer value representing the month from ``1`` - ``12``. ``1``
+        represents January;  (2) case-insensitive month name (e.g., ``"January"`` );  (3)
+        case-insensitive, 3-character short month name (e.g., ``"Jan"`` ).
     quarter : float
         Integer value representing the quarter of the year (from 1-4).
     seconds : float
@@ -1811,23 +1822,24 @@ class Encoding(VegaLiteSchema):
     Attributes
     ----------
     color : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Color of the marks – either fill or stroke color based on  the `filled` property of
-        mark definition. By default, `color` represents fill color for `"area"`, `"bar"`,
-        `"tick"`, `"text"`, `"trail"`, `"circle"`, and `"square"` / stroke color for
-        `"line"` and `"point"`.  __Default value:__ If undefined, the default color depends
-        on [mark config](config.html#mark)'s `color` property.  _Note:_ 1) For fine-grained
-        control over both fill and stroke colors of the marks, please use the `fill` and
-        `stroke` channels.  If either `fill` or `stroke` channel is specified, `color`
-        channel will be ignored. 2) See the scale documentation for more information about
-        customizing [color scheme](scale.html#scheme).
+        Color of the marks – either fill or stroke color based on  the ``filled`` property
+        of mark definition. By default, ``color`` represents fill color for ``"area"``,
+        ``"bar"``, ``"tick"``, ``"text"``, ``"trail"``, ``"circle"``, and ``"square"`` /
+        stroke color for ``"line"`` and ``"point"``.  **Default value:** If undefined, the
+        default color depends on `mark config <config.html#mark>`_ 's ``color`` property.
+        *Note:* 1) For fine-grained control over both fill and stroke colors of the marks,
+        please use the ``fill`` and ``stroke`` channels.  If either ``fill`` or ``stroke``
+        channel is specified, ``color`` channel will be ignored. 2) See the scale
+        documentation for more information about customizing `color scheme
+        <scale.html#scheme>`_.
     detail : anyOf(FieldDef, List(FieldDef))
         Additional levels of detail for grouping data in aggregate views and in line, trail,
          and area marks without mapping data to a specific visual channel.
     fill : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Fill color of the marks. __Default value:__ If undefined, the default color depends
-        on [mark config](config.html#mark)'s `color` property.  _Note:_ When using `fill`
-        channel, `color ` channel will be ignored. To customize both fill and stroke, please
-         use `fill` and `stroke` channels (not `fill` and `color`).
+        Fill color of the marks. **Default value:** If undefined, the default color depends
+        on `mark config <config.html#mark>`_ 's ``color`` property.  *Note:* When using
+        ``fill`` channel, ``color`` channel will be ignored. To customize both fill and
+        stroke, please use ``fill`` and ``stroke`` channels (not ``fill`` and ``color`` ).
     href : anyOf(FieldDefWithCondition, ValueDefWithCondition)
         A URL to load upon mouse click.
     key : FieldDef
@@ -1838,54 +1850,56 @@ class Encoding(VegaLiteSchema):
     latitude : FieldDef
         Latitude position of geographically projected marks.
     latitude2 : FieldDef
-        Latitude-2 position for geographically projected ranged `"area"`, `"bar"`, `"rect"`,
-         and  `"rule"`.
+        Latitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
+        ``"rect"``, and  ``"rule"``.
     longitude : FieldDef
         Longitude position of geographically projected marks.
     longitude2 : FieldDef
-        Longitude-2 position for geographically projected ranged `"area"`, `"bar"`,
-        `"rect"`, and  `"rule"`.
+        Longitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
+        ``"rect"``, and  ``"rule"``.
     opacity : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Opacity of the marks – either can be a value or a range.  __Default value:__ If
-        undefined, the default opacity depends on [mark config](config.html#mark)'s
-        `opacity` property.
+        Opacity of the marks – either can be a value or a range.  **Default value:** If
+        undefined, the default opacity depends on `mark config <config.html#mark>`_ 's
+        ``opacity`` property.
     order : anyOf(OrderFieldDef, List(OrderFieldDef))
-        Order of the marks. - For stacked marks, this `order` channel encodes [stack
-        order](https://vega.github.io/vega-lite/docs/stack.html#order). - For line and trail
-         marks, this `order` channel encodes order of data points in the lines. This can be
-        useful for creating [a connected
-        scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).
-        - Otherwise, this `order` channel encodes layer order of the marks.  __Note__: In
-        aggregate plots, `order` field should be `aggregate`d to avoid creating additional
-        aggregation grouping.
+        Order of the marks.   * For stacked marks, this ``order`` channel encodes `stack
+        order <https://vega.github.io/vega-lite/docs/stack.html#order>`_. * For line and
+        trail marks, this ``order`` channel encodes order of data points in the lines. This
+        can be useful for creating `a connected scatterplot
+        <https://vega.github.io/vega-lite/examples/connected_scatterplot.html>`_. *
+        Otherwise, this ``order`` channel encodes layer order of the marks.  **Note** : In
+        aggregate plots, ``order`` field should be ``aggregate`` d to avoid creating
+        additional aggregation grouping.
     shape : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        For `point` marks the supported values are `"circle"` (default), `"square"`,
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or else a custom SVG
-        path string. For `geoshape` marks it should be a field definition of the geojson
-        data  __Default value:__ If undefined, the default shape depends on [mark
-        config](config.html#point-config)'s `shape` property.
+        For ``point`` marks the supported values are ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or else a
+        custom SVG path string. For ``geoshape`` marks it should be a field definition of
+        the geojson data  **Default value:** If undefined, the default shape depends on
+        `mark config <config.html#point-config>`_ 's ``shape`` property.
     size : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Size of the mark. - For `"point"`, `"square"` and `"circle"`, – the symbol size, or
-        pixel area of the mark. - For `"bar"` and `"tick"` – the bar and tick's size. - For
-        `"text"` – the text's font size. - Size is unsupported for `"line"`, `"area"`, and
-        `"rect"`. (Use `"trail"` instead of line with varying size)
+        Size of the mark.   * For ``"point"``, ``"square"`` and ``"circle"``, – the symbol
+        size, or pixel area of the mark. * For ``"bar"`` and ``"tick"`` – the bar and tick's
+         size. * For ``"text"`` – the text's font size. * Size is unsupported for
+        ``"line"``, ``"area"``, and ``"rect"``. (Use ``"trail"`` instead of line with
+        varying size)
     stroke : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Stroke color of the marks. __Default value:__ If undefined, the default color
-        depends on [mark config](config.html#mark)'s `color` property.  _Note:_ When using
-        `stroke` channel, `color ` channel will be ignored. To customize both stroke and
-        fill, please use `stroke` and `fill` channels (not `stroke` and `color`).
+        Stroke color of the marks. **Default value:** If undefined, the default color
+        depends on `mark config <config.html#mark>`_ 's ``color`` property.  *Note:* When
+        using ``stroke`` channel, ``color`` channel will be ignored. To customize both
+        stroke and fill, please use ``stroke`` and ``fill`` channels (not ``stroke`` and
+        ``color`` ).
     text : anyOf(TextFieldDefWithCondition, TextValueDefWithCondition)
-        Text of the `text` mark.
+        Text of the ``text`` mark.
     tooltip : anyOf(TextFieldDefWithCondition, TextValueDefWithCondition, List(TextFieldDef))
         The tooltip text to show upon mouse hover.
     x : anyOf(PositionFieldDef, ValueDef)
-        X coordinates of the marks, or width of horizontal `"bar"` and `"area"`.
+        X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"``.
     x2 : anyOf(FieldDef, ValueDef)
-        X2 coordinates for ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
+        X2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
     y : anyOf(PositionFieldDef, ValueDef)
-        Y coordinates of the marks, or height of vertical `"bar"` and `"area"`.
+        Y coordinates of the marks, or height of vertical ``"bar"`` and ``"area"``.
     y2 : anyOf(FieldDef, ValueDef)
-        Y2 coordinates for ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
+        Y2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
     """
     _schema = {'$ref': '#/definitions/Encoding'}
     _rootschema = Root._schema
@@ -1910,25 +1924,26 @@ class EncodingWithFacet(VegaLiteSchema):
     Attributes
     ----------
     color : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Color of the marks – either fill or stroke color based on  the `filled` property of
-        mark definition. By default, `color` represents fill color for `"area"`, `"bar"`,
-        `"tick"`, `"text"`, `"trail"`, `"circle"`, and `"square"` / stroke color for
-        `"line"` and `"point"`.  __Default value:__ If undefined, the default color depends
-        on [mark config](config.html#mark)'s `color` property.  _Note:_ 1) For fine-grained
-        control over both fill and stroke colors of the marks, please use the `fill` and
-        `stroke` channels.  If either `fill` or `stroke` channel is specified, `color`
-        channel will be ignored. 2) See the scale documentation for more information about
-        customizing [color scheme](scale.html#scheme).
+        Color of the marks – either fill or stroke color based on  the ``filled`` property
+        of mark definition. By default, ``color`` represents fill color for ``"area"``,
+        ``"bar"``, ``"tick"``, ``"text"``, ``"trail"``, ``"circle"``, and ``"square"`` /
+        stroke color for ``"line"`` and ``"point"``.  **Default value:** If undefined, the
+        default color depends on `mark config <config.html#mark>`_ 's ``color`` property.
+        *Note:* 1) For fine-grained control over both fill and stroke colors of the marks,
+        please use the ``fill`` and ``stroke`` channels.  If either ``fill`` or ``stroke``
+        channel is specified, ``color`` channel will be ignored. 2) See the scale
+        documentation for more information about customizing `color scheme
+        <scale.html#scheme>`_.
     column : FacetFieldDef
         Horizontal facets for trellis plots.
     detail : anyOf(FieldDef, List(FieldDef))
         Additional levels of detail for grouping data in aggregate views and in line, trail,
          and area marks without mapping data to a specific visual channel.
     fill : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Fill color of the marks. __Default value:__ If undefined, the default color depends
-        on [mark config](config.html#mark)'s `color` property.  _Note:_ When using `fill`
-        channel, `color ` channel will be ignored. To customize both fill and stroke, please
-         use `fill` and `stroke` channels (not `fill` and `color`).
+        Fill color of the marks. **Default value:** If undefined, the default color depends
+        on `mark config <config.html#mark>`_ 's ``color`` property.  *Note:* When using
+        ``fill`` channel, ``color`` channel will be ignored. To customize both fill and
+        stroke, please use ``fill`` and ``stroke`` channels (not ``fill`` and ``color`` ).
     href : anyOf(FieldDefWithCondition, ValueDefWithCondition)
         A URL to load upon mouse click.
     key : FieldDef
@@ -1939,56 +1954,58 @@ class EncodingWithFacet(VegaLiteSchema):
     latitude : FieldDef
         Latitude position of geographically projected marks.
     latitude2 : FieldDef
-        Latitude-2 position for geographically projected ranged `"area"`, `"bar"`, `"rect"`,
-         and  `"rule"`.
+        Latitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
+        ``"rect"``, and  ``"rule"``.
     longitude : FieldDef
         Longitude position of geographically projected marks.
     longitude2 : FieldDef
-        Longitude-2 position for geographically projected ranged `"area"`, `"bar"`,
-        `"rect"`, and  `"rule"`.
+        Longitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
+        ``"rect"``, and  ``"rule"``.
     opacity : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Opacity of the marks – either can be a value or a range.  __Default value:__ If
-        undefined, the default opacity depends on [mark config](config.html#mark)'s
-        `opacity` property.
+        Opacity of the marks – either can be a value or a range.  **Default value:** If
+        undefined, the default opacity depends on `mark config <config.html#mark>`_ 's
+        ``opacity`` property.
     order : anyOf(OrderFieldDef, List(OrderFieldDef))
-        Order of the marks. - For stacked marks, this `order` channel encodes [stack
-        order](https://vega.github.io/vega-lite/docs/stack.html#order). - For line and trail
-         marks, this `order` channel encodes order of data points in the lines. This can be
-        useful for creating [a connected
-        scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).
-        - Otherwise, this `order` channel encodes layer order of the marks.  __Note__: In
-        aggregate plots, `order` field should be `aggregate`d to avoid creating additional
-        aggregation grouping.
+        Order of the marks.   * For stacked marks, this ``order`` channel encodes `stack
+        order <https://vega.github.io/vega-lite/docs/stack.html#order>`_. * For line and
+        trail marks, this ``order`` channel encodes order of data points in the lines. This
+        can be useful for creating `a connected scatterplot
+        <https://vega.github.io/vega-lite/examples/connected_scatterplot.html>`_. *
+        Otherwise, this ``order`` channel encodes layer order of the marks.  **Note** : In
+        aggregate plots, ``order`` field should be ``aggregate`` d to avoid creating
+        additional aggregation grouping.
     row : FacetFieldDef
         Vertical facets for trellis plots.
     shape : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        For `point` marks the supported values are `"circle"` (default), `"square"`,
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or else a custom SVG
-        path string. For `geoshape` marks it should be a field definition of the geojson
-        data  __Default value:__ If undefined, the default shape depends on [mark
-        config](config.html#point-config)'s `shape` property.
+        For ``point`` marks the supported values are ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or else a
+        custom SVG path string. For ``geoshape`` marks it should be a field definition of
+        the geojson data  **Default value:** If undefined, the default shape depends on
+        `mark config <config.html#point-config>`_ 's ``shape`` property.
     size : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Size of the mark. - For `"point"`, `"square"` and `"circle"`, – the symbol size, or
-        pixel area of the mark. - For `"bar"` and `"tick"` – the bar and tick's size. - For
-        `"text"` – the text's font size. - Size is unsupported for `"line"`, `"area"`, and
-        `"rect"`. (Use `"trail"` instead of line with varying size)
+        Size of the mark.   * For ``"point"``, ``"square"`` and ``"circle"``, – the symbol
+        size, or pixel area of the mark. * For ``"bar"`` and ``"tick"`` – the bar and tick's
+         size. * For ``"text"`` – the text's font size. * Size is unsupported for
+        ``"line"``, ``"area"``, and ``"rect"``. (Use ``"trail"`` instead of line with
+        varying size)
     stroke : anyOf(MarkPropFieldDefWithCondition, MarkPropValueDefWithCondition)
-        Stroke color of the marks. __Default value:__ If undefined, the default color
-        depends on [mark config](config.html#mark)'s `color` property.  _Note:_ When using
-        `stroke` channel, `color ` channel will be ignored. To customize both stroke and
-        fill, please use `stroke` and `fill` channels (not `stroke` and `color`).
+        Stroke color of the marks. **Default value:** If undefined, the default color
+        depends on `mark config <config.html#mark>`_ 's ``color`` property.  *Note:* When
+        using ``stroke`` channel, ``color`` channel will be ignored. To customize both
+        stroke and fill, please use ``stroke`` and ``fill`` channels (not ``stroke`` and
+        ``color`` ).
     text : anyOf(TextFieldDefWithCondition, TextValueDefWithCondition)
-        Text of the `text` mark.
+        Text of the ``text`` mark.
     tooltip : anyOf(TextFieldDefWithCondition, TextValueDefWithCondition, List(TextFieldDef))
         The tooltip text to show upon mouse hover.
     x : anyOf(PositionFieldDef, ValueDef)
-        X coordinates of the marks, or width of horizontal `"bar"` and `"area"`.
+        X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"``.
     x2 : anyOf(FieldDef, ValueDef)
-        X2 coordinates for ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
+        X2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
     y : anyOf(PositionFieldDef, ValueDef)
-        Y coordinates of the marks, or height of vertical `"bar"` and `"area"`.
+        Y coordinates of the marks, or height of vertical ``"bar"`` and ``"area"``.
     y2 : anyOf(FieldDef, ValueDef)
-        Y2 coordinates for ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
+        Y2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
     """
     _schema = {'$ref': '#/definitions/EncodingWithFacet'}
     _rootschema = Root._schema
@@ -2016,9 +2033,9 @@ class LayerSpec(VegaLiteSchema):
     Attributes
     ----------
     layer : List(anyOf(LayerSpec, CompositeUnitSpec))
-        Layer or single view specifications to be layered.  __Note__: Specifications inside
-        `layer` cannot use `row` and `column` channels as layering facet specifications is
-        not allowed.
+        Layer or single view specifications to be layered.  **Note** : Specifications inside
+         ``layer`` cannot use ``row`` and ``column`` channels as layering facet
+        specifications is not allowed.
     data : Data
         An object describing the data source
     description : string
@@ -2027,24 +2044,24 @@ class LayerSpec(VegaLiteSchema):
         A shared key-value mapping between encoding channels and definition of fields in the
          underlying layers.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its y-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
-        For y-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to
-        y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
-        __Note__: For plots with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the height of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The height of a visualization.  **Default value:**   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its y-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the height will be
+        the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For y-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the height is `determined by the range step, paddings, and the
+        cardinality of the field mapped to y-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_. Otherwise, if the
+        ``rangeStep`` is ``null``, the height will be the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``y`` channel, the ``height`` will be the value of ``rangeStep``.  **Note** : For
+         plots with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        height of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     name : string
         Name of the visualization for later reference.
     projection : Projection
@@ -2057,27 +2074,28 @@ class LayerSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the
-        following rules:  - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its x-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
-        be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the width is [determined by the range step, paddings, and the
-        cardinality of the field mapped to
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
-        the `rangeStep` is `null`, the width will be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-        no field is mapped to `x` channel, the `width` will be the value of
-        [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
-        with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the width of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The width of a visualization.  **Default value:** This will be determined by the
+        following rules:   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its x-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the width will be
+        the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For x-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the width is `determined by the range step, paddings, and the
+        cardinality of the field mapped to x-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_.   Otherwise, if the
+        ``rangeStep`` is ``null``, the width will be the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``x`` channel, the ``width`` will be the value of `
+        ``config.scale.textXRangeStep``
+        <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`_ for
+        ``text`` mark and the value of ``rangeStep`` for other marks.  **Note:** For plots
+        with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        width of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     """
     _schema = {'$ref': '#/definitions/LayerSpec'}
     _rootschema = Root._schema
@@ -2099,48 +2117,48 @@ class FacetFieldDef(VegaLiteSchema):
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     header : Header
         An object defining properties of a facet's header.
     sort : SortOrder
-        Sort order for a facet field. This can be `"ascending"`, `"descending"`.
+        Sort order for a facet field. This can be ``"ascending"``, ``"descending"``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/FacetFieldDef'}
     _rootschema = Root._schema
@@ -2180,44 +2198,44 @@ class FieldDef(VegaLiteSchema):
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/FieldDef'}
     _rootschema = Root._schema
@@ -2232,7 +2250,7 @@ class FieldDefWithCondition(VegaLiteSchema):
     """FieldDefWithCondition schema wrapper
 
     Mapping(required=[type])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -2242,49 +2260,49 @@ class FieldDefWithCondition(VegaLiteSchema):
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/FieldDefWithCondition'}
     _rootschema = Root._schema
@@ -2300,7 +2318,7 @@ class MarkPropFieldDefWithCondition(VegaLiteSchema):
     """MarkPropFieldDefWithCondition schema wrapper
 
     Mapping(required=[type])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -2310,70 +2328,70 @@ class MarkPropFieldDefWithCondition(VegaLiteSchema):
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     legend : anyOf(Legend, None)
-        An object defining properties of the legend. If `null`, the legend for the encoding
-        channel will be removed.  __Default value:__ If undefined, default [legend
-        properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
+        An object defining properties of the legend. If ``null``, the legend for the
+        encoding channel will be removed.  **Default value:** If undefined, default `legend
+        properties <https://vega.github.io/vega-lite/docs/legend.html>`_ are applied.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/MarkPropFieldDefWithCondition'}
     _rootschema = Root._schema
@@ -2391,7 +2409,7 @@ class TextFieldDefWithCondition(VegaLiteSchema):
     """TextFieldDefWithCondition schema wrapper
 
     Mapping(required=[type])
-    A FieldDef with Condition<ValueDef>
+    A FieldDef with Condition :raw-html:`<ValueDef>`
     {
        condition: {value: ...},
        field: ...,
@@ -2401,52 +2419,52 @@ class TextFieldDefWithCondition(VegaLiteSchema):
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     condition : anyOf(ConditionalValueDef, List(ConditionalValueDef))
-        One or more value definition(s) with a selection predicate.  __Note:__ A field
-        definition's `condition` property can only contain [value
-        definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def) since
-        Vega-Lite only allows at most one encoded field per encoding channel.
+        One or more value definition(s) with a selection predicate.  **Note:** A field
+        definition's ``condition`` property can only contain `value definitions
+        <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`_ since Vega-Lite
+        only allows at most one encoded field per encoding channel.
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     format : string
-        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`_ for a
         text field. If not defined, this will be determined automatically.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/TextFieldDefWithCondition'}
     _rootschema = Root._schema
@@ -2489,7 +2507,7 @@ class FieldOneOfPredicate(VegaLiteSchema):
     field : string
         Field to be filtered
     oneOf : anyOf(List(string), List(float), List(boolean), List(DateTime))
-        A set of values that the `field`'s value should be a member of, for a data item
+        A set of values that the ``field`` 's value should be a member of, for a data item
         included in the filtered data.
     timeUnit : TimeUnit
         time unit for the field to be filtered.
@@ -2531,16 +2549,16 @@ class FilterTransform(VegaLiteSchema):
     Attributes
     ----------
     filter : LogicalOperandPredicate
-        The `filter` property must be one of the predicate definitions: (1) an
-        [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string,
-        where `datum` can be used to refer to the current data object; (2) one of the field
-        predicates: [equal
-        predicate](https://vega.github.io/vega-lite/docs/filter.html#equal-predicate);
-        [range predicate](filter.html#range-predicate), [one-of
-        predicate](https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate); (3)
-        a [selection
-        predicate](https://vega.github.io/vega-lite/docs/filter.html#selection-predicate);
-        or (4) a logical operand that combines (1), (2), or (3).
+        The ``filter`` property must be one of the predicate definitions: (1) an `expression
+         <https://vega.github.io/vega-lite/docs/types.html#expression>`_ string, where
+        ``datum`` can be used to refer to the current data object; (2) one of the field
+        predicates: `equal predicate
+        <https://vega.github.io/vega-lite/docs/filter.html#equal-predicate>`_ ; `range
+        predicate <filter.html#range-predicate>`_, `one-of predicate
+        <https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate>`_ ; (3) a
+        `selection predicate
+        <https://vega.github.io/vega-lite/docs/filter.html#selection-predicate>`_ ; or (4) a
+         logical operand that combines (1), (2), or (3).
     """
     _schema = {'$ref': '#/definitions/FilterTransform'}
     _rootschema = Root._schema
@@ -2605,7 +2623,7 @@ class FacetSpec(VegaLiteSchema):
     Attributes
     ----------
     facet : FacetMapping
-        An object that describes mappings between `row` and `column` channels and their
+        An object that describes mappings between ``row`` and ``column`` channels and their
         field definitions.
     spec : anyOf(LayerSpec, CompositeUnitSpec)
         A specification of the view that gets faceted.
@@ -2673,7 +2691,7 @@ class RepeatSpec(VegaLiteSchema):
     ----------
     repeat : Repeat
         An object that describes what fields should be repeated into views that are laid out
-         as a `row` or `column`.
+         as a ``row`` or ``column``.
     spec : Spec
 
     data : Data
@@ -2719,9 +2737,10 @@ class CompositeUnitSpecAlias(VegaLiteSchema):
     Attributes
     ----------
     mark : AnyMark
-        A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
-         `"line"`, `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark
-        definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``, ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and
+        ``"text"`` ) or a `mark definition object
+        <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`_.
     data : Data
         An object describing the data source
     description : string
@@ -2729,30 +2748,30 @@ class CompositeUnitSpecAlias(VegaLiteSchema):
     encoding : Encoding
         A key-value mapping between encoding channels and definition of fields.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its y-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
-        For y-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to
-        y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
-        __Note__: For plots with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the height of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The height of a visualization.  **Default value:**   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its y-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the height will be
+        the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For y-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the height is `determined by the range step, paddings, and the
+        cardinality of the field mapped to y-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_. Otherwise, if the
+        ``rangeStep`` is ``null``, the height will be the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``y`` channel, the ``height`` will be the value of ``rangeStep``.  **Note** : For
+         plots with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        height of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     name : string
         Name of the visualization for later reference.
     projection : Projection
         An object defining properties of geographic projection, which will be applied to
-        `shape` path for `"geoshape"` marks and to `latitude` and `"longitude"` channels for
-         other marks.
+        ``shape`` path for ``"geoshape"`` marks and to ``latitude`` and ``"longitude"``
+        channels for other marks.
     selection : Mapping(required=[])
         A key-value mapping between selection names and definitions.
     title : anyOf(string, TitleParams)
@@ -2760,27 +2779,28 @@ class CompositeUnitSpecAlias(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the
-        following rules:  - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its x-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
-        be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the width is [determined by the range step, paddings, and the
-        cardinality of the field mapped to
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
-        the `rangeStep` is `null`, the width will be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-        no field is mapped to `x` channel, the `width` will be the value of
-        [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
-        with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the width of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The width of a visualization.  **Default value:** This will be determined by the
+        following rules:   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its x-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the width will be
+        the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For x-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the width is `determined by the range step, paddings, and the
+        cardinality of the field mapped to x-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_.   Otherwise, if the
+        ``rangeStep`` is ``null``, the width will be the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``x`` channel, the ``width`` will be the value of `
+        ``config.scale.textXRangeStep``
+        <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`_ for
+        ``text`` mark and the value of ``rangeStep`` for other marks.  **Note:** For plots
+        with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        width of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     """
     _schema = {'$ref': '#/definitions/CompositeUnitSpecAlias'}
     _rootschema = Root._schema
@@ -2803,9 +2823,10 @@ class FacetedCompositeUnitSpecAlias(VegaLiteSchema):
     Attributes
     ----------
     mark : AnyMark
-        A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
-         `"line"`, `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark
-        definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``, ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and
+        ``"text"`` ) or a `mark definition object
+        <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`_.
     data : Data
         An object describing the data source
     description : string
@@ -2813,30 +2834,30 @@ class FacetedCompositeUnitSpecAlias(VegaLiteSchema):
     encoding : EncodingWithFacet
         A key-value mapping between encoding channels and definition of fields.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its y-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
-        For y-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to
-        y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
-        __Note__: For plots with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the height of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The height of a visualization.  **Default value:**   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its y-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the height will be
+        the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For y-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the height is `determined by the range step, paddings, and the
+        cardinality of the field mapped to y-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_. Otherwise, if the
+        ``rangeStep`` is ``null``, the height will be the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``y`` channel, the ``height`` will be the value of ``rangeStep``.  **Note** : For
+         plots with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        height of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     name : string
         Name of the visualization for later reference.
     projection : Projection
         An object defining properties of geographic projection, which will be applied to
-        `shape` path for `"geoshape"` marks and to `latitude` and `"longitude"` channels for
-         other marks.
+        ``shape`` path for ``"geoshape"`` marks and to ``latitude`` and ``"longitude"``
+        channels for other marks.
     selection : Mapping(required=[])
         A key-value mapping between selection names and definitions.
     title : anyOf(string, TitleParams)
@@ -2844,27 +2865,28 @@ class FacetedCompositeUnitSpecAlias(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the
-        following rules:  - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its x-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
-        be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the width is [determined by the range step, paddings, and the
-        cardinality of the field mapped to
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
-        the `rangeStep` is `null`, the width will be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-        no field is mapped to `x` channel, the `width` will be the value of
-        [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
-        with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the width of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The width of a visualization.  **Default value:** This will be determined by the
+        following rules:   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its x-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the width will be
+        the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For x-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the width is `determined by the range step, paddings, and the
+        cardinality of the field mapped to x-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_.   Otherwise, if the
+        ``rangeStep`` is ``null``, the width will be the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``x`` channel, the ``width`` will be the value of `
+        ``config.scale.textXRangeStep``
+        <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`_ for
+        ``text`` mark and the value of ``rangeStep`` for other marks.  **Note:** For plots
+        with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        width of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     """
     _schema = {'$ref': '#/definitions/FacetedCompositeUnitSpecAlias'}
     _rootschema = Root._schema
@@ -2933,27 +2955,27 @@ class Header(VegaLiteSchema):
     Attributes
     ----------
     format : string
-        The formatting pattern for labels. This is D3's [number format
-        pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and
-        D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for
-        time field.  See the [format documentation](format.html) for more information.
-        __Default value:__  derived from [numberFormat](config.html#format) config for
-        quantitative fields and from [timeFormat](config.html#format) config for temporal
+        The formatting pattern for labels. This is D3's `number format pattern
+        <https://github.com/d3/d3-format#locale_format>`_ for quantitative fields and D3's
+        `time format pattern <https://github.com/d3/d3-time-format#locale_format>`_ for time
+         field.  See the `format documentation <format.html>`_ for more information.
+        **Default value:**  derived from `numberFormat <config.html#format>`_ config for
+        quantitative fields and from `timeFormat <config.html#format>`_ config for temporal
         fields.
     labelAngle : float
-        The rotation angle of the header labels.  __Default value:__ `0`.
+        The rotation angle of the header labels.  **Default value:** ``0``.
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/Header'}
     _rootschema = Root._schema
@@ -2983,8 +3005,8 @@ class InlineData(VegaLiteSchema):
     ----------
     values : InlineDataset
         The full data set, included inline. This can be an array of objects or primitive
-        values or a string. Arrays of primitive values are ingested as objects with a `data`
-         property. Strings are parsed according to the specified format type.
+        values or a string. Arrays of primitive values are ingested as objects with a
+        ``data`` property. Strings are parsed according to the specified format type.
     format : DataFormat
         An object that specifies the format for parsing the data values.
     """
@@ -3035,7 +3057,7 @@ class IntervalSelection(VegaLiteSchema):
         within the same view. This allows a user to interactively pan and zoom the view.
     empty : enum('all', 'none')
         By default, all data values are considered to lie within an empty selection. When
-        set to `none`, empty selections contain no data values.
+        set to ``none``, empty selections contain no data values.
     encodings : List(SingleDefChannel)
         An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
@@ -3044,29 +3066,29 @@ class IntervalSelection(VegaLiteSchema):
         selection.
     mark : BrushConfig
         An interval selection also adds a rectangle mark to depict the extents of the
-        interval. The `mark` property can be used to customize the appearance of the mark.
+        interval. The ``mark`` property can be used to customize the appearance of the mark.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`_ (object or
         selector) that triggers the selection. For interval selections, the event stream
-        must specify a [start and
-        end](https://vega.github.io/vega/docs/event-streams/#between-filters).
+        must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`_.
     resolve : SelectionResolution
         With layered and multi-view displays, a strategy that determines how selections'
         data queries are resolved when applied in a filter transform, conditional encoding
         rule, or scale domain.
     translate : anyOf(string, boolean)
         When truthy, allows a user to interactively move an interval selection
-        back-and-forth. Can be `true`, `false` (to disable panning), or a [Vega event stream
-         definition](https://vega.github.io/vega/docs/event-streams/) which must include a
-        start and end event to trigger continuous panning.  __Default value:__ `true`, which
-         corresponds to `[mousedown, window:mouseup] > window:mousemove!` which corresponds
-        to clicks and dragging within an interval selection to reposition it.
+        back-and-forth. Can be ``true``, ``false`` (to disable panning), or a `Vega event
+        stream definition <https://vega.github.io/vega/docs/event-streams/>`_ which must
+        include a start and end event to trigger continuous panning.  **Default value:**
+        ``true``, which corresponds to ``[mousedown, window:mouseup] > window:mousemove!``
+        which corresponds to clicks and dragging within an interval selection to reposition
+        it.
     zoom : anyOf(string, boolean)
         When truthy, allows a user to interactively resize an interval selection. Can be
-        `true`, `false` (to disable zooming), or a [Vega event stream
-        definition](https://vega.github.io/vega/docs/event-streams/). Currently, only
-        `wheel` events are supported.   __Default value:__ `true`, which corresponds to
-        `wheel!`.
+        ``true``, ``false`` (to disable zooming), or a `Vega event stream definition
+        <https://vega.github.io/vega/docs/event-streams/>`_. Currently, only ``wheel``
+        events are supported.  **Default value:** ``true``, which corresponds to ``wheel!``.
     """
     _schema = {'$ref': '#/definitions/IntervalSelection'}
     _rootschema = Root._schema
@@ -3091,7 +3113,7 @@ class IntervalSelectionConfig(VegaLiteSchema):
         within the same view. This allows a user to interactively pan and zoom the view.
     empty : enum('all', 'none')
         By default, all data values are considered to lie within an empty selection. When
-        set to `none`, empty selections contain no data values.
+        set to ``none``, empty selections contain no data values.
     encodings : List(SingleDefChannel)
         An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
@@ -3100,29 +3122,29 @@ class IntervalSelectionConfig(VegaLiteSchema):
         selection.
     mark : BrushConfig
         An interval selection also adds a rectangle mark to depict the extents of the
-        interval. The `mark` property can be used to customize the appearance of the mark.
+        interval. The ``mark`` property can be used to customize the appearance of the mark.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`_ (object or
         selector) that triggers the selection. For interval selections, the event stream
-        must specify a [start and
-        end](https://vega.github.io/vega/docs/event-streams/#between-filters).
+        must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`_.
     resolve : SelectionResolution
         With layered and multi-view displays, a strategy that determines how selections'
         data queries are resolved when applied in a filter transform, conditional encoding
         rule, or scale domain.
     translate : anyOf(string, boolean)
         When truthy, allows a user to interactively move an interval selection
-        back-and-forth. Can be `true`, `false` (to disable panning), or a [Vega event stream
-         definition](https://vega.github.io/vega/docs/event-streams/) which must include a
-        start and end event to trigger continuous panning.  __Default value:__ `true`, which
-         corresponds to `[mousedown, window:mouseup] > window:mousemove!` which corresponds
-        to clicks and dragging within an interval selection to reposition it.
+        back-and-forth. Can be ``true``, ``false`` (to disable panning), or a `Vega event
+        stream definition <https://vega.github.io/vega/docs/event-streams/>`_ which must
+        include a start and end event to trigger continuous panning.  **Default value:**
+        ``true``, which corresponds to ``[mousedown, window:mouseup] > window:mousemove!``
+        which corresponds to clicks and dragging within an interval selection to reposition
+        it.
     zoom : anyOf(string, boolean)
         When truthy, allows a user to interactively resize an interval selection. Can be
-        `true`, `false` (to disable zooming), or a [Vega event stream
-        definition](https://vega.github.io/vega/docs/event-streams/). Currently, only
-        `wheel` events are supported.   __Default value:__ `true`, which corresponds to
-        `wheel!`.
+        ``true``, ``false`` (to disable zooming), or a `Vega event stream definition
+        <https://vega.github.io/vega/docs/event-streams/>`_. Currently, only ``wheel``
+        events are supported.  **Default value:** ``true``, which corresponds to ``wheel!``.
     """
     _schema = {'$ref': '#/definitions/IntervalSelectionConfig'}
     _rootschema = Root._schema
@@ -3146,23 +3168,25 @@ class JsonDataFormat(VegaLiteSchema):
         If set to auto (the default), perform automatic type inference to determine the
         desired data types. Alternatively, a parsing directive object can be provided for
         explicit data types. Each property of the object corresponds to a field name, and
-        the value to the desired data type (one of `"number"`, `"boolean"` or `"date"`). For
-         example, `"parse": {"modified_on": "date"}` parses the `modified_on` field in each
-        input record a Date value.  For `"date"`, we parse data based using Javascript's
-        [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).
-         For Specific date formats can be provided (e.g., `{foo: 'date:"%m%d%Y"'}`), using
-        the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC
-         date format parsing is supported similarly (e.g., `{foo: 'utc:"%m%d%Y"'}`). See
-        more about [UTC time](timeunit.html#utc)
+        the value to the desired data type (one of ``"number"``, ``"boolean"`` or ``"date"``
+         ). For example, ``"parse": {"modified_on": "date"}`` parses the ``modified_on``
+        field in each input record a Date value.  For ``"date"``, we parse data based using
+        Javascript's ` ``Date.parse()``
+        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse>`_.
+         For Specific date formats can be provided (e.g., ``{foo: 'date:"%m%d%Y"'}`` ),
+        using the `d3-time-format syntax
+        <https://github.com/d3/d3-time-format#locale_format>`_. UTC date format parsing is
+        supported similarly (e.g., ``{foo: 'utc:"%m%d%Y"'}`` ). See more about `UTC time
+        <timeunit.html#utc>`_
     property : string
         The JSON property containing the desired data. This parameter can be used when the
         loaded JSON file may have surrounding structure or meta-data. For example
-        `"property": "values.features"` is equivalent to retrieving `json.values.features`
-        from the loaded JSON object.
+        ``"property": "values.features"`` is equivalent to retrieving
+        ``json.values.features`` from the loaded JSON object.
     type : enum('json')
-        Type of input data: `"json"`, `"csv"`, `"tsv"`. The default format type is
-        determined by the extension of the file URL. If no extension is detected, `"json"`
-        will be used by default.
+        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``. The default format type is
+        determined by the extension of the file URL. If no extension is detected, ``"json"``
+         will be used by default.
     """
     _schema = {'$ref': '#/definitions/JsonDataFormat'}
     _rootschema = Root._schema
@@ -3182,40 +3206,40 @@ class Legend(VegaLiteSchema):
     entryPadding : float
         Padding (in pixels) between legend entries in a symbol legend.
     format : string
-        The formatting pattern for labels. This is D3's [number format
-        pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and
-        D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for
-        time field.  See the [format documentation](format.html) for more information.
-        __Default value:__  derived from [numberFormat](config.html#format) config for
-        quantitative fields and from [timeFormat](config.html#format) config for temporal
+        The formatting pattern for labels. This is D3's `number format pattern
+        <https://github.com/d3/d3-format#locale_format>`_ for quantitative fields and D3's
+        `time format pattern <https://github.com/d3/d3-time-format#locale_format>`_ for time
+         field.  See the `format documentation <format.html>`_ for more information.
+        **Default value:**  derived from `numberFormat <config.html#format>`_ config for
+        quantitative fields and from `timeFormat <config.html#format>`_ config for temporal
         fields.
     offset : float
         The offset, in pixels, by which to displace the legend from the edge of the
-        enclosing group or data rectangle.  __Default value:__  `0`
+        enclosing group or data rectangle.  **Default value:**  ``0``
     orient : LegendOrient
         The orientation of the legend, which determines how the legend is positioned within
         the scene. One of "left", "right", "top-left", "top-right", "bottom-left",
-        "bottom-right", "none".  __Default value:__ `"right"`
+        "bottom-right", "none".  **Default value:** ``"right"``
     padding : float
         The padding, in pixels, between the legend and axis.
     tickCount : float
         The desired number of tick values for quantitative legends.
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     type : enum('symbol', 'gradient')
-        The type of the legend. Use `"symbol"` to create a discrete legend and `"gradient"`
-        for a continuous color gradient.  __Default value:__ `"gradient"` for non-binned
-        quantitative fields and temporal fields; `"symbol"` otherwise.
+        The type of the legend. Use ``"symbol"`` to create a discrete legend and
+        ``"gradient"`` for a continuous color gradient.  **Default value:** ``"gradient"``
+        for non-binned quantitative fields and temporal fields; ``"symbol"`` otherwise.
     values : anyOf(List(float), List(string), List(DateTime))
         Explicitly set the visible legend values.
     zindex : float
@@ -3269,23 +3293,23 @@ class LegendConfig(VegaLiteSchema):
     labelFont : string
         The font of the legend label.
     labelFontSize : float
-        The font size of legend label.  __Default value:__ `10`.
+        The font size of legend label.  **Default value:** ``10``.
     labelLimit : float
         Maximum allowed pixel width of axis tick labels.
     labelOffset : float
         The offset of the legend label.
     offset : float
         The offset, in pixels, by which to displace the legend from the edge of the
-        enclosing group or data rectangle.  __Default value:__  `0`
+        enclosing group or data rectangle.  **Default value:**  ``0``
     orient : LegendOrient
         The orientation of the legend, which determines how the legend is positioned within
         the scene. One of "left", "right", "top-left", "top-right", "bottom-left",
-        "bottom-right", "none".  __Default value:__ `"right"`
+        "bottom-right", "none".  **Default value:** ``"right"``
     padding : float
         The padding, in pixels, between the legend and axis.
     shortTimeLabels : boolean
-        Whether month names and weekday names should be abbreviated.  __Default value:__
-        `false`
+        Whether month names and weekday names should be abbreviated.  **Default value:**
+        ``false``
     strokeColor : string
         Border stroke color for the full legend.
     strokeDash : List(float)
@@ -3311,9 +3335,9 @@ class LegendConfig(VegaLiteSchema):
     titleFontSize : float
         The font size of the legend title.
     titleFontWeight : FontWeight
-        The font weight of the legend title. This can be either a string (e.g `"bold"`,
-        `"normal"`) or a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400`
-        and `"bold"` = `700`).
+        The font weight of the legend title. This can be either a string (e.g ``"bold"``,
+        ``"normal"`` ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where
+        ``"normal"`` = ``400`` and ``"bold"`` = ``700`` ).
     titleLimit : float
         Maximum allowed pixel width of axis titles.
     titlePadding : float
@@ -3406,124 +3430,127 @@ class LineConfig(VegaLiteSchema):
     Attributes
     ----------
     align : HorizontalAlign
-        The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
-        __Default value:__ `"middle"`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+        **Default value:** ``"middle"``
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
-        and will override `color`.  __Default value:__ <span style="color:
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
-        [style config](mark.html#style-config).
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.  **Default value:** :raw-html:`<span
+        style="color: #4682b4;">&#9632;</span>` ``"#4682b4"``  **Note:** This property
+        cannot be used in a `style config <mark.html#style-config>`_.
     cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
     'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
     'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
     'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor
-        type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`_ can be used.
     dx : float
         The horizontal offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     dy : float
         The vertical offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     fill : string
-        Default Fill Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Fill Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     fillOpacity : float
-        The fill opacity (value between [0,1]).  __Default value:__ `1`
+        The fill opacity (value between [0,1]).  **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.
-        __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
-         This property cannot be used in a [style config](mark.html#style-config).
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.  **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and
+        ``area`` marks.  **Note:** This property cannot be used in a `style config
+        <mark.html#style-config>`_.
     font : string
-        The typeface to set the text in (e.g., `"Helvetica Neue"`).
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : float
         The font size, in pixels.
     fontStyle : FontStyle
-        The font style (e.g., `"italic"`).
+        The font style (e.g., ``"italic"`` ).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
-        (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
         The line interpolation method to use for line and area marks. One of the following:
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
-        close the linear segments to form a polygon. - `"step"`: alternate between
-        horizontal and vertical segments, as in a step function. - `"step-before"`:
-        alternate between vertical and horizontal segments, as in a step function. -
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
-        `"basis-open"`: an open B-spline; may not intersect the start or end. -
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
-        Cardinal spline; may not intersect the start or end, but will intersect other
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
-        the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+           * ``"linear"`` : piecewise linear segments, as in a polyline. *
+        ``"linear-closed"`` : close the linear segments to form a polygon. * ``"step"`` :
+        alternate between horizontal and vertical segments, as in a step function. *
+        ``"step-before"`` : alternate between vertical and horizontal segments, as in a step
+         function. * ``"step-after"`` : alternate between horizontal and vertical segments,
+        as in a step function. * ``"basis"`` : a B-spline, with control point duplication on
+         the ends. * ``"basis-open"`` : an open B-spline; may not intersect the start or
+        end. * ``"basis-closed"`` : a closed B-spline, as in a loop. * ``"cardinal"`` : a
+        Cardinal spline, with control point duplication on the ends. * ``"cardinal-open"`` :
+         an open Cardinal spline; may not intersect the start or end, but will intersect
+        other control points. * ``"cardinal-closed"`` : a closed Cardinal spline, as in a
+        loop. * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+        straighten the spline. * ``"monotone"`` : cubic interpolation that preserves
+        monotonicity in y.
     limit : float
         The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
-        `bar` charts and `1` otherwise.
+        The overall opacity (value between [0,1]).  **Default value:** ``0.7`` for
+        non-aggregate plots with ``point``, ``tick``, ``circle``, or ``square`` marks or
+        layered ``bar`` charts and ``1`` otherwise.
     orient : Orient
         The orientation of a non-stacked bar, tick, area, and line charts. The value is
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines
-        whether the size of the bar and tick should be applied to x or y dimension. - For
-        area, this property determines the orient property of the Vega output. - For line
+        either horizontal (default) or vertical.   * For bar, rule and tick, this determines
+         whether the size of the bar and tick   should be applied to x or y dimension. * For
+         area, this property determines the orient property of the Vega output. * For line
         and trail marks, this property determines the sort order of the points in the line
-        if `config.sortLineBy` is not specified. For stacked charts, this is always
-        determined by the orientation of the stack; therefore explicitly specified value
+           if ``config.sortLineBy`` is not specified.   For stacked charts, this is always
+        determined by the orientation of the stack;   therefore explicitly specified value
         will be ignored.
     point : anyOf(boolean, MarkProperties, enum('transparent'))
         A flag for overlaying points on top of line or area marks, or an object defining the
-         properties of the overlayed points.  - If this property is `"transparent"`,
-        transparent points will be used (for enhancing tooltips and selections).  - If this
-        property is an empty object (`{}`) or `true`, filled points with default properties
-        will be used.  - If this property is `false`, no points would be automatically added
-         to line or area marks.  __Default value:__ `false`.
+         properties of the overlayed points.   *    If this property is ``"transparent"``,
+        transparent points will be used (for enhancing tooltips and selections).  *    If
+        this property is an empty object ( ``{}`` ) or ``true``, filled points with default
+        properties will be used.  *    If this property is ``false``, no points would be
+        automatically added to line or area marks.  **Default value:** ``false``.
     radius : float
         Polar coordinate radial offset, in pixels, of the text label from the origin
-        determined by the `x` and `y` properties.
+        determined by the ``x`` and ``y`` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
-          __Default value:__ `"circle"`
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.  **Default value:** ``"circle"``
     size : float
         The pixel area each the point/circle/square. For example: in the case of circles,
-        the radius is determined in part by the square root of the size value.  __Default
-        value:__ `30`
+        the radius is determined in part by the square root of the size value.  **Default
+        value:** ``30``
     stroke : string
-        Default Stroke Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Stroke Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     strokeCap : enum('butt', 'round', 'square')
-        The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
-        __Default value:__ `"square"`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.  **Default value:** ``"square"``
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : float
         The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeOpacity : float
-        The stroke opacity (value between [0,1]).  __Default value:__ `1`
+        The stroke opacity (value between [0,1]).  **Default value:** ``1``
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
         Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
-        Placeholder text if the `text` channel is not specified
+        Placeholder text if the ``text`` channel is not specified
     theta : float
         Polar coordinate angle, in radians, of the text label from the origin determined by
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
-        `0` indicating "north".
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
     """
     _schema = {'$ref': '#/definitions/LineConfig'}
     _rootschema = Root._schema
@@ -3732,12 +3759,12 @@ class LookupTransform(VegaLiteSchema):
     lookup : string
         Key in primary data source.
     default : string
-        The default value to use if lookup fails.  __Default value:__ `null`
+        The default value to use if lookup fails.  **Default value:** ``null``
     as : anyOf(string, List(string))
-        The field or fields for storing the computed formula value. If `from.fields` is
-        specified, the transform will use the same names for `as`. If `from.fields` is not
-        specified, `as` has to be a string and we put the whole object into the data under
-        the specified name.
+        The field or fields for storing the computed formula value. If ``from.fields`` is
+        specified, the transform will use the same names for ``as``. If ``from.fields`` is
+        not specified, ``as`` has to be a string and we put the whole object into the data
+        under the specified name.
     from : LookupData
         Secondary data reference.
     """
@@ -3770,117 +3797,120 @@ class MarkConfig(VegaLiteSchema):
     Attributes
     ----------
     align : HorizontalAlign
-        The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
-        __Default value:__ `"middle"`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+        **Default value:** ``"middle"``
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
-        and will override `color`.  __Default value:__ <span style="color:
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
-        [style config](mark.html#style-config).
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.  **Default value:** :raw-html:`<span
+        style="color: #4682b4;">&#9632;</span>` ``"#4682b4"``  **Note:** This property
+        cannot be used in a `style config <mark.html#style-config>`_.
     cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
     'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
     'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
     'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor
-        type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`_ can be used.
     dx : float
         The horizontal offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     dy : float
         The vertical offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     fill : string
-        Default Fill Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Fill Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     fillOpacity : float
-        The fill opacity (value between [0,1]).  __Default value:__ `1`
+        The fill opacity (value between [0,1]).  **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.
-        __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
-         This property cannot be used in a [style config](mark.html#style-config).
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.  **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and
+        ``area`` marks.  **Note:** This property cannot be used in a `style config
+        <mark.html#style-config>`_.
     font : string
-        The typeface to set the text in (e.g., `"Helvetica Neue"`).
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : float
         The font size, in pixels.
     fontStyle : FontStyle
-        The font style (e.g., `"italic"`).
+        The font style (e.g., ``"italic"`` ).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
-        (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
         The line interpolation method to use for line and area marks. One of the following:
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
-        close the linear segments to form a polygon. - `"step"`: alternate between
-        horizontal and vertical segments, as in a step function. - `"step-before"`:
-        alternate between vertical and horizontal segments, as in a step function. -
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
-        `"basis-open"`: an open B-spline; may not intersect the start or end. -
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
-        Cardinal spline; may not intersect the start or end, but will intersect other
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
-        the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+           * ``"linear"`` : piecewise linear segments, as in a polyline. *
+        ``"linear-closed"`` : close the linear segments to form a polygon. * ``"step"`` :
+        alternate between horizontal and vertical segments, as in a step function. *
+        ``"step-before"`` : alternate between vertical and horizontal segments, as in a step
+         function. * ``"step-after"`` : alternate between horizontal and vertical segments,
+        as in a step function. * ``"basis"`` : a B-spline, with control point duplication on
+         the ends. * ``"basis-open"`` : an open B-spline; may not intersect the start or
+        end. * ``"basis-closed"`` : a closed B-spline, as in a loop. * ``"cardinal"`` : a
+        Cardinal spline, with control point duplication on the ends. * ``"cardinal-open"`` :
+         an open Cardinal spline; may not intersect the start or end, but will intersect
+        other control points. * ``"cardinal-closed"`` : a closed Cardinal spline, as in a
+        loop. * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+        straighten the spline. * ``"monotone"`` : cubic interpolation that preserves
+        monotonicity in y.
     limit : float
         The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
-        `bar` charts and `1` otherwise.
+        The overall opacity (value between [0,1]).  **Default value:** ``0.7`` for
+        non-aggregate plots with ``point``, ``tick``, ``circle``, or ``square`` marks or
+        layered ``bar`` charts and ``1`` otherwise.
     orient : Orient
         The orientation of a non-stacked bar, tick, area, and line charts. The value is
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines
-        whether the size of the bar and tick should be applied to x or y dimension. - For
-        area, this property determines the orient property of the Vega output. - For line
+        either horizontal (default) or vertical.   * For bar, rule and tick, this determines
+         whether the size of the bar and tick   should be applied to x or y dimension. * For
+         area, this property determines the orient property of the Vega output. * For line
         and trail marks, this property determines the sort order of the points in the line
-        if `config.sortLineBy` is not specified. For stacked charts, this is always
-        determined by the orientation of the stack; therefore explicitly specified value
+           if ``config.sortLineBy`` is not specified.   For stacked charts, this is always
+        determined by the orientation of the stack;   therefore explicitly specified value
         will be ignored.
     radius : float
         Polar coordinate radial offset, in pixels, of the text label from the origin
-        determined by the `x` and `y` properties.
+        determined by the ``x`` and ``y`` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
-          __Default value:__ `"circle"`
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.  **Default value:** ``"circle"``
     size : float
         The pixel area each the point/circle/square. For example: in the case of circles,
-        the radius is determined in part by the square root of the size value.  __Default
-        value:__ `30`
+        the radius is determined in part by the square root of the size value.  **Default
+        value:** ``30``
     stroke : string
-        Default Stroke Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Stroke Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     strokeCap : enum('butt', 'round', 'square')
-        The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
-        __Default value:__ `"square"`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.  **Default value:** ``"square"``
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : float
         The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeOpacity : float
-        The stroke opacity (value between [0,1]).  __Default value:__ `1`
+        The stroke opacity (value between [0,1]).  **Default value:** ``1``
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
         Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
-        Placeholder text if the `text` channel is not specified
+        Placeholder text if the ``text`` channel is not specified
     theta : float
         Polar coordinate angle, in radians, of the text label from the origin determined by
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
-        `0` indicating "north".
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
     """
     _schema = {'$ref': '#/definitions/MarkConfig'}
     _rootschema = Root._schema
@@ -3913,148 +3943,152 @@ class MarkDef(VegaLiteSchema):
     Attributes
     ----------
     type : Mark
-        The mark type. One of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`, `"area"`,
-         `"point"`, `"geoshape"`, `"rule"`, and `"text"`.
+        The mark type. One of ``"bar"``, ``"circle"``, ``"square"``, ``"tick"``, ``"line"``,
+         ``"area"``, ``"point"``, ``"geoshape"``, ``"rule"``, and ``"text"``.
     align : HorizontalAlign
-        The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
-        __Default value:__ `"middle"`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+        **Default value:** ``"middle"``
     binSpacing : float
         Offset between bars for binned field.  Ideal value for this is either 0 (Preferred
-        by statisticians) or 1 (Vega-Lite Default, D3 example style).  __Default value:__
-        `1`
+        by statisticians) or 1 (Vega-Lite Default, D3 example style).  **Default value:**
+        ``1``
     clip : boolean
         Whether a mark be clipped to the enclosing group’s width and height.
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
-        and will override `color`.  __Default value:__ <span style="color:
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
-        [style config](mark.html#style-config).
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.  **Default value:** :raw-html:`<span
+        style="color: #4682b4;">&#9632;</span>` ``"#4682b4"``  **Note:** This property
+        cannot be used in a `style config <mark.html#style-config>`_.
     cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
     'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
     'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
     'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor
-        type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`_ can be used.
     dx : float
         The horizontal offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     dy : float
         The vertical offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     fill : string
-        Default Fill Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Fill Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     fillOpacity : float
-        The fill opacity (value between [0,1]).  __Default value:__ `1`
+        The fill opacity (value between [0,1]).  **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.
-        __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
-         This property cannot be used in a [style config](mark.html#style-config).
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.  **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and
+        ``area`` marks.  **Note:** This property cannot be used in a `style config
+        <mark.html#style-config>`_.
     font : string
-        The typeface to set the text in (e.g., `"Helvetica Neue"`).
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : float
         The font size, in pixels.
     fontStyle : FontStyle
-        The font style (e.g., `"italic"`).
+        The font style (e.g., ``"italic"`` ).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
-        (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
         The line interpolation method to use for line and area marks. One of the following:
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
-        close the linear segments to form a polygon. - `"step"`: alternate between
-        horizontal and vertical segments, as in a step function. - `"step-before"`:
-        alternate between vertical and horizontal segments, as in a step function. -
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
-        `"basis-open"`: an open B-spline; may not intersect the start or end. -
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
-        Cardinal spline; may not intersect the start or end, but will intersect other
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
-        the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+           * ``"linear"`` : piecewise linear segments, as in a polyline. *
+        ``"linear-closed"`` : close the linear segments to form a polygon. * ``"step"`` :
+        alternate between horizontal and vertical segments, as in a step function. *
+        ``"step-before"`` : alternate between vertical and horizontal segments, as in a step
+         function. * ``"step-after"`` : alternate between horizontal and vertical segments,
+        as in a step function. * ``"basis"`` : a B-spline, with control point duplication on
+         the ends. * ``"basis-open"`` : an open B-spline; may not intersect the start or
+        end. * ``"basis-closed"`` : a closed B-spline, as in a loop. * ``"cardinal"`` : a
+        Cardinal spline, with control point duplication on the ends. * ``"cardinal-open"`` :
+         an open Cardinal spline; may not intersect the start or end, but will intersect
+        other control points. * ``"cardinal-closed"`` : a closed Cardinal spline, as in a
+        loop. * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+        straighten the spline. * ``"monotone"`` : cubic interpolation that preserves
+        monotonicity in y.
     limit : float
         The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     line : anyOf(boolean, MarkProperties)
         A flag for overlaying line on top of area marks, or an object defining the
-        properties of the overlayed lines.  - If this value is an empty object (`{}`) or
-        `true`, lines with default properties will be used.  - If this value is `false`, no
-        lines would be automatically added to area marks.  __Default value:__ `false`.
+        properties of the overlayed lines.   *    If this value is an empty object ( ``{}``
+        ) or ``true``, lines with default properties will be used.  *    If this value is
+        ``false``, no lines would be automatically added to area marks.  **Default value:**
+        ``false``.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
-        `bar` charts and `1` otherwise.
+        The overall opacity (value between [0,1]).  **Default value:** ``0.7`` for
+        non-aggregate plots with ``point``, ``tick``, ``circle``, or ``square`` marks or
+        layered ``bar`` charts and ``1`` otherwise.
     orient : Orient
         The orientation of a non-stacked bar, tick, area, and line charts. The value is
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines
-        whether the size of the bar and tick should be applied to x or y dimension. - For
-        area, this property determines the orient property of the Vega output. - For line
+        either horizontal (default) or vertical.   * For bar, rule and tick, this determines
+         whether the size of the bar and tick   should be applied to x or y dimension. * For
+         area, this property determines the orient property of the Vega output. * For line
         and trail marks, this property determines the sort order of the points in the line
-        if `config.sortLineBy` is not specified. For stacked charts, this is always
-        determined by the orientation of the stack; therefore explicitly specified value
+           if ``config.sortLineBy`` is not specified.   For stacked charts, this is always
+        determined by the orientation of the stack;   therefore explicitly specified value
         will be ignored.
     point : anyOf(boolean, MarkProperties, enum('transparent'))
         A flag for overlaying points on top of line or area marks, or an object defining the
-         properties of the overlayed points.  - If this property is `"transparent"`,
-        transparent points will be used (for enhancing tooltips and selections).  - If this
-        property is an empty object (`{}`) or `true`, filled points with default properties
-        will be used.  - If this property is `false`, no points would be automatically added
-         to line or area marks.  __Default value:__ `false`.
+         properties of the overlayed points.   *    If this property is ``"transparent"``,
+        transparent points will be used (for enhancing tooltips and selections).  *    If
+        this property is an empty object ( ``{}`` ) or ``true``, filled points with default
+        properties will be used.  *    If this property is ``false``, no points would be
+        automatically added to line or area marks.  **Default value:** ``false``.
     radius : float
         Polar coordinate radial offset, in pixels, of the text label from the origin
-        determined by the `x` and `y` properties.
+        determined by the ``x`` and ``y`` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
-          __Default value:__ `"circle"`
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.  **Default value:** ``"circle"``
     size : float
         The pixel area each the point/circle/square. For example: in the case of circles,
-        the radius is determined in part by the square root of the size value.  __Default
-        value:__ `30`
+        the radius is determined in part by the square root of the size value.  **Default
+        value:** ``30``
     stroke : string
-        Default Stroke Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Stroke Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     strokeCap : enum('butt', 'round', 'square')
-        The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
-        __Default value:__ `"square"`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.  **Default value:** ``"square"``
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : float
         The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeOpacity : float
-        The stroke opacity (value between [0,1]).  __Default value:__ `1`
+        The stroke opacity (value between [0,1]).  **Default value:** ``1``
     strokeWidth : float
         The stroke width, in pixels.
     style : anyOf(string, List(string))
         A string or array of strings indicating the name of custom styles to apply to the
         mark. A style is a named collection of mark property defaults defined within the
-        [style configuration](mark.html#style-config). If style is an array, later styles
-        will override earlier styles. Any [mark properties](encoding.html#mark-prop)
-        explicitly defined within the `encoding` will override a style default.  __Default
-        value:__ The mark's name.  For example, a bar mark will have style `"bar"` by
-        default. __Note:__ Any specified style will augment the default style. For example,
-        a bar mark with `"style": "foo"` will receive from `config.style.bar` and
-        `config.style.foo` (the specified style `"foo"` has higher precedence).
+        `style configuration <mark.html#style-config>`_. If style is an array, later styles
+        will override earlier styles. Any `mark properties <encoding.html#mark-prop>`_
+        explicitly defined within the ``encoding`` will override a style default.  **Default
+         value:** The mark's name.  For example, a bar mark will have style ``"bar"`` by
+        default. **Note:** Any specified style will augment the default style. For example,
+        a bar mark with ``"style": "foo"`` will receive from ``config.style.bar`` and
+        ``config.style.foo`` (the specified style ``"foo"`` has higher precedence).
     tension : float
         Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
-        Placeholder text if the `text` channel is not specified
+        Placeholder text if the ``text`` channel is not specified
     theta : float
         Polar coordinate angle, in radians, of the text label from the origin determined by
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
-        `0` indicating "north".
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
     """
     _schema = {'$ref': '#/definitions/MarkDef'}
     _rootschema = Root._schema
@@ -4089,133 +4123,136 @@ class MarkProperties(VegaLiteSchema):
     Attributes
     ----------
     align : HorizontalAlign
-        The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
-        __Default value:__ `"middle"`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+        **Default value:** ``"middle"``
     binSpacing : float
         Offset between bars for binned field.  Ideal value for this is either 0 (Preferred
-        by statisticians) or 1 (Vega-Lite Default, D3 example style).  __Default value:__
-        `1`
+        by statisticians) or 1 (Vega-Lite Default, D3 example style).  **Default value:**
+        ``1``
     clip : boolean
         Whether a mark be clipped to the enclosing group’s width and height.
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
-        and will override `color`.  __Default value:__ <span style="color:
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
-        [style config](mark.html#style-config).
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.  **Default value:** :raw-html:`<span
+        style="color: #4682b4;">&#9632;</span>` ``"#4682b4"``  **Note:** This property
+        cannot be used in a `style config <mark.html#style-config>`_.
     cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
     'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
     'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
     'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor
-        type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`_ can be used.
     dx : float
         The horizontal offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     dy : float
         The vertical offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     fill : string
-        Default Fill Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Fill Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     fillOpacity : float
-        The fill opacity (value between [0,1]).  __Default value:__ `1`
+        The fill opacity (value between [0,1]).  **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.
-        __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
-         This property cannot be used in a [style config](mark.html#style-config).
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.  **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and
+        ``area`` marks.  **Note:** This property cannot be used in a `style config
+        <mark.html#style-config>`_.
     font : string
-        The typeface to set the text in (e.g., `"Helvetica Neue"`).
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : float
         The font size, in pixels.
     fontStyle : FontStyle
-        The font style (e.g., `"italic"`).
+        The font style (e.g., ``"italic"`` ).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
-        (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
         The line interpolation method to use for line and area marks. One of the following:
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
-        close the linear segments to form a polygon. - `"step"`: alternate between
-        horizontal and vertical segments, as in a step function. - `"step-before"`:
-        alternate between vertical and horizontal segments, as in a step function. -
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
-        `"basis-open"`: an open B-spline; may not intersect the start or end. -
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
-        Cardinal spline; may not intersect the start or end, but will intersect other
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
-        the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+           * ``"linear"`` : piecewise linear segments, as in a polyline. *
+        ``"linear-closed"`` : close the linear segments to form a polygon. * ``"step"`` :
+        alternate between horizontal and vertical segments, as in a step function. *
+        ``"step-before"`` : alternate between vertical and horizontal segments, as in a step
+         function. * ``"step-after"`` : alternate between horizontal and vertical segments,
+        as in a step function. * ``"basis"`` : a B-spline, with control point duplication on
+         the ends. * ``"basis-open"`` : an open B-spline; may not intersect the start or
+        end. * ``"basis-closed"`` : a closed B-spline, as in a loop. * ``"cardinal"`` : a
+        Cardinal spline, with control point duplication on the ends. * ``"cardinal-open"`` :
+         an open Cardinal spline; may not intersect the start or end, but will intersect
+        other control points. * ``"cardinal-closed"`` : a closed Cardinal spline, as in a
+        loop. * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+        straighten the spline. * ``"monotone"`` : cubic interpolation that preserves
+        monotonicity in y.
     limit : float
         The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
-        `bar` charts and `1` otherwise.
+        The overall opacity (value between [0,1]).  **Default value:** ``0.7`` for
+        non-aggregate plots with ``point``, ``tick``, ``circle``, or ``square`` marks or
+        layered ``bar`` charts and ``1`` otherwise.
     orient : Orient
         The orientation of a non-stacked bar, tick, area, and line charts. The value is
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines
-        whether the size of the bar and tick should be applied to x or y dimension. - For
-        area, this property determines the orient property of the Vega output. - For line
+        either horizontal (default) or vertical.   * For bar, rule and tick, this determines
+         whether the size of the bar and tick   should be applied to x or y dimension. * For
+         area, this property determines the orient property of the Vega output. * For line
         and trail marks, this property determines the sort order of the points in the line
-        if `config.sortLineBy` is not specified. For stacked charts, this is always
-        determined by the orientation of the stack; therefore explicitly specified value
+           if ``config.sortLineBy`` is not specified.   For stacked charts, this is always
+        determined by the orientation of the stack;   therefore explicitly specified value
         will be ignored.
     radius : float
         Polar coordinate radial offset, in pixels, of the text label from the origin
-        determined by the `x` and `y` properties.
+        determined by the ``x`` and ``y`` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
-          __Default value:__ `"circle"`
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.  **Default value:** ``"circle"``
     size : float
         The pixel area each the point/circle/square. For example: in the case of circles,
-        the radius is determined in part by the square root of the size value.  __Default
-        value:__ `30`
+        the radius is determined in part by the square root of the size value.  **Default
+        value:** ``30``
     stroke : string
-        Default Stroke Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Stroke Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     strokeCap : enum('butt', 'round', 'square')
-        The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
-        __Default value:__ `"square"`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.  **Default value:** ``"square"``
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : float
         The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeOpacity : float
-        The stroke opacity (value between [0,1]).  __Default value:__ `1`
+        The stroke opacity (value between [0,1]).  **Default value:** ``1``
     strokeWidth : float
         The stroke width, in pixels.
     style : anyOf(string, List(string))
         A string or array of strings indicating the name of custom styles to apply to the
         mark. A style is a named collection of mark property defaults defined within the
-        [style configuration](mark.html#style-config). If style is an array, later styles
-        will override earlier styles. Any [mark properties](encoding.html#mark-prop)
-        explicitly defined within the `encoding` will override a style default.  __Default
-        value:__ The mark's name.  For example, a bar mark will have style `"bar"` by
-        default. __Note:__ Any specified style will augment the default style. For example,
-        a bar mark with `"style": "foo"` will receive from `config.style.bar` and
-        `config.style.foo` (the specified style `"foo"` has higher precedence).
+        `style configuration <mark.html#style-config>`_. If style is an array, later styles
+        will override earlier styles. Any `mark properties <encoding.html#mark-prop>`_
+        explicitly defined within the ``encoding`` will override a style default.  **Default
+         value:** The mark's name.  For example, a bar mark will have style ``"bar"`` by
+        default. **Note:** Any specified style will augment the default style. For example,
+        a bar mark with ``"style": "foo"`` will receive from ``config.style.bar`` and
+        ``config.style.foo`` (the specified style ``"foo"`` has higher precedence).
     tension : float
         Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
-        Placeholder text if the `text` channel is not specified
+        Placeholder text if the ``text`` channel is not specified
     theta : float
         Polar coordinate angle, in radians, of the text label from the origin determined by
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
-        `0` indicating "north".
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
     """
     _schema = {'$ref': '#/definitions/MarkProperties'}
     _rootschema = Root._schema
@@ -4266,7 +4303,7 @@ class MultiSelection(VegaLiteSchema):
 
     empty : enum('all', 'none')
         By default, all data values are considered to lie within an empty selection. When
-        set to `none`, empty selections contain no data values.
+        set to ``none``, empty selections contain no data values.
     encodings : List(SingleDefChannel)
         An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
@@ -4275,24 +4312,24 @@ class MultiSelection(VegaLiteSchema):
         selection.
     nearest : boolean
         When true, an invisible voronoi diagram is computed to accelerate discrete
-        selection. The data value _nearest_ the mouse cursor is added to the selection.  See
-         the [nearest transform](nearest.html) documentation for more information.
+        selection. The data value *nearest* the mouse cursor is added to the selection.  See
+         the `nearest transform <nearest.html>`_ documentation for more information.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`_ (object or
         selector) that triggers the selection. For interval selections, the event stream
-        must specify a [start and
-        end](https://vega.github.io/vega/docs/event-streams/#between-filters).
+        must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`_.
     resolve : SelectionResolution
         With layered and multi-view displays, a strategy that determines how selections'
         data queries are resolved when applied in a filter transform, conditional encoding
         rule, or scale domain.
     toggle : anyOf(string, boolean)
         Controls whether data values should be toggled or only ever inserted into multi
-        selections. Can be `true`, `false` (for insertion only), or a [Vega
-        expression](https://vega.github.io/vega/docs/expressions/).  __Default value:__
-        `true`, which corresponds to `event.shiftKey` (i.e., data values are toggled when a
-        user interacts with the shift-key pressed).  See the [toggle transform](toggle.html)
-         documentation for more information.
+        selections. Can be ``true``, ``false`` (for insertion only), or a `Vega expression
+        <https://vega.github.io/vega/docs/expressions/>`_.  **Default value:** ``true``,
+        which corresponds to ``event.shiftKey`` (i.e., data values are toggled when a user
+        interacts with the shift-key pressed).  See the `toggle transform <toggle.html>`_
+        documentation for more information.
     """
     _schema = {'$ref': '#/definitions/MultiSelection'}
     _rootschema = Root._schema
@@ -4313,7 +4350,7 @@ class MultiSelectionConfig(VegaLiteSchema):
     ----------
     empty : enum('all', 'none')
         By default, all data values are considered to lie within an empty selection. When
-        set to `none`, empty selections contain no data values.
+        set to ``none``, empty selections contain no data values.
     encodings : List(SingleDefChannel)
         An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
@@ -4322,24 +4359,24 @@ class MultiSelectionConfig(VegaLiteSchema):
         selection.
     nearest : boolean
         When true, an invisible voronoi diagram is computed to accelerate discrete
-        selection. The data value _nearest_ the mouse cursor is added to the selection.  See
-         the [nearest transform](nearest.html) documentation for more information.
+        selection. The data value *nearest* the mouse cursor is added to the selection.  See
+         the `nearest transform <nearest.html>`_ documentation for more information.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`_ (object or
         selector) that triggers the selection. For interval selections, the event stream
-        must specify a [start and
-        end](https://vega.github.io/vega/docs/event-streams/#between-filters).
+        must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`_.
     resolve : SelectionResolution
         With layered and multi-view displays, a strategy that determines how selections'
         data queries are resolved when applied in a filter transform, conditional encoding
         rule, or scale domain.
     toggle : anyOf(string, boolean)
         Controls whether data values should be toggled or only ever inserted into multi
-        selections. Can be `true`, `false` (for insertion only), or a [Vega
-        expression](https://vega.github.io/vega/docs/expressions/).  __Default value:__
-        `true`, which corresponds to `event.shiftKey` (i.e., data values are toggled when a
-        user interacts with the shift-key pressed).  See the [toggle transform](toggle.html)
-         documentation for more information.
+        selections. Can be ``true``, ``false`` (for insertion only), or a `Vega expression
+        <https://vega.github.io/vega/docs/expressions/>`_.  **Default value:** ``true``,
+        which corresponds to ``event.shiftKey`` (i.e., data values are toggled when a user
+        interacts with the shift-key pressed).  See the `toggle transform <toggle.html>`_
+        documentation for more information.
     """
     _schema = {'$ref': '#/definitions/MultiSelectionConfig'}
     _rootschema = Root._schema
@@ -4402,46 +4439,46 @@ class OrderFieldDef(VegaLiteSchema):
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     sort : SortOrder
-        The sort order. One of `"ascending"` (default) or `"descending"`.
+        The sort order. One of ``"ascending"`` (default) or ``"descending"``.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/OrderFieldDef'}
     _rootschema = Root._schema
@@ -4484,84 +4521,84 @@ class PositionFieldDef(VegaLiteSchema):
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     axis : anyOf(Axis, None)
-        An object defining properties of axis's gridlines, ticks and labels. If `null`, the
-        axis for the encoding channel will be removed.  __Default value:__ If undefined,
-        default [axis properties](https://vega.github.io/vega-lite/docs/axis.html) are
+        An object defining properties of axis's gridlines, ticks and labels. If ``null``,
+        the axis for the encoding channel will be removed.  **Default value:** If undefined,
+         default `axis properties <https://vega.github.io/vega-lite/docs/axis.html>`_ are
         applied.
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     scale : anyOf(Scale, None)
         An object defining properties of the channel's scale, which is the function that
         transforms values in the data domain (numbers, dates, strings, etc) to visual values
-         (pixels, colors, sizes) of the encoding channels.  If `null`, the scale will be
-        [disabled and the data value will be directly
-        encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).  __Default
-        value:__ If undefined, default [scale
-        properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+         (pixels, colors, sizes) of the encoding channels.  If ``null``, the scale will be
+        `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`_.  **Default value:** If
+         undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`_ are applied.
     sort : anyOf(List(string), SortOrder, SortField, None)
-        Sort order for the encoded field. Supported `sort` values include `"ascending"`,
-        `"descending"`, `null` (no sorting), or an array specifying the preferred order of
-        values. For fields with discrete domains, `sort` can also be a [sort field
-        definition object](https://vega.github.io/vega-lite/docs/sort.html#sort-field). For
-        `sort` as an [array specifying the preferred order of
-        values](https://vega.github.io/vega-lite/docs/sort.html#sort-array), the sort order
-        will obey the values in the array, followed by any unspecified values in their
-        original order.  __Default value:__ `"ascending"`
+        Sort order for the encoded field. Supported ``sort`` values include ``"ascending"``,
+         ``"descending"``, ``null`` (no sorting), or an array specifying the preferred order
+         of values. For fields with discrete domains, ``sort`` can also be a `sort field
+        definition object <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`_.
+        For ``sort`` as an `array specifying the preferred order of values
+        <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`_, the sort order will
+        obey the values in the array, followed by any unspecified values in their original
+        order.  **Default value:** ``"ascending"``
     stack : anyOf(StackOffset, None)
-        Type of stacking offset if the field should be stacked. `stack` is only applicable
-        for `x` and `y` channels with continuous domains. For example, `stack` of `y` can be
-         used to customize stacking for a vertical bar chart.  `stack` can be one of the
-        following values: - `"zero"`: stacking with baseline offset at zero value of the
-        scale (for creating typical stacked
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and
-        [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart). -
-        `"normalize"` - stacking with normalized domain (for creating [normalized stacked
-        bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized).
-        <br/> -`"center"` - stacking with center baseline (for
-        [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)). -
-        `null` - No-stacking. This will produce layered
-        [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area
-        chart.  __Default value:__ `zero` for plots with all of the following conditions are
-         true: (1) the mark is `bar` or `area`; (2) the stacked measure channel (x or y) has
-         a linear scale; (3) At least one of non-position channels mapped to an unaggregated
-         field that is different from x and y.  Otherwise, `null` by default.
+        Type of stacking offset if the field should be stacked. ``stack`` is only applicable
+         for ``x`` and ``y`` channels with continuous domains. For example, ``stack`` of
+        ``y`` can be used to customize stacking for a vertical bar chart.  ``stack`` can be
+        one of the following values:   * `"zero"`: stacking with baseline offset at zero
+        value of the scale (for creating typical stacked
+        [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and `area
+        <https://vega.github.io/vega-lite/docs/stack.html#area>`_ chart). * ``"normalize"``
+        - stacking with normalized domain (for creating `normalized stacked bar and area
+        charts <https://vega.github.io/vega-lite/docs/stack.html#normalized>`_.
+        :raw-html:`<br/>`   - ``"center"`` - stacking with center baseline (for `streamgraph
+         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`_ ). * ``null`` -
+        No-stacking. This will produce layered `bar
+        <https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart>`_ and area
+        chart.  **Default value:** ``zero`` for plots with all of the following conditions
+        are true: (1) the mark is ``bar`` or ``area`` ; (2) the stacked measure channel (x
+        or y) has a linear scale; (3) At least one of non-position channels mapped to an
+        unaggregated field that is different from x and y.  Otherwise, ``null`` by default.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/PositionFieldDef'}
     _rootschema = Root._schema
@@ -4596,16 +4633,16 @@ class Projection(VegaLiteSchema):
     ----------
     center : List(float)
         Sets the projection’s center to the specified center, a two-element array of
-        longitude and latitude in degrees.  __Default value:__ `[0, 0]`
+        longitude and latitude in degrees.  **Default value:** ``[0, 0]``
     clipAngle : float
         Sets the projection’s clipping circle radius to the specified angle in degrees. If
-        `null`, switches to [antimeridian](http://bl.ocks.org/mbostock/3788999) cutting
+        ``null``, switches to `antimeridian <http://bl.ocks.org/mbostock/3788999>`_ cutting
         rather than small-circle clipping.
     clipExtent : List(List(float))
         Sets the projection’s viewport clip extent to the specified bounds in pixels. The
-        extent bounds are specified as an array `[[x0, y0], [x1, y1]]`, where `x0` is the
-        left-side of the viewport, `y0` is the top, `x1` is the right and `y1` is the
-        bottom. If `null`, no viewport clipping is performed.
+        extent bounds are specified as an array ``[[x0, y0], [x1, y1]]``, where ``x0`` is
+        the left-side of the viewport, ``y0`` is the top, ``x1`` is the right and ``y1`` is
+        the bottom. If ``null``, no viewport clipping is performed.
     coefficient : float
 
     distance : float
@@ -4617,31 +4654,31 @@ class Projection(VegaLiteSchema):
     parallel : float
 
     precision : Mapping(required=[length])
-        Sets the threshold for the projection’s [adaptive
-        resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels.
-        This value corresponds to the [Douglas–Peucker
-        distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm).
-         If precision is not specified, returns the projection’s current resampling
-        precision which defaults to `√0.5 ≅ 0.70710…`.
+        Sets the threshold for the projection’s `adaptive resampling
+        <http://bl.ocks.org/mbostock/3795544>`_ to the specified value in pixels. This value
+         corresponds to the `Douglas–Peucker distance
+        <http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm>`_. If
+         precision is not specified, returns the projection’s current resampling precision
+        which defaults to ``√0.5 ≅ 0.70710…``.
     radius : float
 
     ratio : float
 
     rotate : List(float)
         Sets the projection’s three-axis rotation to the specified angles, which must be a
-        two- or three-element array of numbers [`lambda`, `phi`, `gamma`] specifying the
-        rotation angles in degrees about each spherical axis. (These correspond to yaw,
-        pitch and roll.)  __Default value:__ `[0, 0, 0]`
+        two- or three-element array of numbers [ ``lambda``, ``phi``, ``gamma`` ] specifying
+         the rotation angles in degrees about each spherical axis. (These correspond to yaw,
+         pitch and roll.)  **Default value:** ``[0, 0, 0]``
     spacing : float
 
     tilt : float
 
     type : ProjectionType
         The cartographic projection to use. This value is case-insensitive, for example
-        `"albers"` and `"Albers"` indicate the same projection type. You can find all valid
-        projection types [in the
-        documentation](https://vega.github.io/vega-lite/docs/projection.html#projection-types).
-          __Default value:__ `mercator`
+        ``"albers"`` and ``"Albers"`` indicate the same projection type. You can find all
+        valid projection types `in the documentation
+        <https://vega.github.io/vega-lite/docs/projection.html#projection-types>`_.
+        **Default value:** ``mercator``
     """
     _schema = {'$ref': '#/definitions/Projection'}
     _rootschema = Root._schema
@@ -4667,16 +4704,16 @@ class ProjectionConfig(VegaLiteSchema):
     ----------
     center : List(float)
         Sets the projection’s center to the specified center, a two-element array of
-        longitude and latitude in degrees.  __Default value:__ `[0, 0]`
+        longitude and latitude in degrees.  **Default value:** ``[0, 0]``
     clipAngle : float
         Sets the projection’s clipping circle radius to the specified angle in degrees. If
-        `null`, switches to [antimeridian](http://bl.ocks.org/mbostock/3788999) cutting
+        ``null``, switches to `antimeridian <http://bl.ocks.org/mbostock/3788999>`_ cutting
         rather than small-circle clipping.
     clipExtent : List(List(float))
         Sets the projection’s viewport clip extent to the specified bounds in pixels. The
-        extent bounds are specified as an array `[[x0, y0], [x1, y1]]`, where `x0` is the
-        left-side of the viewport, `y0` is the top, `x1` is the right and `y1` is the
-        bottom. If `null`, no viewport clipping is performed.
+        extent bounds are specified as an array ``[[x0, y0], [x1, y1]]``, where ``x0`` is
+        the left-side of the viewport, ``y0`` is the top, ``x1`` is the right and ``y1`` is
+        the bottom. If ``null``, no viewport clipping is performed.
     coefficient : float
 
     distance : float
@@ -4688,31 +4725,31 @@ class ProjectionConfig(VegaLiteSchema):
     parallel : float
 
     precision : Mapping(required=[length])
-        Sets the threshold for the projection’s [adaptive
-        resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels.
-        This value corresponds to the [Douglas–Peucker
-        distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm).
-         If precision is not specified, returns the projection’s current resampling
-        precision which defaults to `√0.5 ≅ 0.70710…`.
+        Sets the threshold for the projection’s `adaptive resampling
+        <http://bl.ocks.org/mbostock/3795544>`_ to the specified value in pixels. This value
+         corresponds to the `Douglas–Peucker distance
+        <http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm>`_. If
+         precision is not specified, returns the projection’s current resampling precision
+        which defaults to ``√0.5 ≅ 0.70710…``.
     radius : float
 
     ratio : float
 
     rotate : List(float)
         Sets the projection’s three-axis rotation to the specified angles, which must be a
-        two- or three-element array of numbers [`lambda`, `phi`, `gamma`] specifying the
-        rotation angles in degrees about each spherical axis. (These correspond to yaw,
-        pitch and roll.)  __Default value:__ `[0, 0, 0]`
+        two- or three-element array of numbers [ ``lambda``, ``phi``, ``gamma`` ] specifying
+         the rotation angles in degrees about each spherical axis. (These correspond to yaw,
+         pitch and roll.)  **Default value:** ``[0, 0, 0]``
     spacing : float
 
     tilt : float
 
     type : ProjectionType
         The cartographic projection to use. This value is case-insensitive, for example
-        `"albers"` and `"Albers"` indicate the same projection type. You can find all valid
-        projection types [in the
-        documentation](https://vega.github.io/vega-lite/docs/projection.html#projection-types).
-          __Default value:__ `mercator`
+        ``"albers"`` and ``"Albers"`` indicate the same projection type. You can find all
+        valid projection types `in the documentation
+        <https://vega.github.io/vega-lite/docs/projection.html#projection-types>`_.
+        **Default value:** ``mercator``
     """
     _schema = {'$ref': '#/definitions/ProjectionConfig'}
     _rootschema = Root._schema
@@ -4751,17 +4788,17 @@ class RangeConfig(VegaLiteSchema):
     Attributes
     ----------
     category : anyOf(List(string), VgScheme)
-        Default range for _nominal_ (categorical) fields.
+        Default range for *nominal* (categorical) fields.
     diverging : anyOf(List(string), VgScheme)
-        Default range for diverging _quantitative_ fields.
+        Default range for diverging *quantitative* fields.
     heatmap : anyOf(List(string), VgScheme)
-        Default range for _quantitative_ heatmaps.
+        Default range for *quantitative* heatmaps.
     ordinal : anyOf(List(string), VgScheme)
-        Default range for _ordinal_ fields.
+        Default range for *ordinal* fields.
     ramp : anyOf(List(string), VgScheme)
-        Default range for _quantitative_ and _temporal_ fields.
+        Default range for *quantitative* and *temporal* fields.
     symbol : List(string)
-        Default range palette for the `shape` channel.
+        Default range palette for the ``shape`` channel.
     """
     _schema = {'$ref': '#/definitions/RangeConfig'}
     _rootschema = Root._schema
@@ -4826,7 +4863,7 @@ class Resolve(VegaLiteSchema):
 
     Mapping(required=[])
     Defines how scales, axes, and legends from different specs should be combined. Resolve is a
-    mapping from `scale`, `axis`, and `legend` to a mapping from channels to resolutions.
+    mapping from ``scale``, ``axis``, and ``legend`` to a mapping from channels to resolutions.
 
     Attributes
     ----------
@@ -4864,131 +4901,136 @@ class Scale(VegaLiteSchema):
     Attributes
     ----------
     base : float
-        The logarithm base of the `log` scale (default `10`).
+        The logarithm base of the ``log`` scale (default ``10`` ).
     clamp : boolean
-        If `true`, values that exceed the data domain are clamped to either the minimum or
-        maximum range value  __Default value:__ derived from the [scale
-        config](config.html#scale-config)'s `clamp` (`true` by default).
+        If ``true``, values that exceed the data domain are clamped to either the minimum or
+         maximum range value  **Default value:** derived from the `scale config
+        <config.html#scale-config>`_ 's ``clamp`` ( ``true`` by default).
     domain : anyOf(List(float), List(string), List(boolean), List(DateTime),
     enum('unaggregated'), SelectionDomain)
-        Customized domain values.  For _quantitative_ fields, `domain` can take the form of
-        a two-element array with minimum and maximum values.  [Piecewise
-        scales](scale.html#piecewise) can be created by providing a `domain` with more than
-        two entries. If the input field is aggregated, `domain` can also be a string value
-        `"unaggregated"`, indicating that the domain should include the raw data values
-        prior to the aggregation.  For _temporal_ fields, `domain` can be a two-element
-        array minimum and maximum values, in the form of either timestamps or the [DateTime
-        definition objects](types.html#datetime).  For _ordinal_ and _nominal_ fields,
-        `domain` can be an array that lists valid input values.  The `selection` property
-        can be used to [interactively determine](selection.html#scale-domains) the scale
-        domain.
+        Customized domain values.  For *quantitative* fields, ``domain`` can take the form
+        of a two-element array with minimum and maximum values.  `Piecewise scales
+        <scale.html#piecewise>`_ can be created by providing a ``domain`` with more than two
+         entries. If the input field is aggregated, ``domain`` can also be a string value
+        ``"unaggregated"``, indicating that the domain should include the raw data values
+        prior to the aggregation.  For *temporal* fields, ``domain`` can be a two-element
+        array minimum and maximum values, in the form of either timestamps or the `DateTime
+        definition objects <types.html#datetime>`_.  For *ordinal* and *nominal* fields,
+        ``domain`` can be an array that lists valid input values.  The ``selection``
+        property can be used to `interactively determine <selection.html#scale-domains>`_
+        the scale domain.
     exponent : float
-        The exponent of the `pow` scale.
+        The exponent of the ``pow`` scale.
     interpolate : anyOf(ScaleInterpolate, ScaleInterpolateParams)
         The interpolation method for range values. By default, a general interpolator for
         numbers, dates, strings and colors (in RGB space) is used. For color ranges, this
         property allows interpolation in alternative color spaces. Legal values include
-        `rgb`, `hsl`, `hsl-long`, `lab`, `hcl`, `hcl-long`, `cubehelix` and `cubehelix-long`
-         ('-long' variants use longer paths in polar coordinate spaces). If object-valued,
-        this property accepts an object with a string-valued _type_ property and an optional
-         numeric _gamma_ property applicable to rgb and cubehelix interpolators. For more,
-        see the [d3-interpolate documentation](https://github.com/d3/d3-interpolate).
-        __Note:__ Sequential scales do not support `interpolate` as they have a fixed
-        interpolator.  Since Vega-Lite uses sequential scales for quantitative fields by
-        default, you have to set the scale `type` to other quantitative scale type such as
-        `"linear"` to customize `interpolate`.
+        ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and
+        ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces).
+        If object-valued, this property accepts an object with a string-valued *type*
+        property and an optional numeric *gamma* property applicable to rgb and cubehelix
+        interpolators. For more, see the `d3-interpolate documentation
+        <https://github.com/d3/d3-interpolate>`_.  **Note:** Sequential scales do not
+        support ``interpolate`` as they have a fixed interpolator.  Since Vega-Lite uses
+        sequential scales for quantitative fields by default, you have to set the scale
+        ``type`` to other quantitative scale type such as ``"linear"`` to customize
+        ``interpolate``.
     nice : anyOf(boolean, float, NiceTime, Mapping(required=[interval, step]))
         Extending the domain so that it starts and ends on nice round values. This method
         typically modifies the scale’s domain, and may only extend the bounds to the nearest
          round value. Nicing is useful if the domain is computed from data and may be
-        irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain
-        might be _[0.2, 1.0]_.  For quantitative scales such as linear, `nice` can be either
-         a boolean flag or a number. If `nice` is a number, it will represent a desired tick
-         count. This allows greater control over the step size used to extend the bounds,
-        guaranteeing that the returned ticks will exactly cover the domain.  For temporal
-        fields with time and utc scales, the `nice` value can be a string indicating the
-        desired time interval. Legal values are `"millisecond"`, `"second"`, `"minute"`,
-        `"hour"`, `"day"`, `"week"`, `"month"`, and `"year"`. Alternatively, `time` and
-        `utc` scales can accept an object-valued interval specifier of the form
-        `{"interval": "month", "step": 3}`, which includes a desired number of interval
-        steps. Here, the domain would snap to quarter (Jan, Apr, Jul, Oct) boundaries.
-        __Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise.
+        irregular. For example, for a domain of *[0.201479…, 0.996679…]*, a nice domain
+        might be *[0.2, 1.0]*.  For quantitative scales such as linear, ``nice`` can be
+        either a boolean flag or a number. If ``nice`` is a number, it will represent a
+        desired tick count. This allows greater control over the step size used to extend
+        the bounds, guaranteeing that the returned ticks will exactly cover the domain.  For
+         temporal fields with time and utc scales, the ``nice`` value can be a string
+        indicating the desired time interval. Legal values are ``"millisecond"``,
+        ``"second"``, ``"minute"``, ``"hour"``, ``"day"``, ``"week"``, ``"month"``, and
+        ``"year"``. Alternatively, ``time`` and ``utc`` scales can accept an object-valued
+        interval specifier of the form ``{"interval": "month", "step": 3}``, which includes
+        a desired number of interval steps. Here, the domain would snap to quarter (Jan,
+        Apr, Jul, Oct) boundaries.  **Default value:** ``true`` for unbinned *quantitative*
+        fields; ``false`` otherwise.
     padding : float
-        For _[continuous](scale.html#continuous)_ scales, expands the scale domain to
+        For * `continuous <scale.html#continuous>`_ * scales, expands the scale domain to
         accommodate the specified number of pixels on each of the scale range. The scale
         range must represent pixels for this parameter to function as intended. Padding
-        adjustment is performed prior to all other adjustments, including the effects of
-        the zero, nice, domainMin, and domainMax properties.  For _[band](scale.html#band)_
-        scales, shortcut for setting `paddingInner` and `paddingOuter` to the same value.
-        For _[point](scale.html#point)_ scales, alias for `paddingOuter`.  __Default
-        value:__ For _continuous_ scales, derived from the [scale
-        config](scale.html#config)'s `continuousPadding`. For _band and point_ scales, see
-        `paddingInner` and `paddingOuter`.
+        adjustment is performed prior to all other adjustments, including the effects of the
+         zero, nice, domainMin, and domainMax properties.  For * `band <scale.html#band>`_ *
+         scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same
+        value.  For * `point <scale.html#point>`_ * scales, alias for ``paddingOuter``.
+        **Default value:** For *continuous* scales, derived from the `scale config
+        <scale.html#config>`_ 's ``continuousPadding``. For *band and point* scales, see
+        ``paddingInner`` and ``paddingOuter``.
     paddingInner : float
         The inner padding (spacing) within each band step of band scales, as a fraction of
         the step size. This value must lie in the range [0,1].  For point scale, this
         property is invalid as point scales do not have internal band widths (only step
-        sizes between bands).  __Default value:__ derived from the [scale
-        config](scale.html#config)'s `bandPaddingInner`.
+        sizes between bands).  **Default value:** derived from the `scale config
+        <scale.html#config>`_ 's ``bandPaddingInner``.
     paddingOuter : float
         The outer padding (spacing) at the ends of the range of band and point scales, as a
-        fraction of the step size. This value must lie in the range [0,1].  __Default
-        value:__ derived from the [scale config](scale.html#config)'s `bandPaddingOuter` for
-         band scales and `pointPadding` for point scales.
+        fraction of the step size. This value must lie in the range [0,1].  **Default
+        value:** derived from the `scale config <scale.html#config>`_ 's
+        ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales.
     range : anyOf(List(float), List(string), string)
-        The range of the scale. One of:  - A string indicating a [pre-defined named scale
-        range](scale.html#range-config) (e.g., example, `"symbol"`, or `"diverging"`).  -
-        For [continuous scales](scale.html#continuous), two-element array indicating
-        minimum and maximum values, or an array with more than two entries for specifying a
-        [piecewise scale](scale.html#piecewise).  - For [discrete](scale.html#discrete) and
-        [discretizing](scale.html#discretizing) scales, an array of desired output values.
-        __Notes:__  1) For [sequential](scale.html#sequential),
-        [ordinal](scale.html#ordinal), and discretizing color scales, you can also specify a
-         color [`scheme`](scale.html#scheme) instead of `range`.  2) Any directly specified
-        `range` for `x` and `y` channels will be ignored. Range can be customized via the
-        view's corresponding [size](size.html) (`width` and `height`) or via [range steps
-        and paddings properties](#range-step) for [band](#band) and [point](#point) scales.
+        The range of the scale. One of:   *    A string indicating a `pre-defined named
+        scale range <scale.html#range-config>`_ (e.g., example, ``"symbol"``, or
+        ``"diverging"`` ).  *    For `continuous scales <scale.html#continuous>`_,
+        two-element array indicating  minimum and maximum values, or an array with more than
+         two entries for specifying a `piecewise scale <scale.html#piecewise>`_.  *    For
+        `discrete <scale.html#discrete>`_ and `discretizing <scale.html#discretizing>`_
+        scales, an array of desired output values.  **Notes:**  1) For `sequential
+        <scale.html#sequential>`_, `ordinal <scale.html#ordinal>`_, and discretizing color
+        scales, you can also specify a color ` ``scheme`` <scale.html#scheme>`_ instead of
+        ``range``.  2) Any directly specified ``range`` for ``x`` and ``y`` channels will be
+         ignored. Range can be customized via the view's corresponding `size <size.html>`_ (
+         ``width`` and ``height`` ) or via `range steps and paddings properties
+        <#range-step>`_ for `band <#band>`_ and `point <#point>`_ scales.
     rangeStep : anyOf(float, None)
-        The distance between the starts of adjacent bands or points in
-        [band](scale.html#band) and [point](scale.html#point) scales.  If `rangeStep` is
-        `null` or if the view contains the scale's corresponding [size](size.html) (`width`
-        for `x` scales and `height` for `y` scales), `rangeStep` will be automatically
-        determined to fit the size of the view.  __Default value:__  derived the [scale
-        config](config.html#scale-config)'s `textXRangeStep` (`90` by default) for x-scales
-        of `text` marks and `rangeStep` (`21` by default) for x-scales of other marks and
-        y-scales.  __Warning__: If `rangeStep` is `null` and the cardinality of the scale's
-        domain is higher than `width` or `height`, the rangeStep might become less than one
-        pixel and the mark might not appear correctly.
+        The distance between the starts of adjacent bands or points in `band
+        <scale.html#band>`_ and `point <scale.html#point>`_ scales.  If ``rangeStep`` is
+        ``null`` or if the view contains the scale's corresponding `size <size.html>`_ (
+        ``width`` for ``x`` scales and ``height`` for ``y`` scales), ``rangeStep`` will be
+        automatically determined to fit the size of the view.  **Default value:**  derived
+        the `scale config <config.html#scale-config>`_ 's ``textXRangeStep`` ( ``90`` by
+        default) for x-scales of ``text`` marks and ``rangeStep`` ( ``21`` by default) for
+        x-scales of other marks and y-scales.  **Warning** : If ``rangeStep`` is ``null``
+        and the cardinality of the scale's domain is higher than ``width`` or ``height``,
+        the rangeStep might become less than one pixel and the mark might not appear
+        correctly.
     round : boolean
-        If `true`, rounds numeric output values to integers. This can be helpful for
-        snapping to the pixel grid.  __Default value:__ `false`.
+        If ``true``, rounds numeric output values to integers. This can be helpful for
+        snapping to the pixel grid.  **Default value:** ``false``.
     scheme : anyOf(string, SchemeParams)
-        A string indicating a color [scheme](scale.html#scheme) name (e.g., `"category10"`
-        or `"viridis"`) or a [scheme parameter object](scale.html#scheme-params).  Discrete
-        color schemes may be used with [discrete](scale.html#discrete) or
-        [discretizing](scale.html#discretizing) scales. Continuous color schemes are
-        intended for use with [sequential](scales.html#sequential) scales.  For the full
-        list of supported schemes, please refer to the [Vega
-        Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.
+        A string indicating a color `scheme <scale.html#scheme>`_ name (e.g.,
+        ``"category10"`` or ``"viridis"`` ) or a `scheme parameter object
+        <scale.html#scheme-params>`_.  Discrete color schemes may be used with `discrete
+        <scale.html#discrete>`_ or `discretizing <scale.html#discretizing>`_ scales.
+        Continuous color schemes are intended for use with `sequential
+        <scales.html#sequential>`_ scales.  For the full list of supported schemes, please
+        refer to the `Vega Scheme <https://vega.github.io/vega/docs/schemes/#reference>`_
+        reference.
     type : ScaleType
         The type of scale.  Vega-Lite supports the following categories of scale types:  1)
-        [**Continuous Scales**](scale.html#continuous) -- mapping continuous domains to
-        continuous output ranges ([`"linear"`](scale.html#linear),
-        [`"pow"`](scale.html#pow), [`"sqrt"`](scale.html#sqrt), [`"log"`](scale.html#log),
-        [`"time"`](scale.html#time), [`"utc"`](scale.html#utc),
-        [`"sequential"`](scale.html#sequential)).  2) [**Discrete
-        Scales**](scale.html#discrete) -- mapping discrete domains to discrete
-        ([`"ordinal"`](scale.html#ordinal)) or continuous ([`"band"`](scale.html#band) and
-        [`"point"`](scale.html#point)) output ranges.  3) [**Discretizing
-        Scales**](scale.html#discretizing) -- mapping continuous domains to discrete output
-        ranges ([`"bin-linear"`](scale.html#bin-linear) and
-        [`"bin-ordinal"`](scale.html#bin-ordinal)).  __Default value:__ please see the
-        [scale type table](scale.html#type).
+        ` **Continuous Scales** <scale.html#continuous>`_ -- mapping continuous domains to
+        continuous output ranges ( ` ``"linear"`` <scale.html#linear>`_, ` ``"pow"``
+        <scale.html#pow>`_, ` ``"sqrt"`` <scale.html#sqrt>`_, ` ``"log"``
+        <scale.html#log>`_, ` ``"time"`` <scale.html#time>`_, ` ``"utc"``
+        <scale.html#utc>`_, ` ``"sequential"`` <scale.html#sequential>`_ ).  2) ` **Discrete
+         Scales** <scale.html#discrete>`_ -- mapping discrete domains to discrete ( `
+        ``"ordinal"`` <scale.html#ordinal>`_ ) or continuous ( ` ``"band"``
+        <scale.html#band>`_ and ` ``"point"`` <scale.html#point>`_ ) output ranges.  3) `
+        **Discretizing Scales** <scale.html#discretizing>`_ -- mapping continuous domains to
+         discrete output ranges ( ` ``"bin-linear"`` <scale.html#bin-linear>`_ and `
+        ``"bin-ordinal"`` <scale.html#bin-ordinal>`_ ).  **Default value:** please see the
+        `scale type table <scale.html#type>`_.
     zero : boolean
-        If `true`, ensures that a zero baseline value is included in the scale domain.
-        __Default value:__ `true` for x and y channels if the quantitative field is not
-        binned and no custom `domain` is provided; `false` otherwise.  __Note:__ Log, time,
-        and utc scales do not support `zero`.
+        If ``true``, ensures that a zero baseline value is included in the scale domain.
+        **Default value:** ``true`` for x and y channels if the quantitative field is not
+        binned and no custom ``domain`` is provided; ``false`` otherwise.  **Note:** Log,
+        time, and utc scales do not support ``zero``.
     """
     _schema = {'$ref': '#/definitions/Scale'}
     _rootschema = Root._schema
@@ -5012,62 +5054,64 @@ class ScaleConfig(VegaLiteSchema):
     Attributes
     ----------
     bandPaddingInner : float
-        Default inner padding for `x` and `y` band-ordinal scales.  __Default value:__ `0.1`
+        Default inner padding for ``x`` and ``y`` band-ordinal scales.  **Default value:**
+        ``0.1``
     bandPaddingOuter : float
-        Default outer padding for `x` and `y` band-ordinal scales. If not specified, by
+        Default outer padding for ``x`` and ``y`` band-ordinal scales. If not specified, by
         default, band scale's paddingOuter is paddingInner/2.
     clamp : boolean
         If true, values that exceed the data domain are clamped to either the minimum or
         maximum range value
     continuousPadding : float
-        Default padding for continuous scales.  __Default:__ `5` for continuous x-scale of a
-         vertical bar and continuous y-scale of a horizontal bar.; `0` otherwise.
+        Default padding for continuous scales.  **Default:** ``5`` for continuous x-scale of
+         a vertical bar and continuous y-scale of a horizontal bar.; ``0`` otherwise.
     maxBandSize : float
         The default max value for mapping quantitative fields to bar's size/bandSize.  If
-        undefined (default), we will use the scale's `rangeStep` - 1.
+        undefined (default), we will use the scale's ``rangeStep`` - 1.
     maxFontSize : float
         The default max value for mapping quantitative fields to text's size/fontSize.
-        __Default value:__ `40`
+        **Default value:** ``40``
     maxOpacity : float
-        Default max opacity for mapping a field to opacity.  __Default value:__ `0.8`
+        Default max opacity for mapping a field to opacity.  **Default value:** ``0.8``
     maxSize : float
         Default max value for point size scale.
     maxStrokeWidth : float
         Default max strokeWidth for the scale of strokeWidth for rule and line marks and of
-        size for trail marks.  __Default value:__ `4`
+        size for trail marks.  **Default value:** ``4``
     minBandSize : float
         The default min value for mapping quantitative fields to bar and tick's
-        size/bandSize scale with zero=false.  __Default value:__ `2`
+        size/bandSize scale with zero=false.  **Default value:** ``2``
     minFontSize : float
         The default min value for mapping quantitative fields to tick's size/fontSize scale
-        with zero=false  __Default value:__ `8`
+        with zero=false  **Default value:** ``8``
     minOpacity : float
-        Default minimum opacity for mapping a field to opacity.  __Default value:__ `0.3`
+        Default minimum opacity for mapping a field to opacity.  **Default value:** ``0.3``
     minSize : float
-        Default minimum value for point size scale with zero=false.  __Default value:__ `9`
+        Default minimum value for point size scale with zero=false.  **Default value:**
+        ``9``
     minStrokeWidth : float
         Default minimum strokeWidth for the scale of strokeWidth for rule and line marks and
-         of size for trail marks with zero=false.  __Default value:__ `1`
+         of size for trail marks with zero=false.  **Default value:** ``1``
     pointPadding : float
-        Default outer padding for `x` and `y` point-ordinal scales.  __Default value:__
-        `0.5`
+        Default outer padding for ``x`` and ``y`` point-ordinal scales.  **Default value:**
+        ``0.5``
     rangeStep : anyOf(float, None)
-        Default range step for band and point scales of (1) the `y` channel and (2) the `x`
-        channel when the mark is not `text`.  __Default value:__ `21`
+        Default range step for band and point scales of (1) the ``y`` channel and (2) the
+        ``x`` channel when the mark is not ``text``.  **Default value:** ``21``
     round : boolean
         If true, rounds numeric output values to integers. This can be helpful for snapping
-        to the pixel grid. (Only available for `x`, `y`, and `size` scales.)
+        to the pixel grid. (Only available for ``x``, ``y``, and ``size`` scales.)
     textXRangeStep : float
-        Default range step for `x` band and point scales of text marks.  __Default value:__
-        `90`
+        Default range step for ``x`` band and point scales of text marks.  **Default
+        value:** ``90``
     useUnaggregatedDomain : boolean
         Use the source data range before aggregation as scale domain instead of aggregated
-        data for aggregate axis.  This is equivalent to setting `domain` to `"unaggregate"`
-        for aggregated _quantitative_ fields by default.  This property only works with
-        aggregate functions that produce values within the raw data domain (`"mean"`,
-        `"average"`, `"median"`, `"q1"`, `"q3"`, `"min"`, `"max"`). For other aggregations
-        that produce values outside of the raw data domain (e.g. `"count"`, `"sum"`), this
-        property is ignored.  __Default value:__ `false`
+        data for aggregate axis.  This is equivalent to setting ``domain`` to
+        ``"unaggregate"`` for aggregated *quantitative* fields by default.  This property
+        only works with aggregate functions that produce values within the raw data domain (
+         ``"mean"``, ``"average"``, ``"median"``, ``"q1"``, ``"q3"``, ``"min"``, ``"max"``
+        ). For other aggregations that produce values outside of the raw data domain (e.g.
+        ``"count"``, ``"sum"`` ), this property is ignored.  **Default value:** ``false``
     """
     _schema = {'$ref': '#/definitions/ScaleConfig'}
     _rootschema = Root._schema
@@ -5176,13 +5220,13 @@ class SchemeParams(VegaLiteSchema):
     Attributes
     ----------
     name : string
-        A color scheme name for sequential/ordinal scales (e.g., `"category10"` or
-        `"viridis"`).  For the full list of supported schemes, please refer to the [Vega
-        Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.
+        A color scheme name for sequential/ordinal scales (e.g., ``"category10"`` or
+        ``"viridis"`` ).  For the full list of supported schemes, please refer to the `Vega
+        Scheme <https://vega.github.io/vega/docs/schemes/#reference>`_ reference.
     extent : List(float)
         For sequential and diverging schemes only, determines the extent of the color range
-        to use. For example `[0.2, 1]` will rescale the color scheme such that color values
-        in the range _[0, 0.2)_ are excluded from the scheme.
+        to use. For example ``[0.2, 1]`` will rescale the color scheme such that color
+        values in the range *[0, 0.2)* are excluded from the scheme.
     """
     _schema = {'$ref': '#/definitions/SchemeParams'}
     _rootschema = Root._schema
@@ -5199,21 +5243,21 @@ class SelectionConfig(VegaLiteSchema):
     Attributes
     ----------
     interval : IntervalSelectionConfig
-        The default definition for an [`interval`](selection.html#type) selection. All
-        properties and transformations for an interval selection definition (except `type`)
-        may be specified here.  For instance, setting `interval` to `{"translate": false}`
-        disables the ability to move interval selections by default.
+        The default definition for an ` ``interval`` <selection.html#type>`_ selection. All
+        properties and transformations for an interval selection definition (except ``type``
+         ) may be specified here.  For instance, setting ``interval`` to ``{"translate":
+        false}`` disables the ability to move interval selections by default.
     multi : MultiSelectionConfig
-        The default definition for a [`multi`](selection.html#type) selection. All
-        properties and transformations for a multi selection definition (except `type`) may
-        be specified here.  For instance, setting `multi` to `{"toggle": "event.altKey"}`
-        adds additional values to multi selections when clicking with the alt-key pressed by
-         default.
+        The default definition for a ` ``multi`` <selection.html#type>`_ selection. All
+        properties and transformations for a multi selection definition (except ``type`` )
+        may be specified here.  For instance, setting ``multi`` to ``{"toggle":
+        "event.altKey"}`` adds additional values to multi selections when clicking with the
+        alt-key pressed by default.
     single : SingleSelectionConfig
-        The default definition for a [`single`](selection.html#type) selection. All
-        properties and transformations   for a single selection definition (except `type`)
-        may be specified here.  For instance, setting `single` to `{"on": "dblclick"}`
-        populates single selections on double-click by default.
+        The default definition for a ` ``single`` <selection.html#type>`_ selection. All
+        properties and transformations   for a single selection definition (except ``type``
+        ) may be specified here.  For instance, setting ``single`` to ``{"on": "dblclick"}``
+         populates single selections on double-click by default.
     """
     _schema = {'$ref': '#/definitions/SelectionConfig'}
     _rootschema = Root._schema
@@ -5300,13 +5344,13 @@ class SingleSelection(VegaLiteSchema):
 
     bind : anyOf(VgBinding, Mapping(required=[]))
         Establish a two-way binding between a single selection and input elements (also
-        known as dynamic query widgets). A binding takes the form of Vega's [input element
-        binding definition](https://vega.github.io/vega/docs/signals/#bind) or can be a
-        mapping between projected field/encodings and binding definitions.  See the [bind
-        transform](bind.html) documentation for more information.
+        known as dynamic query widgets). A binding takes the form of Vega's `input element
+        binding definition <https://vega.github.io/vega/docs/signals/#bind>`_ or can be a
+        mapping between projected field/encodings and binding definitions.  See the `bind
+        transform <bind.html>`_ documentation for more information.
     empty : enum('all', 'none')
         By default, all data values are considered to lie within an empty selection. When
-        set to `none`, empty selections contain no data values.
+        set to ``none``, empty selections contain no data values.
     encodings : List(SingleDefChannel)
         An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
@@ -5315,13 +5359,13 @@ class SingleSelection(VegaLiteSchema):
         selection.
     nearest : boolean
         When true, an invisible voronoi diagram is computed to accelerate discrete
-        selection. The data value _nearest_ the mouse cursor is added to the selection.  See
-         the [nearest transform](nearest.html) documentation for more information.
+        selection. The data value *nearest* the mouse cursor is added to the selection.  See
+         the `nearest transform <nearest.html>`_ documentation for more information.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`_ (object or
         selector) that triggers the selection. For interval selections, the event stream
-        must specify a [start and
-        end](https://vega.github.io/vega/docs/event-streams/#between-filters).
+        must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`_.
     resolve : SelectionResolution
         With layered and multi-view displays, a strategy that determines how selections'
         data queries are resolved when applied in a filter transform, conditional encoding
@@ -5346,13 +5390,13 @@ class SingleSelectionConfig(VegaLiteSchema):
     ----------
     bind : anyOf(VgBinding, Mapping(required=[]))
         Establish a two-way binding between a single selection and input elements (also
-        known as dynamic query widgets). A binding takes the form of Vega's [input element
-        binding definition](https://vega.github.io/vega/docs/signals/#bind) or can be a
-        mapping between projected field/encodings and binding definitions.  See the [bind
-        transform](bind.html) documentation for more information.
+        known as dynamic query widgets). A binding takes the form of Vega's `input element
+        binding definition <https://vega.github.io/vega/docs/signals/#bind>`_ or can be a
+        mapping between projected field/encodings and binding definitions.  See the `bind
+        transform <bind.html>`_ documentation for more information.
     empty : enum('all', 'none')
         By default, all data values are considered to lie within an empty selection. When
-        set to `none`, empty selections contain no data values.
+        set to ``none``, empty selections contain no data values.
     encodings : List(SingleDefChannel)
         An array of encoding channels. The corresponding data field values must match for a
         data tuple to fall within the selection.
@@ -5361,13 +5405,13 @@ class SingleSelectionConfig(VegaLiteSchema):
         selection.
     nearest : boolean
         When true, an invisible voronoi diagram is computed to accelerate discrete
-        selection. The data value _nearest_ the mouse cursor is added to the selection.  See
-         the [nearest transform](nearest.html) documentation for more information.
+        selection. The data value *nearest* the mouse cursor is added to the selection.  See
+         the `nearest transform <nearest.html>`_ documentation for more information.
     on : VgEventStream
-        A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`_ (object or
         selector) that triggers the selection. For interval selections, the event stream
-        must specify a [start and
-        end](https://vega.github.io/vega/docs/event-streams/#between-filters).
+        must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`_.
     resolve : SelectionResolution
         With layered and multi-view displays, a strategy that determines how selections'
         data queries are resolved when applied in a filter transform, conditional encoding
@@ -5403,17 +5447,17 @@ class SortField(VegaLiteSchema):
     Attributes
     ----------
     op : AggregateOp
-        An [aggregate operation](aggregate.html#ops) to perform on the field prior to
-        sorting (e.g., `"count"`, `"mean"` and `"median"`). This property is required in
-        cases where the sort field and the data reference field do not match. The input data
-         objects will be aggregated, grouped by the encoded data field.  For a full list of
-        operations, please see the documentation for [aggregate](aggregate.html#ops).
+        An `aggregate operation <aggregate.html#ops>`_ to perform on the field prior to
+        sorting (e.g., ``"count"``, ``"mean"`` and ``"median"`` ). This property is required
+         in cases where the sort field and the data reference field do not match. The input
+        data objects will be aggregated, grouped by the encoded data field.  For a full list
+         of operations, please see the documentation for `aggregate <aggregate.html#ops>`_.
     field : anyOf(string, RepeatRef)
-        The data [field](field.html) to sort by.  __Default value:__ If unspecified,
+        The data `field <field.html>`_ to sort by.  **Default value:** If unspecified,
         defaults to the field specified in the outer data reference.
     order : SortOrder
-        The sort order. One of `"ascending"` (default), `"descending"`, or `null` (no not
-        sort).
+        The sort order. One of ``"ascending"`` (default), ``"descending"``, or ``null`` (no
+        not sort).
     """
     _schema = {'$ref': '#/definitions/SortField'}
     _rootschema = Root._schema
@@ -5466,119 +5510,122 @@ class TextConfig(VegaLiteSchema):
     Attributes
     ----------
     align : HorizontalAlign
-        The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
-        __Default value:__ `"middle"`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+        **Default value:** ``"middle"``
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
-        and will override `color`.  __Default value:__ <span style="color:
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
-        [style config](mark.html#style-config).
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.  **Default value:** :raw-html:`<span
+        style="color: #4682b4;">&#9632;</span>` ``"#4682b4"``  **Note:** This property
+        cannot be used in a `style config <mark.html#style-config>`_.
     cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
     'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
     'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
     'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor
-        type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`_ can be used.
     dx : float
         The horizontal offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     dy : float
         The vertical offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     fill : string
-        Default Fill Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Fill Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     fillOpacity : float
-        The fill opacity (value between [0,1]).  __Default value:__ `1`
+        The fill opacity (value between [0,1]).  **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.
-        __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
-         This property cannot be used in a [style config](mark.html#style-config).
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.  **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and
+        ``area`` marks.  **Note:** This property cannot be used in a `style config
+        <mark.html#style-config>`_.
     font : string
-        The typeface to set the text in (e.g., `"Helvetica Neue"`).
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : float
         The font size, in pixels.
     fontStyle : FontStyle
-        The font style (e.g., `"italic"`).
+        The font style (e.g., ``"italic"`` ).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
-        (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
         The line interpolation method to use for line and area marks. One of the following:
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
-        close the linear segments to form a polygon. - `"step"`: alternate between
-        horizontal and vertical segments, as in a step function. - `"step-before"`:
-        alternate between vertical and horizontal segments, as in a step function. -
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
-        `"basis-open"`: an open B-spline; may not intersect the start or end. -
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
-        Cardinal spline; may not intersect the start or end, but will intersect other
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
-        the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+           * ``"linear"`` : piecewise linear segments, as in a polyline. *
+        ``"linear-closed"`` : close the linear segments to form a polygon. * ``"step"`` :
+        alternate between horizontal and vertical segments, as in a step function. *
+        ``"step-before"`` : alternate between vertical and horizontal segments, as in a step
+         function. * ``"step-after"`` : alternate between horizontal and vertical segments,
+        as in a step function. * ``"basis"`` : a B-spline, with control point duplication on
+         the ends. * ``"basis-open"`` : an open B-spline; may not intersect the start or
+        end. * ``"basis-closed"`` : a closed B-spline, as in a loop. * ``"cardinal"`` : a
+        Cardinal spline, with control point duplication on the ends. * ``"cardinal-open"`` :
+         an open Cardinal spline; may not intersect the start or end, but will intersect
+        other control points. * ``"cardinal-closed"`` : a closed Cardinal spline, as in a
+        loop. * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+        straighten the spline. * ``"monotone"`` : cubic interpolation that preserves
+        monotonicity in y.
     limit : float
         The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
-        `bar` charts and `1` otherwise.
+        The overall opacity (value between [0,1]).  **Default value:** ``0.7`` for
+        non-aggregate plots with ``point``, ``tick``, ``circle``, or ``square`` marks or
+        layered ``bar`` charts and ``1`` otherwise.
     orient : Orient
         The orientation of a non-stacked bar, tick, area, and line charts. The value is
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines
-        whether the size of the bar and tick should be applied to x or y dimension. - For
-        area, this property determines the orient property of the Vega output. - For line
+        either horizontal (default) or vertical.   * For bar, rule and tick, this determines
+         whether the size of the bar and tick   should be applied to x or y dimension. * For
+         area, this property determines the orient property of the Vega output. * For line
         and trail marks, this property determines the sort order of the points in the line
-        if `config.sortLineBy` is not specified. For stacked charts, this is always
-        determined by the orientation of the stack; therefore explicitly specified value
+           if ``config.sortLineBy`` is not specified.   For stacked charts, this is always
+        determined by the orientation of the stack;   therefore explicitly specified value
         will be ignored.
     radius : float
         Polar coordinate radial offset, in pixels, of the text label from the origin
-        determined by the `x` and `y` properties.
+        determined by the ``x`` and ``y`` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
-          __Default value:__ `"circle"`
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.  **Default value:** ``"circle"``
     shortTimeLabels : boolean
         Whether month names and weekday names should be abbreviated.
     size : float
         The pixel area each the point/circle/square. For example: in the case of circles,
-        the radius is determined in part by the square root of the size value.  __Default
-        value:__ `30`
+        the radius is determined in part by the square root of the size value.  **Default
+        value:** ``30``
     stroke : string
-        Default Stroke Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Stroke Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     strokeCap : enum('butt', 'round', 'square')
-        The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
-        __Default value:__ `"square"`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.  **Default value:** ``"square"``
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : float
         The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeOpacity : float
-        The stroke opacity (value between [0,1]).  __Default value:__ `1`
+        The stroke opacity (value between [0,1]).  **Default value:** ``1``
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
         Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
-        Placeholder text if the `text` channel is not specified
+        Placeholder text if the ``text`` channel is not specified
     theta : float
         Polar coordinate angle, in radians, of the text label from the origin determined by
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
-        `0` indicating "north".
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
     """
     _schema = {'$ref': '#/definitions/TextConfig'}
     _rootschema = Root._schema
@@ -5612,47 +5659,47 @@ class TextFieldDef(VegaLiteSchema):
     Attributes
     ----------
     type : Type
-        The encoded field's type of measurement (`"quantitative"`, `"temporal"`,
-        `"ordinal"`, or `"nominal"`). It can also be a `"geojson"` type for encoding
-        ['geoshape'](geoshape.html).
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ). It can also be a ``"geojson"`` type for encoding
+        `'geoshape' <geoshape.html>`_.
     aggregate : Aggregate
-        Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`,
-        `count`).  __Default value:__ `undefined` (None)
+        Aggregation function for the field (e.g., ``mean``, ``sum``, ``median``, ``min``,
+        ``max``, ``count`` ).  **Default value:** ``undefined`` (None)
     bin : anyOf(boolean, BinParams)
-        A flag for binning a `quantitative` field, or [an object defining binning
-        parameters](https://vega.github.io/vega-lite/docs/bin.html#params). If `true`,
-        default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be
-         applied.  __Default value:__ `false`
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`_. If ``true``,
+        default `binning parameters <https://vega.github.io/vega-lite/docs/bin.html>`_ will
+        be applied.  **Default value:** ``false``
     field : anyOf(string, RepeatRef)
-        __Required.__ A string defining the name of the field from which to pull a data
-        value or an object defining iterated values from the
-        [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.  __Note:__
-        Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g.,
-        `"field": "foo.bar"` and `"field": "foo['bar']"`). If field names contain dots or
-        brackets but are not nested, you can use `\\` to escape dots and brackets (e.g.,
-        `"a\\.b"` and `"a\\[0\\]"`). See more details about escaping in the [field
-        documentation](https://vega.github.io/vega-lite/docs/field.html).  __Note:__ `field`
-         is not required if `aggregate` is `count`.
+        **Required.** A string defining the name of the field from which to pull a data
+        value or an object defining iterated values from the ` ``repeat``
+        <https://vega.github.io/vega-lite/docs/repeat.html>`_ operator.  **Note:** Dots (
+        ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested objects (e.g.,
+         ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ). If field names contain dots
+         or brackets but are not nested, you can use ``\\`` to escape dots and brackets
+        (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ). See more details about escaping in the
+        `field documentation <https://vega.github.io/vega-lite/docs/field.html>`_.
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
     format : string
-        The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`_ for a
         text field. If not defined, this will be determined automatically.
     timeUnit : TimeUnit
-        Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field. or [a
-        temporal field that gets casted as
-        ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).  __Default value:__
-        `undefined` (None)
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field. or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`_.  **Default value:**
+        ``undefined`` (None)
     title : anyOf(string, None)
-        A title for the field. If `null`, the title will be removed.  __Default value:__
-        derived from the field's name and transformation function (`aggregate`, `bin` and
-        `timeUnit`).  If the field has an aggregate function, the function is displayed as
-        part of the title (e.g., `"Sum of Profit"`). If the field is binned or has a time
-        unit applied, the applied function is shown in parentheses (e.g., `"Profit
-        (binned)"`, `"Transaction Date (year-month)"`).  Otherwise, the title is simply the
-        field name.  __Notes__:  1) You can customize the default field title format by
-        providing the [`fieldTitle` property in the [config](config.html) or [`fieldTitle`
-        function via the `compile` function's options](compile.html#field-title).  2) If
-        both field definition's `title` and axis, header, or legend `title` are defined,
-        axis/header/legend title will be used.
+        A title for the field. If ``null``, the title will be removed.  **Default value:**
+        derived from the field's name and transformation function ( ``aggregate``, ``bin``
+        and ``timeUnit`` ).  If the field has an aggregate function, the function is
+        displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the field is binned
+        or has a time unit applied, the applied function is shown in parentheses (e.g.,
+        ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).  Otherwise, the title
+        is simply the field name.  **Notes** :  1) You can customize the default field title
+         format by providing the [ ``fieldTitle`` property in the `config <config.html>`_ or
+         ` ``fieldTitle`` function via the ``compile`` function's options
+        <compile.html#field-title>`_.  2) If both field definition's ``title`` and axis,
+        header, or legend ``title`` are defined, axis/header/legend title will be used.
     """
     _schema = {'$ref': '#/definitions/TextFieldDef'}
     _rootschema = Root._schema
@@ -5671,121 +5718,124 @@ class TickConfig(VegaLiteSchema):
     Attributes
     ----------
     align : HorizontalAlign
-        The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
     angle : float
         The rotation angle of the text, in degrees.
     bandSize : float
-        The width of the ticks.  __Default value:__  2/3 of rangeStep.
+        The width of the ticks.  **Default value:**  2/3 of rangeStep.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
-        __Default value:__ `"middle"`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+        **Default value:** ``"middle"``
     color : string
-        Default color.  Note that `fill` and `stroke` have higher precedence than `color`
-        and will override `color`.  __Default value:__ <span style="color:
-        #4682b4;">&#9632;</span> `"#4682b4"`  __Note:__ This property cannot be used in a
-        [style config](mark.html#style-config).
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.  **Default value:** :raw-html:`<span
+        style="color: #4682b4;">&#9632;</span>` ``"#4682b4"``  **Note:** This property
+        cannot be used in a `style config <mark.html#style-config>`_.
     cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
     'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
     'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
     'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor
-        type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`_ can be used.
     dx : float
         The horizontal offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     dy : float
         The vertical offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     fill : string
-        Default Fill Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Fill Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     fillOpacity : float
-        The fill opacity (value between [0,1]).  __Default value:__ `1`
+        The fill opacity (value between [0,1]).  **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
-        __Default value:__ `true` for all marks except `point` and `false` for `point`.
-        __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.  __Note:__
-         This property cannot be used in a [style config](mark.html#style-config).
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.  **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and
+        ``area`` marks.  **Note:** This property cannot be used in a `style config
+        <mark.html#style-config>`_.
     font : string
-        The typeface to set the text in (e.g., `"Helvetica Neue"`).
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : float
         The font size, in pixels.
     fontStyle : FontStyle
-        The font style (e.g., `"italic"`).
+        The font style (e.g., ``"italic"`` ).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
-        (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
         The line interpolation method to use for line and area marks. One of the following:
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
-        close the linear segments to form a polygon. - `"step"`: alternate between
-        horizontal and vertical segments, as in a step function. - `"step-before"`:
-        alternate between vertical and horizontal segments, as in a step function. -
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
-        `"basis-open"`: an open B-spline; may not intersect the start or end. -
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
-        Cardinal spline; may not intersect the start or end, but will intersect other
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
-        the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+           * ``"linear"`` : piecewise linear segments, as in a polyline. *
+        ``"linear-closed"`` : close the linear segments to form a polygon. * ``"step"`` :
+        alternate between horizontal and vertical segments, as in a step function. *
+        ``"step-before"`` : alternate between vertical and horizontal segments, as in a step
+         function. * ``"step-after"`` : alternate between horizontal and vertical segments,
+        as in a step function. * ``"basis"`` : a B-spline, with control point duplication on
+         the ends. * ``"basis-open"`` : an open B-spline; may not intersect the start or
+        end. * ``"basis-closed"`` : a closed B-spline, as in a loop. * ``"cardinal"`` : a
+        Cardinal spline, with control point duplication on the ends. * ``"cardinal-open"`` :
+         an open Cardinal spline; may not intersect the start or end, but will intersect
+        other control points. * ``"cardinal-closed"`` : a closed Cardinal spline, as in a
+        loop. * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+        straighten the spline. * ``"monotone"`` : cubic interpolation that preserves
+        monotonicity in y.
     limit : float
         The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
-        `bar` charts and `1` otherwise.
+        The overall opacity (value between [0,1]).  **Default value:** ``0.7`` for
+        non-aggregate plots with ``point``, ``tick``, ``circle``, or ``square`` marks or
+        layered ``bar`` charts and ``1`` otherwise.
     orient : Orient
         The orientation of a non-stacked bar, tick, area, and line charts. The value is
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines
-        whether the size of the bar and tick should be applied to x or y dimension. - For
-        area, this property determines the orient property of the Vega output. - For line
+        either horizontal (default) or vertical.   * For bar, rule and tick, this determines
+         whether the size of the bar and tick   should be applied to x or y dimension. * For
+         area, this property determines the orient property of the Vega output. * For line
         and trail marks, this property determines the sort order of the points in the line
-        if `config.sortLineBy` is not specified. For stacked charts, this is always
-        determined by the orientation of the stack; therefore explicitly specified value
+           if ``config.sortLineBy`` is not specified.   For stacked charts, this is always
+        determined by the orientation of the stack;   therefore explicitly specified value
         will be ignored.
     radius : float
         Polar coordinate radial offset, in pixels, of the text label from the origin
-        determined by the `x` and `y` properties.
+        determined by the ``x`` and ``y`` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
-          __Default value:__ `"circle"`
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.  **Default value:** ``"circle"``
     size : float
         The pixel area each the point/circle/square. For example: in the case of circles,
-        the radius is determined in part by the square root of the size value.  __Default
-        value:__ `30`
+        the radius is determined in part by the square root of the size value.  **Default
+        value:** ``30``
     stroke : string
-        Default Stroke Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Stroke Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     strokeCap : enum('butt', 'round', 'square')
-        The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
-        __Default value:__ `"square"`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.  **Default value:** ``"square"``
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : float
         The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeOpacity : float
-        The stroke opacity (value between [0,1]).  __Default value:__ `1`
+        The stroke opacity (value between [0,1]).  **Default value:** ``1``
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
         Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
-        Placeholder text if the `text` channel is not specified
+        Placeholder text if the ``text`` channel is not specified
     theta : float
         Polar coordinate angle, in radians, of the text label from the origin determined by
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
-        `0` indicating "north".
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
     thickness : float
-        Thickness of the tick mark.  __Default value:__  `1`
+        Thickness of the tick mark.  **Default value:**  ``1``
     """
     _schema = {'$ref': '#/definitions/TickConfig'}
     _rootschema = Root._schema
@@ -5867,22 +5917,22 @@ class TitleParams(VegaLiteSchema):
     text : string
         The title text.
     anchor : Anchor
-        The anchor position for placing the title. One of `"start"`, `"middle"`, or `"end"`.
-         For example, with an orientation of top these anchor positions map to a left-,
-        center-, or right-aligned title.  __Default value:__ `"middle"` for
-        [single](spec.html) and [layered](layer.html) views. `"start"` for other composite
-        views.  __Note:__ [For now](https://github.com/vega/vega-lite/issues/2875), `anchor`
-         is only customizable only for [single](spec.html) and [layered](layer.html) views.
-          For other composite views, `anchor` is always `"start"`.
+        The anchor position for placing the title. One of ``"start"``, ``"middle"``, or
+        ``"end"``. For example, with an orientation of top these anchor positions map to a
+        left-, center-, or right-aligned title.  **Default value:** ``"middle"`` for `single
+         <spec.html>`_ and `layered <layer.html>`_ views. ``"start"`` for other composite
+        views.  **Note:** `For now <https://github.com/vega/vega-lite/issues/2875>`_,
+        ``anchor`` is only customizable only for `single <spec.html>`_ and `layered
+        <layer.html>`_ views.  For other composite views, ``anchor`` is always ``"start"``.
     offset : float
         The orthogonal offset in pixels by which to displace the title from its position
         along the edge of the chart.
     orient : TitleOrient
-        The orientation of the title relative to the chart. One of `"top"` (the default),
-        `"bottom"`, `"left"`, or `"right"`.
+        The orientation of the title relative to the chart. One of ``"top"`` (the default),
+        ``"bottom"``, ``"left"``, or ``"right"``.
     style : anyOf(string, List(string))
-        A [mark style property](config.html#style) to apply to the title text mark.
-        __Default value:__ `"group-title"`.
+        A `mark style property <config.html#style>`_ to apply to the title text mark.
+        **Default value:** ``"group-title"``.
     """
     _schema = {'$ref': '#/definitions/TitleParams'}
     _rootschema = Root._schema
@@ -5901,16 +5951,17 @@ class TopLevelLayerSpec(VegaLiteSchema):
     Attributes
     ----------
     layer : List(anyOf(LayerSpec, CompositeUnitSpec))
-        Layer or single view specifications to be layered.  __Note__: Specifications inside
-        `layer` cannot use `row` and `column` channels as layering facet specifications is
-        not allowed.
+        Layer or single view specifications to be layered.  **Note** : Specifications inside
+         ``layer`` cannot use ``row`` and ``column`` channels as layering facet
+        specifications is not allowed.
     autosize : anyOf(AutosizeType, AutoSizeParams)
         Sets how the visualization size should be determined. If a string, should be one of
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
-        content sizing and automatic resizing. `"fit"` is only supported for single and
-        layered views that don't use `rangeStep`.  __Default value__: `pad`
+        ``"pad"``, ``"fit"`` or ``"none"``. Object values can additionally specify
+        parameters for content sizing and automatic resizing. ``"fit"`` is only supported
+        for single and layered views that don't use ``rangeStep``.  **Default value** :
+        ``pad``
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__
+        CSS color property to use as the background of visualization.  **Default value:**
         none (transparent)
     config : Config
         Vega-Lite configuration object.  This property can only be defined at the top-level
@@ -5920,39 +5971,39 @@ class TopLevelLayerSpec(VegaLiteSchema):
     datasets : Datasets
         A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
-         primitive values are ingested as objects with a `data` property.
+         primitive values are ingested as objects with a ``data`` property.
     description : string
         Description of this mark for commenting purpose.
     encoding : Encoding
         A shared key-value mapping between encoding channels and definition of fields in the
          underlying layers.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its y-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
-        For y-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to
-        y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
-        __Note__: For plots with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the height of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The height of a visualization.  **Default value:**   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its y-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the height will be
+        the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For y-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the height is `determined by the range step, paddings, and the
+        cardinality of the field mapped to y-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_. Otherwise, if the
+        ``rangeStep`` is ``null``, the height will be the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``y`` channel, the ``height`` will be the value of ``rangeStep``.  **Note** : For
+         plots with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        height of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     name : string
         Name of the visualization for later reference.
     padding : Padding
         The default visualization padding, in pixels, from the edge of the visualization
         canvas to the data rectangle.  If a number, specifies padding for all sides. If an
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default
-        value__: `5`
+        object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.  **Default
+        value** : ``5``
     projection : Projection
         An object defining properties of the geographic projection shared by underlying
         layers.
@@ -5963,32 +6014,34 @@ class TopLevelLayerSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the
-        following rules:  - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its x-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
-        be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the width is [determined by the range step, paddings, and the
-        cardinality of the field mapped to
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
-        the `rangeStep` is `null`, the width will be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-        no field is mapped to `x` channel, the `width` will be the value of
-        [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
-        with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the width of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The width of a visualization.  **Default value:** This will be determined by the
+        following rules:   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its x-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the width will be
+        the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For x-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the width is `determined by the range step, paddings, and the
+        cardinality of the field mapped to x-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_.   Otherwise, if the
+        ``rangeStep`` is ``null``, the width will be the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``x`` channel, the ``width`` will be the value of `
+        ``config.scale.textXRangeStep``
+        <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`_ for
+        ``text`` mark and the value of ``rangeStep`` for other marks.  **Note:** For plots
+        with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        width of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     $schema : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
-        you have a reason to change this, use
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
-        allows automatic validation and autocomplete in editors that support JSON schema.
+        URL to `JSON schema <http://json-schema.org/>`_ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelLayerSpec'}
     _rootschema = Root._schema
@@ -6016,11 +6069,12 @@ class TopLevelHConcatSpec(VegaLiteSchema):
         A list of views that should be concatenated and put into a row.
     autosize : anyOf(AutosizeType, AutoSizeParams)
         Sets how the visualization size should be determined. If a string, should be one of
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
-        content sizing and automatic resizing. `"fit"` is only supported for single and
-        layered views that don't use `rangeStep`.  __Default value__: `pad`
+        ``"pad"``, ``"fit"`` or ``"none"``. Object values can additionally specify
+        parameters for content sizing and automatic resizing. ``"fit"`` is only supported
+        for single and layered views that don't use ``rangeStep``.  **Default value** :
+        ``pad``
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__
+        CSS color property to use as the background of visualization.  **Default value:**
         none (transparent)
     config : Config
         Vega-Lite configuration object.  This property can only be defined at the top-level
@@ -6030,7 +6084,7 @@ class TopLevelHConcatSpec(VegaLiteSchema):
     datasets : Datasets
         A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
-         primitive values are ingested as objects with a `data` property.
+         primitive values are ingested as objects with a ``data`` property.
     description : string
         Description of this mark for commenting purpose.
     name : string
@@ -6038,9 +6092,9 @@ class TopLevelHConcatSpec(VegaLiteSchema):
     padding : Padding
         The default visualization padding, in pixels, from the edge of the visualization
         canvas to the data rectangle.  If a number, specifies padding for all sides. If an
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default
-        value__: `5`
+        object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.  **Default
+        value** : ``5``
     resolve : Resolve
         Scale, axis, and legend resolutions for horizontally concatenated charts.
     title : anyOf(string, TitleParams)
@@ -6048,10 +6102,11 @@ class TopLevelHConcatSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     $schema : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
-        you have a reason to change this, use
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
-        allows automatic validation and autocomplete in editors that support JSON schema.
+        URL to `JSON schema <http://json-schema.org/>`_ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelHConcatSpec'}
     _rootschema = Root._schema
@@ -6075,16 +6130,17 @@ class TopLevelRepeatSpec(VegaLiteSchema):
     ----------
     repeat : Repeat
         An object that describes what fields should be repeated into views that are laid out
-         as a `row` or `column`.
+         as a ``row`` or ``column``.
     spec : Spec
 
     autosize : anyOf(AutosizeType, AutoSizeParams)
         Sets how the visualization size should be determined. If a string, should be one of
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
-        content sizing and automatic resizing. `"fit"` is only supported for single and
-        layered views that don't use `rangeStep`.  __Default value__: `pad`
+        ``"pad"``, ``"fit"`` or ``"none"``. Object values can additionally specify
+        parameters for content sizing and automatic resizing. ``"fit"`` is only supported
+        for single and layered views that don't use ``rangeStep``.  **Default value** :
+        ``pad``
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__
+        CSS color property to use as the background of visualization.  **Default value:**
         none (transparent)
     config : Config
         Vega-Lite configuration object.  This property can only be defined at the top-level
@@ -6094,7 +6150,7 @@ class TopLevelRepeatSpec(VegaLiteSchema):
     datasets : Datasets
         A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
-         primitive values are ingested as objects with a `data` property.
+         primitive values are ingested as objects with a ``data`` property.
     description : string
         Description of this mark for commenting purpose.
     name : string
@@ -6102,9 +6158,9 @@ class TopLevelRepeatSpec(VegaLiteSchema):
     padding : Padding
         The default visualization padding, in pixels, from the edge of the visualization
         canvas to the data rectangle.  If a number, specifies padding for all sides. If an
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default
-        value__: `5`
+        object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.  **Default
+        value** : ``5``
     resolve : Resolve
         Scale and legend resolutions for repeated charts.
     title : anyOf(string, TitleParams)
@@ -6112,10 +6168,11 @@ class TopLevelRepeatSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     $schema : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
-        you have a reason to change this, use
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
-        allows automatic validation and autocomplete in editors that support JSON schema.
+        URL to `JSON schema <http://json-schema.org/>`_ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelRepeatSpec'}
     _rootschema = Root._schema
@@ -6142,11 +6199,12 @@ class TopLevelVConcatSpec(VegaLiteSchema):
         A list of views that should be concatenated and put into a column.
     autosize : anyOf(AutosizeType, AutoSizeParams)
         Sets how the visualization size should be determined. If a string, should be one of
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
-        content sizing and automatic resizing. `"fit"` is only supported for single and
-        layered views that don't use `rangeStep`.  __Default value__: `pad`
+        ``"pad"``, ``"fit"`` or ``"none"``. Object values can additionally specify
+        parameters for content sizing and automatic resizing. ``"fit"`` is only supported
+        for single and layered views that don't use ``rangeStep``.  **Default value** :
+        ``pad``
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__
+        CSS color property to use as the background of visualization.  **Default value:**
         none (transparent)
     config : Config
         Vega-Lite configuration object.  This property can only be defined at the top-level
@@ -6156,7 +6214,7 @@ class TopLevelVConcatSpec(VegaLiteSchema):
     datasets : Datasets
         A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
-         primitive values are ingested as objects with a `data` property.
+         primitive values are ingested as objects with a ``data`` property.
     description : string
         Description of this mark for commenting purpose.
     name : string
@@ -6164,9 +6222,9 @@ class TopLevelVConcatSpec(VegaLiteSchema):
     padding : Padding
         The default visualization padding, in pixels, from the edge of the visualization
         canvas to the data rectangle.  If a number, specifies padding for all sides. If an
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default
-        value__: `5`
+        object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.  **Default
+        value** : ``5``
     resolve : Resolve
         Scale, axis, and legend resolutions for vertically concatenated charts.
     title : anyOf(string, TitleParams)
@@ -6174,10 +6232,11 @@ class TopLevelVConcatSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     $schema : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
-        you have a reason to change this, use
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
-        allows automatic validation and autocomplete in editors that support JSON schema.
+        URL to `JSON schema <http://json-schema.org/>`_ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelVConcatSpec'}
     _rootschema = Root._schema
@@ -6202,17 +6261,18 @@ class TopLevelFacetSpec(VegaLiteSchema):
     data : Data
         An object describing the data source
     facet : FacetMapping
-        An object that describes mappings between `row` and `column` channels and their
+        An object that describes mappings between ``row`` and ``column`` channels and their
         field definitions.
     spec : anyOf(LayerSpec, CompositeUnitSpec)
         A specification of the view that gets faceted.
     autosize : anyOf(AutosizeType, AutoSizeParams)
         Sets how the visualization size should be determined. If a string, should be one of
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
-        content sizing and automatic resizing. `"fit"` is only supported for single and
-        layered views that don't use `rangeStep`.  __Default value__: `pad`
+        ``"pad"``, ``"fit"`` or ``"none"``. Object values can additionally specify
+        parameters for content sizing and automatic resizing. ``"fit"`` is only supported
+        for single and layered views that don't use ``rangeStep``.  **Default value** :
+        ``pad``
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__
+        CSS color property to use as the background of visualization.  **Default value:**
         none (transparent)
     config : Config
         Vega-Lite configuration object.  This property can only be defined at the top-level
@@ -6220,7 +6280,7 @@ class TopLevelFacetSpec(VegaLiteSchema):
     datasets : Datasets
         A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
-         primitive values are ingested as objects with a `data` property.
+         primitive values are ingested as objects with a ``data`` property.
     description : string
         Description of this mark for commenting purpose.
     name : string
@@ -6228,9 +6288,9 @@ class TopLevelFacetSpec(VegaLiteSchema):
     padding : Padding
         The default visualization padding, in pixels, from the edge of the visualization
         canvas to the data rectangle.  If a number, specifies padding for all sides. If an
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default
-        value__: `5`
+        object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.  **Default
+        value** : ``5``
     resolve : Resolve
         Scale, axis, and legend resolutions for facets.
     title : anyOf(string, TitleParams)
@@ -6238,10 +6298,11 @@ class TopLevelFacetSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     $schema : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
-        you have a reason to change this, use
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
-        allows automatic validation and autocomplete in editors that support JSON schema.
+        URL to `JSON schema <http://json-schema.org/>`_ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelFacetSpec'}
     _rootschema = Root._schema
@@ -6267,16 +6328,18 @@ class TopLevelFacetedUnitSpec(VegaLiteSchema):
     data : Data
         An object describing the data source
     mark : AnyMark
-        A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
-         `"line"`, `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark
-        definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``, ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and
+        ``"text"`` ) or a `mark definition object
+        <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`_.
     autosize : anyOf(AutosizeType, AutoSizeParams)
         Sets how the visualization size should be determined. If a string, should be one of
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
-        content sizing and automatic resizing. `"fit"` is only supported for single and
-        layered views that don't use `rangeStep`.  __Default value__: `pad`
+        ``"pad"``, ``"fit"`` or ``"none"``. Object values can additionally specify
+        parameters for content sizing and automatic resizing. ``"fit"`` is only supported
+        for single and layered views that don't use ``rangeStep``.  **Default value** :
+        ``pad``
     background : string
-        CSS color property to use as the background of visualization.  __Default value:__
+        CSS color property to use as the background of visualization.  **Default value:**
         none (transparent)
     config : Config
         Vega-Lite configuration object.  This property can only be defined at the top-level
@@ -6284,42 +6347,42 @@ class TopLevelFacetedUnitSpec(VegaLiteSchema):
     datasets : Datasets
         A global data store for named datasets. This is a mapping from names to inline
         datasets. This can be an array of objects or primitive values or a string. Arrays of
-         primitive values are ingested as objects with a `data` property.
+         primitive values are ingested as objects with a ``data`` property.
     description : string
         Description of this mark for commenting purpose.
     encoding : EncodingWithFacet
         A key-value mapping between encoding channels and definition of fields.
     height : float
-        The height of a visualization.  __Default value:__ - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its y-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will
-         be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). -
-        For y-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the height is [determined by the range step, paddings, and the
-         cardinality of the field mapped to
-        y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the
-         `rangeStep` is `null`, the height will be the value of
-        [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-         no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.
-        __Note__: For plots with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the height of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The height of a visualization.  **Default value:**   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its y-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the height will be
+        the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For y-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the height is `determined by the range step, paddings, and the
+        cardinality of the field mapped to y-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_. Otherwise, if the
+        ``rangeStep`` is ``null``, the height will be the value of ` ``config.view.height``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``y`` channel, the ``height`` will be the value of ``rangeStep``.  **Note** : For
+         plots with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        height of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     name : string
         Name of the visualization for later reference.
     padding : Padding
         The default visualization padding, in pixels, from the edge of the visualization
         canvas to the data rectangle.  If a number, specifies padding for all sides. If an
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}` to specify padding for each side of the visualization.  __Default
-        value__: `5`
+        object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.  **Default
+        value** : ``5``
     projection : Projection
         An object defining properties of geographic projection, which will be applied to
-        `shape` path for `"geoshape"` marks and to `latitude` and `"longitude"` channels for
-         other marks.
+        ``shape`` path for ``"geoshape"`` marks and to ``latitude`` and ``"longitude"``
+        channels for other marks.
     selection : Mapping(required=[])
         A key-value mapping between selection names and definitions.
     title : anyOf(string, TitleParams)
@@ -6327,32 +6390,34 @@ class TopLevelFacetedUnitSpec(VegaLiteSchema):
     transform : List(Transform)
         An array of data transformations such as filter and new field calculation.
     width : float
-        The width of a visualization.  __Default value:__ This will be determined by the
-        following rules:  - If a view's
-        [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is
-        `"fit"` or its x-channel has a [continuous
-        scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will
-        be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - For
-         x-axis with a band or point scale: if
-        [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric
-        value or unspecified, the width is [determined by the range step, paddings, and the
-        cardinality of the field mapped to
-        x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if
-        the `rangeStep` is `null`, the width will be the value of
-        [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config). - If
-        no field is mapped to `x` channel, the `width` will be the value of
-        [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height)
-         for `text` mark and the value of `rangeStep` for other marks.  __Note:__ For plots
-        with [`row` and `column`
-        channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this
-        represents the width of a single view.  __See also:__ The documentation for [width
-        and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+        The width of a visualization.  **Default value:** This will be determined by the
+        following rules:   * If a view's ` ``autosize``
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`_ type is ``"fit"`` or
+        its x-channel has a `continuous scale
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`_, the width will be
+        the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * For x-axis with a band
+         or point scale: if ` ``rangeStep``
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_ is a numeric value or
+        unspecified, the width is `determined by the range step, paddings, and the
+        cardinality of the field mapped to x-channel
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`_.   Otherwise, if the
+        ``rangeStep`` is ``null``, the width will be the value of ` ``config.view.width``
+        <https://vega.github.io/vega-lite/docs/spec.html#config>`_. * If no field is mapped
+        to ``x`` channel, the ``width`` will be the value of `
+        ``config.scale.textXRangeStep``
+        <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`_ for
+        ``text`` mark and the value of ``rangeStep`` for other marks.  **Note:** For plots
+        with ` ``row`` and ``column`` channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`_, this represents the
+        width of a single view.  **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`_ contains more examples.
     $schema : string
-        URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless
-        you have a reason to change this, use
-        `https://vega.github.io/schema/vega-lite/v2.json`. Setting the `$schema` property
-        allows automatic validation and autocomplete in editors that support JSON schema.
+        URL to `JSON schema <http://json-schema.org/>`_ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
     """
     _schema = {'$ref': '#/definitions/TopLevelFacetedUnitSpec'}
     _rootschema = Root._schema
@@ -6392,32 +6457,34 @@ class TopoDataFormat(VegaLiteSchema):
     ----------
     feature : string
         The name of the TopoJSON object set to convert to a GeoJSON feature collection. For
-        example, in a map of the world, there may be an object set named `"countries"`.
+        example, in a map of the world, there may be an object set named ``"countries"``.
         Using the feature property, we can extract this set and generate a GeoJSON feature
         object for each country.
     mesh : string
-        The name of the TopoJSON object set to convert to mesh. Similar to the `feature`
-        option, `mesh` extracts a named TopoJSON object set.   Unlike the `feature` option,
-        the corresponding geo data is returned as a single, unified mesh instance, not as
-        individual GeoJSON features. Extracting a mesh is useful for more efficiently
-        drawing borders or other geographic elements that you do not need to associate with
-        specific regions such as individual countries, states or counties.
+        The name of the TopoJSON object set to convert to mesh. Similar to the ``feature``
+        option, ``mesh`` extracts a named TopoJSON object set.   Unlike the ``feature``
+        option, the corresponding geo data is returned as a single, unified mesh instance,
+        not as individual GeoJSON features. Extracting a mesh is useful for more efficiently
+         drawing borders or other geographic elements that you do not need to associate with
+         specific regions such as individual countries, states or counties.
     parse : anyOf(enum('auto'), Mapping(required=[]))
         If set to auto (the default), perform automatic type inference to determine the
         desired data types. Alternatively, a parsing directive object can be provided for
         explicit data types. Each property of the object corresponds to a field name, and
-        the value to the desired data type (one of `"number"`, `"boolean"` or `"date"`). For
-         example, `"parse": {"modified_on": "date"}` parses the `modified_on` field in each
-        input record a Date value.  For `"date"`, we parse data based using Javascript's
-        [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).
-         For Specific date formats can be provided (e.g., `{foo: 'date:"%m%d%Y"'}`), using
-        the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC
-         date format parsing is supported similarly (e.g., `{foo: 'utc:"%m%d%Y"'}`). See
-        more about [UTC time](timeunit.html#utc)
+        the value to the desired data type (one of ``"number"``, ``"boolean"`` or ``"date"``
+         ). For example, ``"parse": {"modified_on": "date"}`` parses the ``modified_on``
+        field in each input record a Date value.  For ``"date"``, we parse data based using
+        Javascript's ` ``Date.parse()``
+        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse>`_.
+         For Specific date formats can be provided (e.g., ``{foo: 'date:"%m%d%Y"'}`` ),
+        using the `d3-time-format syntax
+        <https://github.com/d3/d3-time-format#locale_format>`_. UTC date format parsing is
+        supported similarly (e.g., ``{foo: 'utc:"%m%d%Y"'}`` ). See more about `UTC time
+        <timeunit.html#utc>`_
     type : enum('topojson')
-        Type of input data: `"json"`, `"csv"`, `"tsv"`. The default format type is
-        determined by the extension of the file URL. If no extension is detected, `"json"`
-        will be used by default.
+        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``. The default format type is
+        determined by the extension of the file URL. If no extension is detected, ``"json"``
+         will be used by default.
     """
     _schema = {'$ref': '#/definitions/TopoDataFormat'}
     _rootschema = Root._schema
@@ -6443,7 +6510,7 @@ class Type(VegaLiteSchema):
     """Type schema wrapper
 
     anyOf(BasicType, GeoType)
-    Constants and utilities for data type
+    Constants and utilities for data type :raw-html:`<br>`
      Data type based on level of measurement
     """
     _schema = {'$ref': '#/definitions/Type'}
@@ -6461,8 +6528,8 @@ class UrlData(VegaLiteSchema):
     Attributes
     ----------
     url : string
-        An URL from which to load the data set. Use the `format.type` property to ensure the
-         loaded data is correctly parsed.
+        An URL from which to load the data set. Use the ``format.type`` property to ensure
+        the loaded data is correctly parsed.
     format : DataFormat
         An object that specifies the format for parsing the data file.
     """
@@ -6510,8 +6577,8 @@ class ValueDef(VegaLiteSchema):
     Attributes
     ----------
     value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values
-        between `0` to `1` for opacity).
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
     """
     _schema = {'$ref': '#/definitions/ValueDef'}
     _rootschema = Root._schema
@@ -6613,38 +6680,38 @@ class VgAxisConfig(VegaLiteSchema):
     Attributes
     ----------
     bandPosition : float
-        An interpolation fraction indicating where, for `band` scales, axis ticks should be
-        positioned. A value of `0` places ticks at the left edge of their bands. A value of
-        `0.5` places ticks in the middle of their bands.
+        An interpolation fraction indicating where, for ``band`` scales, axis ticks should
+        be positioned. A value of ``0`` places ticks at the left edge of their bands. A
+        value of ``0.5`` places ticks in the middle of their bands.
     domain : boolean
         A boolean flag indicating if the domain (the axis baseline) should be included as
-        part of the axis.  __Default value:__ `true`
+        part of the axis.  **Default value:** ``true``
     domainColor : string
-        Color of axis domain line.  __Default value:__  (none, using Vega default).
+        Color of axis domain line.  **Default value:**  (none, using Vega default).
     domainWidth : float
-        Stroke width of axis domain line  __Default value:__  (none, using Vega default).
+        Stroke width of axis domain line  **Default value:**  (none, using Vega default).
     grid : boolean
         A boolean flag indicating if grid lines should be included as part of the axis
-        __Default value:__ `true` for [continuous scales](scale.html#continuous) that are
-        not binned; otherwise, `false`.
+        **Default value:** ``true`` for `continuous scales <scale.html#continuous>`_ that
+        are not binned; otherwise, ``false``.
     gridColor : string
         Color of gridlines.
     gridDash : List(float)
         The offset (in pixels) into which to begin drawing with the grid dash array.
     gridOpacity : float
-        The stroke opacity of grid (value between [0,1])  __Default value:__ (`1` by
+        The stroke opacity of grid (value between [0,1])  **Default value:** ( ``1`` by
         default)
     gridWidth : float
         The grid width, in pixels.
     labelAngle : float
-        The rotation angle of the axis labels.  __Default value:__ `-90` for nominal and
-        ordinal fields; `0` otherwise.
+        The rotation angle of the axis labels.  **Default value:** ``-90`` for nominal and
+        ordinal fields; ``0`` otherwise.
     labelBound : anyOf(boolean, float)
-        Indicates if labels should be hidden if they exceed the axis range. If `false `(the
-        default) no bounds overlap analysis is performed. If `true`, labels will be hidden
-        if they exceed the axis range by more than 1 pixel. If this property is a number, it
-         specifies the pixel tolerance: the maximum amount by which a label bounding box may
-         exceed the axis range.  __Default value:__ `false`.
+        Indicates if labels should be hidden if they exceed the axis range. If ``false``
+        (the default) no bounds overlap analysis is performed. If ``true``, labels will be
+        hidden if they exceed the axis range by more than 1 pixel. If this property is a
+        number, it specifies the pixel tolerance: the maximum amount by which a label
+        bounding box may exceed the axis range.  **Default value:** ``false``.
     labelColor : string
         The color of the tick label, can be in hex color code or regular color name.
     labelFlush : anyOf(boolean, float)
@@ -6655,8 +6722,8 @@ class VgAxisConfig(VegaLiteSchema):
         pixels by which to offset the first and last labels; for example, a value of 2 will
         flush-align the first and last labels and also push them 2 pixels outward from the
         center of the axis. The additional adjustment can sometimes help the labels better
-        visually group with corresponding axis ticks.  __Default value:__ `true` for axis of
-         a continuous x-scale. Otherwise, `false`.
+        visually group with corresponding axis ticks.  **Default value:** ``true`` for axis
+        of a continuous x-scale. Otherwise, ``false``.
     labelFont : string
         The font of the tick label.
     labelFontSize : float
@@ -6664,25 +6731,25 @@ class VgAxisConfig(VegaLiteSchema):
     labelLimit : float
         Maximum allowed pixel width of axis tick labels.
     labelOverlap : anyOf(boolean, enum('parity'), enum('greedy'))
-        The strategy to use for resolving overlap of axis labels. If `false` (the default),
-        no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of
-        removing every other label is used (this works well for standard linear axes). If
-        set to `"greedy"`, a linear scan of the labels is performed, removing any labels
-        that overlaps with the last visible label (this often works better for log-scaled
-        axes).  __Default value:__ `true` for non-nominal fields with non-log scales;
-        `"greedy"` for log scales; otherwise `false`.
+        The strategy to use for resolving overlap of axis labels. If ``false`` (the
+        default), no overlap reduction is attempted. If set to ``true`` or ``"parity"``, a
+        strategy of removing every other label is used (this works well for standard linear
+        axes). If set to ``"greedy"``, a linear scan of the labels is performed, removing
+        any labels that overlaps with the last visible label (this often works better for
+        log-scaled axes).  **Default value:** ``true`` for non-nominal fields with non-log
+        scales; ``"greedy"`` for log scales; otherwise ``false``.
     labelPadding : float
         The padding, in pixels, between axis and text labels.
     labels : boolean
         A boolean flag indicating if labels should be included as part of the axis.
-        __Default value:__  `true`.
+        **Default value:**  ``true``.
     maxExtent : float
         The maximum extent in pixels that axis ticks and labels should use. This determines
-        a maximum offset value for axis titles.  __Default value:__ `undefined`.
+        a maximum offset value for axis titles.  **Default value:** ``undefined``.
     minExtent : float
         The minimum extent in pixels that axis ticks and labels should use. This determines
-        a minimum offset value for axis titles.  __Default value:__ `30` for y-axis;
-        `undefined` for x-axis.
+        a minimum offset value for axis titles.  **Default value:** ``30`` for y-axis;
+        ``undefined`` for x-axis.
     tickColor : string
         The color of the axis's tick.
     tickRound : boolean
@@ -6703,13 +6770,13 @@ class VgAxisConfig(VegaLiteSchema):
     titleColor : string
         Color of the title, can be in hex color code or regular color name.
     titleFont : string
-        Font of the title. (e.g., `"Helvetica Neue"`).
+        Font of the title. (e.g., ``"Helvetica Neue"`` ).
     titleFontSize : float
         Font size of the title.
     titleFontWeight : FontWeight
-        Font weight of the title. This can be either a string (e.g `"bold"`, `"normal"`) or
-        a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` =
-        `700`).
+        Font weight of the title. This can be either a string (e.g ``"bold"``, ``"normal"``
+        ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400``
+         and ``"bold"`` = ``700`` ).
     titleLimit : float
         Maximum allowed pixel width of axis titles.
     titleMaxLength : float
@@ -6838,107 +6905,109 @@ class VgMarkConfig(VegaLiteSchema):
     Attributes
     ----------
     align : HorizontalAlign
-        The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
     angle : float
         The rotation angle of the text, in degrees.
     baseline : VerticalAlign
-        The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
-        __Default value:__ `"middle"`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+        **Default value:** ``"middle"``
     cursor : enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress',
     'wait', 'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
     'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
     'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
     'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
-        The mouse cursor used over the mark. Any valid [CSS cursor
-        type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`_ can be used.
     dx : float
         The horizontal offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     dy : float
         The vertical offset, in pixels, between the text label and its anchor point. The
-        offset is applied after rotation by the _angle_ property.
+        offset is applied after rotation by the *angle* property.
     fill : string
-        Default Fill Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Fill Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     fillOpacity : float
-        The fill opacity (value between [0,1]).  __Default value:__ `1`
+        The fill opacity (value between [0,1]).  **Default value:** ``1``
     font : string
-        The typeface to set the text in (e.g., `"Helvetica Neue"`).
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : float
         The font size, in pixels.
     fontStyle : FontStyle
-        The font style (e.g., `"italic"`).
+        The font style (e.g., ``"italic"`` ).
     fontWeight : FontWeight
-        The font weight. This can be either a string (e.g `"bold"`, `"normal"`) or a number
-        (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     href : string
         A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     interpolate : Interpolate
         The line interpolation method to use for line and area marks. One of the following:
-        - `"linear"`: piecewise linear segments, as in a polyline. - `"linear-closed"`:
-        close the linear segments to form a polygon. - `"step"`: alternate between
-        horizontal and vertical segments, as in a step function. - `"step-before"`:
-        alternate between vertical and horizontal segments, as in a step function. -
-        `"step-after"`: alternate between horizontal and vertical segments, as in a step
-        function. - `"basis"`: a B-spline, with control point duplication on the ends. -
-        `"basis-open"`: an open B-spline; may not intersect the start or end. -
-        `"basis-closed"`: a closed B-spline, as in a loop. - `"cardinal"`: a Cardinal
-        spline, with control point duplication on the ends. - `"cardinal-open"`: an open
-        Cardinal spline; may not intersect the start or end, but will intersect other
-        control points. - `"cardinal-closed"`: a closed Cardinal spline, as in a loop. -
-        `"bundle"`: equivalent to basis, except the tension parameter is used to straighten
-        the spline. - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+           * ``"linear"`` : piecewise linear segments, as in a polyline. *
+        ``"linear-closed"`` : close the linear segments to form a polygon. * ``"step"`` :
+        alternate between horizontal and vertical segments, as in a step function. *
+        ``"step-before"`` : alternate between vertical and horizontal segments, as in a step
+         function. * ``"step-after"`` : alternate between horizontal and vertical segments,
+        as in a step function. * ``"basis"`` : a B-spline, with control point duplication on
+         the ends. * ``"basis-open"`` : an open B-spline; may not intersect the start or
+        end. * ``"basis-closed"`` : a closed B-spline, as in a loop. * ``"cardinal"`` : a
+        Cardinal spline, with control point duplication on the ends. * ``"cardinal-open"`` :
+         an open Cardinal spline; may not intersect the start or end, but will intersect
+        other control points. * ``"cardinal-closed"`` : a closed Cardinal spline, as in a
+        loop. * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+        straighten the spline. * ``"monotone"`` : cubic interpolation that preserves
+        monotonicity in y.
     limit : float
         The maximum length of the text mark in pixels (default 0, indicating no limit). The
         text value will be automatically truncated if the rendered size exceeds the limit.
     opacity : float
-        The overall opacity (value between [0,1]).  __Default value:__ `0.7` for
-        non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered
-        `bar` charts and `1` otherwise.
+        The overall opacity (value between [0,1]).  **Default value:** ``0.7`` for
+        non-aggregate plots with ``point``, ``tick``, ``circle``, or ``square`` marks or
+        layered ``bar`` charts and ``1`` otherwise.
     orient : Orient
         The orientation of a non-stacked bar, tick, area, and line charts. The value is
-        either horizontal (default) or vertical. - For bar, rule and tick, this determines
-        whether the size of the bar and tick should be applied to x or y dimension. - For
-        area, this property determines the orient property of the Vega output. - For line
+        either horizontal (default) or vertical.   * For bar, rule and tick, this determines
+         whether the size of the bar and tick   should be applied to x or y dimension. * For
+         area, this property determines the orient property of the Vega output. * For line
         and trail marks, this property determines the sort order of the points in the line
-        if `config.sortLineBy` is not specified. For stacked charts, this is always
-        determined by the orientation of the stack; therefore explicitly specified value
+           if ``config.sortLineBy`` is not specified.   For stacked charts, this is always
+        determined by the orientation of the stack;   therefore explicitly specified value
         will be ignored.
     radius : float
         Polar coordinate radial offset, in pixels, of the text label from the origin
-        determined by the `x` and `y` properties.
+        determined by the ``x`` and ``y`` properties.
     shape : string
-        The default symbol shape to use. One of: `"circle"` (default), `"square"`,
-        `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
-          __Default value:__ `"circle"`
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.  **Default value:** ``"circle"``
     size : float
         The pixel area each the point/circle/square. For example: in the case of circles,
-        the radius is determined in part by the square root of the size value.  __Default
-        value:__ `30`
+        the radius is determined in part by the square root of the size value.  **Default
+        value:** ``30``
     stroke : string
-        Default Stroke Color.  This has higher precedence than `config.color`  __Default
-        value:__ (None)
+        Default Stroke Color.  This has higher precedence than ``config.color``  **Default
+        value:** (None)
     strokeCap : enum('butt', 'round', 'square')
-        The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
-        __Default value:__ `"square"`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.  **Default value:** ``"square"``
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : float
         The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeOpacity : float
-        The stroke opacity (value between [0,1]).  __Default value:__ `1`
+        The stroke opacity (value between [0,1]).  **Default value:** ``1``
     strokeWidth : float
         The stroke width, in pixels.
     tension : float
         Depending on the interpolation type, sets the tension parameter (for line and area
         marks).
     text : string
-        Placeholder text if the `text` channel is not specified
+        Placeholder text if the ``text`` channel is not specified
     theta : float
         Polar coordinate angle, in radians, of the text label from the origin determined by
-        the `x` and `y` properties. Values for `theta` follow the same convention of `arc`
-        mark `startAngle` and `endAngle` properties: angles are measured in radians, with
-        `0` indicating "north".
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
     """
     _schema = {'$ref': '#/definitions/VgMarkConfig'}
     _rootschema = Root._schema
@@ -7074,13 +7143,13 @@ class VgTitleConfig(VegaLiteSchema):
     Attributes
     ----------
     anchor : Anchor
-        The anchor position for placing the title. One of `"start"`, `"middle"`, or `"end"`.
-         For example, with an orientation of top these anchor positions map to a left-,
-        center-, or right-aligned title.  __Default value:__ `"middle"` for
-        [single](spec.html) and [layered](layer.html) views. `"start"` for other composite
-        views.  __Note:__ [For now](https://github.com/vega/vega-lite/issues/2875), `anchor`
-         is only customizable only for [single](spec.html) and [layered](layer.html) views.
-          For other composite views, `anchor` is always `"start"`.
+        The anchor position for placing the title. One of ``"start"``, ``"middle"``, or
+        ``"end"``. For example, with an orientation of top these anchor positions map to a
+        left-, center-, or right-aligned title.  **Default value:** ``"middle"`` for `single
+         <spec.html>`_ and `layered <layer.html>`_ views. ``"start"`` for other composite
+        views.  **Note:** `For now <https://github.com/vega/vega-lite/issues/2875>`_,
+        ``anchor`` is only customizable only for `single <spec.html>`_ and `layered
+        <layer.html>`_ views.  For other composite views, ``anchor`` is always ``"start"``.
     angle : float
         Angle in degrees of title text.
     baseline : VerticalAlign
@@ -7090,11 +7159,11 @@ class VgTitleConfig(VegaLiteSchema):
     font : string
         Font name for title text.
     fontSize : float
-        Font size in pixels for title text.  __Default value:__ `10`.
+        Font size in pixels for title text.  **Default value:** ``10``.
     fontWeight : FontWeight
-        Font weight for title text. This can be either a string (e.g `"bold"`, `"normal"`)
-        or a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` =
-         `700`).
+        Font weight for title text. This can be either a string (e.g ``"bold"``,
+        ``"normal"`` ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where
+        ``"normal"`` = ``400`` and ``"bold"`` = ``700`` ).
     limit : float
         The maximum allowed length in pixels of legend labels.
     offset : float
@@ -7123,29 +7192,29 @@ class ViewConfig(VegaLiteSchema):
     clip : boolean
         Whether the view should be clipped.
     fill : string
-        The fill color.  __Default value:__ (none)
+        The fill color.  **Default value:** (none)
     fillOpacity : float
-        The fill opacity (value between [0,1]).  __Default value:__ (none)
+        The fill opacity (value between [0,1]).  **Default value:** (none)
     height : float
         The default height of the single plot or each plot in a trellis plot when the
-        visualization has a continuous (non-ordinal) y-scale with `rangeStep` = `null`.
-        __Default value:__ `200`
+        visualization has a continuous (non-ordinal) y-scale with ``rangeStep`` = ``null``.
+          **Default value:** ``200``
     stroke : string
-        The stroke color.  __Default value:__ (none)
+        The stroke color.  **Default value:** (none)
     strokeDash : List(float)
         An array of alternating stroke, space lengths for creating dashed or dotted lines.
-        __Default value:__ (none)
+        **Default value:** (none)
     strokeDashOffset : float
         The offset (in pixels) into which to begin drawing with the stroke dash array.
-        __Default value:__ (none)
+        **Default value:** (none)
     strokeOpacity : float
-        The stroke opacity (value between [0,1]).  __Default value:__ (none)
+        The stroke opacity (value between [0,1]).  **Default value:** (none)
     strokeWidth : float
-        The stroke width, in pixels.  __Default value:__ (none)
+        The stroke width, in pixels.  **Default value:** (none)
     width : float
         The default width of the single plot or each plot in a trellis plot when the
         visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with
-        `rangeStep` = `null`.  __Default value:__ `200`
+        ``rangeStep`` = ``null``.  **Default value:** ``200``
     """
     _schema = {'$ref': '#/definitions/ViewConfig'}
     _rootschema = Root._schema
@@ -7167,18 +7236,18 @@ class WindowFieldDef(VegaLiteSchema):
     Attributes
     ----------
     op : anyOf(AggregateOp, WindowOnlyOp)
-        The window or aggregation operations to apply within a window, including `rank`,
-        `lead`, `sum`, `average` or `count`. See the list of all supported operations
-        [here](https://vega.github.io/vega-lite/docs/window.html#ops).
+        The window or aggregation operations to apply within a window, including ``rank``,
+        ``lead``, ``sum``, ``average`` or ``count``. See the list of all supported
+        operations `here <https://vega.github.io/vega-lite/docs/window.html#ops>`_.
     field : string
         The data field for which to compute the aggregate or window function. This can be
-        omitted for window functions that do not operate over a field such as `count`,
-        `rank`, `dense_rank`.
+        omitted for window functions that do not operate over a field such as ``count``,
+        ``rank``, ``dense_rank``.
     param : float
         Parameter values for the window functions. Parameter values can be omitted for
         operations that do not accept a parameter.  See the list of all supported operations
-         and their parameters
-        [here](https://vega.github.io/vega-lite/docs/transforms/window.html).
+         and their parameters `here
+        <https://vega.github.io/vega-lite/docs/transforms/window.html>`_.
     as : string
         The output name for the window operation.
     """
@@ -7235,14 +7304,15 @@ class WindowTransform(VegaLiteSchema):
         A frame specification as a two-element array indicating how the sliding window
         should proceed. The array entries should either be a number indicating the offset
         from the current data object, or null to indicate unbounded rows preceding or
-        following the current data object. The default value is `[null, 0]`, indicating that
-         the sliding window includes the current object and all preceding objects. The value
-         `[-5, 5]` indicates that the window should include five objects preceding and five
-        objects following the current object. Finally, `[null, null]` indicates that the
-        window frame should always include all data objects. The only operators affected are
-         the aggregation operations and the `first_value`, `last_value`, and `nth_value`
-        window operations. The other window operations are not affected by this.  __Default
-        value:__:  `[null, 0]` (includes the current object and all preceding objects)
+        following the current data object. The default value is ``[null, 0]``, indicating
+        that the sliding window includes the current object and all preceding objects. The
+        value ``[-5, 5]`` indicates that the window should include five objects preceding
+        and five objects following the current object. Finally, ``[null, null]`` indicates
+        that the window frame should always include all data objects. The only operators
+        affected are the aggregation operations and the ``first_value``, ``last_value``, and
+         ``nth_value`` window operations. The other window operations are not affected by
+        this.  **Default value:** :  ``[null, 0]`` (includes the current object and all
+        preceding objects)
     groupby : List(string)
         The data fields for partitioning the data objects into separate windows. If
         unspecified, all data points will be a single group.
@@ -7252,13 +7322,13 @@ class WindowTransform(VegaLiteSchema):
         window frame to expand to include all peer values. If set to true, the window frame
         will be defined by offset values only. This setting only affects those operations
         that depend on the window frame, namely aggregation operations and the first_value,
-        last_value, and nth_value window operations.  __Default value:__ `false`
+        last_value, and nth_value window operations.  **Default value:** ``false``
     sort : List(WindowSortField)
         A comparator definition for sorting data objects within a window. If two data
         objects are considered equal by the comparator, they are considered “peer” values of
          equal rank. If sort is not specified, the order is undefined: data objects are
         processed in the order they are observed and none are considered peers (the
-        ignorePeers parameter is ignored and treated as if set to `true`).
+        ignorePeers parameter is ignored and treated as if set to ``true`` ).
     """
     _schema = {'$ref': '#/definitions/WindowTransform'}
     _rootschema = Root._schema

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -8,11 +8,28 @@ from os.path import abspath, join, dirname
 import textwrap
 from urllib import request
 
+import m2r
+
 # import schemapi from here
 sys.path.insert(0, abspath(dirname(__file__)))
 from schemapi import codegen
-from schemapi.codegen import SchemaGenerator, CodeSnippet, schema_class
+from schemapi.codegen import CodeSnippet
 from schemapi.utils import get_valid_identifier, SchemaInfo, indent_arglist
+
+
+class SchemaGenerator(codegen.SchemaGenerator):
+    def _process_description(self, description):
+        description = m2r.convert(description)
+        description = description.replace(m2r.prolog, '')
+        description = description.replace(":raw-html-m2r:", ":raw-html:")
+        description = description.replace(r'\ ,', ',')
+        description = description.replace(r'\ ', ' ')
+        return description.strip()
+
+
+def schema_class(*args, **kwargs):
+    return SchemaGenerator(*args, **kwargs).schema_class()
+
 
 SCHEMA_URL_TEMPLATE = ('https://vega.github.io/schema/'
                        '{library}/{version}.json')

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -88,6 +88,9 @@ class SchemaGenerator(object):
         super({classname}, self).__init__({super_arglist})
     """).lstrip()
 
+    def _process_description(self, description):
+        return description
+
     def __init__(self, classname, schema, rootschema=None,
                  basename='SchemaBase', schemarepr=None, rootschemarepr=None,
                  nodefault=()):
@@ -128,7 +131,7 @@ class SchemaGenerator(object):
                '',
                info.medium_description]
         if info.description:
-            doc += info.description.splitlines()
+            doc += self._process_description(info.description).splitlines()
 
         if info.properties:
             nonkeyword, required, kwds, invalid_kwds, additional = _get_args(info)
@@ -138,7 +141,7 @@ class SchemaGenerator(object):
             for prop in sorted(required) + sorted(kwds) + sorted(invalid_kwds):
                 propinfo = info.properties[prop]
                 doc += ["{0} : {1}".format(prop, propinfo.short_description),
-                        "    {0}".format(propinfo.description)]
+                        "    {0}".format(self._process_description(propinfo.description))]
         if len(doc) > 1:
             doc += ['']
         return indent_docstring(doc, indent_level=indent, width=100, lstrip=True)
@@ -179,7 +182,3 @@ class SchemaGenerator(object):
         if indent:
             initfunc = ('\n' + indent * ' ').join(initfunc.splitlines())
         return initfunc
-
-
-def schema_class(*args, **kwargs):
-    return SchemaGenerator(*args, **kwargs).schema_class()

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -1,6 +1,8 @@
 """Code generation utilities"""
 from .utils import SchemaInfo, is_valid_identifier, indent_docstring, indent_arglist
 
+import textwrap
+
 
 class CodeSnippet(object):
     """Object whose repr() is a string of code"""
@@ -9,84 +11,6 @@ class CodeSnippet(object):
 
     def __repr__(self):
         return self.code
-
-
-SCHEMA_CLASS_TEMPLATE = '''
-class {classname}({basename}):
-    """{docstring}"""
-    _schema = {schema!r}
-    _rootschema = {rootschema!r}
-
-    {init_code}
-'''
-
-
-def schema_class(classname, schema, rootschema=None, basename='SchemaBase',
-                 schemarepr=None, rootschemarepr=None):
-    """Generate code for a schema class
-
-    Parameters
-    ----------
-    classname : string
-        The name of the class to generate
-    schema : dict
-        The dictionary defining the schema class
-    rootschema : dict (optional)
-        The root schema for the class
-    basename : string (default: "SchemaBase")
-        The name of the base class to use in the class definition
-    schemarepr : CodeSnippet or object, optional
-        An object whose repr will be used in the place of the explicit schema.
-        This can be useful, for example, when the generated code should reference
-        a predefined schema object. The user must ensure that the schema within
-        the evaluated code is identical to the schema used to generate the code.
-    rootschemarepr : CodeSnippet or object, optional
-        An object whose repr will be used in the place of the explicit root
-        schema.
-    """
-    rootschema = rootschema if rootschema is not None else schema
-    schemarepr = schemarepr if schemarepr is not None else schema
-    if rootschemarepr is None:
-        if rootschema is schema:
-            rootschemarepr = CodeSnippet('_schema')
-        else:
-            rootschemarepr = rootschema
-    return SCHEMA_CLASS_TEMPLATE.format(
-        classname=classname,
-        basename=basename,
-        schema=schemarepr,
-        rootschema=rootschemarepr,
-        docstring=docstring(classname=classname, schema=schema,
-                            rootschema=rootschema, indent=4),
-        init_code=init_code(classname=classname, schema=schema,
-                            rootschema=rootschema, indent=4)
-    )
-
-
-def docstring(classname, schema, rootschema=None, indent=4):
-    # TODO: add a general description at the top, derived from the schema.
-    #       for example, a non-object definition should list valid type, enum
-    #       values, etc.
-    # TODO: use _get_args here for more information on allOf objects
-    info = SchemaInfo(schema, rootschema)
-    doc = ["{0} schema wrapper".format(classname),
-           '',
-           info.medium_description]
-    if info.description:
-        doc += info.description.splitlines()
-
-    if info.properties:
-        nonkeyword, required, kwds, invalid_kwds, additional = _get_args(info)
-        doc += ['',
-                'Attributes',
-                '----------']
-        for prop in sorted(required) + sorted(kwds) + sorted(invalid_kwds):
-            propinfo = info.properties[prop]
-            doc += ["{0} : {1}".format(prop, propinfo.short_description),
-                    "    {0}".format(propinfo.description)]
-    if len(doc) > 1:
-        doc += ['']
-    return indent_docstring(doc, indent_level=indent, width=100, lstrip=True)
 
 
 def _get_args(info):
@@ -128,45 +52,134 @@ def _get_args(info):
     return (nonkeyword, required, kwds, invalid_kwds, additional)
 
 
-INIT_DEF = """
-def __init__({arglist}):
-    super({classname}, self).__init__({super_arglist})
-""".lstrip()
+class SchemaGenerator(object):
+    """Class that defines methods for generating code from schemas
+
+    Parameters
+    ----------
+    classname : string
+        The name of the class to generate
+    schema : dict
+        The dictionary defining the schema class
+    rootschema : dict (optional)
+        The root schema for the class
+    basename : string (default: "SchemaBase")
+        The name of the base class to use in the class definition
+    schemarepr : CodeSnippet or object, optional
+        An object whose repr will be used in the place of the explicit schema.
+        This can be useful, for example, when the generated code should reference
+        a predefined schema object. The user must ensure that the schema within
+        the evaluated code is identical to the schema used to generate the code.
+    rootschemarepr : CodeSnippet or object, optional
+        An object whose repr will be used in the place of the explicit root
+        schema.
+    """
+    schema_class_template = textwrap.dedent('''
+    class {classname}({basename}):
+        """{docstring}"""
+        _schema = {schema!r}
+        _rootschema = {rootschema!r}
+
+        {init_code}
+    ''')
+
+    init_template = textwrap.dedent("""
+    def __init__({arglist}):
+        super({classname}, self).__init__({super_arglist})
+    """).lstrip()
+
+    def __init__(self, classname, schema, rootschema=None,
+                 basename='SchemaBase', schemarepr=None, rootschemarepr=None,
+                 nodefault=()):
+        self.classname = classname
+        self.schema = schema
+        self.rootschema = rootschema
+        self.basename = basename
+        self.schemarepr = schemarepr
+        self.rootschemarepr = rootschemarepr
+        self.nodefault = nodefault
+
+    def schema_class(self):
+        """Generate code for a schema class"""
+        rootschema = self.rootschema if self.rootschema is not None else self.schema
+        schemarepr = self.schemarepr if self.schemarepr is not None else self.schema
+        rootschemarepr = self.rootschemarepr
+        if rootschemarepr is None:
+            if rootschema is self.schema:
+                rootschemarepr = CodeSnippet('_schema')
+            else:
+                rootschemarepr = rootschema
+        return self.schema_class_template.format(
+            classname=self.classname,
+            basename=self.basename,
+            schema=schemarepr,
+            rootschema=rootschemarepr,
+            docstring=self.docstring(indent=4),
+            init_code=self.init_code(indent=4)
+        )
+
+    def docstring(self, indent=0):
+        # TODO: add a general description at the top, derived from the schema.
+        #       for example, a non-object definition should list valid type, enum
+        #       values, etc.
+        # TODO: use _get_args here for more information on allOf objects
+        info = SchemaInfo(self.schema, self.rootschema)
+        doc = ["{0} schema wrapper".format(self.classname),
+               '',
+               info.medium_description]
+        if info.description:
+            doc += info.description.splitlines()
+
+        if info.properties:
+            nonkeyword, required, kwds, invalid_kwds, additional = _get_args(info)
+            doc += ['',
+                    'Attributes',
+                    '----------']
+            for prop in sorted(required) + sorted(kwds) + sorted(invalid_kwds):
+                propinfo = info.properties[prop]
+                doc += ["{0} : {1}".format(prop, propinfo.short_description),
+                        "    {0}".format(propinfo.description)]
+        if len(doc) > 1:
+            doc += ['']
+        return indent_docstring(doc, indent_level=indent, width=100, lstrip=True)
+
+    def init_code(self, indent=0):
+        """Return code suitablde for the __init__ function of a Schema class"""
+        info = SchemaInfo(self.schema, rootschema=self.rootschema)
+        nonkeyword, required, kwds, invalid_kwds, additional =_get_args(info)
+
+        nodefault=set(self.nodefault)
+        required -= nodefault
+        kwds -= nodefault
+
+        args = ['self']
+        super_args = []
+
+        if nodefault:
+            args.extend(sorted(nodefault))
+        elif nonkeyword:
+            args.append('*args')
+            super_args.append('*args')
+
+        args.extend('{0}=Undefined'.format(p)
+                    for p in sorted(required) + sorted(kwds))
+        super_args.extend('{0}={0}'.format(p)
+                          for p in sorted(nodefault) + sorted(required) + sorted(kwds))
+
+        if additional:
+            args.append('**kwds')
+            super_args.append('**kwds')
+
+        arg_indent_level = 9 + indent
+        super_arg_indent_level = 23 + len(self.classname) + indent
+
+        initfunc = self.init_template.format(classname=self.classname,
+                                             arglist=indent_arglist(args, indent_level=arg_indent_level),
+                                             super_arglist=indent_arglist(super_args, indent_level=super_arg_indent_level))
+        if indent:
+            initfunc = ('\n' + indent * ' ').join(initfunc.splitlines())
+        return initfunc
 
 
-def init_code(classname, schema, rootschema=None, indent=0, nodefault=()):
-    """Return code suitablde for the __init__ function of a Schema class"""
-    info = SchemaInfo(schema, rootschema=rootschema)
-    nonkeyword, required, kwds, invalid_kwds, additional =_get_args(info)
-
-    nodefault=set(nodefault)
-    required -= nodefault
-    kwds -= nodefault
-
-    args = ['self']
-    super_args = []
-
-    if nodefault:
-        args.extend(sorted(nodefault))
-    elif nonkeyword:
-        args.append('*args')
-        super_args.append('*args')
-
-    args.extend('{0}=Undefined'.format(p)
-                for p in sorted(required) + sorted(kwds))
-    super_args.extend('{0}={0}'.format(p)
-                      for p in sorted(nodefault) + sorted(required) + sorted(kwds))
-
-    if additional:
-        args.append('**kwds')
-        super_args.append('**kwds')
-
-    arg_indent_level = 9 + indent
-    super_arg_indent_level = 23 + len(classname) + indent
-
-    initfunc = INIT_DEF.format(classname=classname,
-                               arglist=indent_arglist(args, indent_level=arg_indent_level),
-                               super_arglist=indent_arglist(super_args, indent_level=super_arg_indent_level))
-    if indent:
-        initfunc = ('\n' + indent * ' ').join(initfunc.splitlines())
-    return initfunc
+def schema_class(*args, **kwargs):
+    return SchemaGenerator(*args, **kwargs).schema_class()

--- a/tools/schemapi/decorator.py
+++ b/tools/schemapi/decorator.py
@@ -32,18 +32,18 @@ def schemaclass(*args, init_func=True, docstring=True, property_map=True):
             warnings.warn("class is not an instance of SchemaBase.")
 
         name = cls.__name__
+        gen = codegen.SchemaGenerator(name, schema=cls._schema,
+                                      rootschema=cls._rootschema)
 
         if init_func and '__init__' not in cls.__dict__:
-            init_code = codegen.init_code(name, schema=cls._schema,
-                                          rootschema=cls._rootschema)
+            init_code = gen.init_code()
             globals_ = {name: cls, 'Undefined': Undefined}
             locals_ = {}
             exec(init_code, globals_, locals_)
             setattr(cls, '__init__', locals_['__init__'])
 
         if docstring and not cls.__doc__:
-            setattr(cls, '__doc__', codegen.docstring(name, schema=cls._schema,
-                                                      rootschema=cls._rootschema))
+            setattr(cls, '__doc__', gen.docstring())
         return cls
 
     if len(args) == 0:


### PR DESCRIPTION
Auto-generated docstrings in altair come from vega-lite, which uses markdown format. Sphinx does not properly render markdown from docstrings, and this leads to poorly formatted docs (see generated docs here: https://altair-viz.github.io/user_guide/API.html#module-altair)

This PR uses the [m2r](https://pypi.org/project/m2r/)  package to convert descriptions from markdown to RST in the process of generating Altair's code.

The results aren't perfect, but they're much better than before.