### PR TITLE
Toplevel datasets

### DIFF
--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -16,7 +16,15 @@ from .plugin_registry import PluginRegistry
 DataTransformerType = Callable
 
 class DataTransformerRegistry(PluginRegistry[DataTransformerType]):
-    pass
+    _global_settings = {'consolidate_datasets': False}
+
+    @property
+    def consolidate_datasets(self):
+        return self._global_settings['consolidate_datasets']
+
+    @consolidate_datasets.setter
+    def consolidate_datasets(self, value):
+        self._global_settings['consolidate_datasets'] = value
 
 
 # ==============================================================================

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -2,6 +2,8 @@
 
 import warnings
 
+import hashlib
+import json
 import jsonschema
 import six
 import pandas as pd
@@ -15,15 +17,53 @@ from .theme import themes
 
 # ------------------------------------------------------------------------
 # Data Utilities
-def _prepare_data(data):
-    """Convert input data to data for use within schema"""
+def _dataset_name(data):
+    """Generate a unique hash of the data"""
+    def hash_(dct):
+        dct_str = json.dumps(dct, sort_keys=True)
+        return hashlib.md5(dct_str.encode()).hexdigest()
+
+    if isinstance(data, core.InlineData):
+        return 'data-' + hash_(data.values)
+    elif isinstance(data, dict) and 'values' in data:
+        return 'data-' + hash_(data['values'])
+    else:
+        raise ValueError("Cannot generate name for data {0}".format(data))
+
+
+def _prepare_data(data, context):
+    """Convert input data to data for use within schema
+
+    Parameters
+    ----------
+    data :
+        The input dataset in the form of a DataFrame, dictionary, altair data
+        object, or other type that is recognized by the data transformers.
+    context : dict
+        The to_dict context in which the data is being prepared. This is used
+        to keep track of information that needs to be passed up and down the
+        recursive serialization routine, such as global named datasets.
+    """
     if data is Undefined:
         return data
+    if isinstance(data, core.InlineData):
+        if data_transformers.consolidate_datasets:
+            name = _dataset_name(data)
+            context['datasets'][name] = data.values
+            return core.NamedData(name=name)
+        else:
+            return data
     elif isinstance(data, (dict, core.Data, core.InlineData,
-                         core.UrlData, core.NamedData)):
+                           core.UrlData, core.NamedData)):
         return data
     elif isinstance(data, pd.DataFrame):
-        return pipe(data, data_transformers.get())
+        data = pipe(data, data_transformers.get())
+        if data_transformers.consolidate_datasets and isinstance(data, dict) and 'values' in data:
+            name = _dataset_name(data)
+            context['datasets'][name] = data['values']
+            return core.NamedData(name=name)
+        else:
+            return data
     elif isinstance(data, six.string_types):
         return core.UrlData(data)
     else:
@@ -40,7 +80,8 @@ class LookupData(core.LookupData):
     def to_dict(self, *args, **kwargs):
         """Convert the chart to a dictionary suitable for JSON export"""
         copy = self.copy(ignore=['data'])
-        copy.data = _prepare_data(copy.data)
+        context = kwargs.get('context', {})
+        copy.data = _prepare_data(copy.data, context)
         return super(LookupData, copy).to_dict(*args, **kwargs)
 
 
@@ -309,22 +350,29 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
     def to_dict(self, *args, **kwargs):
         """Convert the chart to a dictionary suitable for JSON export"""
-        copy = self.copy()
-        original_data = getattr(copy, 'data', Undefined)
-        copy.data = _prepare_data(original_data)
-
-        # We make use of two context markers:
+        # We make use of three context markers:
         # - 'data' points to the data that should be referenced for column type
         #   inference.
         # - 'top_level' is a boolean flag that is assumed to be true; if it's
         #   true then a "$schema" arg is added to the dict.
-        context = kwargs.get('context', {}).copy()
+        # - 'datasets' is a dict of named datasets that should be inserted
+        #   in the top-level object
 
+        # note: not a deep copy because we want datasets and data arguments to
+        # be passed by reference
+        context = kwargs.get('context', {}).copy()
+        context.setdefault('datasets', {})
         is_top_level = context.get('top_level', True)
-        context['top_level'] = False
+
+        copy = self.copy()
+        original_data = getattr(copy, 'data', Undefined)
+        copy.data = _prepare_data(original_data, context)
 
         if original_data is not Undefined:
             context['data'] = original_data
+
+        # remaining to_dict calls are not at top level
+        context['top_level'] = False
         kwargs['context'] = context
 
         try:
@@ -339,6 +387,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             kwargs['validate'] = 'deep'
             dct = super(TopLevelMixin, copy).to_dict(*args, **kwargs)
 
+        # TODO: following entries are added after validation. Should they be validated?
         if is_top_level:
             # since this is top-level we add $schema if it's missing
             if '$schema' not in dct:
@@ -347,6 +396,10 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             # apply theme from theme registry
             the_theme = themes.get()
             dct = utils.update_nested(the_theme(), dct, copy=True)
