### PR TITLE
Run data transformers on all inputs types

### DIFF
--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -1,6 +1,7 @@
 import json
 import random
 import hashlib
+import warnings
 
 import pandas as pd
 from toolz.curried import curry, pipe  # noqa
@@ -52,6 +53,7 @@ def limit_rows(data, max_rows=5000):
     try:
         check_data_type(data)
     except TypeError:
+        warnings.warn("limit_rows transformation can't work on type {0}".format(type(data)))
         return data
     if isinstance(data, pd.DataFrame):
         values = data
@@ -74,6 +76,7 @@ def sample(data, n=None, frac=None):
     try:
         check_data_type(data)
     except TypeError:
+        warnings.warn("sample transformation can't work on type {0}".format(type(data)))
         return data
     if isinstance(data, pd.DataFrame):
         return data.sample(n=n, frac=frac)
@@ -125,6 +128,7 @@ def to_values(data):
     try:
         check_data_type(data)
     except TypeError:
+        warnings.warn("to_values transformation can't work on type {0}".format(type(data)))
         return data
     if isinstance(data, pd.DataFrame):
         data = sanitize_dataframe(data)

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -4,11 +4,13 @@ import hashlib
 import warnings
 
 import pandas as pd
+import six
 from toolz.curried import curry, pipe  # noqa
 from typing import Callable
 
 from .core import sanitize_dataframe
 from .plugin_registry import PluginRegistry
+from ..vegalite.schema import core
 
 
 # ==============================================================================
@@ -138,6 +140,12 @@ def to_values(data):
             raise KeyError('values expected in data dict, but not present.')
         return data
 
+@curry
+def to_url(data):
+    """Replace a string with with UrlData"""
+    if isinstance(data, six.string_types):
+        return core.UrlData(data)
+    return data
 
 def check_data_type(data):
     """Raise if the data is not a dict or DataFrame."""

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -1,7 +1,6 @@
 import json
 import random
 import hashlib
-import warnings
 
 import pandas as pd
 import six
@@ -55,7 +54,6 @@ def limit_rows(data, max_rows=5000):
     try:
         check_data_type(data)
     except TypeError:
-        warnings.warn("limit_rows transformation can't work on type {0}".format(type(data)))
         return data
     if isinstance(data, pd.DataFrame):
         values = data
@@ -78,7 +76,6 @@ def sample(data, n=None, frac=None):
     try:
         check_data_type(data)
     except TypeError:
-        warnings.warn("sample transformation can't work on type {0}".format(type(data)))
         return data
     if isinstance(data, pd.DataFrame):
         return data.sample(n=n, frac=frac)
@@ -130,7 +127,6 @@ def to_values(data):
     try:
         check_data_type(data)
     except TypeError:
-        warnings.warn("to_values transformation can't work on type {0}".format(type(data)))
         return data
     if isinstance(data, pd.DataFrame):
         data = sanitize_dataframe(data)

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -49,7 +49,10 @@ def limit_rows(data, max_rows=5000):
 
     If max_rows is None, then do not perform any check.
     """
-    check_data_type(data)
+    try:
+        check_data_type(data)
+    except TypeError:
+        return data
     if isinstance(data, pd.DataFrame):
         values = data
     elif isinstance(data, dict):
@@ -68,7 +71,10 @@ def limit_rows(data, max_rows=5000):
 @curry
 def sample(data, n=None, frac=None):
     """Reduce the size of the data model by sampling without replacement."""
-    check_data_type(data)
+    try:
+        check_data_type(data)
+    except TypeError:
+        return data
     if isinstance(data, pd.DataFrame):
         return data.sample(n=n, frac=frac)
     elif isinstance(data, dict):
@@ -116,7 +122,10 @@ def to_csv(data, prefix='altair-data', extension='csv',
 @curry
 def to_values(data):
     """Replace a DataFrame by a data model with values."""
-    check_data_type(data)
+    try:
+        check_data_type(data)
+    except TypeError:
+        return data
     if isinstance(data, pd.DataFrame):
         data = sanitize_dataframe(data)
         return {'values': data.to_dict(orient='records')}

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -51,17 +51,12 @@ def limit_rows(data, max_rows=5000):
 
     If max_rows is None, then do not perform any check.
     """
-    try:
-        check_data_type(data)
-    except TypeError:
-        return data
     if isinstance(data, pd.DataFrame):
         values = data
