### PR TITLE
Removed datum imports from example gallery

### DIFF
--- a/altair/vegalite/v2/examples/aggregate_bar_chart.py
+++ b/altair/vegalite/v2/examples/aggregate_bar_chart.py
@@ -6,9 +6,8 @@ by age in the year 2000.
 """
 # category: bar charts
 import altair as alt
-from altair.expr import datum
-
 from vega_datasets import data
+
 pop = data.population.url
 
 alt.Chart(pop).mark_bar().encode(
@@ -18,5 +17,5 @@ alt.Chart(pop).mark_bar().encode(
     height=300,
     width=300
 ).transform_filter(
-    datum.year == 2000
+    alt.datum.year == 2000
 )

--- a/altair/vegalite/v2/examples/grouped_bar_chart.py
+++ b/altair/vegalite/v2/examples/grouped_bar_chart.py
@@ -7,7 +7,6 @@ encoded on the age groups and x-axes encoded on gender.
 """
 # category: bar charts
 import altair as alt
-from altair.expr import datum, if_
 from vega_datasets import data
 
 source = data.population.url
@@ -22,7 +21,7 @@ alt.Chart(source).mark_bar(stroke='transparent').encode(
 ).configure_axis(
     domainWidth=0.8
 ).transform_filter(
-    datum.year == 2000
+    alt.datum.year == 2000
 ).transform_calculate(
-    'gender', if_(datum.sex == 2, 'Female', 'Male')
+    'gender', alt.expr.if_(alt.datum.sex == 2, 'Female', 'Male')
 )

