### PR TITLE
JOSS paper/bib: minor edits

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -19,10 +19,18 @@
 @inproceedings{2017-voyager2,
  title = {Voyager 2: Augmenting Visual Analysis with Partial View Specifications},
  author = {Wongsuphasawat, Kanit and Qu, Zening and Moritz, Dominik and Chang, Riley and Ouk, Felix and Anand, Anushka and Mackinlay, Jock and Howe, Bill and Heer, Jeffrey},
- booktitle = {ACM Human Factors in Computing Systems ({CHI})},
+ booktitle = {Proceedings of the 2017 {CHI Conference on Human Factors in Computing Systems}},
+ series = {CHI '17},
  year = {2017},
+ isbn = {978-1-4503-4655-9},
+ location = {Denver, Colorado, USA},
+ pages = {2648--2659},
+ numpages = {12},
  url = {http://idl.cs.washington.edu/papers/voyager2},
  doi = {10.1145/3025453.3025768},
+ acmid = {3025768},
+ publisher = {ACM},
+ address = {New York, NY, USA},
 }
 
 @article{2016-voyager,
@@ -35,7 +43,7 @@
 }
 
 @article{2016-reactive-vega-architecture,
- title = {Reactive Vega: A Streaming Dataflow Architecture for Declarative Interactive Visualization},
+ title = {Reactive {Vega}: A Streaming Dataflow Architecture for Declarative Interactive Visualization},
  author = {Satyanarayan, Arvind and Russell, Ryan and Hoffswell, Jane and Heer, Jeffrey},
  journal = {IEEE Trans. Visualization \& Comp. Graphics (Proc. InfoVis)},
  year = {2016},
@@ -54,7 +62,8 @@
 
 @book{2005-grammar,
  author = {Wilkinson, Leland},
- title = {The Grammar of Graphics (Statistics and Computing)},
+ title = {The Grammar of Graphics},
+ series = {Statistics and Computing},
  year = {2005},
  isbn = {0387245448},
  publisher = {Springer-Verlag New York, Inc.},

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -61,7 +61,7 @@ properties (position, color, size, etc.).
 
 Altair is based on the Vega-Lite visualization grammar [@2017-vega-lite], which allows a wide range of statistical
 visualizations to be expressed using a small number of grammar primitives. Vega-Lite implements a view composition
-algebra in conjunction with a novel grammar of interactions that allow users to specify interactive charts in an few
+algebra in conjunction with a novel grammar of interactions that allow users to specify interactive charts in a few
 lines of code. Vega-Lite is declarative; visualizations are specified using JSON data that follows the
 [Vega-Lite JSON schema](https://github.com/vega/schema). As a Python library, Altair provides an API oriented towards
 scientists and data scientists doing exploratory data analysis [@1977-exploratory]. Altair's Python API emits Vega-Lite


### PR DESCRIPTION
A trivial grammar fix and some mildly pedantic bib fixes. Capitalization of proper nouns in titles and `@inproceedings` `booktitle` is necessary when using pandoc-citeproc (or biber, but not classic bibtex). I also populated additional fields (some used by APA style) for [this paper](https://dl.acm.org/citation.cfm?id=3025768).