### PR TITLE
ENH: add renderer set_embed_options() method

### DIFF
--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -33,10 +33,53 @@ class RendererRegistry(PluginRegistry[RendererType]):
             """),
     }
 
+    def set_embed_options(self, defaultStyle=None, renderer=None,
+                          width=None, height=None, padding=None,
+                          scaleFactor=None, actions=None, **kwargs):
+        """Set options for embeddings of Vega & Vega-Lite charts.
+
+        Options are fully documented at https://github.com/vega/vega-embed.
+        Similar to the `enable()` method, this can be used as either
+        a persistent global switch, or as a temporary local setting using
+        a context manager (i.e. a `with` statement).
+
+        Parameters
+        ----------
+        defaultStyle : bool or string
+            Specify a default stylesheet for embed actions.
+        renderer : string
+            The renderer to use for the view. One of "canvas" (default) or "svg"
+        width : integer
+            The view width in pixels
+        height : integer
+            The view height in pixels
+        padding : integer
+            The view padding in pixels
+        scaleFactor : number
+            The number by which to multiply the width and height (default 1)
+            of an exported PNG or SVG image.
+        actions : bool or dict
+            Determines if action links ("Export as PNG/SVG", "View Source",
+            "View Vega" (only for Vega-Lite), "Open in Vega Editor") are
+            included with the embedded view. If the value is true, all action
+            links will be shown and none if the value is false. This property
+            can take a key-value mapping object that maps keys (export, source,
+            compiled, editor) to boolean values for determining if
+            each action link should be shown.
+        **kwargs :
+            Additional options are passed directly to embed options.
+        """
+        options = {'defaultStyle': defaultStyle, 'renderer': renderer,
+                   'width': width, 'height': height, 'padding': padding,
+                   'scaleFactor': scaleFactor, 'actions': actions}
+        kwargs.update({key: val for key, val in options.items()
+                       if val is not None})
+        return self.enable(None, embed_options=kwargs)
+
+
 # ==============================================================================
 # VegaLite v1/v2 renderer logic
 # ==============================================================================
-
 
 
 class Displayable(object):

--- a/altair/vegalite/v2/tests/test_renderers.py
+++ b/altair/vegalite/v2/tests/test_renderers.py
@@ -12,17 +12,30 @@ def chart():
 
 def test_colab_renderer_embed_options(chart):
     """Test that embed_options in renderer metadata are correctly manifest in html"""
-    with alt.renderers.enable('colab', embed_options=dict(actions=False)):
+    def assert_actions_true(chart):
+        bundle = chart._repr_mimebundle_(None, None)
+        html = bundle['text/html']
+        assert ('embedOpt = {"actions": true, "mode": "vega-lite"}' in html or
+                'embedOpt = {"mode": "vega-lite", "actions": true}' in html)
+
+    def assert_actions_false(chart):
         bundle = chart._repr_mimebundle_(None, None)
         html = bundle['text/html']
         assert ('embedOpt = {"actions": false, "mode": "vega-lite"}' in html or
                 'embedOpt = {"mode": "vega-lite", "actions": false}' in html)
 
-    with alt.renderers.enable('colab', embed_options=dict(actions=True)):
-        bundle = chart._repr_mimebundle_(None, None)
-        html = bundle['text/html']
-        assert ('embedOpt = {"actions": true, "mode": "vega-lite"}' in html or
-                'embedOpt = {"mode": "vega-lite", "actions": true}' in html)
+    with alt.renderers.enable('colab', embed_options=dict(actions=False)):
+        assert_actions_false(chart)
+
+    with alt.renderers.enable('colab'):
+        with alt.renderers.enable(embed_options=dict(actions=True)):
+            assert_actions_true(chart)
+
+        with alt.renderers.set_embed_options(actions=False):
+            assert_actions_false(chart)
+
+        with alt.renderers.set_embed_options(actions=True):
+            assert_actions_true(chart)
 
 
 def test_default_renderer_embed_options(chart, renderer='default'):


### PR DESCRIPTION
This adds a renderer method that makes it easier for the user to correctly specify options for vega-embed. Instead of, for example,
```python
alt.renderers.enable(embed_options={'renderer': 'svg', 'actions': False})
```
with this PR you can do
```
alt.renderers.set_embed_options(renderer='svg', actions=False)
```
with tab completion for the available options.