### PR TITLE
DOC: Removed pandas and numpy imports from examples

### DIFF
--- a/altair/vegalite/v2/examples/bar_chart_sorted.py
+++ b/altair/vegalite/v2/examples/bar_chart_sorted.py
@@ -5,9 +5,8 @@ This example shows a basic sorted bar chart.
 """
 # category: bar charts
 import altair as alt
-import pandas as pd
 
-data = pd.DataFrame({
+data = alt.pd.DataFrame({
     'a': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'],
     'b': [28, 55, 43, 91, 81, 53, 19, 87, 52]
 })

--- a/altair/vegalite/v2/examples/bar_chart_with_highlight.py
+++ b/altair/vegalite/v2/examples/bar_chart_with_highlight.py
@@ -5,13 +5,11 @@ This example shows a Bar chart that highlights values beyond a threshold.
 """
 # category: bar charts
 import altair as alt
-import pandas as pd
 
-data = pd.DataFrame({"Day": range(1, 16),
+data = alt.pd.DataFrame({"Day": range(1, 16),
                      "Value": [54.8, 112.1, 63.6, 37.6, 79.7, 137.9, 120.1, 103.3,
                                394.8, 199.5, 72.3, 51.1, 112.0, 174.5, 130.5]})
-
-data2 = pd.DataFrame([{"ThresholdValue": 300, "Threshold": "hazardous"}])
+data2 = alt.pd.DataFrame([{"ThresholdValue": 300, "Threshold": "hazardous"}])
 
 bar1 = alt.Chart(data).mark_bar().encode(
     x='Day:O',

--- a/altair/vegalite/v2/examples/bar_chart_with_labels.py
+++ b/altair/vegalite/v2/examples/bar_chart_with_labels.py
@@ -5,9 +5,8 @@ This example shows a basic horizontal bar chart with labels created with Altair.
 """
 # category: bar charts
 import altair as alt
-import pandas as pd
 
-data = pd.DataFrame({
+data = alt.pd.DataFrame({
     'a': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'],
     'b': [28, 55, 43, 91, 81, 53, 19, 87, 52]
 })
@@ -21,8 +20,6 @@ text = bars.mark_text(
     align='left',
     baseline='middle',
     dx=3
-).encode(
-    text='b'
-)
+).encode(text='b')
 
 bars + text

--- a/altair/vegalite/v2/examples/candlestick_chart.py
+++ b/altair/vegalite/v2/examples/candlestick_chart.py
@@ -5,9 +5,8 @@ A candlestick chart inspired from Protovis (http://mbostock.github.io/protovis/e
 """
 # category: bar charts
 import altair as alt
-import pandas as pd
 
-df = pd.DataFrame(
+df = alt.pd.DataFrame(
 [
       {
         "date": "2009-06-01",

--- a/altair/vegalite/v2/examples/gantt_chart.py
+++ b/altair/vegalite/v2/examples/gantt_chart.py
@@ -5,9 +5,8 @@ This example shows how to make a simple Gantt chart.
 """
 # category: bar charts
 import altair as alt
-import pandas as pd
 
-data = pd.DataFrame([
+data = alt.pd.DataFrame([
     {"task": "A", "start": 1, "end": 3},
     {"task": "B", "start": 3, "end": 8},
     {"task": "C", "start": 8, "end": 10}

--- a/altair/vegalite/v2/examples/horizon_graph.py
+++ b/altair/vegalite/v2/examples/horizon_graph.py
@@ -5,9 +5,8 @@ This example shows how to make a Horizon Graph with 2 layers. (See https://idl.c
 """
 # category: area charts
 import altair as alt
-import pandas as pd
 
-df = pd.DataFrame([
+df = alt.pd.DataFrame([
     {"x": 1,  "y": 28}, {"x": 2,  "y": 55},
     {"x": 3,  "y": 43}, {"x": 4,  "y": 91},
     {"x": 5,  "y": 81}, {"x": 6,  "y": 53},

--- a/altair/vegalite/v2/examples/isotype.py
+++ b/altair/vegalite/v2/examples/isotype.py
@@ -6,10 +6,9 @@ Inspired by [Only An Ocean Between, 1943](http://www.thomwhite.co.uk/?p=1303). P
 This is adapted from Vega-Lite example https://vega.github.io/editor/#/examples/vega-lite/isotype_bar_chart
 '''
 # category: case studies
-import pandas as pd
 import altair as alt
 
-df =  pd.DataFrame([
+df = alt.pd.DataFrame([
       {'country': 'Great Britain', 'animal': 'cattle', 'col': 3},
       {'country': 'Great Britain', 'animal': 'cattle', 'col': 2},
       {'country': 'Great Britain', 'animal': 'cattle', 'col': 1},

--- a/altair/vegalite/v2/examples/layered_chart_bar_mark.py
+++ b/altair/vegalite/v2/examples/layered_chart_bar_mark.py
@@ -5,9 +5,8 @@ This example shows how to layer two charts on top of one another.
 """
 # category: bar charts
 import altair as alt
-import pandas as pd
 
-data = pd.DataFrame({
+data = alt.pd.DataFrame({
     'project': ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
     'score': [25, 57, 23, 19, 8, 47, 8],
     'goal': [25, 47, 30, 27, 38, 19, 4]}

--- a/altair/vegalite/v2/examples/layered_histogram.py
+++ b/altair/vegalite/v2/examples/layered_histogram.py
@@ -4,18 +4,17 @@ Layered Histogram
 This example shows how to use opacity to make a layered histogram in Altair.
 """
 # category: histograms
-import pandas as pd
 import altair as alt
-import numpy as np
-np.random.seed(42)
+
+alt.pd.np.random.seed(42)
 
 # Generating Data
-df = pd.DataFrame({'Trial A': np.random.normal(0, 0.8, 1000),
-                   'Trial B': np.random.normal(-2, 1, 1000),
-                   'Trial C': np.random.normal(3, 2, 1000)})
+df = alt.pd.DataFrame({'Trial A': alt.pd.np.random.normal(0, 0.8, 1000),
+                   'Trial B': alt.pd.np.random.normal(-2, 1, 1000),
+                   'Trial C': alt.pd.np.random.normal(3, 2, 1000)})
 
 # Tidying Data
-df = pd.melt(df, id_vars=df.index.name,
+df = alt.pd.melt(df, id_vars=df.index.name,
              value_vars=df.columns,
              var_name='Experiment',
              value_name='Measurement')

--- a/altair/vegalite/v2/examples/multiline_tooltip.py
+++ b/altair/vegalite/v2/examples/multiline_tooltip.py
@@ -14,12 +14,10 @@ and tie a *nearest* selection to these, tied to the "x" field.
 """
 # category: interactive charts
 import altair as alt
-import pandas as pd
-import numpy as np
 
-np.random.seed(42)
-data = pd.DataFrame(np.cumsum(np.random.randn(100, 3), 0).round(2),
-                    columns=['A', 'B', 'C'], index=pd.RangeIndex(100, name='x'))
+alt.pd.np.random.seed(42)
+data = alt.pd.DataFrame(alt.pd.np.cumsum(alt.pd.np.random.randn(100, 3), 0).round(2),
+                    columns=['A', 'B', 'C'], index=alt.pd.RangeIndex(100, name='x'))
 data = data.reset_index().melt('x', var_name='category', value_name='y')
 
 # Create a selection that chooses the nearest point & selects based on x-value

--- a/altair/vegalite/v2/examples/percentage_of_total.py
+++ b/altair/vegalite/v2/examples/percentage_of_total.py
@@ -6,9 +6,8 @@ as a percentage of total values.
 """
 # category: bar charts
 import altair as alt
-import pandas as pd
 
-activities = pd.DataFrame({'Activity': ['Sleeping', 'Eating', 'TV', 'Work', 'Exercise'],
+activities = alt.pd.DataFrame({'Activity': ['Sleeping', 'Eating', 'TV', 'Work', 'Exercise'],
                            'Time': [8, 2, 4, 8, 2]})
 
 alt.Chart(activities).mark_bar().encode(

--- a/altair/vegalite/v2/examples/poly_fit.py
+++ b/altair/vegalite/v2/examples/poly_fit.py
@@ -4,27 +4,25 @@ Polynomial Fit Plot
 This example shows how to overlay data with a fitted polynomial
 """
 # category: scatter plots
-import numpy as np
-import pandas as pd
 import altair as alt
 
 # Generate some random data
-rng = np.random.RandomState(1)
+rng = alt.pd.np.random.RandomState(1)
 x = rng.rand(40) ** 2
 y = 10 - 1. / (x + 0.1) + rng.randn(40)
-df = pd.DataFrame({'x': x, 'y': y})
+df = alt.pd.DataFrame({'x': x, 'y': y})
 
 # Define the degree of the polynomial fit
 degree_list = [1, 3, 5]
 
 # Build a dataframe with the fitted data
-poly_data = pd.DataFrame({'xfit': np.linspace(df['x'].min(), df['x'].max(), 500)})
+poly_data = alt.pd.DataFrame({'xfit': alt.pd.np.linspace(df['x'].min(), df['x'].max(), 500)})
 
 for degree in degree_list:
-    poly_data[str(degree)] = np.poly1d(np.polyfit(df['x'], df['y'], degree))(poly_data['xfit'])
+    poly_data[str(degree)] = alt.pd.np.poly1d(alt.pd.np.polyfit(df['x'], df['y'], degree))(poly_data['xfit'])
 
 # Tidy the dataframe so 'degree' is a variable
-poly_data = pd.melt(poly_data,
+poly_data = alt.pd.melt(poly_data,
                     id_vars=['xfit'],
                     value_vars=[str(deg) for deg in degree_list],
                     var_name='degree', value_name='yfit')

--- a/altair/vegalite/v2/examples/scatter_with_histogram.py
+++ b/altair/vegalite/v2/examples/scatter_with_histogram.py
@@ -2,27 +2,25 @@
 Scatter Plot and Histogram with Interval Selection
 ==================================================
 
-This example shows how to link a scatter plot and a histogram 
-together such that an interval selection in the histogram will 
-plot the selected values in the scatter plot. 
+This example shows how to link a scatter plot and a histogram
+together such that an interval selection in the histogram will
+plot the selected values in the scatter plot.
 
-Note that both subplots need to know about the `mbin` field created 
+Note that both subplots need to know about the `mbin` field created
 by the `transform_bin` method. In order to achieve this, the data is
-not passed to the `Chart()` instances creating the subplots, but 
+not passed to the `Chart()` instances creating the subplots, but
 directly in the `hconcat()` function, which joins the two plots together.
 """
 # category: interactive charts
 
 import altair as alt
-import pandas as pd
-import numpy as np
 
-x = np.random.normal(size=100)
-y = np.random.normal(size=100)
+x = alt.pd.np.random.normal(size=100)
+y = alt.pd.np.random.normal(size=100)
 
-m = np.random.normal(15, 1, size=100)
+m = alt.pd.np.random.normal(15, 1, size=100)
 
-df = pd.DataFrame({"x": x, "y":y, "m":m})
+df = alt.pd.DataFrame({"x": x, "y":y, "m":m})
 
 # interval selection in the scatter plot
 pts = alt.selection(type="interval", encodings=["x"])
@@ -45,7 +43,7 @@ mag = alt.Chart().mark_bar().encode(
     color=alt.condition(pts, alt.value("black"), alt.value("lightgray"))
 ).properties(
     selection=pts,
-    width=300, 
+    width=300,
     height=300
 )
 

--- a/altair/vegalite/v2/examples/scatter_with_labels.py
+++ b/altair/vegalite/v2/examples/scatter_with_labels.py
@@ -5,9 +5,8 @@ This example shows a basic scatter plot with labels created with Altair.
 """
 # category: scatter plots
 import altair as alt
-import pandas as pd
 
-data = pd.DataFrame({
+data = alt.pd.DataFrame({
     'x': [1, 3, 5, 7, 9],
     'y': [1, 3, 5, 7, 9],
     'label': ['A', 'B', 'C', 'D', 'E']

--- a/altair/vegalite/v2/examples/select_detail.py
+++ b/altair/vegalite/v2/examples/select_detail.py
@@ -12,32 +12,30 @@ aggregating identical metadata for the final plot.
 """
 # category: interactive charts
 import altair as alt
-import pandas as pd
-import numpy as np
 
-np.random.seed(0)
+alt.pd.np.random.seed(0)
 
 n_objects = 20
 n_times = 50
 
 # Create one (x, y) pair of metadata per object
-locations = pd.DataFrame({
+locations = alt.pd.DataFrame({
     'id': range(n_objects),
-    'x': np.random.randn(n_objects),
-    'y': np.random.randn(n_objects)
+    'x': alt.pd.np.random.randn(n_objects),
+    'y': alt.pd.np.random.randn(n_objects)
 })
 
 # Create a 50-element time-series for each object
-timeseries = pd.DataFrame(np.random.randn(n_times, n_objects).cumsum(0),
+timeseries = alt.pd.DataFrame(alt.pd.np.random.randn(n_times, n_objects).cumsum(0),
                           columns=locations['id'],
-                          index=pd.RangeIndex(0, n_times, name='time'))
+                          index=alt.pd.RangeIndex(0, n_times, name='time'))
 
 # Melt the wide-form timeseries into a long-form view
 timeseries = timeseries.reset_index().melt('time')
 
 # Merge the (x, y) metadata into the long-form view
 timeseries['id'] = timeseries['id'].astype(int)  # make merge not complain
-data = pd.merge(timeseries, locations, on='id')
+data = alt.pd.merge(timeseries, locations, on='id')
 
 # Data is prepared, now make a chart
 

--- a/altair/vegalite/v2/examples/simple_bar_chart.py
+++ b/altair/vegalite/v2/examples/simple_bar_chart.py
@@ -5,9 +5,8 @@ This example shows a basic bar chart created with Altair.
 """
 # category: simple charts
 import altair as alt
-import pandas as pd
 
-data = pd.DataFrame({
+data = alt.pd.DataFrame({
     'a': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'],
     'b': [28, 55, 43, 91, 81, 53, 19, 87, 52]
 })

--- a/altair/vegalite/v2/examples/simple_heatmap.py
+++ b/altair/vegalite/v2/examples/simple_heatmap.py
@@ -5,15 +5,13 @@ This example shows a simple heatmap for showing gridded data.
 """
 # category: simple charts
 import altair as alt
-import numpy as np
-import pandas as pd
 
 # Compute x^2 + y^2 across a 2D grid
-x, y = np.meshgrid(range(-5, 5), range(-5, 5))
+x, y = alt.pd.np.meshgrid(range(-5, 5), range(-5, 5))
 z = x ** 2 + y ** 2
 
 # Convert this grid to columnar data expected by Altair
-data = pd.DataFrame({'x': x.ravel(),
+data = alt.pd.DataFrame({'x': x.ravel(),
                      'y': y.ravel(),
                      'z': z.ravel()})
 

--- a/altair/vegalite/v2/examples/simple_line_chart.py
+++ b/altair/vegalite/v2/examples/simple_line_chart.py
@@ -5,14 +5,10 @@ This chart shows the most basic line chart, made from a dataframe with two
 columns.
 """
 # category: simple charts
-
 import altair as alt
-import numpy as np
-import pandas as pd
 
-x = np.arange(100)
-data = pd.DataFrame({'x': x,
-                     'sin(x)': np.sin(x / 5)})
+x = alt.pd.np.arange(100)
+data = alt.pd.DataFrame({'x': x, 'sin(x)': alt.pd.np.sin(x / 5)})
 
 alt.Chart(data).mark_line().encode(
     x='x',

--- a/altair/vegalite/v2/examples/simple_line_chart_with_markers.py
+++ b/altair/vegalite/v2/examples/simple_line_chart_with_markers.py
@@ -5,14 +5,10 @@ This chart shows the most basic line chart with markers, made from a dataframe w
 columns.
 """
 # category: simple charts
-
 import altair as alt
-import numpy as np
-import pandas as pd
 
-x = np.arange(100)
-data = pd.DataFrame({'x': x,
-                     'sin(x)': np.sin(x / 5)})
+x = alt.pd.np.arange(100)
+data = alt.pd.DataFrame({'x': x, 'sin(x)': alt.pd.np.sin(x / 5)})
 
 alt.Chart(data).mark_line(point=True).encode(
     x='x',

--- a/altair/vegalite/v2/examples/simple_scatter_with_errorbars.py
+++ b/altair/vegalite/v2/examples/simple_scatter_with_errorbars.py
@@ -9,25 +9,22 @@ A simple scatter plot of a data set with errorbars.
 
 import altair as alt
 
-import numpy as np
-import pandas as pd
-
 # generate some data points with uncertainties
-np.random.seed(0)
+alt.pd.np.random.seed(0)
 x = [1, 2, 3, 4, 5]
-y = np.random.normal(10, 0.5, size=len(x))
+y = alt.pd.np.random.normal(10, 0.5, size=len(x))
 yerr = 0.2
 
 # set up data frame
-data = pd.DataFrame({"x":x, "y":y, "yerr":yerr})
+data = alt.pd.DataFrame({"x":x, "y":y, "yerr":yerr})
 
 # generate the points
 points = alt.Chart(data).mark_point(filled=True, size=50).encode(
-    alt.X("x", 
+    alt.X("x",
           scale=alt.Scale(domain=(0,6)),
           axis=alt.Axis(title='x')
     ),
-    y=alt.Y('y', 
+    y=alt.Y('y',
             scale=alt.Scale(zero=False, domain=(10, 11)),
             axis=alt.Axis(title="y")),
     color=alt.value('black')

--- a/altair/vegalite/v2/examples/stem_and_leaf.py
+++ b/altair/vegalite/v2/examples/stem_and_leaf.py
@@ -5,12 +5,10 @@ This example shows how to make a stem and leaf plot.
 """
 # category: other charts
 import altair as alt
-import pandas as pd
-import numpy as np
-np.random.seed(42)
 
 # Generating random data
-df = pd.DataFrame({'samples': np.random.normal(50, 15, 100).astype(int).astype(str)})
+alt.pd.np.random.seed(42)
+df = alt.pd.DataFrame({'samples': alt.pd.np.random.normal(50, 15, 100).astype(int).astype(str)})
 
 # Splitting stem and leaf
 df['stem'] = df['samples'].str[:-1]

--- a/altair/vegalite/v2/examples/top_k_letters.py
+++ b/altair/vegalite/v2/examples/top_k_letters.py
@@ -7,8 +7,6 @@ the first paragraph of Dickens' *A Tale of Two Cities* by number of occurances.
 """
 # category: case studies
 import altair as alt
-import pandas as pd
-import numpy as np
 
 # Excerpt from A Tale of Two Cities; public domain text
 text = """
@@ -22,10 +20,10 @@ that some of its noisiest authorities insisted on its being received, for good
 or for evil, in the superlative degree of comparison only.
 """
 
-data = pd.DataFrame(
-    {'letters': np.array([c for c in text if c.isalpha()])}
+data = alt.pd.DataFrame(
+    {'letters': alt.pd.np.array([c for c in text if c.isalpha()])}
 )
-                     
+
 alt.Chart(data).transform_aggregate(
     count='count()',
     groupby=['letters']


### PR DESCRIPTION
A number of examples are cluttered by pandas and numpy imports at the top. I have removed them. In their place you will find references to the libraries via the `alt` variable. For instance, this:

```python
import pandas as pd

source = pd.DataFrame([whatever])
```

Has been replaced by:

```python
source = alt.pd([whatever])
```

I propose this change because it seems to me that pandas and numpy usage in the examples is primarily to generate test data. For that reason, including pandas code only distracts the user from the core purpose of the example, demonstrating Altair configuration options. Therefore, the less we see of it the better. 