### PR TITLE
DOC: Trimmed slope_graph.py example

### DIFF
--- a/altair/vegalite/v2/examples/slope_graph.py
+++ b/altair/vegalite/v2/examples/slope_graph.py
@@ -9,12 +9,8 @@ from vega_datasets import data
 
 source = data.barley()
 
-# The year here is stored by pandas as an integer. When treating columns as dates,
-# it is best to use either a string representation or a datetime representation.
-source.year = source.year.astype(str)
-
 alt.Chart(source).mark_line().encode(
-    x='year',
+    x='year:O',  # When using datetime values, ordinal encoding is crucial to get the right look.
     y='median(yield)',
     color='site'
 )


### PR DESCRIPTION
The method for handling the x-axis layout offered by the Slope Graph example can be improved, I think, but substituting our handy dandy shorthand. 