### PR TITLE
MAINT: fix handling of display metadata

### DIFF
--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -70,7 +70,7 @@ class Displayable(object):
             return {}
 
 
-def default_renderer(spec, mime_type, str_repr, **metadata):
+def default_renderer_base(spec, mime_type, str_repr, **metadata):
     """A default renderer for VegaLite 1/2 that works for modern frontends.
 
     This renderer works with modern frontends (JupyterLab, nteract) that know
@@ -83,7 +83,7 @@ def default_renderer(spec, mime_type, str_repr, **metadata):
     return bundle, metadata
 
 
-def json_renderer(spec, str_repr, **metadata):
+def json_renderer_base(spec, str_repr, **metadata):
     """A renderer that returns a MIME type of application/json.
 
     In JupyterLab/nteract this is rendered as a nice JSON tree.

--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -70,26 +70,27 @@ class Displayable(object):
             return {}
 
 
-def default_renderer_base(spec, mime_type, str_repr, **metadata):
-    """A default renderer for VegaLite 1/2 that works for modern frontends.
+def default_renderer_base(spec, mime_type, str_repr, **options):
+    """A default renderer for Vega or VegaLite that works for modern frontends.
 
     This renderer works with modern frontends (JupyterLab, nteract) that know
     how to render the custom VegaLite MIME type listed above.
     """
     assert isinstance(spec, dict)
     bundle = {}
-    bundle['text/plain'] = str_repr
+    metadata = {}
+
     bundle[mime_type] = spec
+    bundle['text/plain'] = str_repr
+    if options:
+        metadata[mime_type] = options
     return bundle, metadata
 
 
-def json_renderer_base(spec, str_repr, **metadata):
+def json_renderer_base(spec, str_repr, **options):
     """A renderer that returns a MIME type of application/json.
 
     In JupyterLab/nteract this is rendered as a nice JSON tree.
     """
-    assert isinstance(spec, dict)
-    bundle = {}
-    bundle['text/plain'] = str_repr
-    bundle['application/json'] = spec
-    return bundle, metadata
+    return default_renderer_base(spec, mime_type='application/json',
+                                 str_repr=str_repr, **options)

--- a/altair/vega/display.py
+++ b/altair/vega/display.py
@@ -1,11 +1,11 @@
-from ..utils.display import Displayable, default_renderer, json_renderer
+from ..utils.display import Displayable, default_renderer_base, json_renderer_base
 from ..utils.display import MimeBundleType, RendererType
 
 
 __all__ = (
     "Displayable",
-    "default_renderer",
-    "json_renderer",
+    "default_renderer_base",
+    "json_renderer_base",
     "MimeBundleType",
     "RendererType"
 )

--- a/altair/vega/v2/display.py
+++ b/altair/vega/v2/display.py
@@ -2,8 +2,8 @@ import os
 
 from ...utils import PluginRegistry
 from ..display import Displayable
-from ..display import default_renderer as default_renderer_base
-from ..display import json_renderer as json_renderer_base
+from ..display import default_renderer_base
+from ..display import json_renderer_base
 from ..display import RendererType
 
 

--- a/altair/vega/v3/display.py
+++ b/altair/vega/v3/display.py
@@ -2,8 +2,8 @@ import os
 
 from ...utils import PluginRegistry
 from ..display import Displayable
-from ..display import default_renderer as default_renderer_base
-from ..display import json_renderer as json_renderer_base
+from ..display import default_renderer_base
+from ..display import json_renderer_base
 from ..display import RendererType
 
 

--- a/altair/vegalite/display.py
+++ b/altair/vegalite/display.py
@@ -1,10 +1,10 @@
-from ..utils.display import Displayable, default_renderer, json_renderer
+from ..utils.display import Displayable, default_renderer_base, json_renderer_base
 from ..utils.display import RendererRegistry
 
 
 __all__ = (
     "Displayable",
-    "default_renderer",
-    "json_renderer",
+    "default_renderer_base",
+    "json_renderer_base",
     "RendererRegistry"
 )

--- a/altair/vegalite/v1/display.py
+++ b/altair/vegalite/v1/display.py
@@ -3,8 +3,8 @@ import os
 from ...utils.mimebundle import spec_to_mimebundle
 
 from ..display import Displayable
-from ..display import default_renderer as default_renderer_base
-from ..display import json_renderer as json_renderer_base
+from ..display import default_renderer_base
+from ..display import json_renderer_base
 from ..display import RendererRegistry
 
 from .schema import SCHEMA_VERSION

--- a/altair/vegalite/v2/display.py
+++ b/altair/vegalite/v2/display.py
@@ -2,8 +2,8 @@ import os
 
 from ...utils.mimebundle import spec_to_mimebundle
 from ..display import Displayable
-from ..display import default_renderer as default_renderer_base
-from ..display import json_renderer as json_renderer_base
+from ..display import default_renderer_base
+from ..display import json_renderer_base
 from ..display import RendererRegistry
 
 from .schema import SCHEMA_VERSION


### PR DESCRIPTION
I realized that mimebundle metadata should be passed with the same mimetype key as the main data. This PR fixes that.

It also cleans up the way that display functions are defined.