### PR TITLE
DOC: Add example of bar chart with negative values

### DIFF
--- a/altair/examples/negative_bar_chart.py
+++ b/altair/examples/negative_bar_chart.py
@@ -1,0 +1,19 @@
+"""
+Bar Chart with Negative Values
+==============================
+This example shows a bar chart with both positive and negative values.
+"""
+# category: bar charts
+import altair as alt
+
+source = "https://raw.githubusercontent.com/datadesk/vega-datasets/gh-pages/data/us-employment.csv"
+
+alt.Chart(source).mark_bar().encode(
+    x="month:T",
+    y="nonfarm_change:Q",
+    color=alt.condition(
+        alt.datum.nonfarm_change > 0,
+        alt.value("steelblue"),  # The positive color
+        alt.value("orange")  # The negative color
+    ),
+).properties(width=600)


### PR DESCRIPTION
![visualization 1](https://user-images.githubusercontent.com/9993/48821166-09d34a80-ed0d-11e8-9939-a9a3f3241b7a.png)

```python
import altair as alt

source = "https://raw.githubusercontent.com/datadesk/vega-datasets/gh-pages/data/us-employment.csv"

alt.Chart(source).mark_bar().encode(
    x="month:T",
    y="nonfarm_change:Q",
    color=alt.condition(
        alt.datum.nonfarm_change > 0,
        alt.value("steelblue"),  # The positive color
        alt.value("orange")  # The negative color
    ),
).properties(width=600)
```

This should not be merged until the next version of vega_datasets is released and the source line can be updated as follows:

```python
from vega_datasets import data

source = data.us_unemployment()
```