### PR TITLE
JOSS paper: fix multiple citation

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -76,7 +76,7 @@ generated from the Vega-Lite JSON schema, ensuring strict conformance with the V
 data produced by Altair and consumed by Vega-Lite provides a natural serialization and file format for statistical
 visualizations. This is leveraged by JupyterLab, which provides built-in rendering of these files. Third, the JSON data 
 provides a clean integration point for non-programming based visualization user-interfaces such as Voyager
-[@2016-voyager,@2017-voyager2].
+[@2016-voyager;@2017-voyager2].
 
 In addition to [static documentation](https://altair-viz.github.io/), Altair includes a set of Jupyter Notebooks with
 examples and an interactive tutorial. These notebooks can be read by anyone with only a web-browser through


### PR DESCRIPTION
Commas separate an optional locator while semicolons separate distinct
references.  This is best documentation I'm aware of:

https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html#citation_syntax

The previous formatting was incorrect:
![a](https://user-images.githubusercontent.com/3303/48532191-93da6980-e85c-11e8-90da-36a6f0ee572c.png)
