### PR TITLE
added example that links an interval selection in a histogram with a scatter plot

### DIFF
--- a/altair/vegalite/v2/examples/scatter_with_histogram.py
+++ b/altair/vegalite/v2/examples/scatter_with_histogram.py
@@ -1,0 +1,50 @@
+"""
+Scatter Plot and Histogram with Interval Selection
+==================================================
+
+This example shows how to link a scatter plot and a histogram 
+together such that an interval selection in the histogram will 
+plot the selected values in the scatter plot. 
+
+Note that the binning  has to be applied to *both* 
+the scatter plot and the bar chart via the `transform_bin` mehtod 
+in order for this to work! 
+
+
+"""
+# category: interactive charts
+
+import altair as alt
+import pandas as pd
+import numpy as np
+
+x = np.random.normal(size=100)
+y = np.random.normal(size=100)
+
+m = np.random.normal(15, 1, size=100)
+
+df = pd.DataFrame({"x": x, "y":y, "m":m})
+
+pts = alt.selection(type="interval", encodings=["x"])
+
+points = alt.Chart(df).mark_point(filled=True, color="black").encode(
+    x = alt.X("x"),
+    y = alt.Y("y")
+).transform_filter(
+    pts.ref()
+).transform_bin(
+ "mbin", field="m", bin=alt.Bin(maxbins=20)   
+).properties(width=300, height=300)
+
+mag = alt.Chart(df).mark_bar().encode(
+    x = alt.X("mbin", type="nominal"),
+    y = alt.Y("count()"),
+    color = alt.condition(pts, alt.value("black"), alt.value("lightgray"))
+).transform_bin(
+    "mbin", field="m", bin=alt.Bin(maxbins=20)
+).properties(
+    selection=pts,
+    width=300, 
+    height=300)
+
+points | mag


### PR DESCRIPTION
Here's something else that took me a while to figure out yesterday, while I was trying to reproduce the [cross-highlights example](https://altair-viz.github.io/gallery/interactive_cross_highlight.html) on some of my own data: the behaviour is different when selecting a bar chart made from nominal categories to when there's a histogram binning step of quantitative information in the middle. 

I found that the only way I could make it work is by applying the `transform_bin` method to both charts. I don't know if that's the correct way to do it, or if there's a better way, but in either case, I thought it might be nice to have an example that shows this behaviour. 