### PR TITLE
DOC: Change the default category to Other Charts

### DIFF
--- a/altair/sphinxext/altairgallery.py
+++ b/altair/sphinxext/altairgallery.py
@@ -158,7 +158,7 @@ def populate_examples(**kwds):
             get_docstring_and_rest(example['filename'])
         example.update(kwds)
         if category is None:
-            category = 'general'
+            category = 'other charts'
         example.update({'docstring': docstring,
                         'title': docstring.strip().split('\n')[0],
                         'code': code,


### PR DESCRIPTION
I tried a fresh doc build to see all of the changes that have happened recently. It threw a `keyerror: 'General'` when running `altairgallery.py`

I poked around to try to figure out what was going on. It seems that when populating the examples the default category was 'general' but that category has since been abandoned. 

I changed the default to be 'other charts' which fixed the error when building the docs. 

Not sure if that is the best solution but it's a start. 