### PR TITLE
DOC: fix typo in user guide

### DIFF
--- a/doc/user_guide/saving_charts.rst
+++ b/doc/user_guide/saving_charts.rst
@@ -69,7 +69,7 @@ JSON format
 The fundamental chart representation output by Altair is a JSON string format;
 one of the core methods provided by Altair is :meth:`Chart.to_json`, which
 returns a JSON string that represents the chart content.
-Additinoally, you can save a chart to a JSON file using :meth:`Chart.save`,
+Additionally, you can save a chart to a JSON file using :meth:`Chart.save`,
 by passing a filename with a ``.json`` extension.
 
 For example, here we save a simple scatter-plot to JSON:


### PR DESCRIPTION
Small typo Additinoally -> Additionally