### PR TITLE
ENH: make to_json & to_csv transformers have deterministic filenames

### DIFF
--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -161,5 +161,10 @@ def _data_to_csv_string(data):
     if isinstance(data, pd.DataFrame):
         data = sanitize_dataframe(data)
         return data.to_csv(index=False)
+    elif isinstance(data, dict):
+        if 'values' not in data:
+            raise KeyError('values expected in data dict, but not present')
+        return pd.DataFrame.from_dict(data['values']).to_csv(index=False)
     else:
-        raise NotImplementedError('to_csv only works with Pandas DataFrame objects.')
+        raise NotImplementedError("to_csv only works with data expressed as "
+                                  "a DataFrame or as a dict")

--- a/altair/utils/tests/test_data.py
+++ b/altair/utils/tests/test_data.py
@@ -1,8 +1,11 @@
+import os
+
 import pytest
 import pandas as pd
 
 
-from ..data import limit_rows, MaxRowsError, sample, pipe, to_values
+from ..data import (limit_rows, MaxRowsError, sample, pipe, to_values,
+                    to_json, to_csv)
 
 
 def _create_dataframe(N):
@@ -63,3 +66,39 @@ def test_type_error():
     for f in (sample, limit_rows, to_values):
         with pytest.raises(TypeError):
             pipe(0, f)
+
+
+def test_to_json():
+    """Test to_json
+    - make certain the filename is deterministic
+    - make certain the file contents match the data
+    """
+    data = _create_dataframe(10)
+    try:
+        result1 = pipe(data, to_json)
+        result2 = pipe(data, to_json)
+        filename = result1['url']
+        output = pd.read_json(filename)
+    finally:
+        os.remove(filename)
+
+    assert result1 == result2
+    assert output.equals(data)
+
+
+def test_to_csv():
+    """Test to_csv
+    - make certain the filename is deterministic
+    - make certain the file contents match the data
+    """
+    data = _create_dataframe(10)
+    try:
+        result1 = pipe(data, to_csv)
+        result2 = pipe(data, to_csv)
+        filename = result1['url']
+        output = pd.read_csv(filename)
+    finally:
+        os.remove(filename)
+
+    assert result1 == result2
+    assert output.equals(data)

--- a/altair/utils/tests/test_data.py
+++ b/altair/utils/tests/test_data.py
@@ -68,7 +68,7 @@ def test_type_error():
             pipe(0, f)
 
 
-def test_to_json():
+def test_dataframe_to_json():
     """Test to_json
     - make certain the filename is deterministic
     - make certain the file contents match the data
@@ -86,8 +86,26 @@ def test_to_json():
     assert output.equals(data)
 
 
-def test_to_csv():
-    """Test to_csv
+def test_dict_to_json():
+    """Test to_json
+    - make certain the filename is deterministic
+    - make certain the file contents match the data
+    """
+    data = _create_data_with_values(10)
+    try:
+        result1 = pipe(data, to_json)
+        result2 = pipe(data, to_json)
+        filename = result1['url']
+        output = pd.read_json(filename).to_dict(orient='records')
+    finally:
+        os.remove(filename)
+
+    assert result1 == result2
+    assert data == {'values': output}
+
+
+def test_dataframe_to_csv():
+    """Test to_csv with dataframe input
     - make certain the filename is deterministic
     - make certain the file contents match the data
     """
@@ -102,3 +120,21 @@ def test_to_csv():
 
     assert result1 == result2
     assert output.equals(data)
+
+
+def test_dict_to_csv():
+    """Test to_csv with dict input
+    - make certain the filename is deterministic
+    - make certain the file contents match the data
+    """
+    data = _create_data_with_values(10)
+    try:
+        result1 = pipe(data, to_csv)
+        result2 = pipe(data, to_csv)
+        filename = result1['url']
+        output = pd.read_csv(filename).to_dict(orient='records')
+    finally:
+        os.remove(filename)
+
+    assert result1 == result2
+    assert data == {'values': output}


### PR DESCRIPTION
Addresses #857

- [x] update functions
- [x] add tests

The idea here is that when someone uses the ``json`` or ``csv`` data transformer, the dataframes are stored on disk with a filename that is determined from the hash of the data contents. This prevents the proliferation of temporary files when doing a lot of plotting.