+
+            # update datasets
+            if context['datasets']:
+                dct.setdefault('datasets', {}).update(context['datasets'])
 
         return dct
 


### PR DESCRIPTION
With this change, you can run:
```
alt.data_transformers.enable(consolidate_datasets=True)
```
and then in all rendered charts, inline data will be replaced with named data and added to the top-level ``datasets`` attribute. This automatically assigns the name to any identical datasets.

This addresses the issue that typical usage patterns end up embedding multiple copies of the dataset within compound charts. I think that this consolidation behavior should probably be the default, but I'd like to get it in as an option to start with.

As an example, consider the following chart, using a standard concatenation pattern:
```python
import altair as alt
import pandas as pd

data = pd.DataFrame({
    'a': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'],
    'b': [28, 55, 43, 91, 81, 53, 19, 87, 52],
    'c': [43, 91, 81, 53, 19, 87, 52, 28, 55]
})

base = alt.Chart(data).mark_bar().encode(
    y='a'
).properties(width=200)

chart = base.encode(x='b') | base.encode(x='c')
chart
```
![visualization 13](https://user-images.githubusercontent.com/781659/41666809-3a6d8c62-7460-11e8-9567-c51c6aed53a6.png)

If we look at the spec produced by the chart, we see that this causes the dataset to be duplicated between the two charts:
```python
>>> chart.to_dict()
{'$schema': 'https://vega.github.io/schema/vega-lite/v2.5.2.json',
 'config': {'view': {'height': 300, 'width': 400}},
 'hconcat': [{'data': {'values': [{'a': 'A', 'b': 28, 'c': 43},
     {'a': 'B', 'b': 55, 'c': 91},
     {'a': 'C', 'b': 43, 'c': 81},
     {'a': 'D', 'b': 91, 'c': 53},
     {'a': 'E', 'b': 81, 'c': 19},
     {'a': 'F', 'b': 53, 'c': 87},
     {'a': 'G', 'b': 19, 'c': 52},
     {'a': 'H', 'b': 87, 'c': 28},
     {'a': 'I', 'b': 52, 'c': 55}]},
   'encoding': {'x': {'field': 'b', 'type': 'quantitative'},
    'y': {'field': 'a', 'type': 'nominal'}},
   'mark': 'bar',
   'width': 200},
  {'data': {'values': [{'a': 'A', 'b': 28, 'c': 43},
     {'a': 'B', 'b': 55, 'c': 91},
     {'a': 'C', 'b': 43, 'c': 81},
     {'a': 'D', 'b': 91, 'c': 53},
     {'a': 'E', 'b': 81, 'c': 19},
     {'a': 'F', 'b': 53, 'c': 87},
     {'a': 'G', 'b': 19, 'c': 52},
     {'a': 'H', 'b': 87, 'c': 28},
     {'a': 'I', 'b': 52, 'c': 55}]},
   'encoding': {'x': {'field': 'c', 'type': 'quantitative'},
    'y': {'field': 'a', 'type': 'nominal'}},
   'mark': 'bar',
   'width': 200}]}
```
This is not a big problem for small datasets, but with large datasets and charts with many layers or panels, this can lead to unnecessarily large specs.

Within the mechanism in this PR, you can do the following:
```python
>>> alt.data_transformers.enable(consolidate_datasets=True)
>>> chart.to_dict()
{'$schema': 'https://vega.github.io/schema/vega-lite/v2.5.2.json',
 'config': {'view': {'height': 300, 'width': 400}},
 'datasets': {'data-ee7f01090b9e4fcef2554f6712660b80': [
   {'a': 'A', 'b': 28, 'c': 43},
   {'a': 'B', 'b': 55, 'c': 91},
   {'a': 'C', 'b': 43, 'c': 81},
   {'a': 'D', 'b': 91, 'c': 53},
   {'a': 'E', 'b': 81, 'c': 19},
   {'a': 'F', 'b': 53, 'c': 87},
   {'a': 'G', 'b': 19, 'c': 52},
   {'a': 'H', 'b': 87, 'c': 28},
   {'a': 'I', 'b': 52, 'c': 55}]},
 'hconcat': [{'data': {'name': 'data-ee7f01090b9e4fcef2554f6712660b80'},
   'encoding': {'x': {'field': 'b', 'type': 'quantitative'},
    'y': {'field': 'a', 'type': 'nominal'}},
   'mark': 'bar',
   'width': 200},
  {'data': {'name': 'data-ee7f01090b9e4fcef2554f6712660b80'},
   'encoding': {'x': {'field': 'c', 'type': 'quantitative'},
    'y': {'field': 'a', 'type': 'nominal'}},
   'mark': 'bar',
   'width': 200}]}
```
Notice that the data in each subchart is replaced by a named reference to a single dataset at the top level. This should all be transparent to the user, but result in more efficient chart specifications.

The only reason I hesitate in making this the default is that I'm worried there may be corner cases I'm not thinking about where this would break a working chart.