### PR TITLE
DOC: Add line chart with markers example

### DIFF
--- a/altair/vegalite/v2/examples/connected_scatterplot.py
+++ b/altair/vegalite/v2/examples/connected_scatterplot.py
@@ -2,7 +2,8 @@
 Connected Scatterplot (Lines with Custom Paths)
 -----------------------------------------------
 
-This example show how the order encoding can be used to draw a custom path. The dataset tracks miles driven per capita along with gas prices annually from 1956 to 2010. It is based on Hannah Fairfield's article 'Driving Shifts Into Reverse'. See https://archive.nytimes.com/www.nytimes.com/imagepages/2010/05/02/business/02metrics.html for the original. 
+This example show how the order encoding can be used to draw a custom path. The dataset tracks miles driven per capita along with gas prices annually from 1956 to 2010. 
+It is based on Hannah Fairfield's article 'Driving Shifts Into Reverse'. See https://archive.nytimes.com/www.nytimes.com/imagepages/2010/05/02/business/02metrics.html for the original. 
 """
 # category: scatter plots
 import altair as alt

--- a/altair/vegalite/v2/examples/connected_scatterplot.py
+++ b/altair/vegalite/v2/examples/connected_scatterplot.py
@@ -2,7 +2,7 @@
 Connected Scatterplot (Lines with Custom Paths)
 -----------------------------------------------
 
-This example shows how layering can be used to build a plot. This dataset tracks miles driven per capita along with gas prices annually from 1956 to 2010. It is based on the May 2, 2010 New York Times article 'Driving Shifts Into Reverse'. See http://mbostock.github.io/protovis/ex/driving.html .
+This example show how the order encoding can be used to draw a custom path. The dataset tracks miles driven per capita along with gas prices annually from 1956 to 2010. It is based on Hannah Fairfield's article 'Driving Shifts Into Reverse'. See https://archive.nytimes.com/www.nytimes.com/imagepages/2010/05/02/business/02metrics.html for the original. 
 """
 # category: scatter plots
 import altair as alt
@@ -10,15 +10,8 @@ from vega_datasets import data
 
 driving = data.driving()
 
-lines = alt.Chart(driving).mark_line().encode(
+alt.Chart(driving).mark_line(point=True).encode(
     alt.X('miles', scale=alt.Scale(zero=False)),
     alt.Y('gas', scale=alt.Scale(zero=False)),
     order='year'
 )
-
-points = alt.Chart(driving).mark_circle().encode(
-    alt.X('miles', scale=alt.Scale(zero=False)),
-    alt.Y('gas', scale=alt.Scale(zero=False))
-)
-
-lines + points

--- a/altair/vegalite/v2/examples/multiple_marks.py
+++ b/altair/vegalite/v2/examples/multiple_marks.py
@@ -10,11 +10,8 @@ from vega_datasets import data
 
 stocks = data.stocks()
 
-alt.LayerChart(stocks).encode(
+alt.Chart(stocks).mark_line(point=True).encode(
     x='date:T',
     y='price:Q',
     color='symbol:N'
-).add_layers(
-    alt.Chart().mark_point(),
-    alt.Chart().mark_line()
 )

--- a/altair/vegalite/v2/examples/simple_line_chart_with_markers.py
+++ b/altair/vegalite/v2/examples/simple_line_chart_with_markers.py
@@ -1,0 +1,20 @@
+"""
+Simple Line Chart with Markers
+------------------------------
+This chart shows the most basic line chart with markers, made from a dataframe with two
+columns.
+"""
+# category: simple charts
+
+import altair as alt
+import numpy as np
+import pandas as pd
+
+x = np.arange(100)
+data = pd.DataFrame({'x': x,
+                     'sin(x)': np.sin(x / 5)})
+
+alt.Chart(data).mark_line(point=True).encode(
+    x='x',
+    y='sin(x)'
+)

--- a/doc/user_guide/encoding.rst
+++ b/doc/user_guide/encoding.rst
@@ -460,15 +460,8 @@ For line marks, the `order` channel encodes the order in which data points are c
 
     driving = data.driving()
 
-    points = alt.Chart(driving).mark_circle().encode(
-        alt.X('miles', scale=alt.Scale(zero=False)),
-        alt.Y('gas', scale=alt.Scale(zero=False))
-    )
-
-    lines = alt.Chart(driving).mark_line().encode(
+    alt.Chart(driving).mark_line(point=True).encode(
         alt.X('miles', scale=alt.Scale(zero=False)),
         alt.Y('gas', scale=alt.Scale(zero=False)),
         order='year'
     )
-
-    points + lines


### PR DESCRIPTION
Added a simple example of a line chart with markers discussed in #876 

I can also update 

- [Connected Scatterplot (Lines with Custom Paths)](https://altair-viz.github.io/gallery/connected_scatterplot.html)

- [Multiple Marks](https://altair-viz.github.io/gallery/multiple_marks.html)

if you think using `mark_line(point=True)` is preferred to the layering method.