### PR TITLE
DOC: Normalized Stacked Area Chart example

### DIFF
--- a/altair/vegalite/v2/examples/layered_area_chart.py
+++ b/altair/vegalite/v2/examples/layered_area_chart.py
@@ -1,0 +1,16 @@
+"""
+Layered Area Chart
+------------------
+This example shows a layered area chart.
+"""
+# category: area charts
+import altair as alt
+from vega_datasets import data
+
+iowa = data.iowa_electricity()
+
+alt.Chart(iowa).mark_area(opacity=0.3).encode(
+    x="year:T",
+    y=alt.Y("net_generation:Q", stack=None),
+    color="source:N"
+)

--- a/altair/vegalite/v2/examples/normalized_stacked_area_chart.py
+++ b/altair/vegalite/v2/examples/normalized_stacked_area_chart.py
@@ -3,7 +3,7 @@ Normalized Stacked Area Chart
 -----------------------------
 This example shows how to make a normalized stacked area chart.
 """
-# category: simple charts
+# category: area charts
 import altair as alt
 from vega_datasets import data
 

--- a/altair/vegalite/v2/examples/normalized_stacked_area_chart.py
+++ b/altair/vegalite/v2/examples/normalized_stacked_area_chart.py
@@ -1,0 +1,16 @@
+"""
+Normalized Stacked Area Chart
+-----------------------------
+This example shows how to make a normalized stacked area chart.
+"""
+# category: simple charts
+import altair as alt
+from vega_datasets import data
+
+source = data.unemployment_across_industries.url
+
+alt.Chart(source).mark_area().encode(
+    x="date:T",
+    y=alt.Y("count:Q", stack="normalize"),
+    color="series:N"
+)

--- a/altair/vegalite/v2/examples/normalized_stacked_area_chart.py
+++ b/altair/vegalite/v2/examples/normalized_stacked_area_chart.py
@@ -7,10 +7,10 @@ This example shows how to make a normalized stacked area chart.
 import altair as alt
 from vega_datasets import data
 
-source = data.unemployment_across_industries.url
+iowa = data.iowa_electricity()
 
-alt.Chart(source).mark_area().encode(
-    x="date:T",
-    y=alt.Y("count:Q", stack="normalize"),
-    color="series:N"
+alt.Chart(iowa).mark_area().encode(
+    x="year:T",
+    y=alt.Y("net_generation:Q", stack="normalize"),
+    color="source:N"
 )

--- a/altair/vegalite/v2/examples/simple_stacked_area_chart.py
+++ b/altair/vegalite/v2/examples/simple_stacked_area_chart.py
@@ -7,10 +7,10 @@ This example shows how to make a simple stacked area chart.
 import altair as alt
 from vega_datasets import data
 
-source = data.unemployment_across_industries.url
+iowa = data.iowa_electricity()
 
-alt.Chart(source).mark_area().encode(
-    x="date:T",
-    y="count:Q",
-    color="series:N"
+alt.Chart(iowa).mark_area().encode(
+    x="year:T",
+    y="net_generation:Q",
+    color="source:N"
 )

--- a/altair/vegalite/v2/examples/trellis_area.py
+++ b/altair/vegalite/v2/examples/trellis_area.py
@@ -1,23 +1,17 @@
 """
 Trellis Area
 -----------------
-This example shows stock prices of four large companies as a small multiples of area charts.
+This example shows small multiples of an area chart.
 """
 # category: area charts
 import altair as alt
-from altair.expr import datum
 from vega_datasets import data
 
-source = data.stocks()
+iowa = data.iowa_electricity()
 
-alt.Chart(source).mark_area().encode(
-    alt.X('date:T', axis=alt.Axis(format='%Y', title='Time', grid=False)),
-    alt.Y('price:Q', axis=alt.Axis(title='Price', grid=False)),
-    alt.Color('symbol', legend=None),
-    alt.Row('symbol:N', header=alt.Header(title='Symbol'))
-).properties(
-    width=300,
-    height=40
-).transform_filter(
-    datum.symbol != 'GOOG'
+alt.Chart(iowa).mark_area().encode(
+    x="year:T",
+    y="net_generation:Q",
+    color="source:N",
+    row="source:N"
 )

--- a/altair/vegalite/v2/examples/trellis_area.py
+++ b/altair/vegalite/v2/examples/trellis_area.py
@@ -1,6 +1,6 @@
 """
-Trellis Area
------------------
+Trellis Area Chart
+------------------
 This example shows small multiples of an area chart.
 """
 # category: area charts


### PR DESCRIPTION
The same as the simple area chart example, but normalized. 

```python
import altair as alt
from vega_datasets import data

source = data.unemployment_across_industries.url

alt.Chart(source).mark_area().encode(
    x="date:T",
    y=alt.Y("count:Q", stack="normalize"),
    color="series:N"
)
```

![visualization 17](https://user-images.githubusercontent.com/9993/39656789-6857cdf4-4fb7-11e8-81c8-f0ff6be7fee7.png)