-    elif isinstance(data, dict):
-        if 'values' in data:
-            values = data['values']
-        else:
-            return data
+    elif isinstance(data, dict) and 'values' in data:
+        values = data['values']
+    else:
+        return data
     if max_rows is not None and len(values) > max_rows:
         raise MaxRowsError('The number of rows in your dataset is greater '
                            'than the maximum allowed ({0}). '
@@ -73,10 +68,6 @@ def limit_rows(data, max_rows=5000):
 @curry
 def sample(data, n=None, frac=None):
     """Reduce the size of the data model by sampling without replacement."""
-    try:
-        check_data_type(data)
-    except TypeError:
-        return data
     if isinstance(data, pd.DataFrame):
         return data.sample(n=n, frac=frac)
     elif isinstance(data, dict):
@@ -85,6 +76,7 @@ def sample(data, n=None, frac=None):
             n = n if n else int(frac*len(values))
             values = random.sample(values, n)
             return {'values': values}
+    return data
 
 
 @curry
@@ -124,10 +116,6 @@ def to_csv(data, prefix='altair-data', extension='csv',
 @curry
 def to_values(data):
     """Replace a DataFrame by a data model with values."""
-    try:
-        check_data_type(data)
-    except TypeError:
-        return data
     if isinstance(data, pd.DataFrame):
         data = sanitize_dataframe(data)
         return {'values': data.to_dict(orient='records')}
@@ -135,6 +123,7 @@ def to_values(data):
         if 'values' not in data:
             raise KeyError('values expected in data dict, but not present.')
         return data
+    return data
 
 @curry
 def to_url(data):
@@ -142,11 +131,6 @@ def to_url(data):
     if isinstance(data, six.string_types):
         return core.UrlData(data)
     return data
-
-def check_data_type(data):
-    """Raise if the data is not a dict or DataFrame."""
-    if not isinstance(data, (dict, pd.DataFrame)):
-        raise TypeError('Expected dict or DataFrame, got: {}'.format(type(data)))
 
 
 # ==============================================================================
@@ -159,7 +143,6 @@ def _compute_data_hash(data_str):
 
 def _data_to_json_string(data):
     """Return a JSON string representation of the input data"""
-    check_data_type(data)
     if isinstance(data, pd.DataFrame):
         data = sanitize_dataframe(data)
         return data.to_json(orient='records')
@@ -174,7 +157,6 @@ def _data_to_json_string(data):
 
 def _data_to_csv_string(data):
     """return a CSV string representation of the input data"""
-    check_data_type(data)
     if isinstance(data, pd.DataFrame):
         data = sanitize_dataframe(data)
         return data.to_csv(index=False)

--- a/altair/utils/tests/test_data.py
+++ b/altair/utils/tests/test_data.py
@@ -61,11 +61,10 @@ def test_to_values():
     assert result=={'values': data.to_dict(orient='records')}
 
 
-def test_type_error():
-    """Ensure that TypeError is raised for types other than dict/DataFrame."""
+def test_type_check():
+    """Ensure that the data is not changed for types other than dict/DataFrame."""
     for f in (sample, limit_rows, to_values):
-        with pytest.raises(TypeError):
-            pipe(0, f)
+        assert pipe(0, f) == 0
 
 
 def test_dataframe_to_json():

--- a/altair/vega/data.py
+++ b/altair/vega/data.py
@@ -2,7 +2,7 @@ import pandas as pd
 from toolz.curried import curry, pipe
 from ..utils.core import sanitize_dataframe
 from ..utils.data import (
-    MaxRowsError, sample, to_csv, to_json, to_values, check_data_type
+    MaxRowsError, sample, to_csv, to_json, to_values
 )
 
 
@@ -32,5 +32,4 @@ __all__ = (
     'to_csv',
     'to_json',
     'to_values',
-    'check_data_type'
 )

--- a/altair/vegalite/data.py
+++ b/altair/vegalite/data.py
@@ -3,7 +3,7 @@ from toolz.curried import curry, pipe
 from ..utils.core import sanitize_dataframe
 from ..utils.data import (
     MaxRowsError, limit_rows, sample, to_csv, to_json, to_values,
-    check_data_type, DataTransformerRegistry, to_url
+    DataTransformerRegistry, to_url
 )
 
 
@@ -24,6 +24,5 @@ __all__ = (
     'to_csv',
     'to_json',
     'to_url',
-    'to_values',
-    'check_data_type'
+    'to_values'
 )

--- a/altair/vegalite/data.py
+++ b/altair/vegalite/data.py
@@ -3,13 +3,13 @@ from toolz.curried import curry, pipe
 from ..utils.core import sanitize_dataframe
 from ..utils.data import (
     MaxRowsError, limit_rows, sample, to_csv, to_json, to_values,
-    check_data_type, DataTransformerRegistry
+    check_data_type, DataTransformerRegistry, to_url
 )
 
 
 @curry
 def default_data_transformer(data, max_rows=5000):
-    return pipe(data, limit_rows(max_rows=max_rows), to_values)
+    return pipe(data, to_url, limit_rows(max_rows=max_rows), to_values)
 
 
 __all__ = (

--- a/altair/vegalite/data.py
+++ b/altair/vegalite/data.py
@@ -23,6 +23,7 @@ __all__ = (
     'sample',
     'to_csv',
     'to_json',
+    'to_url',
     'to_values',
     'check_data_type'
 )

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -4,7 +4,6 @@ import warnings
 
 import jsonschema
 import six
-import pandas as pd
 
 from .schema import core, channels, mixins, Undefined, SCHEMA_URL
 

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -17,18 +17,10 @@ from .theme import themes
 # Data Utilities
 def _prepare_data(data):
     """Convert input data to data for use within schema"""
-    if data is Undefined:
-        return data
-    elif isinstance(data, (dict, core.Data, core.InlineData,
-                         core.UrlData, core.NamedData)):
-        return data
-    elif isinstance(data, pd.DataFrame):
-        return pipe(data, data_transformers.get())
-    elif isinstance(data, six.string_types):
-        return core.UrlData(data)
-    else:
-        warnings.warn("data of type {0} not recognized".format(type(data)))
-        return data
+    if isinstance(data, six.string_types):
+        data = core.UrlData(data)
+    return pipe(data, data_transformers.get())
+
 
 
 # ------------------------------------------------------------------------

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -17,8 +17,6 @@ from .theme import themes
 # Data Utilities
 def _prepare_data(data):
     """Convert input data to data for use within schema"""
-    if isinstance(data, six.string_types):
-        data = core.UrlData(data)
     return pipe(data, data_transformers.get())
 
 

--- a/doc/user_guide/data_transformers.rst
+++ b/doc/user_guide/data_transformers.rst
@@ -19,16 +19,22 @@ These data transformations are managed by the data transformation API of Altair.
     API of Vega and Vega-Lite.
 
 A data transformer is a Python function that takes in the item passed in as the data and
-transforms it::
+transforms it. If it can't handle the type passed in, it should return it unchanged::
 
-    def data_transformer(data) :
-        # Transform and return the data
-        return fn(data)
+    def data_transformer(data):
+        if isinstance(data, MyType):
+            # Transform and return the data
+            return fn(data)    
+        return data
 
 Built-in data transformers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Altair includes a default set of data transformers with the following signatures.
+
+Convert strings into URL data::
+
+    to_url(data)
 
 Raise a ``MaxRowsError`` if a Dataframe has more than ``max_rows`` rows::
 

--- a/doc/user_guide/data_transformers.rst
+++ b/doc/user_guide/data_transformers.rst
@@ -18,15 +18,12 @@ These data transformations are managed by the data transformation API of Altair.
     The data transformation API of Altair should not be confused with the ``transform``
     API of Vega and Vega-Lite.
 
-A data transformer is a Python function that takes a Vega-Lite data ``dict`` or
-Pandas ``DataFrame`` and returns a transformed version of either of these types::
+A data transformer is a Python function that takes in the item passed in as the data and
+transforms it::
 
-    from typing import Union
-    Data = Union[dict, pd.DataFrame]
-
-    def data_transformer(data: Data) -> Data:
+    def data_transformer(data) :
         # Transform and return the data
-        return transformed_data
+        return fn(data)
 
 Built-in data transformers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This closes #843 by running the data transformers on all inputs types.

This will allow users to specify transformations for custom input types, like Ibis expressions. 

It changes the existing transformations to just raise a warning if they are called on types they can't handle, instead of raising an exception.