### PR TITLE
Longer webdriver timeout

### DIFF
--- a/altair/utils/headless.py
+++ b/altair/utils/headless.py
@@ -107,7 +107,7 @@ EXTRACT_CODE = {
 
 def compile_spec(spec, format, mode,
                  vega_version, vegaembed_version, vegalite_version,
-                 driver_timeout=10, webdriver='chrome'):
+                 driver_timeout=20, webdriver='chrome'):
     # TODO: detect & use local Jupyter caches of JS packages?
 
     if format not in ['png', 'svg', 'vega']:


### PR DESCRIPTION
Allows altair to not time out on less responsive development computers (like my slow laptop). Addresses Issue #929 