### PR TITLE
Add link to altair slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ visualization.
 We are also seeking contributions of additional Jupyter notebook-based examples
 in our separate GitHub repository: https://github.com/altair-viz/altair_notebooks.
 
-The altair users mailing list can be found at https://groups.google.com/forum/#!forum/altair-viz
+The altair users mailing list can be found at https://groups.google.com/forum/#!forum/altair-viz. If you are working on Altair, you can talk to other developers in the `#altair` channel of the [Vega slack](https://bit.ly/join-vega-slack).
 
 ## Whence Altair?
 


### PR DESCRIPTION
I'm not sure what you think is the right role of the slack channel but I thought it would be good to have the link in the readme. 