### PR TITLE
 BUG: fix handling of categoricals

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -110,7 +110,8 @@ def sanitize_dataframe(df):
         if str(dtype) == 'category':
             # XXXX: work around bug in to_json for categorical types
             # https://github.com/pydata/pandas/issues/10778
-            df[col_name] = df[col_name].astype(str)
+            col = df[col_name].astype(object)
+            df[col_name] = col.where(col.notnull(), None)
         elif str(dtype) == 'bool':
             # convert numpy bools to objects; np.bool is not JSON serializable
             df[col_name] = df[col_name].astype(object)

--- a/altair/utils/tests/test_utils.py
+++ b/altair/utils/tests/test_utils.py
@@ -40,6 +40,8 @@ def test_sanitize_dataframe():
                        'b': np.array([True, False, True, True, False]),
                        'd': pd.date_range('2012-01-01', periods=5, freq='H'),
                        'c': pd.Series(list('ababc'), dtype='category'),
+                       'c2': pd.Series([1, 'A', 2.5, 'B', None],
+                                       dtype='category'),
                        'o': pd.Series([np.array(i) for i in range(5)]),
                        'p': pd.date_range('2012-01-01', periods=5, freq='H').tz_localize('UTC')})
 
@@ -50,8 +52,12 @@ def test_sanitize_dataframe():
     df.iloc[0, df.columns.get_loc('o')] = np.array(np.nan)
 
     # JSON serialize. This will fail on non-sanitized dataframes
+    print(df[['s', 'c2']])
     df_clean = sanitize_dataframe(df)
+    print(df_clean[['s', 'c2']])
+    print(df_clean[['s', 'c2']].to_dict())
     s = json.dumps(df_clean.to_dict(orient='records'))
+    print(s)
 
     # Re-construct pandas dataframe
     df2 = pd.read_json(s)


### PR DESCRIPTION
Previously all categoricals were converted to strings.

Now the data type is respected, and null values are appropriately handled.