### PR TITLE
BUG: appropriately handle non-string column/field names:

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -86,6 +86,7 @@ def sanitize_dataframe(df):
     """Sanitize a DataFrame to prepare it for serialization.
 
     * Make a copy
+    * Convert all column names to strings
     * Raise ValueError if it has a hierarchical index.
     * Convert categoricals to strings.
     * Convert np.bool_ dtypes to Python bool objects
@@ -105,6 +106,9 @@ def sanitize_dataframe(df):
             return val.tolist()
         else:
             return val
+
+    # All column names must be strings
+    df.columns = map(str, df.columns)
 
     for col_name, dtype in df.dtypes.iteritems():
         if str(dtype) == 'category':
@@ -209,7 +213,7 @@ def parse_shorthand(shorthand, data=None, parse_aggregates=True,
     >>> parse_shorthand('count()', data) == {'aggregate': 'count', 'type': 'quantitative'}
     True
     """
-    if not shorthand:
+    if shorthand == '' or shorthand is None:
         return {}
 
     valid_typecodes = list(TYPECODE_MAP) + list(INV_TYPECODE_MAP)
@@ -239,9 +243,12 @@ def parse_shorthand(shorthand, data=None, parse_aggregates=True,
     # find matches depending on valid fields passed
     if isinstance(shorthand, dict):
         attrs = shorthand
-    else:
+    elif isinstance(shorthand, six.string_types):
         attrs = next(exp.match(shorthand).groupdict() for exp in regexps
                      if exp.match(shorthand))
+    else:
+        raise ValueError("column names must be strings, but {0} is of type {1}"
+                         "".format(shorthand, type(shorthand).__name__))
 
     # Handle short form of the type expression
     if 'type' in attrs:

--- a/altair/utils/tests/test_core.py
+++ b/altair/utils/tests/test_core.py
@@ -1,5 +1,7 @@
 import pandas as pd
 
+import pytest
+
 import altair as alt
 from .. import parse_shorthand, update_nested
 
@@ -8,7 +10,16 @@ def test_parse_shorthand():
     def check(s, **kwargs):
         assert parse_shorthand(s) == kwargs
 
+    # empty shorthand leads to empty dict
     check('')
+
+    # dict shorthand is processed
+    check({'type': 'Q', 'field': 'foo'},
+          type='quantitative', field='foo')
+
+    # invalid type leads to a value error
+    with pytest.raises(ValueError):
+        check(0)
 
     # Fields alone
     check('foobar', field='foobar')

--- a/altair/utils/tests/test_utils.py
+++ b/altair/utils/tests/test_utils.py
@@ -2,6 +2,8 @@ import pytest
 import warnings
 import json
 
+import six
+
 import numpy as np
 import pandas as pd
 
@@ -77,3 +79,9 @@ def test_sanitize_dataframe_infs():
     df_clean = sanitize_dataframe(df)
     assert list(df_clean.dtypes) == [object]
     assert list(df_clean['x']) == [0, 1, 2, None, None, None]
+
+
+def test_sanitize_dataframe_colnames():
+    df = pd.DataFrame(list(zip([1,2,3], [4,5, 6])))
+    df_clean = sanitize_dataframe(df)
+    assert all(isinstance(col, six.string_types) for col in df_clean.columns)


### PR DESCRIPTION
- in parse_shorthand, raise an informative error if the column is not a string or dict
- in sanitize_dataframe, convert non-string column names to strings

Fixes #898