### PR TITLE
markdown style links in the examples are changed to rst links.

### DIFF
--- a/altair/vegalite/v2/examples/candlestick_chart.py
+++ b/altair/vegalite/v2/examples/candlestick_chart.py
@@ -1,7 +1,7 @@
 """
 Candlestick Chart
 =================
-A candlestick chart inspired from Protovis(http://mbostock.github.io/protovis/ex/candlestick.html). This example shows the performance of the Chicago Board Options Exchange Volatility Index (VIX) in the summer of 2009. The thick bar represents the opening and closing prices, while the thin bar shows intraday high and low prices; if the index closed higher on a given day, the bars are colored green rather than red.
+A candlestick chart inspired from Protovis (http://mbostock.github.io/protovis/ex/candlestick.html). This example shows the performance of the Chicago Board Options Exchange Volatility Index (VIX) in the summer of 2009. The thick bar represents the opening and closing prices, while the thin bar shows intraday high and low prices; if the index closed higher on a given day, the bars are colored green rather than red.
 """
 # category: bar charts
 import altair as alt

--- a/altair/vegalite/v2/examples/cumulative_wiki_donations.py
+++ b/altair/vegalite/v2/examples/cumulative_wiki_donations.py
@@ -2,7 +2,7 @@
 Cumulative Wikipedia Donations
 ==============================
 
-This chart shows cumulative donations to Wikipedia over the past 10 years. Inspired by this [Reddit post](https://www.reddit.com/r/dataisbeautiful/comments/7guwd0/cumulative_wikimedia_donations_over_the_past_10/) but using lines instead of areas.
+This chart shows cumulative donations to Wikipedia over the past 10 years. Inspired by this `Reddit post <https://www.reddit.com/r/dataisbeautiful/comments/7guwd0/cumulative_wikimedia_donations_over_the_past_10/>`_ but using lines instead of areas.
 """
 # category: case studies
 import altair as alt

--- a/altair/vegalite/v2/examples/error_bars_with_ci.py
+++ b/altair/vegalite/v2/examples/error_bars_with_ci.py
@@ -3,7 +3,7 @@ Error Bars showing Confidence Interval
 ======================================
 This example shows how to show error bars using covidence intervals.
 The confidence intervals are computed internally in vega by
-a non-parametric [bootstrap of the mean](https://github.com/vega/vega-statistics/blob/master/src/bootstrapCI.js).
+a non-parametric `bootstrap of the mean <https://github.com/vega/vega-statistics/blob/master/src/bootstrapCI.js>`_.
 """
 # category: bar charts
 import altair as alt

--- a/altair/vegalite/v2/examples/gapminder_bubble_plot.py
+++ b/altair/vegalite/v2/examples/gapminder_bubble_plot.py
@@ -3,7 +3,7 @@ Gapminder Bubble Plot
 =====================
 This example shows how to make a bubble plot showing the correlation between
 health and income for 187 countries in the world (modified from an example
-in Lisa Charlotte Rost's blog post ('One Chart, Twelve Charting Libraries')[http://lisacharlotterost.github.io/2016/05/17/one-chart-code/)].
+in Lisa Charlotte Rost's blog post `'One Chart, Twelve Charting Libraries' <http://lisacharlotterost.github.io/2016/05/17/one-chart-code/>`_.
 """
 # category: case studies
 import altair as alt


### PR DESCRIPTION
Markdown links are not properly rendered in the gallery (e.g. https://altair-viz.github.io/gallery/cumulative_wiki_donations.html). Also includes a minor typo fix. 