### PR TITLE
DOC: Regroup error bars chart in the example gallery

### DIFF
--- a/altair/examples/error_bars_with_ci.py
+++ b/altair/examples/error_bars_with_ci.py
@@ -1,11 +1,9 @@
 """
 Error Bars showing Confidence Interval
 ======================================
-This example shows how to show error bars using confidence intervals.
-The confidence intervals are computed internally in vega by
-a non-parametric `bootstrap of the mean <https://github.com/vega/vega-statistics/blob/master/src/bootstrapCI.js>`_.
+This example shows how to show error bars using confidence intervals. The confidence intervals are computed internally in vega by a non-parametric `bootstrap of the mean <https://github.com/vega/vega-statistics/blob/master/src/bootstrapCI.js>`_.
 """
-# category: bar charts
+# category: other charts
 import altair as alt
 from vega_datasets import data
 


### PR DESCRIPTION
IMHO, this is a not a traditional bar chart. Grouping it where we have it now has the potential to confuse readers. 