### PR TITLE
"typing" package apparently creates issues if installed on Python3.7+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ numpy
 pandas
 six
 toolz
-typing
+typing;python_version<"3.5"


### PR DESCRIPTION
see  https://ci.appveyor.com/project/ericpre/hyperspy-bundle/builds/19660402/job/gs9l31okjhplckur