### PR TITLE
DOC: Added more fully developed us_employment case study

### DIFF
--- a/altair/examples/us_employment.py
+++ b/altair/examples/us_employment.py
@@ -8,7 +8,7 @@ import altair as alt
 import pandas as pd
 from vega_datasets import data
 
-source = "https://vega.github.io/vega-datasets/data/us-employment.csv"
+source = data.us_employment()
 presidents = alt.pd.DataFrame([
     {
         "start": "2006-01-01",

--- a/altair/examples/us_employment.py
+++ b/altair/examples/us_employment.py
@@ -1,0 +1,56 @@
+"""
+The U.S. employment crash during the Great Recession
+----------------------------------------------------
+This example is a fully developed bar chart with negative values using the sample dataset of U.S. employment changes during the Great Recession.
+"""
+# category: case studies
+import altair as alt
+import pandas as pd
+from vega_datasets import data
+
+source = "https://vega.github.io/vega-datasets/data/us-employment.csv"
+presidents = alt.pd.DataFrame([
+    {
+        "start": "2006-01-01",
+        "end": "2009-01-19",
+        "president": "Bush"
+    },
+    {
+        "start": "2009-01-20",
+        "end": "2015-12-31",
+        "president": "Obama"
+    }
+])
+
+
+bars = alt.Chart(source, title="The U.S. employment crash during the Great Recession").mark_bar().encode(
+    x=alt.X("month:T", axis=alt.Axis(title="")),
+    y=alt.Y("nonfarm_change:Q", axis=alt.Axis(title="Change in non-farm employment (in thousands)")),
+    color=alt.condition(
+        alt.datum.nonfarm_change > 0,
+        alt.value("steelblue"),
+        alt.value("orange")
+    )
+)
+
+rule = alt.Chart(presidents).mark_rule(
+    color="black",
+    strokeWidth=2
+).encode(
+    x='end:T'
+).transform_filter(alt.datum.president == "Bush")
+
+text = alt.Chart(presidents).mark_text(
+    align='left',
+    baseline='middle',
+    dx=7,
+    dy=-135,
+    size=11
+).encode(
+    x='start:T',
+    x2='end:T',
+    text='president',
+    color=alt.value('#000000')
+)
+
+(bars + rule + text).properties(width=600)

--- a/altair/examples/us_employment.py
+++ b/altair/examples/us_employment.py
@@ -22,7 +22,6 @@ presidents = alt.pd.DataFrame([
     }
 ])
 
-
 bars = alt.Chart(source, title="The U.S. employment crash during the Great Recession").mark_bar().encode(
     x=alt.X("month:T", axis=alt.Axis(title="")),
     y=alt.Y("nonfarm_change:Q", axis=alt.Axis(title="Change in non-farm employment (in thousands)")),

--- a/altair/examples/us_employment.py
+++ b/altair/examples/us_employment.py
@@ -9,7 +9,7 @@ import pandas as pd
 from vega_datasets import data
 
 source = data.us_employment()
-presidents = alt.pd.DataFrame([
+presidents = pd.DataFrame([
     {
         "start": "2006-01-01",
         "end": "2009-01-19",


### PR DESCRIPTION
I'm still not sure how to get the January bar on the left to start exactly where I'd like it, but here's a run at further developing this new dataset into a case study example.

![visualization 4](https://user-images.githubusercontent.com/9993/49039616-2213f100-f175-11e8-8be0-7fe75d11984b.png)

```python
import altair as alt
import pandas as pd
from vega_datasets import data

source = data.us_employment()
presidents = pd.DataFrame([
    {
        "start": "2006-01-01",
        "end": "2009-01-19",
        "president": "Bush"
    },
    {
        "start": "2009-01-20",
        "end": "2015-12-31",
        "president": "Obama"
    }
])

bars = alt.Chart(source, title="The U.S. employment crash during the Great Recession").mark_bar().encode(
    x=alt.X("month:T", axis=alt.Axis(title="")),
    y=alt.Y("nonfarm_change:Q", axis=alt.Axis(title="Change in non-farm employment (in thousands)")),
    color=alt.condition(
        alt.datum.nonfarm_change > 0,
        alt.value("steelblue"),
        alt.value("orange")
    )
)

rule = alt.Chart(presidents).mark_rule(
  color="black",
  strokeWidth=2
).encode(
  x='end:T'
).transform_filter(alt.datum.president == "Bush")

text = alt.Chart(presidents).mark_text(
    align='left',
    baseline='middle',
    dx=7,
    dy=-135,
    size=11
).encode(
    x='start:T',
    x2='end:T',
    text='president',
    color=alt.value('#000000')
)

(bars + rule + text).properties(width=600)
```