### PR TITLE
DOC: Cleaned up trellis scatter example

### DIFF
--- a/altair/examples/trellis_scatter_plot.py
+++ b/altair/examples/trellis_scatter_plot.py
@@ -7,10 +7,10 @@ This example shows how to make a trellis scatter plot.
 import altair as alt
 from vega_datasets import data
 
-source = data.movies.url
+source = data.cars()
 
 alt.Chart(source).mark_point().encode(
-    x='Worldwide_Gross:Q',
-    y='US_DVD_Sales:Q',
-    column='MPAA_Rating:N'
+    x='Horsepower:Q',
+    y='Miles_per_Gallon:Q',
+    row='Origin:N'
 )


### PR DESCRIPTION
The current example is too wide and breaks out of the template. I'd also like to try to gradually standardize this section of examples to use a common local dataset. Cars seems like a good one we're already using in other examples, and it fits pretty well here. 