### PR TITLE
DOC: Create Filled Step Chart example

### DIFF
--- a/altair/vegalite/v2/examples/filled_step_chart.py
+++ b/altair/vegalite/v2/examples/filled_step_chart.py
@@ -1,0 +1,20 @@
+"""
+Filled Step Chart
+-----------------
+This example shows Google's stock price over time as a step chart with its area filled in. 
+"""
+# category: line charts
+import altair as alt
+from vega_datasets import data
+
+chart = alt.Chart(stocks).encode(
+    x='date',
+    y='price'
+).transform_filter(
+    alt.datum.symbol == 'GOOG'
+)
+
+line = chart.mark_line(color="darkblue")
+area = chart.mark_area(color="lightblue")
+
+(line + area).configure_mark(interpolate='step-after')

--- a/altair/vegalite/v2/examples/filled_step_chart.py
+++ b/altair/vegalite/v2/examples/filled_step_chart.py
@@ -7,6 +7,8 @@ This example shows Google's stock price over time as a step chart with its area 
 import altair as alt
 from vega_datasets import data
 
+stocks = data.stocks()
+
 chart = alt.Chart(stocks).encode(
     x='date',
     y='price'

--- a/altair/vegalite/v2/examples/filled_step_chart.py
+++ b/altair/vegalite/v2/examples/filled_step_chart.py
@@ -1,22 +1,19 @@
 """
 Filled Step Chart
 -----------------
-This example shows Google's stock price over time as a step chart with its area filled in. 
+This example shows Google's stock price over time as a step chart with its area filled in and its line emphasized.
 """
 # category: line charts
 import altair as alt
 from vega_datasets import data
 
-stocks = data.stocks()
+source = data.stocks()
 
-chart = alt.Chart(stocks).encode(
+alt.Chart(source).mark_area(
+    color="lightblue",
+    interpolate='step-after',
+    line=True
+).encode(
     x='date',
     y='price'
-).transform_filter(
-    alt.datum.symbol == 'GOOG'
-)
-
-line = chart.mark_line(color="darkblue")
-area = chart.mark_area(color="lightblue")
-
-(line + area).configure_mark(interpolate='step-after')
+).transform_filter(alt.datum.symbol == 'GOOG')


### PR DESCRIPTION
One chart variation I find myself making occasionally is a step chart with its area filled in. I've added one as an example in this patch by making a few modifications to the existing step chart example. 

![visualization](https://user-images.githubusercontent.com/9993/46907908-07d8c900-cecf-11e8-8706-1d9c4a29fa55.png)

