### PR TITLE
allow other transformers to work when saving to other formats

### DIFF
--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -403,11 +403,11 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         # By default we override the data transformer. This makes it so
         # that save() will succeed even for large datasets that would
         # normally trigger a MaxBinsError
-        if override_data_transformer:
+        if data_transformers.active != 'default':
+            result = save(**kwds)
+        else:
             with data_transformers.enable('default', max_rows=None):
                 result = save(**kwds)
-        else:
-            result = save(**kwds)
         return result
 
     # Layering and stacking

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -372,7 +372,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         )
         return self.save(fp, format=None, **kwargs)
 
-    def save(self, fp, format=None, override_data_transformer=False, **kwargs):
+    def save(self, fp, format=None, **kwargs):
         """Save a chart to file in a variety of formats
 
         Supported formats are json, html, png, svg

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -372,7 +372,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         )
         return self.save(fp, format=None, **kwargs)
 
-    def save(self, fp, format=None, override_data_transformer=True, **kwargs):
+    def save(self, fp, format=None, override_data_transformer=False, **kwargs):
         """Save a chart to file in a variety of formats
 
         Supported formats are json, html, png, svg


### PR DESCRIPTION
The changes the logic so that if you have registered a custom data_transformer - you will still be able to save the plot to the allowed formats (png, html etc...).

I ran into this when using gpdvega, I would get this error when saving to other formats:
```
TypeError: Object of type 'Polygon' is not JSON serializable
```

With this logic change - I can now save using another registered data_transformer.