### PR TITLE
DOC: add parallel coordinates example

### DIFF
--- a/altair/vegalite/v2/examples/parallel_coordinates.py
+++ b/altair/vegalite/v2/examples/parallel_coordinates.py
@@ -1,0 +1,25 @@
+"""
+Parallel Coordinates Example
+----------------------------
+A `Parallel Coordinates <https://en.wikipedia.org/wiki/Parallel_coordinates>`_
+chart is a chart that lets you visualize the individual data points by drawing
+a single line for each of them.
+Such a chart can be created in Altair, but requires some data preprocessing
+to transform the data into a suitable representation.
+This example shows a parallel coordinates chart with the Iris dataset.
+"""
+# category: other charts
+
+import altair as alt
+from vega_datasets import data
+
+iris = data.iris()
+iris_transformed = iris.reset_index().melt(['species', 'index'])
+
+alt.Chart(iris_transformed).mark_line().encode(
+    x='variable:N',
+    y='value:Q',
+    color='species:N',
+    detail='index:N',
+    opacity=alt.value(0.5)
+).properties(width=500)


### PR DESCRIPTION
This adds an example of a  parallel coordinates chart:

```python
import altair as alt
from vega_datasets import data

iris = data.iris()
iris_transformed = iris.reset_index().melt(['species', 'index'])

alt.Chart(iris_transformed).mark_line().encode(
    x='variable:N',
    y='value:Q',
    color='species:N',
    detail='index:N',
    opacity=alt.value(0.5)
).properties(width=500)
```
![visualization 4](https://user-images.githubusercontent.com/781659/40249187-0d2415d4-5a87-11e8-9d16-05efbf09e075.png)

