### PR TITLE
DOC: Replace link of pdvega repo

### DIFF
--- a/doc/user_guide/ecosystem.rst
+++ b/doc/user_guide/ecosystem.rst
@@ -39,7 +39,7 @@ pdvega is a library that allows you to quickly create interactive Vega-Lite_ plo
 
 
 .. List of links.
-.. _pdvega: https://github.com/jakevdp/pdvega
+.. _pdvega: https://github.com/altair-viz/pdvega
 .. _Vega-Lite: https://vega.github.io/vega-lite/
 .. _Jupyter: http://jupyter.org/
 


### PR DESCRIPTION
pdvega is no under altair-viz. The old link was not working anymore.