--- a/altair/vegalite/v2/examples/horizon_graph.py
+++ b/altair/vegalite/v2/examples/horizon_graph.py
@@ -5,21 +5,20 @@ This example shows how to make a Horizon Graph with 2 layers. (See https://idl.c
 """
 # category: area charts
 import altair as alt
-from altair.expr import datum
 import pandas as pd
 
 df = pd.DataFrame([
-      {"x": 1,  "y": 28}, {"x": 2,  "y": 55},
-      {"x": 3,  "y": 43}, {"x": 4,  "y": 91},
-      {"x": 5,  "y": 81}, {"x": 6,  "y": 53},
-      {"x": 7,  "y": 19}, {"x": 8,  "y": 87},
-      {"x": 9,  "y": 52}, {"x": 10, "y": 48},
-      {"x": 11, "y": 24}, {"x": 12, "y": 49},
-      {"x": 13, "y": 87}, {"x": 14, "y": 66},
-      {"x": 15, "y": 17}, {"x": 16, "y": 27},
-      {"x": 17, "y": 68}, {"x": 18, "y": 16},
-      {"x": 19, "y": 49}, {"x": 20, "y": 15}
-    ])
+    {"x": 1,  "y": 28}, {"x": 2,  "y": 55},
+    {"x": 3,  "y": 43}, {"x": 4,  "y": 91},
+    {"x": 5,  "y": 81}, {"x": 6,  "y": 53},
+    {"x": 7,  "y": 19}, {"x": 8,  "y": 87},
+    {"x": 9,  "y": 52}, {"x": 10, "y": 48},
+    {"x": 11, "y": 24}, {"x": 12, "y": 49},
+    {"x": 13, "y": 87}, {"x": 14, "y": 66},
+    {"x": 15, "y": 17}, {"x": 16, "y": 27},
+    {"x": 17, "y": 68}, {"x": 18, "y": 16},
+    {"x": 19, "y": 49}, {"x": 20, "y": 15}
+])
 
 area1 = alt.Chart(df).mark_area(
     clip=True,
@@ -36,7 +35,7 @@ area1 = alt.Chart(df).mark_area(
 area2 = area1.encode(
     alt.Y('ny:Q', scale=alt.Scale(domain=[0, 50]))
 ).transform_calculate(
-    "ny", datum.y - 50
+    "ny", alt.datum.y - 50
 )
 
 area1 + area2

--- a/altair/vegalite/v2/examples/layered_bar_chart.py
+++ b/altair/vegalite/v2/examples/layered_bar_chart.py
@@ -5,7 +5,6 @@ This example shows a bar chart showing the US population distribution of age gro
 """
 # category: bar charts
 import altair as alt
-from altair.expr import datum, if_
 from vega_datasets import data
 
 source = data.population.url
@@ -15,7 +14,7 @@ alt.Chart(source).mark_bar(opacity=0.7).encode(
     alt.Y('sum(people):Q', axis=alt.Axis(title='population'), stack=None),
     alt.Color('gender:N', scale=alt.Scale(range=["#EA98D2", "#659CCA"]))
 ).transform_filter(
-    datum.year == 2000
+    alt.datum.year == 2000
 ).transform_calculate(
-    "gender", if_(datum.sex == 2, 'Female', 'Male')
+    "gender", alt.expr.if_(alt.datum.sex == 2, 'Female', 'Male')
 )

--- a/altair/vegalite/v2/examples/layered_heatmap_text.py
+++ b/altair/vegalite/v2/examples/layered_heatmap_text.py
@@ -6,7 +6,6 @@ An example of a layered chart of text over a heatmap using the cars dataset.
 """
 # category: other charts
 import altair as alt
-from altair.expr import datum
 from vega_datasets import data
 
 cars = data.cars.url
@@ -21,7 +20,7 @@ text = alt.Chart(cars).mark_text(baseline='middle').encode(
     x='Cylinders:O',
     y='Origin:O',
     text='count()',
-    color=alt.condition(datum['count_*'] > 100,
+    color=alt.condition(alt.datum['count_*'] > 100,
                         alt.value('black'),
                         alt.value('white'))
 )

--- a/altair/vegalite/v2/examples/line_percent.py
+++ b/altair/vegalite/v2/examples/line_percent.py
@@ -6,7 +6,6 @@ y-axis of a chart as percentages.
 """
 # category: line charts
 import altair as alt
-from altair.expr import datum
 from vega_datasets import data
 
 source = data.jobs.url
@@ -18,5 +17,5 @@ alt.Chart(source).mark_line().encode(
 ).properties(
     title='Percent of work-force working as Welders'
 ).transform_filter(
-    datum.job == 'Welder'
+    alt.datum.job == 'Welder'
 )

--- a/altair/vegalite/v2/examples/natural_disasters.py
+++ b/altair/vegalite/v2/examples/natural_disasters.py
@@ -5,7 +5,6 @@ This example shows a visualization of global deaths from natural disasters.
 """
 # category: case studies
 import altair as alt
-from altair.expr import datum
 from vega_datasets import data
 
 source = data.disasters.url
@@ -26,5 +25,5 @@ alt.Chart(source).mark_circle(
     width=480,
     height=350
 ).transform_filter(
-    datum.Entity != 'All natural disasters'
+    alt.datum.Entity != 'All natural disasters'
 )

--- a/altair/vegalite/v2/examples/one_dot_per_zipcode.py
+++ b/altair/vegalite/v2/examples/one_dot_per_zipcode.py
@@ -5,7 +5,6 @@ This example shows a geographical plot with one dot per zipcode.
 """
 # category: case studies
 import altair as alt
-from altair.expr import datum, substring
 from vega_datasets import data
 
 zipcodes = data.zipcodes.url
@@ -20,5 +19,5 @@ alt.Chart(zipcodes).mark_circle(size=3).encode(
     width=650,
     height=400
 ).transform_calculate(
-    "digit", substring(datum.zip_code, 0, 1)
+    "digit", alt.expr.substring(alt.datum.zip_code, 0, 1)
 )

--- a/altair/vegalite/v2/examples/step_chart.py
+++ b/altair/vegalite/v2/examples/step_chart.py
@@ -10,7 +10,6 @@ The full list of interpolation options includes 'linear',
 """
 # category: line charts
 import altair as alt
-from altair.expr import datum
 from vega_datasets import data
 
 stocks = data.stocks()
@@ -19,5 +18,5 @@ alt.Chart(stocks).mark_line(interpolate='step-after').encode(
     x='date',
     y='price'
 ).transform_filter(
-    datum.symbol == 'GOOG'
+    alt.datum.symbol == 'GOOG'
 )

--- a/altair/vegalite/v2/examples/trellis_area_sort_array.py
+++ b/altair/vegalite/v2/examples/trellis_area_sort_array.py
@@ -2,21 +2,19 @@
 Trellis Area Sort Chart
 -----------------------
 This example shows small multiples of an area chart.
-Stock prices of four large companies 
+Stock prices of four large companies
 sorted by `['MSFT', 'AAPL', 'IBM', 'AMZN']`
 '''
 # category: area charts
 import altair as alt
-from altair.expr import datum
 from vega_datasets import data
 
 
 alt.Chart(data.stocks.url).transform_filter(
-    datum.symbol != 'GOOG'
+    alt.datum.symbol != 'GOOG'
 ).mark_area().encode(
     x='date:T',
     y='price:Q',
     color='symbol:N',
-    row=alt.Row('symbol:N', sort=['MSFT', 'AAPL', 'IBM', 'AMZN']
-    )
+    row=alt.Row('symbol:N', sort=['MSFT', 'AAPL', 'IBM', 'AMZN'])
 ).properties(height=50, width=400)

--- a/altair/vegalite/v2/examples/us_population_over_time.py
+++ b/altair/vegalite/v2/examples/us_population_over_time.py
@@ -7,7 +7,6 @@ distribution over time.
 """
 # category: case studies
 import altair as alt
-from altair.expr import datum, if_
 from vega_datasets import data
 
 pop = data.population.url
@@ -28,7 +27,7 @@ alt.Chart(pop).mark_bar().encode(
 ).add_selection(
     select_year
 ).transform_calculate(
-    "sex", if_(datum.sex == 1, "Male", "Female")
+    "sex", alt.expr.if_(alt.datum.sex == 1, "Male", "Female")
 ).transform_filter(
     select_year
 )

--- a/altair/vegalite/v2/examples/us_population_pyramid_over_time.py
+++ b/altair/vegalite/v2/examples/us_population_pyramid_over_time.py
@@ -7,7 +7,6 @@ distribution over time.
 '''
 # category: case studies
 import altair as alt
-from altair.expr import datum, if_
 from vega_datasets import data
 
 pop = data.population.url
@@ -20,7 +19,7 @@ base = alt.Chart(pop).add_selection(
 ).transform_filter(
     select_year
 ).transform_calculate(
-    gender=if_(datum.sex == 1, 'Male', 'Female')
+    gender=alt.expr.if_(alt.datum.sex == 1, 'Male', 'Female')
 )
 
 title = alt.Axis(title='population')
@@ -28,7 +27,7 @@ color_scale = alt.Scale(domain=['Male', 'Female'],
                         range=['#1f77b4', '#e377c2'])
 
 left = base.transform_filter(
-    datum.gender == 'Female'
+    alt.datum.gender == 'Female'
 ).encode(
     y=alt.X('age:O', axis=None),
     x=alt.X('sum(people):Q', axis=title, sort=alt.SortOrder('descending')),
@@ -41,7 +40,7 @@ middle = base.encode(
 ).mark_text().properties(width=20)
 
 right = base.transform_filter(
-    datum.gender == 'Male'
+    alt.datum.gender == 'Male'
 ).encode(
     y=alt.X('age:O', axis=None),
     x=alt.X('sum(people):Q', axis=title),


### PR DESCRIPTION
A handful of examples in the gallery used imports like this:

```python
from altair.expr import datum
```

I changed them to use `alt.datum` instead.

I propose this patch because I think it will reduce the number of imports newbies need to learn and enforce consistency in our examples, which is a good thing in itself. 