### PR TITLE
ADD: Trellis Area Sort Chart Example

### DIFF
--- a/altair/vegalite/v2/examples/trellis_area_sort_array.py
+++ b/altair/vegalite/v2/examples/trellis_area_sort_array.py
@@ -1,0 +1,22 @@
+'''
+Trellis Area Sort Chart
+-----------------------
+This example shows small multiples of an area chart.
+Stock prices of four large companies 
+sorted by `['MSFT', 'AAPL', 'IBM', 'AMZN']`
+'''
+# category: area charts
+import altair as alt
+from altair.expr import datum
+from vega_datasets import data
+
+
+alt.Chart(data.stocks.url).transform_filter(
+    datum.symbol != 'GOOG'
+).mark_area().encode(
+    x='date:T',
+    y='price:Q',
+    color='symbol:N',
+    row=alt.Row('symbol:N', sort=['MSFT', 'AAPL', 'IBM', 'AMZN']
+    )
+).properties(height=50, width=400)


### PR DESCRIPTION
Example of Trellis Area Chart with sort order.

```python
import altair as alt
from altair.expr import datum
from vega_datasets import data


alt.Chart(data.stocks.url).transform_filter(
    datum.symbol != 'GOOG'
).mark_area().encode(
    x='date:T',
    y='price:Q',
    color='symbol:N',
    row=alt.Row('symbol:N', sort=['MSFT', 'AAPL', 'IBM', 'AMZN']
    )
).properties(height=50, width=400)
```
![image](https://user-images.githubusercontent.com/3757165/43958239-56d8af04-9cc8-11e8-94b5-e994eec5e9d1.png)
