### PR TITLE
Use vega instead of vega3

### DIFF
--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -19,7 +19,7 @@ class RendererRegistry(PluginRegistry[RendererType]):
     entrypoint_err_messages = {
         'notebook': textwrap.dedent(
             """
-            To use the 'notebook' renderer, you must install the vega3 package
+            To use the 'notebook' renderer, you must install the vega package
             and the associated Jupyter extension.
             See https://altair-viz.github.io/getting_started/installation.html
             for more information.

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -78,16 +78,16 @@ Altair works in the Jupyter notebook, though we recommend using it in JupyterLab
 if available (see :ref:`installation-jupyterlab`).
 
 If using the notebook, Altair works best with notebook version 5.3 or newer.
-Note that using Altair in the notebook also requires the vega3_ package
+Note that using Altair in the notebook also requires the vega_ package
 to be installed and configured.
 
 To install the notebook and Altair with conda, run the following command::
 
-    $ conda install -c conda-forge altair vega_datasets notebook vega3
+    $ conda install -c conda-forge altair vega_datasets notebook vega
 
 To install the notebook and Altair with pip, run the following command::
 
-    $ pip install -U altair vega_datasets notebook vega3
+    $ pip install -U altair vega_datasets notebook vega
 
 Once the packages and extensions are installed, launch the notebook by running::
 
@@ -96,7 +96,7 @@ Once the packages and extensions are installed, launch the notebook by running::
 In the browser window that launches, click the *New* drop-down menu and
 select either "Python 2" or "Python 3", depending on which version of Python
 you are using (note that the kernel you choose *must* match the kernel where
-you installed the vega3 extension).
+you installed the vega extension).
 
 In the notebook that opens, you can run the following code to ensure everything
 is properly set up:
@@ -244,4 +244,4 @@ development version directly from GitHub using:
 .. _Colab: https://colab.research.google.com
 .. _nteract: https://nteract.io
 .. _Jupyter Notebook: https://jupyter-notebook.readthedocs.io/en/stable/
-.. _vega3: https://pypi.python.org/pypi/vega3/
+.. _vega: https://pypi.python.org/pypi/vega/

--- a/doc/user_guide/custom_renderers.rst
+++ b/doc/user_guide/custom_renderers.rst
@@ -49,7 +49,7 @@ The renderers built-in to Altair are the following:
 - ``"nteract"``: identical to ``"default"``
 - ``"colab"``: renderer for Google's Colab notebook, using the
   ``"text/html"`` MIME type.
-- ``"notebook"``: renderer for the classic notebook, provided by the ipyvega3_
+- ``"notebook"``: renderer for the classic notebook, provided by the ipyvega_
   package
 - ``"json"``: renderer that outputs the raw JSON chart specification, using the
   ``'application/json'`` MIME type.
@@ -59,4 +59,4 @@ The renderers built-in to Altair are the following:
   outputting it using the ``'image/svg+xml'`` MIME type.
 
 
-.. _ipyvega3: https://github.com/vega/ipyvega/tree/vega3
+.. _ipyvega: https://github.com/vega/ipyvega/tree/vega

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -119,7 +119,7 @@ To register and enable a new renderer::
     >>> alt.renderers.enable('custom_renderer')
 
 Renderers can also be registered using the `entrypoints`_ API of Python packages.
-For an example, see `ipyvega3`_.
+For an example, see `ipyvega`_.
 
 This same ``renderer`` objects exists separately on all of the Python APIs
 for Vega-Lite/Vega described in :ref:`importing`.
@@ -131,18 +131,18 @@ Displaying in the Jupyter Notebook
 
 To render Vega-Lite 2.x or Vega 3.x in the Jupyter Notebook (as mentioned above
 we recommend these versions), you will need to install and enable the
-`ipyvega3`_ Python package using conda:
+`ipyvega`_ Python package using conda:
 
 .. code-block:: bash
 
-    $ conda install vega3 --channel conda-forge
+    $ conda install vega --channel conda-forge
 
 or ``pip``:
 
 .. code-block:: bash
 
-    $ pip install jupyter pandas vega3
-    $ jupyter nbextension install --sys-prefix --py vega3 # not needed in notebook >= 5.3
+    $ pip install jupyter pandas vega
+    $ jupyter nbextension install --sys-prefix --py vega # not needed in notebook >= 5.3
 
 
 For Vega-Lite 1.x or Vega 2.x, you will need to install and enable the `ipyvega`_ Python
@@ -182,7 +182,7 @@ To add support for Vega-Lite 2.x and Vega 3.x install the following JupyterLab
 extension (which requires nodejs)::
 
     conda install -c conda-forge nodejs  # if you do not already have nodejs installed
-    jupyter labextension install @jupyterlab/vega3-extension
+    jupyter labextension install @jupyterlab/vega-extension
 
 and then import Altair as::
 
@@ -229,7 +229,7 @@ And then you can create Altair plots normally within the notebook.
 
 .. _entrypoints: https://github.com/takluyver/entrypoints
 .. _ipyvega: https://github.com/vega/ipyvega/tree/master
-.. _ipyvega3: https://github.com/vega/ipyvega/tree/vega3
+.. _ipyvega: https://github.com/vega/ipyvega/tree/vega
 .. _JupyterLab: http://jupyterlab.readthedocs.io/en/stable/
 .. _nteract: https://nteract.io
 .. _Colab: https://colab.research.google.com

--- a/doc/user_guide/renderers.rst
+++ b/doc/user_guide/renderers.rst
@@ -33,7 +33,7 @@ Altair ships with the following renderers:
 
       alt.renderers.enable('notebook')
 
-  Note that this requires the vega3_ package; see :ref:`display-notebook`.
+  Note that this requires the vega_ package; see :ref:`display-notebook`.
 
 **Google Colab**
   for Colab_, you must switch to the ``colab`` renderer::
@@ -46,4 +46,4 @@ Altair ships with the following renderers:
 .. _nteract: https://nteract.io
 .. _Colab: https://colab.research.google.com
 .. _Jupyter Notebook: https://jupyter-notebook.readthedocs.io/en/stable/
-.. _vega3: https://github.com/vega/ipyvega/tree/vega3
+.. _vega: https://github.com/vega/ipyvega/tree/vega

--- a/doc/user_guide/troubleshooting.rst
+++ b/doc/user_guide/troubleshooting.rst
@@ -122,7 +122,7 @@ If you are using the notebook (not JupyterLab) and see the the following output:
 it means that either:
 
 1. You have forgotten to enable the notebook renderer. As mentioned
-   in :ref:`installation-notebook`, you need to install the ``vega3`` package and
+   in :ref:`installation-notebook`, you need to install the ``vega`` package and
    Jupyter extension, and then enable it using::
 
        import altair as alt
@@ -134,7 +134,7 @@ it means that either:
 
        NoSuchEntryPoint: No 'notebook' entry point found in group 'altair.vegalite.v2.renderer'
 
-   This means that you have not installed the vega3 package. If you see this error,
+   This means that you have not installed the vega package. If you see this error,
    please make sure to follow the standard installation instructions at
    :ref:`installation-notebook`.
 


### PR DESCRIPTION
I have no rerun the notebooks. 

ipyvega is now `vega` instead of `vega3`