### PR TITLE
DOC: Relabel line chart variable

### DIFF
--- a/altair/examples/line_chart_with_points.py
+++ b/altair/examples/line_chart_with_points.py
@@ -11,10 +11,10 @@ import pandas as pd
 x = np.arange(100)
 source = pd.DataFrame({
   'x': x,
-  'sin(x)': np.sin(x / 5)}
+  'f(x)': np.sin(x / 5)}
 )
 
 alt.Chart(source).mark_line(point=True).encode(
     x='x',
-    y='sin(x)'
+    y='f(x)'
 )

--- a/altair/examples/simple_line_chart.py
+++ b/altair/examples/simple_line_chart.py
@@ -11,10 +11,12 @@ import numpy as np
 import pandas as pd
 
 x = np.arange(100)
-source = pd.DataFrame({'x': x,
-                     'sin(x)': np.sin(x / 5)})
+source = pd.DataFrame({
+  'x': x,
+  'f(x)': np.sin(x / 5)}
+)
 
 alt.Chart(source).mark_line().encode(
     x='x',
-    y='sin(x)'
+    y='f(x)'
 )


### PR DESCRIPTION
I was a little confused by the labels used on the simple line chart example. The label was `'sin(x)'` but then the equation was `sin(x / 5)`. I think it would make more sense just to have `'x'` and `'f(x)'` as labels. I modified the other example where this occurs. 