### PR TITLE
Documentation of Sorting Columns and Legends

### DIFF
--- a/doc/user_guide/encoding.rst
+++ b/doc/user_guide/encoding.rst
@@ -471,12 +471,10 @@ Sorting Legends and Axes
 
 Specific channels can take a  :class:`sort` property which determines the order of the scale being used for the channel. Supported `sort` values depend on the field's scale type. 
 
-*Sorting Encoded Channels*
+Channels with `quantitative` or `ordinal` data types that result in  ``continuous`` scales, ``sort`` can have the following values:
 
-Channels with `quantitative` or `ordinal` data types that result in  `continuous` scales, `sort` can have the following values:
-
-- `ascending` (Default)- the field is sorted by the field's value in ascending order. 
-- `descending` - the field is sorted by the field's value in descending order. 
+- ``ascending`` (Default)- the field is sorted by the field's value in ascending order. 
+- ``descending`` - the field is sorted by the field's value in descending order. 
 
 For channels encoded with a `nominal` categorical data type that results in a discrete scale can use the above values and an explicit list defining the sort order. 
 
@@ -499,7 +497,7 @@ The following example shows a continuous scale on y-axis and other sorts on the 
         ).properties(title='Explicit'),
     )
 
-*Sorting Legends*
+**Sorting Legends**
 
 Legends can also be sorted in the same way by adding the sort property to the channel that creates the legend:
 

--- a/doc/user_guide/encoding.rst
+++ b/doc/user_guide/encoding.rst
@@ -465,3 +465,55 @@ For line marks, the `order` channel encodes the order in which data points are c
         alt.Y('gas', scale=alt.Scale(zero=False)),
         order='year'
     )
+
+Sorting Legends and Axes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Specific channels can take a  :class:`sort` property which determines the order of the scale being used for the channel. Supported `sort` values depend on the field's scale type. 
+
+*Sorting Encoded Channels*
+
+Channels with `quantitative` or `ordinal` data types that result in  `continuous` scales, `sort` can have the following values:
+
+- `ascending` (Default)- the field is sorted by the field's value in ascending order. 
+- `descending` - the field is sorted by the field's value in descending order. 
+
+For channels encoded with a `nominal` categorical data type that results in a discrete scale can use the above values and an explicit list defining the sort order. 
+
+The following example shows a continuous scale on y-axis and other sorts on the x-axis: 
+
+.. altair-plot::
+    import altair as alt
+    from vega_datasets import data
+
+    barley = data.barley()
+
+    base = alt.Chart(barley, height=100).mark_point().encode(
+    y=alt.Y(field='yield', type='quantitative', aggregate='mean', sort='descending')
+    )
+
+    alt.hconcat(
+        base.encode(x=alt.X(field='site', type='nominal', sort='ascending')).properties(title='Ascending Alpha'),
+        base.encode(x=alt.X(field='site', type='nominal', sort='descending')).properties(title='Descending Alpha'),
+        base.encode(x=alt.X(field='site', type='nominal', sort=['Duluth','Grand Rapids','Morris','University Farm','Waseca','Crookston'])
+        ).properties(title='Explicit'),
+    )
+
+*Sorting Legends*
+
+Legends can also be sorted in the same way by adding the sort property to the channel that creates the legend:
+
+The following example shows a plot where the legend sort is different from the x-axis sort: 
+
+.. altair-plot::
+    import altair as alt
+    from vega_datasets import data
+
+    barley = data.barley()
+
+    base = alt.Chart(barley, height=100).mark_point().encode(
+        y=alt.Y(field='yield', type='quantitative', aggregate='mean', sort='descending'),
+        x=alt.X(field='site', type='nominal', sort='ascending'),
+        color=alt.Color(field='site', type='nominal', sort=['Morris','Duluth','Grand Rapids','University Farm','Waseca', 'Crookston']
+        )
+    )

--- a/doc/user_guide/encoding.rst
+++ b/doc/user_guide/encoding.rst
@@ -486,7 +486,7 @@ The following example shows a continuous scale on y-axis and other sorts on the 
 
     barley = data.barley()
 
-    base = alt.Chart(barley, height=100).mark_point().encode(
+    base = alt.Chart(barley, height=100).mark_point(filled=True).encode(
     y=alt.Y(field='yield', type='quantitative', aggregate='mean', sort='descending')
     )
 
@@ -509,9 +509,12 @@ The following example shows a plot where the legend sort is different from the x
 
     barley = data.barley()
 
-    base = alt.Chart(barley, height=100).mark_point().encode(
+    alt.Chart(barley, height=100).mark_point(filled=True).encode(
         y=alt.Y(field='yield', type='quantitative', aggregate='mean', sort='descending'),
         x=alt.X(field='site', type='nominal', sort='ascending'),
         color=alt.Color(field='site', type='nominal', sort=['Morris','Duluth','Grand Rapids','University Farm','Waseca', 'Crookston']
         )
     )
+
+
+As shown, the x-axis is sorted alphabetically ascending while the color legend is sorted as specified with "Morris" first. 


### PR DESCRIPTION
This branch adds a "Sorting Legends and Axes" section to the user guide. This is one of the to-dos in issue #1060  and was raised in #1059. 

The documentation adds two examples that show the various ways to sort [`ascending`,`descending`] and specifying an explicit order as well. 

![sortexample](https://user-images.githubusercontent.com/20745904/43742415-db6ff6ae-999f-11e8-82b4-0eeec7f776c5.png)

In addition, the same example is expanded adding a color legend and sorting that as well. hope this helps. 

I will try to grab one of the other to-dos in #1060 as well. 