### PR TITLE
WIP: Support Vega-Lite 3

### DIFF
--- a/altair/vegalite/__init__.py
+++ b/altair/vegalite/__init__.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-from .v2 import *
+from .v3 import *

--- a/altair/vegalite/v3/__init__.py
+++ b/altair/vegalite/v3/__init__.py
@@ -1,0 +1,21 @@
+# flake8: noqa
+from .schema import *
+from .api import *
+
+from ...datasets import (
+    list_datasets,
+    load_dataset
+)
+
+from ... import expr
+from ...expr import datum
+
+from .display import VegaLite, renderers
+
+from .data import (
+    MaxRowsError,
+    pipe, curry, limit_rows,
+    sample, to_json, to_csv, to_values,
+    default_data_transformer,
+    data_transformers
+)

--- a/altair/vegalite/v3/api.py
+++ b/altair/vegalite/v3/api.py
@@ -1,0 +1,1669 @@
+# -*- coding: utf-8 -*-
+
+import warnings
+
+import hashlib
+import json
+import jsonschema
+import six
+import pandas as pd
+
+from .schema import core, channels, mixins, Undefined, SCHEMA_URL
+
+from .data import data_transformers, pipe
+from ... import utils, expr
+from .display import renderers, VEGALITE_VERSION, VEGAEMBED_VERSION, VEGA_VERSION
+from .theme import themes
+
+# ------------------------------------------------------------------------
+# Data Utilities
+def _dataset_name(values):
+    """Generate a unique hash of the data
+
+    Parameters
+    ----------
+    values : list or dict
+        A list/dict representation of data values.
+
+    Returns
+    -------
+    name : string
+        A unique name generated from the hash of the values.
+    """
+    if isinstance(values, core.InlineDataset):
+        values = values.to_dict()
+    values_json = json.dumps(values, sort_keys=True)
+    hsh = hashlib.md5(values_json.encode()).hexdigest()
+    return 'data-' + hsh
+
+
+def _consolidate_data(data, context):
+    """If data is specified inline, then move it to context['datasets']
+
+    This function will modify context in-place, and return a new version of data
+    """
+    values = Undefined
+    kwds = {}
+
+    if isinstance(data, core.InlineData):
+        if data.name is Undefined and data.values is not Undefined:
+            values = data.values
+            kwds = {'format': data.format}
+
+    elif isinstance(data, dict):
+        if 'name' not in data and 'values' in data:
+            values = data['values']
+            kwds = {k:v for k,v in data.items() if k != 'values'}
+
+    if values is not Undefined:
+        name = _dataset_name(values)
+        data = core.NamedData(name=name, **kwds)
+        context.setdefault('datasets', {})[name] = values
+
+    return data
+
+
+def _prepare_data(data, context):
+    """Convert input data to data for use within schema
+
+    Parameters
+    ----------
+    data :
+        The input dataset in the form of a DataFrame, dictionary, altair data
+        object, or other type that is recognized by the data transformers.
+    context : dict
+        The to_dict context in which the data is being prepared. This is used
+        to keep track of information that needs to be passed up and down the
+        recursive serialization routine, such as global named datasets.
+    """
+    if data is Undefined:
+        return data
+
+    # convert dataframes to dict
+    if isinstance(data, pd.DataFrame):
+        data = pipe(data, data_transformers.get())
+
+    # convert string input to a URLData
+    if isinstance(data, six.string_types):
+        data = core.UrlData(data)
+
+    # consolidate inline data to top-level datasets
+    if data_transformers.consolidate_datasets:
+        data = _consolidate_data(data, context)
+
+    # if data is still not a recognized type, then return
+    if not isinstance(data, (dict, core.Data, core.UrlData,
+                             core.InlineData, core.NamedData)):
+        warnings.warn("data of type {} not recognized".format(type(data)))
+
+    return data
+
+
+# ------------------------------------------------------------------------
+# Aliases & specializations
+Bin = core.BinParams
+
+@utils.use_signature(core.LookupData)
+class LookupData(core.LookupData):
+    def to_dict(self, *args, **kwargs):
+        """Convert the chart to a dictionary suitable for JSON export"""
+        copy = self.copy(ignore=['data'])
+        context = kwargs.get('context', {})
+        copy.data = _prepare_data(copy.data, context)
+        return super(LookupData, copy).to_dict(*args, **kwargs)
+
+
+@utils.use_signature(core.FacetMapping)
+class FacetMapping(core.FacetMapping):
+    _class_is_valid_at_instantiation = False
+
+    def to_dict(self, *args, **kwargs):
+        copy = self.copy()
+        context = kwargs.get('context', {})
+        data = context.get('data', None)
+        if isinstance(self.row, six.string_types):
+            copy.row = core.FacetFieldDef(**utils.parse_shorthand(self.row, data))
+        if isinstance(self.column, six.string_types):
+            copy.column = core.FacetFieldDef(**utils.parse_shorthand(self.column, data))
+        return super(FacetMapping, copy).to_dict(*args, **kwargs)
+
+
+# ------------------------------------------------------------------------
+# Encoding will contain channel objects that aren't valid at instantiation
+core.EncodingWithFacet._class_is_valid_at_instantiation = False
+
+# ------------------------------------------------------------------------
+# These are parameters that are valid at the top level, but are not valid
+# for specs that are within a composite chart
+# (layer, hconcat, vconcat, facet, repeat)
+TOPLEVEL_ONLY_KEYS = {'background', 'config', 'autosize', 'padding', '$schema'}
+
+
+def _get_channels_mapping():
+    mapping = {}
+    for attr in dir(channels):
+        cls = getattr(channels, attr)
+        if isinstance(cls, type) and issubclass(cls, core.SchemaBase):
+            mapping[cls] = attr.replace('Value', '').lower()
+    return mapping
+
+
+# -------------------------------------------------------------------------
+# Tools for working with selections
+class SelectionMapping(core.VegaLiteSchema):
+    """A mapping of selection names to selection definitions.
+
+    This is designed to match the schema of the "selection" property of
+    top-level objects.
+    """
+    _schema = {
+        'type': 'object',
+        'additionalPropeties': {'$ref': '#/definitions/SelectionDef'}
+    }
+    _rootschema = core.Root._schema
+
+    def __add__(self, other):
+        if isinstance(other, SelectionMapping):
+            copy = self.copy()
+            copy._kwds.update(other._kwds)
+            return copy
+        else:
+            return NotImplemented
+
+    def __iadd__(self, other):
+        if isinstance(other, SelectionMapping):
+            self._kwds.update(other._kwds)
+            return self
+        else:
+            return NotImplemented
+
+
+class NamedSelection(SelectionMapping):
+    """A SelectionMapping with a single named selection item"""
+    _schema = {
+        'type': 'object',
+        'additionalPropeties': {'$ref': '#/definitions/SelectionDef'},
+        'minProperties': 1, 'maxProperties': 1
+    }
+    _rootschema = core.Root._schema
+
+    def _get_name(self):
+        if len(self._kwds) != 1:
+            raise ValueError("NamedSelection has multiple properties")
+        return next(iter(self._kwds))
+
+    def ref(self):
+        """Return a selection reference to this object
+
+        Examples
+        --------
+        >>> import altair as alt
+        >>> sel = alt.selection_interval(name='interval')
+        >>> sel.ref()
+        {'selection': 'interval'}
+
+        """
+        return {"selection": self._get_name()}
+
+    def __invert__(self):
+        return core.SelectionNot(**{'not': self._get_name()})
+
+    def __and__(self, other):
+        if isinstance(other, NamedSelection):
+            other = other._get_name()
+        return core.SelectionAnd(**{'and': [self._get_name(), other]})
+
+    def __or__(self, other):
+        if isinstance(other, NamedSelection):
+            other = other._get_name()
+        return core.SelectionOr(**{'or': [self._get_name(), other]})
+
+    def __add__(self, other):
+        copy = SelectionMapping(**self._kwds)
+        copy += other
+        return copy
+
+    def __iadd__(self, other):
+        # this will be delegated to SelectionMapping
+        return NotImplemented
+
+# ------------------------------------------------------------------------
+# Top-Level Functions
+
+def value(value, **kwargs):
+    """Specify a value for use in an encoding"""
+    return dict(value=value, **kwargs)
+
+
+def selection(name=None, type=Undefined, **kwds):
+    """Create a named selection.
+
+    Parameters
+    ----------
+    name : string (optional)
+        The name of the selection. If not specified, a unique name will be
+        created.
+    type : string
+        The type of the selection: one of ["interval", "single", or "multi"]
+    **kwds :
+        additional keywords will be used to construct a SelectionDef instance
+        that controls the selection.
+
+    Returns
+    -------
+    selection: NamedSelection
+        The selection object that can be used in chart creation.
+    """
+    if name is None:
+        name = "selector{:03d}".format(selection.counter)
+        selection.counter += 1
+    return NamedSelection(**{name: core.SelectionDef(type=type, **kwds)})
+
+selection.counter = 1
+
+@utils.use_signature(core.IntervalSelection)
+def selection_interval(**kwargs):
+    """Create a selection with type='interval'"""
+    return selection(type='interval', **kwargs)
+
+
+@utils.use_signature(core.MultiSelection)
+def selection_multi(**kwargs):
+    """Create a selection with type='multi'"""
+    return selection(type='multi', **kwargs)
+
+
+@utils.use_signature(core.SingleSelection)
+def selection_single(**kwargs):
+    """Create a selection with type='single'"""
+    return selection(type='single', **kwargs)
+
+
+@utils.use_signature(core.VgBinding)
+def binding(input, **kwargs):
+    """A generic binding"""
+    return core.VgBinding(input=input, **kwargs)
+
+
+@utils.use_signature(core.VgCheckboxBinding)
+def binding_checkbox(**kwargs):
+    """A checkbox binding"""
+    return core.VgCheckboxBinding(input='checkbox', **kwargs)
+
+
+@utils.use_signature(core.VgRadioBinding)
+def binding_radio(**kwargs):
+    """A radio button binding"""
+    return core.VgRadioBinding(input='radio', **kwargs)
+
+
+@utils.use_signature(core.VgSelectBinding)
+def binding_select(**kwargs):
+    """A select binding"""
+    return core.VgSelectBinding(input='select', **kwargs)
+
+
+@utils.use_signature(core.VgRangeBinding)
+def binding_range(**kwargs):
+    """A range binding"""
+    return core.VgRangeBinding(input='range', **kwargs)
+
+
+def condition(predicate, if_true, if_false, **kwargs):
+    """A conditional attribute or encoding
+
+    Parameters
+    ----------
+    predicate: NamedSelection, LogicalOperandPredicate, expr.Expression, dict, or string
+        the selection predicate or test predicate for the condition.
+        if a string is passed, it will be treated as a test operand.
+    if_true:
+        the spec or object to use if the selection predicate is true
+    if_false:
+        the spec or object to use if the selection predicate is false
+    **kwargs:
+        additional keyword args are added to the resulting dict
+
+    Returns
+    -------
+    spec: dict or VegaLiteSchema
+        the spec that describes the condition
+    """
+    selection_predicates = (core.SelectionNot, core.SelectionOr,
+                            core.SelectionAnd, core.SelectionOperand)
+    test_predicates = (six.string_types, expr.Expression, core.Predicate,
+                       core.LogicalOperandPredicate, core.LogicalNotPredicate,
+                       core.LogicalOrPredicate, core.LogicalAndPredicate,
+                       core.FieldEqualPredicate, core.FieldOneOfPredicate,
+                       core.FieldRangePredicate, core.FieldLTPredicate,
+                       core.FieldGTPredicate, core.FieldLTEPredicate,
+                       core.FieldGTEPredicate, core.SelectionPredicate)
+
+    if isinstance(predicate, NamedSelection):
+        condition = {'selection': predicate._get_name()}
+    elif isinstance(predicate, selection_predicates):
+        condition = {'selection': predicate}
+    elif isinstance(predicate, test_predicates):
+        condition = {'test': predicate}
+    elif isinstance(predicate, dict):
+        condition = predicate
+    else:
+        raise NotImplementedError("condition predicate of type {}"
+                                  "".format(type(predicate)))
+
+    if isinstance(if_true, core.SchemaBase):
+        # convert to dict for now; the from_dict call below will wrap this
+        # dict in the appropriate schema
+        if_true = if_true.to_dict()
+    elif isinstance(if_true, six.string_types):
+        if_true = {'shorthand': if_true}
+        if_true.update(kwargs)
+    condition.update(if_true)
+
+    if isinstance(if_false, core.SchemaBase):
+        # For the selection, the channel definitions all allow selections
+        # already. So use this SchemaBase wrapper if possible.
+        selection = if_false.copy()
+        selection.condition = condition
+    elif isinstance(if_false, six.string_types):
+        selection = {'condition': condition, 'shorthand': if_false}
+        selection.update(kwargs)
+    else:
+        selection = dict(condition=condition, **if_false)
+
+    return selection
+
+
+# --------------------------------------------------------------------
+# Top-level objects
+
+class TopLevelMixin(mixins.ConfigMethodMixin):
+    """Mixin for top-level chart objects such as Chart, LayeredChart, etc."""
+    _class_is_valid_at_instantiation = False
+
+    def to_dict(self, *args, **kwargs):
+        """Convert the chart to a dictionary suitable for JSON export"""
+        # We make use of three context markers:
+        # - 'data' points to the data that should be referenced for column type
+        #   inference.
+        # - 'top_level' is a boolean flag that is assumed to be true; if it's
+        #   true then a "$schema" arg is added to the dict.
+        # - 'datasets' is a dict of named datasets that should be inserted
+        #   in the top-level object
+
+        # note: not a deep copy because we want datasets and data arguments to
+        # be passed by reference
+        context = kwargs.get('context', {}).copy()
+        context.setdefault('datasets', {})
+        is_top_level = context.get('top_level', True)
+
+        copy = self.copy()
+        original_data = getattr(copy, 'data', Undefined)
+        copy.data = _prepare_data(original_data, context)
+
+        if original_data is not Undefined:
+            context['data'] = original_data
+
+        # remaining to_dict calls are not at top level
+        context['top_level'] = False
+        kwargs['context'] = context
+
+        try:
+            dct = super(TopLevelMixin, copy).to_dict(*args, **kwargs)
+        except jsonschema.ValidationError:
+            dct = None
+
+        # If we hit an error, then re-convert with validate='deep' to get
+        # a more useful traceback. We don't do this by default because it's
+        # much slower in the case that there are no errors.
+        if dct is None:
+            kwargs['validate'] = 'deep'
+            dct = super(TopLevelMixin, copy).to_dict(*args, **kwargs)
+
+        # TODO: following entries are added after validation. Should they be validated?
+        if is_top_level:
+            # since this is top-level we add $schema if it's missing
+            if '$schema' not in dct:
+                dct['$schema'] = SCHEMA_URL
+
+            # apply theme from theme registry
+            the_theme = themes.get()
+            dct = utils.update_nested(the_theme(), dct, copy=True)
+
+            # update datasets
+            if context['datasets']:
+                dct.setdefault('datasets', {}).update(context['datasets'])
+
+        return dct
+
+    def to_html(self, base_url="https://cdn.jsdelivr.net/npm/",
+                output_div='vis', embed_options=None, json_kwds=None,
+                fullhtml=True, requirejs=False):
+        return utils.spec_to_html(self.to_dict(), mode='vega-lite',
+                                  vegalite_version=VEGALITE_VERSION,
+                                  vegaembed_version=VEGAEMBED_VERSION,
+                                  vega_version=VEGA_VERSION,
+                                  base_url=base_url, output_div=output_div,
+                                  embed_options=embed_options, json_kwds=json_kwds,
+                                  fullhtml=fullhtml, requirejs=requirejs)
+
+    def savechart(self, fp, format=None, **kwargs):
+        """Save a chart to file in a variety of formats
+
+        Supported formats are json, html, png, svg
+
+        Parameters
+        ----------
+        fp : string filename or file-like object
+            file in which to write the chart.
+        format : string (optional)
+            the format to write: one of ['json', 'html', 'png', 'svg'].
+            If not specified, the format will be determined from the filename.
+        **kwargs :
+            Additional keyword arguments are passed to the output method
+            associated with the specified format.
+
+        """
+        warnings.warn(
+            "Chart.savechart is deprecated in favor of Chart.save",
+            DeprecationWarning
+        )
+        return self.save(fp, format=None, **kwargs)
+
+    def save(self, fp, format=None, override_data_transformer=True,
+             scale_factor=1.0,
+             vegalite_version=VEGALITE_VERSION,
+             vega_version=VEGA_VERSION,
+             vegaembed_version=VEGAEMBED_VERSION,
+             **kwargs):
+        """Save a chart to file in a variety of formats
+
+        Supported formats are json, html, png, svg
+
+        Parameters
+        ----------
+        fp : string filename or file-like object
+            file in which to write the chart.
+        format : string (optional)
+            the format to write: one of ['json', 'html', 'png', 'svg'].
+            If not specified, the format will be determined from the filename.
+        override_data_transformer : boolean (optional)
+            If True (default), then the save action will be done with the
+            default data_transformer with max_rows set to None. If False,
+            then use the currently active data transformer.
+        scale_factor : float
+            For svg or png formats, scale the image by this factor when saving.
+            This can be used to control the size or resolution of the output.
+            Default is 1.0
+        **kwargs :
+            Additional keyword arguments are passed to the output method
+            associated with the specified format.
+
+        """
+        from ...utils.save import save
+
+        kwds = dict(chart=self, fp=fp, format=format,
+                    scale_factor=scale_factor,
+                    vegalite_version=vegalite_version,
+                    vega_version=vega_version,
+                    vegaembed_version=vegaembed_version,
+                    **kwargs)
+
+        # By default we override the data transformer. This makes it so
+        # that save() will succeed even for large datasets that would
+        # normally trigger a MaxRowsError
+        if override_data_transformer:
+            with data_transformers.enable('default', max_rows=None):
+                result = save(**kwds)
+        else:
+            result = save(**kwds)
+        return result
+
+    # Layering and stacking
+
+    def __add__(self, other):
+        return LayerChart(layer=[self, other])
+
+    def __and__(self, other):
+        return VConcatChart(vconcat=[self, other])
+
+    def __or__(self, other):
+        return HConcatChart(hconcat=[self, other])
+
+    def repeat(self, row=Undefined, column=Undefined, **kwargs):
+        """Return a RepeatChart built from the chart
+
+        Fields within the chart can be set to correspond to the row or
+        column using `alt.repeat('row')` and `alt.repeat('column')`.
+
+        Parameters
+        ----------
+        row : list
+            a list of data column names to be mapped to the row facet
+        column : list
+            a list of data column names to be mapped to the column facet
+
+        Returns
+        -------
+        chart : RepeatChart
+            a repeated chart.
+
+        """
+        repeat = core.Repeat(row=row, column=column)
+        return RepeatChart(spec=self, repeat=repeat, **kwargs)
+
+    def properties(self, **kwargs):
+        """Set top-level properties of the Chart.
+
+        Argument names and types are the same as class initialization.
+        """
+        copy = self.copy(deep=True, ignore=['data'])
+        for key, val in kwargs.items():
+            setattr(copy, key, val)
+        return copy
+
+    def add_selection(self, *selections):
+        """Add one or more selections to the chart"""
+        if not selections:
+            return self
+        else:
+            copy = self.copy(deep=True, ignore=['data'])
+            if copy.selection is Undefined:
+                copy.selection = SelectionMapping()
+            for selection in selections:
+                copy.selection += selection
+            return copy
+
+    def project(self, type='mercator', center=Undefined, clipAngle=Undefined, clipExtent=Undefined,
+                coefficient=Undefined, distance=Undefined, fraction=Undefined, lobes=Undefined,
+                parallel=Undefined, precision=Undefined, radius=Undefined, ratio=Undefined,
+                rotate=Undefined, spacing=Undefined, tilt=Undefined, **kwds):
+        """Add a geographic projection to the chartself.
+
+        This is generally used either with ``mark_geoshape`` or with the
+        ``latitude``/``longitude`` encodings.
+
+        Available projection types are
+        ['albers', 'albersUsa', 'azimuthalEqualArea', 'azimuthalEquidistant',
+        'conicConformal', 'conicEqualArea', 'conicEquidistant', 'equirectangular',
+        'gnomonic', 'mercator', 'orthographic', 'stereographic', 'transverseMercator']
+
+        Attributes
+        ----------
+        type : ProjectionType
+            The cartographic projection to use. This value is case-insensitive, for example
+            `"albers"` and `"Albers"` indicate the same projection type. You can find all valid
+            projection types [in the
+            documentation](https://vega.github.io/vega-lite/docs/projection.html#projection-types).
+
+            **Default value:** `mercator`
+        center : List(float)
+            Sets the projection’s center to the specified center, a two-element array of
+            longitude and latitude in degrees.
+
+            **Default value:** `[0, 0]`
+        clipAngle : float
+            Sets the projection’s clipping circle radius to the specified angle in degrees. If
+            `null`, switches to [antimeridian](http://bl.ocks.org/mbostock/3788999) cutting
+            rather than small-circle clipping.
+        clipExtent : List(List(float))
+            Sets the projection’s viewport clip extent to the specified bounds in pixels. The
+            extent bounds are specified as an array `[[x0, y0], [x1, y1]]`, where `x0` is the
+            left-side of the viewport, `y0` is the top, `x1` is the right and `y1` is the
+            bottom. If `null`, no viewport clipping is performed.
+        coefficient : float
+
+        distance : float
+
+        fraction : float
+
+        lobes : float
+
+        parallel : float
+
+        precision : Mapping(required=[length])
+            Sets the threshold for the projection’s [adaptive
+            resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels.
+            This value corresponds to the [Douglas–Peucker
+            distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm).
+             If precision is not specified, returns the projection’s current resampling
+            precision which defaults to `√0.5 ≅ 0.70710…`.
+        radius : float
+
+        ratio : float
+
+        rotate : List(float)
+            Sets the projection’s three-axis rotation to the specified angles, which must be a
+            two- or three-element array of numbers [`lambda`, `phi`, `gamma`] specifying the
+            rotation angles in degrees about each spherical axis. (These correspond to yaw,
+            pitch and roll.)
+
+            **Default value:** `[0, 0, 0]`
+        spacing : float
+
+        tilt : float
+
+        """
+        projection = core.Projection(center=center, clipAngle=clipAngle, clipExtent=clipExtent,
+                                     coefficient=coefficient, distance=distance, fraction=fraction,
+                                     lobes=lobes, parallel=parallel, precision=precision,
+                                     radius=radius, ratio=ratio, rotate=rotate, spacing=spacing,
+                                     tilt=tilt, type=type, **kwds)
+        return self.properties(projection=projection)
+
+    def _add_transform(self, *transforms):
+        """Copy the chart and add specified transforms to chart.transform"""
+        copy = self.copy()
+        if copy.transform is Undefined:
+            copy.transform = list(transforms)
+        else:
+            copy.transform.extend(transforms)
+        return copy
+
+    def transform_aggregate(self, aggregate=Undefined, groupby=Undefined, **kwds):
+        """
+        Add an AggregateTransform to the schema.
+
+        Parameters
+        ----------
+        aggregate : List(:class:`AggregatedFieldDef`)
+            Array of objects that define fields to aggregate.
+        groupby : List(string)
+            The data fields to group by. If not specified, a single group containing all data
+            objects will be used.
+        **kwds :
+            additional keywords are converted to aggregates using standard
+            shorthand parsing.
+
+        Returns
+        -------
+        self : Chart object
+            returns chart to allow for chaining
+
+        Examples
+        --------
+        The aggregate transform allows you to specify transforms directly using
+        the same shorthand syntax as used in encodings:
+
+        >>> import altair as alt
+        >>> chart1 = alt.Chart().transform_aggregate(
+        ...     mean_acc='mean(Acceleration)',
+        ...     groupby=['Origin']
+        ... )
+        >>> print(chart1.transform[0].to_json())  # doctest: +NORMALIZE_WHITESPACE
+        {
+          "aggregate": [
+            {
+              "as": "mean_acc",
+              "field": "Acceleration",
+              "op": "mean"
+            }
+          ],
+          "groupby": [
+            "Origin"
+          ]
+        }
+
+        It also supports including AggregatedFieldDef instances or dicts directly,
+        so you can create the above transform like this:
+
+        >>> chart2 = alt.Chart().transform_aggregate(
+        ...     [alt.AggregatedFieldDef(field='Acceleration', op='mean',
+        ...                             **{'as': 'mean_acc'})],
+        ...     groupby=['Origin']
+        ... )
+        >>> chart2.transform == chart1.transform
+        True
+
+        See Also
+        --------
+        alt.AggregateTransform : underlying transform object
+
+        """
+        if aggregate is Undefined:
+            aggregate = []
+        for key, val in kwds.items():
+            parsed = utils.parse_shorthand(val)
+            dct = {'as': key,
+                   'field': parsed.get('field', Undefined),
+                   'op': parsed.get('aggregate', Undefined)}
+            aggregate.append(core.AggregatedFieldDef(**dct))
+        return self._add_transform(core.AggregateTransform(aggregate=aggregate,
+                                                           groupby=groupby))
+
+    def transform_bin(self, as_=Undefined, field=Undefined, bin=True, **kwargs):
+        """
+        Add a BinTransform to the schema.
+
+        Attributes
+        ----------
+        as_ : anyOf(string, List(string))
+            The output fields at which to write the start and end bin values.
+        bin : anyOf(boolean, :class:`BinParams`)
+            An object indicating bin properties, or simply ``true`` for using default bin
+            parameters.
+        field : string
+            The data field to bin.
+
+        Returns
+        -------
+        self : Chart object
+            returns chart to allow for chaining
+
+        Examples
+        --------
+        >>> import altair as alt
+        >>> chart = alt.Chart().transform_bin("x_binned", "x")
+        >>> chart.transform[0]
+        BinTransform({
+          as: 'x_binned',
+          bin: True,
+          field: 'x'
+        })
+
+        >>> chart = alt.Chart().transform_bin("x_binned", "x",
+        ...                                   bin=alt.Bin(maxbins=10))
+        >>> chart.transform[0]
+        BinTransform({
+          as: 'x_binned',
+          bin: BinParams({
+            maxbins: 10
+          }),
+          field: 'x'
+        })
+
+        See Also
+        --------
+        alt.BinTransform : underlying transform object
+
+        """
+        if as_ is not Undefined:
+            if 'as' in kwargs:
+                raise ValueError("transform_bin: both 'as_' and 'as' passed as arguments.")
+            kwargs['as'] = as_
+        kwargs['bin'] = bin
+        kwargs['field'] = field
+        return self._add_transform(core.BinTransform(**kwargs))
+
+    def transform_calculate(self, as_=Undefined, calculate=Undefined, **kwargs):
+        """
+        Add a CalculateTransform to the schema.
+
+        Attributes
+        ----------
+        as_ : string
+            The field for storing the computed formula value.
+        calculate : string or alt.expr expression
+            A `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`__
+            string. Use the variable ``datum`` to refer to the current data object.
+
+        **kwargs
+            transforms can also be passed by keyword argument; see Examples
+
+        Returns
+        -------
+        self : Chart object
+            returns chart to allow for chaining
+
+        Examples
+        --------
+        >>> import altair as alt
+        >>> from altair import datum, expr
+
+        >>> chart = alt.Chart().transform_calculate(y = 2 * expr.sin(datum.x))
+        >>> chart.transform[0]
+        CalculateTransform({
+          as: 'y',
+          calculate: (2 * sin(datum.x))
+        })
+
+        It's also possible to pass the ``CalculateTransform`` arguments directly:
+
+        >>> kwds = {'as': 'y', 'calculate': '2 * sin(datum.x)'}
+        >>> chart = alt.Chart().transform_calculate(**kwds)
+        >>> chart.transform[0]
+        CalculateTransform({
+          as: 'y',
+          calculate: '2 * sin(datum.x)'
+        })
+
+        As the first form is easier to write and understand, that is the
+        recommended method.
+
+        See Also
+        --------
+        alt.CalculateTransform : underlying transform object
+
+        """
+        if as_ is Undefined:
+            as_ = kwargs.pop('as', Undefined)
+        else:
+            if 'as' in kwargs:
+                raise ValueError("transform_calculate: both 'as_' and 'as' passed as arguments.")
+        if as_ is not Undefined or calculate is not Undefined:
+            dct = {'as': as_, 'calculate': calculate}
+            self = self._add_transform(core.CalculateTransform(**dct))
+        for as_, calculate in kwargs.items():
+            dct = {'as': as_, 'calculate': calculate}
+            self = self._add_transform(core.CalculateTransform(**dct))
+        return self
+
+    def transform_filter(self, filter, **kwargs):
+        """
+        Add a FilterTransform to the schema.
+
+        Attributes
+        ----------
+        filter : a filter expression or :class:`LogicalOperandPredicate`
+            The `filter` property must be one of the predicate definitions:
+            (1) a string or alt.expr expression
+            (2) a range predicate
+            (3) a selection predicate
+            (4) a logical operand combining (1)-(3)
+            (5) a NamedSelection object
+
+        Returns
+        -------
+        self : Chart object
+            returns chart to allow for chaining
+
+        See Also
+        --------
+        alt.FilterTransform : underlying transform object
+
+        """
+        selection_predicates = (core.SelectionNot, core.SelectionOr,
+                                core.SelectionAnd, core.SelectionOperand)
+        if isinstance(filter, NamedSelection):
+            filter = {'selection': filter._get_name()}
+        elif isinstance(filter, selection_predicates):
+            filter = {'selection': filter}
+        return self._add_transform(core.FilterTransform(filter=filter, **kwargs))
+
+    def transform_lookup(self, as_=Undefined, from_=Undefined, lookup=Undefined, default=Undefined, **kwargs):
+        """Add a LookupTransform to the schema
+
+        Attributes
+        ----------
+        as_ : anyOf(string, List(string))
+            The field or fields for storing the computed formula value.
+            If ``from.fields`` is specified, the transform will use the same names for ``as``.
+            If ``from.fields`` is not specified, ``as`` has to be a string and we put the whole
+            object into the data under the specified name.
+        from_ : :class:`LookupData`
+            Secondary data reference.
+        lookup : string
+            Key in primary data source.
+        default : string
+            The default value to use if lookup fails. **Default value:** ``null``
+
+        Returns
+        -------
+        self : Chart object
+            returns chart to allow for chaining
+
+        See Also
+        --------
+        alt.LookupTransform : underlying transform object
+
+        """
+        if as_ is not Undefined:
+            if 'as' in kwargs:
+                raise ValueError("transform_lookup: both 'as_' and 'as' passed as arguments.")
+            kwargs['as'] = as_
+        if from_ is not Undefined:
+            if 'from' in kwargs:
+                raise ValueError("transform_lookup: both 'from_' and 'from' passed as arguments.")
+            kwargs['from'] = from_
+        kwargs['lookup'] = lookup
+        kwargs['default'] = default
+        return self._add_transform(core.LookupTransform(**kwargs))
+
+    def transform_timeunit(self, as_=Undefined, field=Undefined, timeUnit=Undefined, **kwargs):
+        """
+        Add a TimeUnitTransform to the schema.
+
+        Attributes
+        ----------
+        as_ : string
+            The output field to write the timeUnit value.
+        field : string
+            The data field to apply time unit.
+        timeUnit : :class:`TimeUnit`
+            The timeUnit.
+        **kwargs
+            transforms can also be passed by keyword argument; see Examples
+
+        Returns
+        -------
+        self : Chart object
+            returns chart to allow for chaining
+
+        Examples
+        --------
+        >>> import altair as alt
+        >>> from altair import datum, expr
+
+        >>> chart = alt.Chart().transform_timeunit(month='month(date)')
+        >>> chart.transform[0]
+        TimeUnitTransform({
+          as: 'month',
+          field: 'date',
+          timeUnit: 'month'
+        })
+
+        It's also possible to pass the ``TimeUnitTransform`` arguments directly;
+        this is most useful in cases where the desired field name is not a
+        valid python identifier:
+
+        >>> kwds = {'as': 'month', 'timeUnit': 'month', 'field': 'The Month'}
+        >>> chart = alt.Chart().transform_timeunit(**kwds)
+        >>> chart.transform[0]
+        TimeUnitTransform({
+          as: 'month',
+          field: 'The Month',
+          timeUnit: 'month'
+        })
+
+        As the first form is easier to write and understand, that is the
+        recommended method.
+
+        See Also
+        --------
+        alt.TimeUnitTransform : underlying transform object
+
+        """
+        if as_ is Undefined:
+            as_ = kwargs.pop('as', Undefined)
+        else:
+            if 'as' in kwargs:
+                raise ValueError("transform_timeunit: both 'as_' and 'as' passed as arguments.")
+        if as_ is not Undefined:
+            dct = {'as': as_, 'timeUnit': timeUnit, 'field': field}
+            self = self._add_transform(core.TimeUnitTransform(**dct))
+        for as_, shorthand in kwargs.items():
+            dct = utils.parse_shorthand(shorthand,
+                                        parse_timeunits=True,
+                                        parse_aggregates=False,
+                                        parse_types=False)
+            dct.pop('type', None)
+            dct['as'] = as_
+            if 'timeUnit' not in dct:
+                raise ValueError("'{}' must include a valid timeUnit".format(shorthand))
+            self = self._add_transform(core.TimeUnitTransform(**dct))
+        return self
+
+    def transform_window(self, window=Undefined, frame=Undefined, groupby=Undefined,
+                         ignorePeers=Undefined, sort=Undefined, **kwargs):
+        """Add a WindowTransform to the schema
+
+        Attributes
+        ----------
+        window : List(:class:`WindowFieldDef`)
+            The definition of the fields in the window, and what calculations to use.
+        frame : List(anyOf(None, float))
+            A frame specification as a two-element array indicating how the sliding window
+            should proceed. The array entries should either be a number indicating the offset
+            from the current data object, or null to indicate unbounded rows preceding or
+            following the current data object. The default value is ``[null, 0]``, indicating
+            that the sliding window includes the current object and all preceding objects. The
+            value ``[-5, 5]`` indicates that the window should include five objects preceding
+            and five objects following the current object. Finally, ``[null, null]`` indicates
+            that the window frame should always include all data objects. The only operators
+            affected are the aggregation operations and the ``first_value``, ``last_value``, and
+            ``nth_value`` window operations. The other window operations are not affected by
+            this.
+
+            **Default value:** :  ``[null, 0]`` (includes the current object and all preceding
+            objects)
+        groupby : List(string)
+            The data fields for partitioning the data objects into separate windows. If
+            unspecified, all data points will be in a single group.
+        ignorePeers : boolean
+            Indicates if the sliding window frame should ignore peer values. (Peer values are
+            those considered identical by the sort criteria). The default is false, causing the
+            window frame to expand to include all peer values. If set to true, the window frame
+            will be defined by offset values only. This setting only affects those operations
+            that depend on the window frame, namely aggregation operations and the first_value,
+            last_value, and nth_value window operations.
+
+            **Default value:** ``false``
+        sort : List(:class:`SortField`)
+            A sort field definition for sorting data objects within a window. If two data
+            objects are considered equal by the comparator, they are considered “peer” values of
+            equal rank. If sort is not specified, the order is undefined: data objects are
+            processed in the order they are observed and none are considered peers (the
+            ignorePeers parameter is ignored and treated as if set to ``true`` ).
+        **kwargs
+            transforms can also be passed by keyword argument; see Examples
+
+        Examples
+        --------
+        A cumulative line chart
+
+        >>> import altair as alt
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> data = pd.DataFrame({'x': np.arange(100),
+        ...                      'y': np.random.randn(100)})
+        >>> chart = alt.Chart(data).mark_line().encode(
+        ...     x='x:Q',
+        ...     y='ycuml:Q'
+        ... ).transform_window(
+        ...     ycuml='sum(y)'
+        ... )
+        >>> chart.transform[0]
+        WindowTransform({
+          window: [WindowFieldDef({
+            as: 'ycuml',
+            field: 'y',
+            op: 'sum'
+          })]
+        })
+
+        """
+        if kwargs:
+            if window is Undefined:
+                window = []
+            for as_, shorthand in kwargs.items():
+                kwds = {'as': as_}
+                kwds.update(utils.parse_shorthand(shorthand,
+                                                  parse_aggregates=False,
+                                                  parse_window_ops=True,
+                                                  parse_timeunits=False,
+                                                  parse_types=False))
+                window.append(core.WindowFieldDef(**kwds))
+
+        return self._add_transform(core.WindowTransform(window=window, frame=frame, groupby=groupby,
+                                                        ignorePeers=ignorePeers, sort=sort))
+
+    @utils.use_signature(core.Resolve)
+    def _set_resolve(self, **kwargs):
+        """Copy the chart and update the resolve property with kwargs"""
+        if not hasattr(self, 'resolve'):
+            raise ValueError("{} object has no attribute "
+                             "'resolve'".format(self.__class__))
+        copy = self.copy()
+        if copy.resolve is Undefined:
+            copy.resolve = core.Resolve()
+        for key, val in kwargs.items():
+            copy.resolve[key] = val
+        return copy
+
+    @utils.use_signature(core.AxisResolveMap)
+    def resolve_axis(self, *args, **kwargs):
+        return self._set_resolve(axis=core.AxisResolveMap(*args, **kwargs))
+
+    @utils.use_signature(core.LegendResolveMap)
+    def resolve_legend(self, *args, **kwargs):
+        return self._set_resolve(legend=core.LegendResolveMap(*args, **kwargs))
+
+    @utils.use_signature(core.ScaleResolveMap)
+    def resolve_scale(self, *args, **kwargs):
+        return self._set_resolve(scale=core.ScaleResolveMap(*args, **kwargs))
+
+    # Display-related methods
+
+    def _repr_mimebundle_(self, include, exclude):
+        """Return a MIME bundle for display in Jupyter frontends."""
+        # Catch errors explicitly to get around issues in Jupyter frontend
+        # see https://github.com/ipython/ipython/issues/11038
+        try:
+            dct = self.to_dict()
+        except Exception:
+            utils.display_traceback(in_ipython=True)
+            return {}
+        else:
+            return renderers.get()(dct)
+
+    def display(self, renderer=Undefined, theme=Undefined, actions=Undefined,
+                **kwargs):
+        """Display chart in Jupyter notebook or JupyterLab
+
+        Parameters are passed as options to vega-embed within supported frontends.
+        See https://github.com/vega/vega-embed#options for details.
+
+        Parameters
+        ----------
+        renderer : string ('canvas' or 'svg')
+            The renderer to use
+        theme : string
+            The Vega theme name to use; see https://github.com/vega/vega-themes
+        actions : bool or dict
+            Specify whether action links ("Open In Vega Editor", etc.) are
+            included in the view.
+        **kwargs :
+            Additional parameters are also passed to vega-embed as options.
+
+        """
+        from IPython.display import display
+
+        if renderer is not Undefined:
+            kwargs['renderer'] = renderer
+        if theme is not Undefined:
+            kwargs['theme'] = theme
+        if actions is not Undefined:
+            kwargs['actions'] = actions
+
+        if kwargs:
+            options = renderers.options.copy()
+            options['embed_options']= options.get('embed_options', {}).copy()
+            options['embed_options'].update(kwargs)
+            with renderers.enable(**options):
+                display(self)
+        else:
+            display(self)
+
+    def serve(self, ip='127.0.0.1', port=8888, n_retries=50, files=None,
+              jupyter_warning=True, open_browser=True, http_server=None,
+              **kwargs):
+        """Open a browser window and display a rendering of the chart
+
+        Parameters
+        ----------
+        html : string
+            HTML to serve
+        ip : string (default = '127.0.0.1')
+            ip address at which the HTML will be served.
+        port : int (default = 8888)
+            the port at which to serve the HTML
+        n_retries : int (default = 50)
+            the number of nearby ports to search if the specified port
+            is already in use.
+        files : dictionary (optional)
+            dictionary of extra content to serve
+        jupyter_warning : bool (optional)
+            if True (default), then print a warning if this is used
+            within the Jupyter notebook
+        open_browser : bool (optional)
+            if True (default), then open a web browser to the given HTML
+        http_server : class (optional)
+            optionally specify an HTTPServer class to use for showing the
+            figure. The default is Python's basic HTTPServer.
+        **kwargs :
+            additional keyword arguments passed to the save() method
+
+        """
+        from ...utils.server import serve
+
+        html = six.StringIO()
+        self.save(html, format='html', **kwargs)
+        html.seek(0)
+
+        serve(html.read(), ip=ip, port=port, n_retries=n_retries,
+              files=files, jupyter_warning=jupyter_warning,
+              open_browser=open_browser, http_server=http_server)
+
+
+class EncodingMixin(object):
+    @utils.use_signature(core.EncodingWithFacet)
+    def encode(self, *args, **kwargs):
+        # First convert args to kwargs by inferring the class from the argument
+        if args:
+            channels_mapping = _get_channels_mapping()
+            for arg in args:
+                if isinstance(arg, (list, tuple)) and len(arg) > 0:
+                    type_ = type(arg[0])
+                else:
+                    type_ = type(arg)
+
+                encoding = channels_mapping.get(type_, None)
+                if encoding is None:
+                    raise NotImplementedError("non-keyword arg of type {}"
+                                              "".format(type(arg)))
+                if encoding in kwargs:
+                    raise ValueError("encode: encoding {} specified twice"
+                                     "".format(encoding))
+                kwargs[encoding] = arg
+
+        def _wrap_in_channel_class(obj, prop):
+            clsname = prop.title()
+
+            if isinstance(obj, core.SchemaBase):
+                return obj
+
+            if isinstance(obj, six.string_types):
+                obj = {'shorthand': obj}
+
+            if isinstance(obj, (list, tuple)):
+                return [_wrap_in_channel_class(subobj, prop) for subobj in obj]
+
+            if 'value' in obj:
+                clsname += 'Value'
+
+            try:
+                cls = getattr(channels, clsname)
+            except AttributeError:
+                raise ValueError("Unrecognized encoding channel '{}'".format(prop))
+
+            try:
+                # Don't force validation here; some objects won't be valid until
+                # they're created in the context of a chart.
+                return cls.from_dict(obj, validate=False)
+            except jsonschema.ValidationError:
+                # our attempts at finding the correct class have failed
+                return obj
+
+        for prop, obj in list(kwargs.items()):
+            try:
+                condition = obj['condition']
+            except (KeyError, TypeError):
+                pass
+            else:
+                if condition is not Undefined:
+                    obj['condition'] = _wrap_in_channel_class(condition, prop)
+            kwargs[prop] = _wrap_in_channel_class(obj, prop)
+
+
+        copy = self.copy(deep=True, ignore=['data'])
+
+        # get a copy of the dict representation of the previous encoding
+        encoding = copy.encoding
+        if encoding is Undefined:
+            encoding = {}
+        elif isinstance(encoding, dict):
+            pass
+        else:
+            encoding = {k: v for k, v in encoding._kwds.items()
+                        if v is not Undefined}
+
+        # update with the new encodings, and apply them to the copy
+        encoding.update(kwargs)
+        copy.encoding = core.EncodingWithFacet(**encoding)
+        return copy
+
+
+class Chart(TopLevelMixin, EncodingMixin, mixins.MarkMethodMixin,
+            core.TopLevelFacetedUnitSpec):
+    """Create a basic Altair/Vega-Lite chart.
+
+    Although it is possible to set all Chart properties as constructor attributes,
+    it is more idiomatic to use methods such as ``mark_point()``, ``encode()``,
+    ``transform_filter()``, ``properties()``, etc. See Altair's documentation
+    for details and examples: http://altair-viz.github.io/.
+
+    Attributes
+    ----------
+    data : Data
+        An object describing the data source
+    mark : AnyMark
+        A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
+         `"line"`, * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a
+         MarkDef object.
+    encoding : EncodingWithFacet
+        A key-value mapping between encoding channels and definition of fields.
+    autosize : anyOf(AutosizeType, AutoSizeParams)
+        Sets how the visualization size should be determined. If a string, should be one of
+        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
+        content sizing and automatic resizing. `"fit"` is only supported for single and
+        layered views that don't use `rangeStep`.  __Default value__: `pad`
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    config : Config
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    description : string
+        Description of this mark for commenting purpose.
+    height : float
+        The height of a visualization.
+    name : string
+        Name of the visualization for later reference.
+    padding : Padding
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides. If an
+        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}` to specify padding for each side of the visualization.  __Default
+        value__: `5`
+    projection : Projection
+        An object defining properties of geographic projection.  Works with `"geoshape"`
+        marks and `"point"` or `"line"` marks that have a channel (one or more of `"X"`,
+        `"X2"`, `"Y"`, `"Y2"`) with type `"latitude"`, or `"longitude"`.
+    selection : Mapping(required=[])
+        A key-value mapping between selection names and definitions.
+    title : anyOf(string, TitleParams)
+        Title for the plot.
+    transform : List(Transform)
+        An array of data transformations such as filter and new field calculation.
+    width : float
+        The width of a visualization.
+    """
+    def __init__(self, data=Undefined, encoding=Undefined, mark=Undefined,
+                 width=Undefined, height=Undefined, **kwargs):
+        super(Chart, self).__init__(data=data, encoding=encoding, mark=mark,
+                                    width=width, height=height, **kwargs)
+
+    @classmethod
+    def from_dict(cls, dct, validate=True):
+        """Construct class from a dictionary representation
+
+        Parameters
+        ----------
+        dct : dictionary
+            The dict from which to construct the class
+        validate : boolean
+            If True (default), then validate the input against the schema.
+
+        Returns
+        -------
+        obj : Chart object
+            The wrapped schema
+
+        Raises
+        ------
+        jsonschema.ValidationError :
+            if validate=True and dct does not conform to the schema
+        """
+        # First try from_dict for the Chart type
+        try:
+            return super(Chart, cls).from_dict(dct, validate=validate)
+        except jsonschema.ValidationError:
+            pass
+
+        # If this fails, try with all other top level types
+        for class_ in TopLevelMixin.__subclasses__():
+            if class_ is Chart:
+                continue
+            try:
+                return class_.from_dict(dct, validate=validate)
+            except jsonschema.ValidationError:
+                pass
+
+        # As a last resort, try using the Root vegalite object
+        return core.Root.from_dict(dct, validate)
+
+    def interactive(self, name=None, bind_x=True, bind_y=True):
+        """Make chart axes scales interactive
+
+        Parameters
+        ----------
+        name : string
+            The selection name to use for the axes scales. This name should be
+            unique among all selections within the chart.
+        bind_x : boolean, default True
+            If true, then bind the interactive scales to the x-axis
+        bind_y : boolean, default True
+            If true, then bind the interactive scales to the y-axis
+
+        Returns
+        -------
+        chart :
+            copy of self, with interactive axes added
+
+        """
+        encodings = []
+        if bind_x:
+            encodings.append('x')
+        if bind_y:
+            encodings.append('y')
+        copy = self.copy(deep=True, ignore=['data'])
+
+        if copy.selection is Undefined:
+            copy.selection = SelectionMapping()
+        if isinstance(copy.selection, dict):
+            copy.selection = SelectionMapping(**copy.selection)
+        copy.selection += selection(type='interval', bind='scales',
+                                    encodings=encodings)
+        return copy
+
+    def facet(self, row=Undefined, column=Undefined, data=Undefined, **kwargs):
+        """Create a facet chart from the current chart.
+
+        Faceted charts require data to be specified at the top level; if data
+        is not specified, the data from the current chart will be used at the
+        top level.
+        """
+        if data is Undefined:
+            data = self.data
+            self = self.copy()
+            self.data = Undefined
+        return FacetChart(spec=self, facet=FacetMapping(row=row, column=column),
+                          data=data, **kwargs)
+
+
+def _check_if_valid_subspec(spec, classname):
+    """Check if the spec is a valid sub-spec.
+
+    If it is not, then raise a ValueError
+    """
+    err = ('Objects with "{0}" attribute cannot be used within {1}. '
+           'Consider defining the {0} attribute in the {1} object instead.')
+
+    for attr in TOPLEVEL_ONLY_KEYS:
+        if isinstance(spec, core.SchemaBase):
+            val = getattr(spec, attr, Undefined)
+        else:
+            val = spec.get(attr, Undefined)
+        if val is not Undefined:
+            raise ValueError(err.format(attr, classname))
+
+
+@utils.use_signature(core.TopLevelRepeatSpec)
+class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
+    """A chart repeated across rows and columns with small changes"""
+    def __init__(self, data=Undefined, spec=Undefined, repeat=Undefined, **kwargs):
+        _check_if_valid_subspec(spec, 'RepeatChart')
+        super(RepeatChart, self).__init__(data=data, spec=spec, repeat=repeat, **kwargs)
+
+    def interactive(self, name=None, bind_x=True, bind_y=True):
+        """Make chart axes scales interactive
+
+        Parameters
+        ----------
+        name : string
+            The selection name to use for the axes scales. This name should be
+            unique among all selections within the chart.
+        bind_x : boolean, default True
+            If true, then bind the interactive scales to the x-axis
+        bind_y : boolean, default True
+            If true, then bind the interactive scales to the y-axis
+
+        Returns
+        -------
+        chart :
+            copy of self, with interactive axes added
+
+        """
+        copy = self.copy()
+        copy.spec = copy.spec.interactive(name=name, bind_x=bind_x, bind_y=bind_y)
+        return copy
+
+
+def repeat(repeater):
+    """Tie a channel to the row or column within a repeated chart
+
+    The output of this should be passed to the ``field`` attribute of
+    a channel.
+
+    Parameters
+    ----------
+    repeater : {'row'|'column'}
+        The repeater to tie the field to.
+
+    Returns
+    -------
+    repeat : RepeatRef object
+    """
+    assert repeater in ['row', 'column']
+    return core.RepeatRef(repeat=repeater)
+
+
+@utils.use_signature(core.TopLevelHConcatSpec)
+class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):
+    """A chart with horizontally-concatenated facets"""
+    def __init__(self, data=Undefined, hconcat=(), **kwargs):
+        # TODO: move common data to top level?
+        for spec in hconcat:
+            _check_if_valid_subspec(spec, 'HConcatChart')
+        super(HConcatChart, self).__init__(data=data, hconcat=list(hconcat), **kwargs)
+
+    def __ior__(self, other):
+        _check_if_valid_subspec(other, 'HConcatChart')
+        self.hconcat.append(other)
+        return self
+
+    def __or__(self, other):
+        _check_if_valid_subspec(other, 'HConcatChart')
+        copy = self.copy()
+        copy.hconcat.append(other)
+        return copy
+
+    # TODO: think about the most useful class API here
+
+
+def hconcat(*charts, **kwargs):
+    """Concatenate charts horizontally"""
+    return HConcatChart(hconcat=charts, **kwargs)
+
+
+@utils.use_signature(core.TopLevelVConcatSpec)
+class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
+    """A chart with vertically-concatenated facets"""
+    def __init__(self, data=Undefined, vconcat=(), **kwargs):
+        # TODO: move common data to top level?
+        for spec in vconcat:
+            _check_if_valid_subspec(spec, 'VConcatChart')
+        super(VConcatChart, self).__init__(data=data, vconcat=list(vconcat), **kwargs)
+
+    def __iand__(self, other):
+        _check_if_valid_subspec(other, 'VConcatChart')
+        self.vconcat.append(other)
+        return self
+
+    def __and__(self, other):
+        _check_if_valid_subspec(other, 'VConcatChart')
+        copy = self.copy()
+        copy.vconcat.append(other)
+        return copy
+
+    # TODO: think about the most useful class API here
+
+
+def vconcat(*charts, **kwargs):
+    """Concatenate charts vertically"""
+    return VConcatChart(vconcat=charts, **kwargs)
+
+
+@utils.use_signature(core.TopLevelLayerSpec)
+class LayerChart(TopLevelMixin, EncodingMixin, core.TopLevelLayerSpec):
+    """A Chart with layers within a single panel"""
+    def __init__(self, data=Undefined, layer=(), **kwargs):
+        # TODO: move common data to top level?
+        # TODO: check for conflicting interaction
+        for spec in layer:
+            _check_if_valid_subspec(spec, 'LayerChart')
+        super(LayerChart, self).__init__(data=data, layer=list(layer), **kwargs)
+
+    def __iadd__(self, other):
+        _check_if_valid_subspec(other, 'LayerChart')
+        self.layer.append(other)
+        return self
+
+    def __add__(self, other):
+        copy = self.copy()
+        copy.layer.append(other)
+        return copy
+
+    def add_layers(self, *layers):
+        copy = self.copy()
+        for layer in layers:
+            copy += layer
+        return copy
+
+    def interactive(self, name=None, bind_x=True, bind_y=True):
+        """Make chart axes scales interactive
+
+        Parameters
+        ----------
+        name : string
+            The selection name to use for the axes scales. This name should be
+            unique among all selections within the chart.
+        bind_x : boolean, default True
+            If true, then bind the interactive scales to the x-axis
+        bind_y : boolean, default True
+            If true, then bind the interactive scales to the y-axis
+
+        Returns
+        -------
+        chart :
+            copy of self, with interactive axes added
+
+        """
+        if not self.layer:
+            raise ValueError("LayerChart: cannot call interactive() until a "
+                             "layer is defined")
+        copy = self.copy()
+        copy.layer[0] = copy.layer[0].interactive(name=name, bind_x=bind_x, bind_y=bind_y)
+        return copy
+
+    def facet(self, row=Undefined, column=Undefined, data=Undefined, **kwargs):
+        """Create a facet chart from the current chart.
+
+        Faceted charts require data to be specified at the top level; if data
+        is not specified, the data from the current chart will be used at the
+        top level.
+        """
+        if data is Undefined:
+            data = self.data
+            self = self.copy()
+            self.data = Undefined
+        return FacetChart(spec=self, facet=FacetMapping(row=row, column=column),
+                          data=data, **kwargs)
+
+
+def layer(*charts, **kwargs):
+    """layer multiple charts"""
+    return LayerChart(layer=charts, **kwargs)
+
+
+@utils.use_signature(core.TopLevelFacetSpec)
+class FacetChart(TopLevelMixin, core.TopLevelFacetSpec):
+    """A Chart with layers within a single panel"""
+    def __init__(self, data=Undefined, spec=Undefined, facet=Undefined, **kwargs):
+        _check_if_valid_subspec(spec, 'FacetChart')
+        super(FacetChart, self).__init__(data=data, spec=spec, facet=facet, **kwargs)
+
+    def interactive(self, name=None, bind_x=True, bind_y=True):
+        """Make chart axes scales interactive
+
+        Parameters
+        ----------
+        name : string
+            The selection name to use for the axes scales. This name should be
+            unique among all selections within the chart.
+        bind_x : boolean, default True
+            If true, then bind the interactive scales to the x-axis
+        bind_y : boolean, default True
+            If true, then bind the interactive scales to the y-axis
+
+        Returns
+        -------
+        chart :
+            copy of self, with interactive axes added
+
+        """
+        copy = self.copy()
+        copy.spec = copy.spec.interactive(name=name, bind_x=bind_x, bind_y=bind_y)
+        return copy
+
+
+def topo_feature(url, feature, **kwargs):
+    """A convenience function for extracting features from a topojson url
+
+    Parameters
+    ----------
+    url : string
+        An URL from which to load the data set.
+
+    feature : string
+        The name of the TopoJSON object set to convert to a GeoJSON feature collection. For
+        example, in a map of the world, there may be an object set named `"countries"`.
+        Using the feature property, we can extract this set and generate a GeoJSON feature
+        object for each country.
+
+    **kwargs :
+        additional keywords passed to TopoDataFormat
+    """
+    return core.UrlData(url=url, format=core.TopoDataFormat(type='topojson',
+                                                         feature=feature, **kwargs))

--- a/altair/vegalite/v3/data.py
+++ b/altair/vegalite/v3/data.py
@@ -1,0 +1,31 @@
+from ..data import (MaxRowsError, curry, default_data_transformer, limit_rows,
+                    pipe, sample, to_csv, to_json, to_values, DataTransformerRegistry)
+
+
+# ==============================================================================
+# VegaLite 1 data transformers
+# ==============================================================================
+
+
+ENTRY_POINT_GROUP = 'altair.vegalite.v2.data_transformer'  # type: str
+
+
+data_transformers = DataTransformerRegistry(entry_point_group=ENTRY_POINT_GROUP)  # type: DataTransformerRegistry
+data_transformers.register('default', default_data_transformer)
+data_transformers.register('json', to_json)
+data_transformers.register('csv', to_csv)
+data_transformers.enable('default')
+
+
+__all__ = (
+    'MaxRowsError',
+    'curry',
+    'default_data_transformer',
+    'limit_rows',
+    'pipe',
+    'sample',
+    'to_csv',
+    'to_json',
+    'to_values',
+    'data_transformers'
+)

--- a/altair/vegalite/v3/display.py
+++ b/altair/vegalite/v3/display.py
@@ -1,0 +1,114 @@
+import os
+
+from ...utils.mimebundle import spec_to_mimebundle
+from ..display import Displayable
+from ..display import default_renderer_base
+from ..display import json_renderer_base
+from ..display import RendererRegistry
+from ..display import HTMLRenderer
+
+from .schema import SCHEMA_VERSION
+VEGALITE_VERSION = SCHEMA_VERSION.lstrip('v')
+VEGA_VERSION = '4'
+VEGAEMBED_VERSION = '3'
+
+
+# ==============================================================================
+# VegaLite v2 renderer logic
+# ==============================================================================
+
+
+# The MIME type for Vega-Lite 2.x releases.
+VEGALITE_MIME_TYPE = 'application/vnd.vegalite.v2+json'  # type: str
+
+# The entry point group that can be used by other packages to declare other
+# renderers that will be auto-detected. Explicit registration is also
+# allowed by the PluginRegistery API.
+ENTRY_POINT_GROUP = 'altair.vegalite.v2.renderer'  # type: str
+
+# The display message when rendering fails
+DEFAULT_DISPLAY = """\
+<VegaLite 2 object>
+
+If you see this message, it means the renderer has not been properly enabled
+for the frontend that you are using. For more information, see
+https://altair-viz.github.io/user_guide/troubleshooting.html
+"""
+
+renderers = RendererRegistry(entry_point_group=ENTRY_POINT_GROUP)
+
+here = os.path.dirname(os.path.realpath(__file__))
+
+
+def default_renderer(spec, **metadata):
+    return default_renderer_base(spec, VEGALITE_MIME_TYPE, DEFAULT_DISPLAY,
+                                 **metadata)
+
+
+def json_renderer(spec, **metadata):
+    return json_renderer_base(spec, DEFAULT_DISPLAY, **metadata)
+
+
+def png_renderer(spec, **metadata):
+    return spec_to_mimebundle(spec, format='png',
+                              mode='vega-lite',
+                              vega_version=VEGA_VERSION,
+                              vegaembed_version=VEGAEMBED_VERSION,
+                              vegalite_version=VEGALITE_VERSION,
+                              **metadata)
+
+
+def svg_renderer(spec, **metadata):
+    return spec_to_mimebundle(spec, format='svg',
+                              mode='vega-lite',
+                              vega_version=VEGA_VERSION,
+                              vegaembed_version=VEGAEMBED_VERSION,
+                              vegalite_version=VEGALITE_VERSION,
+                              **metadata)
+
+colab_renderer = HTMLRenderer(mode='vega-lite',
+                              fullhtml=True, requirejs=False,
+                              output_div='altair-viz',
+                              vega_version=VEGA_VERSION,
+                              vegaembed_version=VEGAEMBED_VERSION,
+                              vegalite_version=VEGALITE_VERSION)
+
+kaggle_renderer = HTMLRenderer(mode='vega-lite',
+                               fullhtml=False, requirejs=True,
+                               vega_version=VEGA_VERSION,
+                               vegaembed_version=VEGAEMBED_VERSION,
+                               vegalite_version=VEGALITE_VERSION)
+
+renderers.register('default', default_renderer)
+renderers.register('jupyterlab', default_renderer)
+renderers.register('nteract', default_renderer)
+renderers.register('colab', colab_renderer)
+renderers.register('kaggle', kaggle_renderer)
+renderers.register('json', json_renderer)
+renderers.register('png', png_renderer)
+renderers.register('svg', svg_renderer)
+renderers.enable('default')
+
+
+class VegaLite(Displayable):
+    """An IPython/Jupyter display class for rendering VegaLite 2."""
+
+    renderers = renderers
+    schema_path = (__name__, 'schema/vega-lite-schema.json')
+
+
+def vegalite(spec, validate=True):
+    """Render and optionally validate a VegaLite 2 spec.
+
+    This will use the currently enabled renderer to render the spec.
+
+    Parameters
+    ==========
+    spec: dict
+        A fully compliant VegaLite 2 spec, with the data portion fully processed.
+    validate: bool
+        Should the spec be validated against the VegaLite 2 schema?
+    """
+    from IPython.display import display
+
+    display(VegaLite(spec, validate=validate))

--- a/altair/vegalite/v3/html.py
+++ b/altair/vegalite/v3/html.py
@@ -1,0 +1,18 @@
+HTML_TEMPLATE = """
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://cdn.jsdelivr.net/npm/vega@3"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-lite@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-embed@3"></script>
+</head>
+<body>
+  <div id="vis"></div>
+  <script type="text/javascript">
+    var spec = {spec};
+    var opt = {opt};
+    vegaEmbed("#vis", spec, opt);
+  </script>
+</body>
+</html>
+"""

--- a/altair/vegalite/v3/schema/__init__.py
+++ b/altair/vegalite/v3/schema/__init__.py
@@ -1,0 +1,5 @@
+# flake8: noqa
+from .core import *
+from .channels import *
+SCHEMA_VERSION = 'v3.0.0-rc8'
+SCHEMA_URL = 'https://vega.github.io/schema/vega-lite/v3.0.0-rc8.json'

--- a/altair/vegalite/v3/schema/channels.py
+++ b/altair/vegalite/v3/schema/channels.py
@@ -1,0 +1,2830 @@
+# -*- coding: utf-8 -*-
+#
+# The contents of this file are automatically written by
+# tools/generate_schema_wrapper.py. Do not modify directly.
+
+import six
+from . import core
+import pandas as pd
+from altair.utils.schemapi import Undefined
+from altair.utils import parse_shorthand
+
+
+class FieldChannelMixin(object):
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        if self.shorthand is Undefined:
+            kwds = {}
+        elif isinstance(self.shorthand, (tuple, list)):
+            # If given a list of shorthands, then transform it to a list of classes
+            kwds = self._kwds.copy()
+            kwds.pop('shorthand')
+            return [self.__class__(shorthand, **kwds).to_dict()
+                    for shorthand in self.shorthand]
+        elif isinstance(self.shorthand, six.string_types):
+            kwds = parse_shorthand(self.shorthand, data=context.get('data', None))
+            type_defined = self._kwds.get('type', Undefined) is not Undefined
+            if not (type_defined or 'type' in kwds):
+                if isinstance(context.get('data', None), pd.DataFrame):
+                    raise ValueError("{} encoding field is specified without a type; "
+                                     "the type cannot be inferred because it does not "
+                                     "match any column in the data.".format(self.shorthand))
+                else:
+                    raise ValueError("{} encoding field is specified without a type; "
+                                     "the type cannot be automatically inferred because "
+                                     "the data is not specified as a pandas.DataFrame."
+                                     "".format(self.shorthand))
+        else:
+            # shorthand is not a string; we pass the definition to field
+            if self.field is not Undefined:
+                raise ValueError("both shorthand and field specified in {}"
+                                 "".format(self.__class__.__name__))
+            # field is a RepeatSpec or similar; cannot infer type
+            kwds = {'field': self.shorthand}
+
+        # set shorthand to Undefined, because it's not part of the schema
+        self.shorthand = Undefined
+        self._kwds.update({k: v for k, v in kwds.items()
+                           if self._kwds.get(k, Undefined) is Undefined})
+        return super(FieldChannelMixin, self).to_dict(
+            validate=validate,
+            ignore=ignore,
+            context=context
+        )
+
+
+class ValueChannelMixin(object):
+    def to_dict(self, validate=True, ignore=(), context=None):
+        context = context or {}
+        condition = getattr(self, 'condition', Undefined)
+        copy = self  # don't copy unless we need to
+        if condition is not Undefined:
+            if isinstance(condition, core.SchemaBase):
+                pass
+            elif 'field' in condition and 'type' not in condition:
+                kwds = parse_shorthand(condition['field'], context.get('data', None))
+                copy = self.copy()
+                copy.condition.update(kwds)
+        return super(ValueChannelMixin, copy).to_dict(validate=validate,
+                                                      ignore=ignore,
+                                                      context=context)
+
+
+class Color(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
+    """Color schema wrapper
+
+    Mapping(required=[shorthand])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, type=Undefined, **kwds):
+        super(Color, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin,
+                                    condition=condition, field=field, legend=legend, scale=scale,
+                                    sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class ColorValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
+    """ColorValue schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, condition=Undefined, **kwds):
+        super(ColorValue, self).__init__(value=value, condition=condition, **kwds)
+
+
+class Column(FieldChannelMixin, core.FacetFieldDef):
+    """Column schema wrapper
+
+    Mapping(required=[shorthand])
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    header : :class:`Header`
+        An object defining properties of a facet's header.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 header=Undefined, sort=Undefined, timeUnit=Undefined, title=Undefined, type=Undefined,
+                 **kwds):
+        super(Column, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin, field=field,
+                                     header=header, sort=sort, timeUnit=timeUnit, title=title,
+                                     type=type, **kwds)
+
+
+class Detail(FieldChannelMixin, core.FieldDef):
+    """Detail schema wrapper
+
+    Mapping(required=[shorthand])
+    Field Def without scale (and without bin: "binned" support).
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(Detail, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin, field=field,
+                                     timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class Fill(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
+    """Fill schema wrapper
+
+    Mapping(required=[shorthand])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, type=Undefined, **kwds):
+        super(Fill, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin,
+                                   condition=condition, field=field, legend=legend, scale=scale,
+                                   sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class FillValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
+    """FillValue schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, condition=Undefined, **kwds):
+        super(FillValue, self).__init__(value=value, condition=condition, **kwds)
+
+
+class Href(FieldChannelMixin, core.FieldDefWithCondition):
+    """Href schema wrapper
+
+    Mapping(required=[shorthand])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(Href, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin,
+                                   condition=condition, field=field, timeUnit=timeUnit, title=title,
+                                   type=type, **kwds)
+
+
+class HrefValue(ValueChannelMixin, core.ValueDefWithCondition):
+    """HrefValue schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, condition=Undefined, **kwds):
+        super(HrefValue, self).__init__(value=value, condition=condition, **kwds)
+
+
+class Key(FieldChannelMixin, core.FieldDef):
+    """Key schema wrapper
+
+    Mapping(required=[shorthand])
+    Field Def without scale (and without bin: "binned" support).
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(Key, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin, field=field,
+                                  timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class Latitude(FieldChannelMixin, core.FieldDef):
+    """Latitude schema wrapper
+
+    Mapping(required=[shorthand])
+    Field Def without scale (and without bin: "binned" support).
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(Latitude, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin, field=field,
+                                       timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class Latitude2(FieldChannelMixin, core.FieldDef):
+    """Latitude2 schema wrapper
+
+    Mapping(required=[shorthand])
+    Field Def without scale (and without bin: "binned" support).
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(Latitude2, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin, field=field,
+                                        timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class Longitude(FieldChannelMixin, core.FieldDef):
+    """Longitude schema wrapper
+
+    Mapping(required=[shorthand])
+    Field Def without scale (and without bin: "binned" support).
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(Longitude, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin, field=field,
+                                        timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class Longitude2(FieldChannelMixin, core.FieldDef):
+    """Longitude2 schema wrapper
+
+    Mapping(required=[shorthand])
+    Field Def without scale (and without bin: "binned" support).
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(Longitude2, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin, field=field,
+                                         timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class Opacity(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
+    """Opacity schema wrapper
+
+    Mapping(required=[shorthand])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, type=Undefined, **kwds):
+        super(Opacity, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin,
+                                      condition=condition, field=field, legend=legend, scale=scale,
+                                      sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class OpacityValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
+    """OpacityValue schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, condition=Undefined, **kwds):
+        super(OpacityValue, self).__init__(value=value, condition=condition, **kwds)
+
+
+class Order(FieldChannelMixin, core.OrderFieldDef):
+    """Order schema wrapper
+
+    Mapping(required=[shorthand])
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    sort : :class:`SortOrder`
+        The sort order. One of ``"ascending"`` (default) or ``"descending"``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 sort=Undefined, timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(Order, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin, field=field,
+                                    sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class OrderValue(ValueChannelMixin, core.ValueDef):
+    """OrderValue schema wrapper
+
+    Mapping(required=[value])
+    Definition object for a constant value of an encoding channel.
+
+    Attributes
+    ----------
+
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, **kwds):
+        super(OrderValue, self).__init__(value=value, **kwds)
+
+
+class Row(FieldChannelMixin, core.FacetFieldDef):
+    """Row schema wrapper
+
+    Mapping(required=[shorthand])
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    header : :class:`Header`
+        An object defining properties of a facet's header.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 header=Undefined, sort=Undefined, timeUnit=Undefined, title=Undefined, type=Undefined,
+                 **kwds):
+        super(Row, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin, field=field,
+                                  header=header, sort=sort, timeUnit=timeUnit, title=title, type=type,
+                                  **kwds)
+
+
+class Shape(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
+    """Shape schema wrapper
+
+    Mapping(required=[shorthand])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, type=Undefined, **kwds):
+        super(Shape, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin,
+                                    condition=condition, field=field, legend=legend, scale=scale,
+                                    sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class ShapeValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
+    """ShapeValue schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, condition=Undefined, **kwds):
+        super(ShapeValue, self).__init__(value=value, condition=condition, **kwds)
+
+
+class Size(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
+    """Size schema wrapper
+
+    Mapping(required=[shorthand])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, type=Undefined, **kwds):
+        super(Size, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin,
+                                   condition=condition, field=field, legend=legend, scale=scale,
+                                   sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class SizeValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
+    """SizeValue schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, condition=Undefined, **kwds):
+        super(SizeValue, self).__init__(value=value, condition=condition, **kwds)
+
+
+class Stroke(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
+    """Stroke schema wrapper
+
+    Mapping(required=[shorthand])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, type=Undefined, **kwds):
+        super(Stroke, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin,
+                                     condition=condition, field=field, legend=legend, scale=scale,
+                                     sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class StrokeValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
+    """StrokeValue schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, condition=Undefined, **kwds):
+        super(StrokeValue, self).__init__(value=value, condition=condition, **kwds)
+
+
+class Text(FieldChannelMixin, core.TextFieldDefWithCondition):
+    """Text schema wrapper
+
+    Mapping(required=[shorthand])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    format : string
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`__ for a
+        text field. If not defined, this will be determined automatically.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, format=Undefined, timeUnit=Undefined, title=Undefined, type=Undefined,
+                 **kwds):
+        super(Text, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin,
+                                   condition=condition, field=field, format=format, timeUnit=timeUnit,
+                                   title=title, type=type, **kwds)
+
+
+class TextValue(ValueChannelMixin, core.TextValueDefWithCondition):
+    """TextValue schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalTextFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, condition=Undefined, **kwds):
+        super(TextValue, self).__init__(value=value, condition=condition, **kwds)
+
+
+class Tooltip(FieldChannelMixin, core.TextFieldDefWithCondition):
+    """Tooltip schema wrapper
+
+    Mapping(required=[shorthand])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    format : string
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`__ for a
+        text field. If not defined, this will be determined automatically.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, format=Undefined, timeUnit=Undefined, title=Undefined, type=Undefined,
+                 **kwds):
+        super(Tooltip, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin,
+                                      condition=condition, field=field, format=format,
+                                      timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class TooltipValue(ValueChannelMixin, core.TextValueDefWithCondition):
+    """TooltipValue schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalTextFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, condition=Undefined, **kwds):
+        super(TooltipValue, self).__init__(value=value, condition=condition, **kwds)
+
+
+class X(FieldChannelMixin, core.PositionFieldDef):
+    """X schema wrapper
+
+    Mapping(required=[shorthand])
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    axis : anyOf(:class:`Axis`, None)
+        An object defining properties of axis's gridlines, ticks and labels.
+        If ``null``, the axis for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `axis properties
+        <https://vega.github.io/vega-lite/docs/axis.html>`__ are applied.
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    impute : :class:`ImputeParams`
+        An object defining the properties of the Impute Operation to be applied.
+        The field value of the other positional channel is taken as ``key`` of the
+        ``Impute`` Operation.
+        The field of the ``color`` channel if specified is used as ``groupby`` of the
+        ``Impute`` Operation.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    stack : anyOf(:class:`StackOffset`, None)
+        Type of stacking offset if the field should be stacked.
+        ``stack`` is only applicable for ``x`` and ``y`` channels with continuous domains.
+        For example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
+        chart.
+
+        ``stack`` can be one of the following values:
+
+
+        * `"zero"`: stacking with baseline offset at zero value of the scale (for creating
+          typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and
+          `area <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
+        * ``"normalize"`` - stacking with normalized domain (for creating `normalized
+          stacked bar and area charts
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
+          :raw-html:`<br/>`
+        - ``"center"`` - stacking with center baseline (for `streamgraph
+        <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
+        * ``null`` - No-stacking. This will produce layered `bar
+          <https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart>`__ and area
+          chart.
+
+        **Default value:** ``zero`` for plots with all of the following conditions are true:
+        (1) the mark is ``bar`` or ``area`` ;
+        (2) the stacked measure channel (x or y) has a linear scale;
+        (3) At least one of non-position channels mapped to an unaggregated field that is
+        different from x and y.  Otherwise, ``null`` by default.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, axis=Undefined, bin=Undefined,
+                 field=Undefined, impute=Undefined, scale=Undefined, sort=Undefined, stack=Undefined,
+                 timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(X, self).__init__(shorthand=shorthand, aggregate=aggregate, axis=axis, bin=bin,
+                                field=field, impute=impute, scale=scale, sort=sort, stack=stack,
+                                timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class XValue(ValueChannelMixin, core.ValueDef):
+    """XValue schema wrapper
+
+    Mapping(required=[value])
+    Definition object for a constant value of an encoding channel.
+
+    Attributes
+    ----------
+
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, **kwds):
+        super(XValue, self).__init__(value=value, **kwds)
+
+
+class X2(FieldChannelMixin, core.FieldDef):
+    """X2 schema wrapper
+
+    Mapping(required=[shorthand])
+    Field Def without scale (and without bin: "binned" support).
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(X2, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin, field=field,
+                                 timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class X2Value(ValueChannelMixin, core.ValueDef):
+    """X2Value schema wrapper
+
+    Mapping(required=[value])
+    Definition object for a constant value of an encoding channel.
+
+    Attributes
+    ----------
+
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, **kwds):
+        super(X2Value, self).__init__(value=value, **kwds)
+
+
+class Y(FieldChannelMixin, core.PositionFieldDef):
+    """Y schema wrapper
+
+    Mapping(required=[shorthand])
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    axis : anyOf(:class:`Axis`, None)
+        An object defining properties of axis's gridlines, ticks and labels.
+        If ``null``, the axis for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `axis properties
+        <https://vega.github.io/vega-lite/docs/axis.html>`__ are applied.
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    impute : :class:`ImputeParams`
+        An object defining the properties of the Impute Operation to be applied.
+        The field value of the other positional channel is taken as ``key`` of the
+        ``Impute`` Operation.
+        The field of the ``color`` channel if specified is used as ``groupby`` of the
+        ``Impute`` Operation.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    stack : anyOf(:class:`StackOffset`, None)
+        Type of stacking offset if the field should be stacked.
+        ``stack`` is only applicable for ``x`` and ``y`` channels with continuous domains.
+        For example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
+        chart.
+
+        ``stack`` can be one of the following values:
+
+
+        * `"zero"`: stacking with baseline offset at zero value of the scale (for creating
+          typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and
+          `area <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
+        * ``"normalize"`` - stacking with normalized domain (for creating `normalized
+          stacked bar and area charts
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
+          :raw-html:`<br/>`
+        - ``"center"`` - stacking with center baseline (for `streamgraph
+        <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
+        * ``null`` - No-stacking. This will produce layered `bar
+          <https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart>`__ and area
+          chart.
+
+        **Default value:** ``zero`` for plots with all of the following conditions are true:
+        (1) the mark is ``bar`` or ``area`` ;
+        (2) the stacked measure channel (x or y) has a linear scale;
+        (3) At least one of non-position channels mapped to an unaggregated field that is
+        different from x and y.  Otherwise, ``null`` by default.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, axis=Undefined, bin=Undefined,
+                 field=Undefined, impute=Undefined, scale=Undefined, sort=Undefined, stack=Undefined,
+                 timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(Y, self).__init__(shorthand=shorthand, aggregate=aggregate, axis=axis, bin=bin,
+                                field=field, impute=impute, scale=scale, sort=sort, stack=stack,
+                                timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class YValue(ValueChannelMixin, core.ValueDef):
+    """YValue schema wrapper
+
+    Mapping(required=[value])
+    Definition object for a constant value of an encoding channel.
+
+    Attributes
+    ----------
+
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, **kwds):
+        super(YValue, self).__init__(value=value, **kwds)
+
+
+class Y2(FieldChannelMixin, core.FieldDef):
+    """Y2 schema wrapper
+
+    Mapping(required=[shorthand])
+    Field Def without scale (and without bin: "binned" support).
+
+    Attributes
+    ----------
+
+    shorthand : string
+        shorthand for field, aggregate, and type
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, shorthand=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 timeUnit=Undefined, title=Undefined, type=Undefined, **kwds):
+        super(Y2, self).__init__(shorthand=shorthand, aggregate=aggregate, bin=bin, field=field,
+                                 timeUnit=timeUnit, title=title, type=type, **kwds)
+
+
+class Y2Value(ValueChannelMixin, core.ValueDef):
+    """Y2Value schema wrapper
+
+    Mapping(required=[value])
+    Definition object for a constant value of an encoding channel.
+
+    Attributes
+    ----------
+
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _class_is_valid_at_instantiation = False
+
+    def __init__(self, value, **kwds):
+        super(Y2Value, self).__init__(value=value, **kwds)

--- a/altair/vegalite/v3/schema/core.py
+++ b/altair/vegalite/v3/schema/core.py
@@ -1,0 +1,11400 @@
+# -*- coding: utf-8 -*-
+#
+# The contents of this file are automatically written by
+# tools/generate_schema_wrapper.py. Do not modify directly.
+
+from altair.utils.schemapi import SchemaBase, Undefined
+
+import pkgutil
+import json
+
+def load_schema():
+    """Load the json schema associated with this module's functions"""
+    return json.loads(pkgutil.get_data(__name__, 'vega-lite-schema.json').decode('utf-8'))
+
+
+class VegaLiteSchema(SchemaBase):
+    @classmethod
+    def _default_wrapper_classes(cls):
+        return VegaLiteSchema.__subclasses__()
+
+
+class Root(VegaLiteSchema):
+    """Root schema wrapper
+
+    anyOf(:class:`TopLevelFacetedUnitSpec`, :class:`TopLevelFacetSpec`,
+    :class:`TopLevelLayerSpec`, :class:`TopLevelRepeatSpec`, :class:`TopLevelVConcatSpec`,
+    :class:`TopLevelHConcatSpec`)
+    """
+    _schema = load_schema()
+    _rootschema = _schema
+
+    def __init__(self, *args, **kwds):
+        super(Root, self).__init__(*args, **kwds)
+
+
+class Aggregate(VegaLiteSchema):
+    """Aggregate schema wrapper
+
+    enum('argmax', 'argmin', 'average', 'count', 'distinct', 'max', 'mean', 'median', 'min',
+    'missing', 'q1', 'q3', 'ci0', 'ci1', 'stderr', 'stdev', 'stdevp', 'sum', 'valid', 'values',
+    'variance', 'variancep')
+    """
+    _schema = {'$ref': '#/definitions/Aggregate'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Aggregate, self).__init__(*args)
+
+
+class AggregateOp(VegaLiteSchema):
+    """AggregateOp schema wrapper
+
+    enum('argmax', 'argmin', 'average', 'count', 'distinct', 'max', 'mean', 'median', 'min',
+    'missing', 'q1', 'q3', 'ci0', 'ci1', 'stderr', 'stdev', 'stdevp', 'sum', 'valid', 'values',
+    'variance', 'variancep')
+    """
+    _schema = {'$ref': '#/definitions/AggregateOp'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(AggregateOp, self).__init__(*args)
+
+
+class AggregateTransform(VegaLiteSchema):
+    """AggregateTransform schema wrapper
+
+    Mapping(required=[aggregate])
+
+    Attributes
+    ----------
+
+    aggregate : List(:class:`AggregatedFieldDef`)
+        Array of objects that define fields to aggregate.
+    groupby : List(string)
+        The data fields to group by. If not specified, a single group containing all data
+        objects will be used.
+    """
+    _schema = {'$ref': '#/definitions/AggregateTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, aggregate=Undefined, groupby=Undefined, **kwds):
+        super(AggregateTransform, self).__init__(aggregate=aggregate, groupby=groupby, **kwds)
+
+
+class AggregatedFieldDef(VegaLiteSchema):
+    """AggregatedFieldDef schema wrapper
+
+    Mapping(required=[op, as])
+
+    Attributes
+    ----------
+
+    op : :class:`AggregateOp`
+        The aggregation operations to apply to the fields, such as sum, average or count.
+        See the `full list of supported aggregation operations
+        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__
+        for more information.
+    field : string
+        The data field for which to compute aggregate function. This is required for all
+        aggregation operations except ``"count"``.
+    as : string
+        The output field names to use for each aggregated field.
+    """
+    _schema = {'$ref': '#/definitions/AggregatedFieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, op=Undefined, field=Undefined, **kwds):
+        super(AggregatedFieldDef, self).__init__(op=op, field=field, **kwds)
+
+
+class Align(VegaLiteSchema):
+    """Align schema wrapper
+
+    enum('left', 'center', 'right')
+    """
+    _schema = {'$ref': '#/definitions/Align'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Align, self).__init__(*args)
+
+
+class AnyMark(VegaLiteSchema):
+    """AnyMark schema wrapper
+
+    anyOf(:class:`CompositeMark`, :class:`CompositeMarkDef`, :class:`Mark`, :class:`MarkDef`)
+    """
+    _schema = {'$ref': '#/definitions/AnyMark'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(AnyMark, self).__init__(*args, **kwds)
+
+
+class AreaConfig(VegaLiteSchema):
+    """AreaConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    align : :class:`Align`
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
+    angle : float
+        The rotation angle of the text, in degrees.
+    baseline : :class:`TextBaseline`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+
+        **Default value:** ``"middle"``
+    color : string
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.
+
+        **Default value:** :raw-html:`<span style="color: #4682b4;">&#9632;</span>`
+        ``"#4682b4"``
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    cornerRadius : float
+        The radius in pixels of rounded rectangle corners.
+
+        **Default value:** ``0``
+    cursor : :class:`Cursor`
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
+    dir : :class:`Dir`
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
+
+        **Default value:** ``"ltr"``
+    dx : float
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    dy : float
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    ellipsis : string
+        The ellipsis string for text truncated in response to the limit parameter.
+
+        **Default value:** ``"…"``
+    fill : :class:`Color`
+        Default Fill Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    fillOpacity : float
+        The fill opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    filled : boolean
+        Whether the mark's color should be used as fill color instead of stroke color.
+
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.
+
+        **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and ``area`` marks.
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    font : string
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
+    fontSize : float
+        The font size, in pixels.
+    fontStyle : :class:`FontStyle`
+        The font style (e.g., ``"italic"`` ).
+    fontWeight : :class:`FontWeight`
+        The font weight.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    href : string
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    interpolate : :class:`Interpolate`
+        The line interpolation method to use for line and area marks. One of the following:
+
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
+    limit : float
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    line : anyOf(boolean, :class:`OverlayMarkDef`)
+        A flag for overlaying line on top of area marks, or an object defining the
+        properties of the overlayed lines.
+
+
+        If this value is an empty object ( ``{}`` ) or ``true``, lines with default
+        properties will be used.
+
+        If this value is ``false``, no lines would be automatically added to area marks.
+
+        **Default value:** ``false``.
+    opacity : float
+        The overall opacity (value between [0,1]).
+
+        **Default value:** ``0.7`` for non-aggregate plots with ``point``, ``tick``,
+        ``circle``, or ``square`` marks or layered ``bar`` charts and ``1`` otherwise.
+    orient : :class:`Orient`
+        The orientation of a non-stacked bar, tick, area, and line charts.
+        The value is either horizontal (default) or vertical.
+
+
+        * For bar, rule and tick, this determines whether the size of the bar and tick
+        should be applied to x or y dimension.
+        * For area, this property determines the orient property of the Vega output.
+        * For line and trail marks, this property determines the sort order of the points in
+          the line
+        if ``config.sortLineBy`` is not specified.
+        For stacked charts, this is always determined by the orientation of the stack;
+        therefore explicitly specified value will be ignored.
+    point : anyOf(boolean, :class:`OverlayMarkDef`, enum('transparent'))
+        A flag for overlaying points on top of line or area marks, or an object defining the
+        properties of the overlayed points.
+
+
+        If this property is ``"transparent"``, transparent points will be used (for
+        enhancing tooltips and selections).
+
+        If this property is an empty object ( ``{}`` ) or ``true``, filled points with
+        default properties will be used.
+
+        If this property is ``false``, no points would be automatically added to line or
+        area marks.
+
+        **Default value:** ``false``.
+    radius : float
+        Polar coordinate radial offset, in pixels, of the text label from the origin
+        determined by the ``x`` and ``y`` properties.
+    shape : string
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.
+
+        **Default value:** ``"circle"``
+    size : float
+        Default size for marks.
+
+
+        * For ``point`` / ``circle`` / ``square``, this represents the pixel area of the
+          marks. For example: in the case of circles, the radius is determined in part by
+          the square root of the size value.
+        * For ``bar``, this represents the band size of the bar, in pixels.
+        * For ``text``, this represents the font size, in pixels.
+
+        **Default value:** ``30`` for point, circle, square marks; ``rangeStep`` - 1 for bar
+        marks with discrete dimensions; ``5`` for bar marks with continuous dimensions;
+        ``11`` for text marks.
+    stroke : :class:`Color`
+        Default Stroke Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    strokeCap : :class:`StrokeCap`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
+
+        **Default value:** ``"square"``
+    strokeDash : List(float)
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
+    strokeDashOffset : float
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
+    strokeJoin : :class:`StrokeJoin`
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
+
+        **Default value:** ``"miter"``
+    strokeMiterLimit : float
+        The miter limit at which to bevel a line join.
+    strokeOpacity : float
+        The stroke opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    strokeWidth : float
+        The stroke width, in pixels.
+    tension : float
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
+    text : string
+        Placeholder text if the ``text`` channel is not specified
+    theta : float
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
+    tooltip : anyOf(string, :class:`TooltipContent`)
+        The tooltip text string to show upon mouse hover or an object defining which fields
+        should the tooltip be derived from.
+
+
+        * If ``tooltip`` is ``{"content": "encoding"}``, then all fields from ``encoding``
+          will be used.
+        * If ``tooltip`` is ``{"content": "data"}``, then all fields that appear in the
+          highlighted data point will be used.
+    """
+    _schema = {'$ref': '#/definitions/AreaConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, align=Undefined, angle=Undefined, baseline=Undefined, color=Undefined,
+                 cornerRadius=Undefined, cursor=Undefined, dir=Undefined, dx=Undefined, dy=Undefined,
+                 ellipsis=Undefined, fill=Undefined, fillOpacity=Undefined, filled=Undefined,
+                 font=Undefined, fontSize=Undefined, fontStyle=Undefined, fontWeight=Undefined,
+                 href=Undefined, interpolate=Undefined, limit=Undefined, line=Undefined,
+                 opacity=Undefined, orient=Undefined, point=Undefined, radius=Undefined,
+                 shape=Undefined, size=Undefined, stroke=Undefined, strokeCap=Undefined,
+                 strokeDash=Undefined, strokeDashOffset=Undefined, strokeJoin=Undefined,
+                 strokeMiterLimit=Undefined, strokeOpacity=Undefined, strokeWidth=Undefined,
+                 tension=Undefined, text=Undefined, theta=Undefined, tooltip=Undefined, **kwds):
+        super(AreaConfig, self).__init__(align=align, angle=angle, baseline=baseline, color=color,
+                                         cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx,
+                                         dy=dy, ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity,
+                                         filled=filled, font=font, fontSize=fontSize,
+                                         fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                                         interpolate=interpolate, limit=limit, line=line,
+                                         opacity=opacity, orient=orient, point=point, radius=radius,
+                                         shape=shape, size=size, stroke=stroke, strokeCap=strokeCap,
+                                         strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                                         strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                                         strokeOpacity=strokeOpacity, strokeWidth=strokeWidth,
+                                         tension=tension, text=text, theta=theta, tooltip=tooltip,
+                                         **kwds)
+
+
+class AutoSizeParams(VegaLiteSchema):
+    """AutoSizeParams schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    contains : enum('content', 'padding')
+        Determines how size calculation should be performed, one of ``"content"`` or
+        ``"padding"``. The default setting ( ``"content"`` ) interprets the width and height
+        settings as the data rectangle (plotting) dimensions, to which padding is then
+        added. In contrast, the ``"padding"`` setting includes the padding within the view
+        size calculations, such that the width and height settings indicate the **total**
+        intended size of the view.
+
+        **Default value** : ``"content"``
+    resize : boolean
+        A boolean flag indicating if autosize layout should be re-calculated on every view
+        update.
+
+        **Default value** : ``false``
+    type : :class:`AutosizeType`
+        The sizing format type. One of ``"pad"``, ``"fit"`` or ``"none"``. See the `autosize
+        type <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ documentation for
+        descriptions of each.
+
+        **Default value** : ``"pad"``
+    """
+    _schema = {'$ref': '#/definitions/AutoSizeParams'}
+    _rootschema = Root._schema
+
+    def __init__(self, contains=Undefined, resize=Undefined, type=Undefined, **kwds):
+        super(AutoSizeParams, self).__init__(contains=contains, resize=resize, type=type, **kwds)
+
+
+class AutosizeType(VegaLiteSchema):
+    """AutosizeType schema wrapper
+
+    enum('pad', 'fit', 'none')
+    """
+    _schema = {'$ref': '#/definitions/AutosizeType'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(AutosizeType, self).__init__(*args)
+
+
+class Axis(VegaLiteSchema):
+    """Axis schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    bandPosition : float
+        An interpolation fraction indicating where, for ``band`` scales, axis ticks should
+        be positioned. A value of ``0`` places ticks at the left edge of their bands. A
+        value of ``0.5`` places ticks in the middle of their bands.
+
+        **Default value:** ``0.5``
+    domain : boolean
+        A boolean flag indicating if the domain (the axis baseline) should be included as
+        part of the axis.
+
+        **Default value:** ``true``
+    domainColor : :class:`Color`
+        Color of axis domain line.
+
+        **Default value:** ``"gray"``.
+    domainOpacity : float
+        Opacity of the axis domain line.
+    domainWidth : float
+        Stroke width of axis domain line
+
+        **Default value:** ``1``
+    format : string
+        The formatting pattern for labels. This is D3's `number format pattern
+        <https://github.com/d3/d3-format#locale_format>`__ for quantitative fields and D3's
+        `time format pattern <https://github.com/d3/d3-time-format#locale_format>`__ for
+        time field.
+
+        See the `format documentation <https://vega.github.io/vega-lite/docs/format.html>`__
+        for more information.
+
+        **Default value:**  derived from `numberFormat
+        <https://vega.github.io/vega-lite/docs/config.html#format>`__ config for
+        quantitative fields and from `timeFormat
+        <https://vega.github.io/vega-lite/docs/config.html#format>`__ config for temporal
+        fields.
+    grid : boolean
+        A boolean flag indicating if grid lines should be included as part of the axis
+
+        **Default value:** ``true`` for `continuous scales
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__ that are not
+        binned; otherwise, ``false``.
+    gridColor : :class:`Color`
+        Color of gridlines.
+
+        **Default value:** ``"lightGray"``.
+    gridDash : List(float)
+        The offset (in pixels) into which to begin drawing with the grid dash array.
+    gridOpacity : float
+        The stroke opacity of grid (value between [0,1])
+
+        **Default value:** ``1``
+    gridWidth : float
+        The grid width, in pixels.
+
+        **Default value:** ``1``
+    labelAlign : :class:`Align`
+        Horizontal text alignment of axis tick labels, overriding the default setting for
+        the current axis orientation.
+    labelAngle : float
+        The rotation angle of the axis labels.
+
+        **Default value:** ``-90`` for nominal and ordinal fields; ``0`` otherwise.
+    labelBaseline : :class:`TextBaseline`
+        Vertical text baseline of axis tick labels, overriding the default setting for the
+        current axis orientation. Can be ``"top"``, ``"middle"``, ``"bottom"``, or
+        ``"alphabetic"``.
+    labelBound : anyOf(float, boolean)
+        Indicates if labels should be hidden if they exceed the axis range. If ``false``
+        (the default) no bounds overlap analysis is performed. If ``true``, labels will be
+        hidden if they exceed the axis range by more than 1 pixel. If this property is a
+        number, it specifies the pixel tolerance: the maximum amount by which a label
+        bounding box may exceed the axis range.
+
+        **Default value:** ``false``.
+    labelColor : :class:`Color`
+        The color of the tick label, can be in hex color code or regular color name.
+    labelFlush : anyOf(boolean, float)
+        Indicates if the first and last axis labels should be aligned flush with the scale
+        range. Flush alignment for a horizontal axis will left-align the first label and
+        right-align the last label. For vertical axes, bottom and top text baselines are
+        applied instead. If this property is a number, it also indicates the number of
+        pixels by which to offset the first and last labels; for example, a value of 2 will
+        flush-align the first and last labels and also push them 2 pixels outward from the
+        center of the axis. The additional adjustment can sometimes help the labels better
+        visually group with corresponding axis ticks.
+
+        **Default value:** ``true`` for axis of a continuous x-scale. Otherwise, ``false``.
+    labelFlushOffset : float
+        Indicates the number of pixels by which to offset flush-adjusted labels. For
+        example, a value of ``2`` will push flush-adjusted labels 2 pixels outward from the
+        center of the axis. Offsets can help the labels better visually group with
+        corresponding axis ticks.
+
+        **Default value:** ``0``.
+    labelFont : string
+        The font of the tick label.
+    labelFontSize : float
+        The font size of the label, in pixels.
+    labelFontWeight : :class:`FontWeight`
+        Font weight of axis tick labels.
+    labelLimit : float
+        Maximum allowed pixel width of axis tick labels.
+
+        **Default value:** ``180``
+    labelOpacity : float
+        The opacity of the labels.
+    labelOverlap : :class:`LabelOverlap`
+        The strategy to use for resolving overlap of axis labels. If ``false`` (the
+        default), no overlap reduction is attempted. If set to ``true`` or ``"parity"``, a
+        strategy of removing every other label is used (this works well for standard linear
+        axes). If set to ``"greedy"``, a linear scan of the labels is performed, removing
+        any labels that overlaps with the last visible label (this often works better for
+        log-scaled axes).
+
+        **Default value:** ``true`` for non-nominal fields with non-log scales; ``"greedy"``
+        for log scales; otherwise ``false``.
+    labelPadding : float
+        The padding, in pixels, between axis and text labels.
+
+        **Default value:** ``2``
+    labels : boolean
+        A boolean flag indicating if labels should be included as part of the axis.
+
+        **Default value:** ``true``.
+    maxExtent : float
+        The maximum extent in pixels that axis ticks and labels should use. This determines
+        a maximum offset value for axis titles.
+
+        **Default value:** ``undefined``.
+    minExtent : float
+        The minimum extent in pixels that axis ticks and labels should use. This determines
+        a minimum offset value for axis titles.
+
+        **Default value:** ``30`` for y-axis; ``undefined`` for x-axis.
+    offset : float
+        The offset, in pixels, by which to displace the axis from the edge of the enclosing
+        group or data rectangle.
+
+        **Default value:** derived from the `axis config
+        <https://vega.github.io/vega-lite/docs/config.html#facet-scale-config>`__ 's
+        ``offset`` ( ``0`` by default)
+    orient : :class:`AxisOrient`
+        The orientation of the axis. One of ``"top"``, ``"bottom"``, ``"left"`` or
+        ``"right"``. The orientation can be used to further specialize the axis type (e.g.,
+        a y axis oriented for the right edge of the chart).
+
+        **Default value:** ``"bottom"`` for x-axes and ``"left"`` for y-axes.
+    position : float
+        The anchor position of the axis in pixels. For x-axes with top or bottom
+        orientation, this sets the axis group x coordinate. For y-axes with left or right
+        orientation, this sets the axis group y coordinate.
+
+        **Default value** : ``0``
+    tickColor : :class:`Color`
+        The color of the axis's tick.
+
+        **Default value:** ``"gray"``
+    tickCount : float
+        A desired number of ticks, for axes visualizing quantitative scales. The resulting
+        number may be different so that values are "nice" (multiples of 2, 5, 10) and lie
+        within the underlying scale's range.
+    tickExtra : boolean
+        Boolean flag indicating if an extra axis tick should be added for the initial
+        position of the axis. This flag is useful for styling axes for ``band`` scales such
+        that ticks are placed on band boundaries rather in the middle of a band. Use in
+        conjunction with ``"bandPostion": 1`` and an axis ``"padding"`` value of ``0``.
+    tickOffset : float
+        Position offset in pixels to apply to ticks, labels, and gridlines.
+    tickOpacity : float
+        Opacity of the ticks.
+    tickRound : boolean
+        Boolean flag indicating if pixel position values should be rounded to the nearest
+        integer.
+
+        **Default value:** ``true``
+    tickSize : float
+        The size in pixels of axis ticks.
+
+        **Default value:** ``5``
+    tickStep : float
+        A desired step size for ticks. This property will generate the corresponding
+        ``tickCount`` and ``values``. It can be useful for `data that are binned before
+        importing into Vega-Lite <https://vega.github.io/vega-lite/docs/bin.html#binned>`__.
+
+        **Default value** : ``undefined``
+    tickWidth : float
+        The width, in pixels, of ticks.
+
+        **Default value:** ``1``
+    ticks : boolean
+        Boolean value that determines whether the axis should include ticks.
+
+        **Default value:** ``true``
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    titleAlign : :class:`Align`
+        Horizontal text alignment of axis titles.
+    titleAngle : float
+        Angle in degrees of axis titles.
+    titleBaseline : :class:`TextBaseline`
+        Vertical text baseline for axis titles.
+    titleColor : :class:`Color`
+        Color of the title, can be in hex color code or regular color name.
+    titleFont : string
+        Font of the title. (e.g., ``"Helvetica Neue"`` ).
+    titleFontSize : float
+        Font size of the title.
+    titleFontWeight : :class:`FontWeight`
+        Font weight of the title.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    titleLimit : float
+        Maximum allowed pixel width of axis titles.
+    titleOpacity : float
+        Opacity of the axis title.
+    titlePadding : float
+        The padding, in pixels, between title and axis.
+    titleX : float
+        X-coordinate of the axis title relative to the axis group.
+    titleY : float
+        Y-coordinate of the axis title relative to the axis group.
+    values : anyOf(List(float), List(string), List(boolean), List(:class:`DateTime`))
+        Explicitly set the visible axis tick values.
+    zindex : float
+        A non-positive integer indicating z-index of the axis.
+        If zindex is 0, axes should be drawn behind all chart elements.
+        To put them in front, use ``"zindex = 1"``.
+
+        **Default value:** ``1`` (in front of the marks) for actual axis and ``0`` (behind
+        the marks) for grids.
+    """
+    _schema = {'$ref': '#/definitions/Axis'}
+    _rootschema = Root._schema
+
+    def __init__(self, bandPosition=Undefined, domain=Undefined, domainColor=Undefined,
+                 domainOpacity=Undefined, domainWidth=Undefined, format=Undefined, grid=Undefined,
+                 gridColor=Undefined, gridDash=Undefined, gridOpacity=Undefined, gridWidth=Undefined,
+                 labelAlign=Undefined, labelAngle=Undefined, labelBaseline=Undefined,
+                 labelBound=Undefined, labelColor=Undefined, labelFlush=Undefined,
+                 labelFlushOffset=Undefined, labelFont=Undefined, labelFontSize=Undefined,
+                 labelFontWeight=Undefined, labelLimit=Undefined, labelOpacity=Undefined,
+                 labelOverlap=Undefined, labelPadding=Undefined, labels=Undefined, maxExtent=Undefined,
+                 minExtent=Undefined, offset=Undefined, orient=Undefined, position=Undefined,
+                 tickColor=Undefined, tickCount=Undefined, tickExtra=Undefined, tickOffset=Undefined,
+                 tickOpacity=Undefined, tickRound=Undefined, tickSize=Undefined, tickStep=Undefined,
+                 tickWidth=Undefined, ticks=Undefined, title=Undefined, titleAlign=Undefined,
+                 titleAngle=Undefined, titleBaseline=Undefined, titleColor=Undefined,
+                 titleFont=Undefined, titleFontSize=Undefined, titleFontWeight=Undefined,
+                 titleLimit=Undefined, titleOpacity=Undefined, titlePadding=Undefined, titleX=Undefined,
+                 titleY=Undefined, values=Undefined, zindex=Undefined, **kwds):
+        super(Axis, self).__init__(bandPosition=bandPosition, domain=domain, domainColor=domainColor,
+                                   domainOpacity=domainOpacity, domainWidth=domainWidth, format=format,
+                                   grid=grid, gridColor=gridColor, gridDash=gridDash,
+                                   gridOpacity=gridOpacity, gridWidth=gridWidth, labelAlign=labelAlign,
+                                   labelAngle=labelAngle, labelBaseline=labelBaseline,
+                                   labelBound=labelBound, labelColor=labelColor, labelFlush=labelFlush,
+                                   labelFlushOffset=labelFlushOffset, labelFont=labelFont,
+                                   labelFontSize=labelFontSize, labelFontWeight=labelFontWeight,
+                                   labelLimit=labelLimit, labelOpacity=labelOpacity,
+                                   labelOverlap=labelOverlap, labelPadding=labelPadding, labels=labels,
+                                   maxExtent=maxExtent, minExtent=minExtent, offset=offset,
+                                   orient=orient, position=position, tickColor=tickColor,
+                                   tickCount=tickCount, tickExtra=tickExtra, tickOffset=tickOffset,
+                                   tickOpacity=tickOpacity, tickRound=tickRound, tickSize=tickSize,
+                                   tickStep=tickStep, tickWidth=tickWidth, ticks=ticks, title=title,
+                                   titleAlign=titleAlign, titleAngle=titleAngle,
+                                   titleBaseline=titleBaseline, titleColor=titleColor,
+                                   titleFont=titleFont, titleFontSize=titleFontSize,
+                                   titleFontWeight=titleFontWeight, titleLimit=titleLimit,
+                                   titleOpacity=titleOpacity, titlePadding=titlePadding, titleX=titleX,
+                                   titleY=titleY, values=values, zindex=zindex, **kwds)
+
+
+class AxisConfig(VegaLiteSchema):
+    """AxisConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    bandPosition : float
+        An interpolation fraction indicating where, for ``band`` scales, axis ticks should
+        be positioned. A value of ``0`` places ticks at the left edge of their bands. A
+        value of ``0.5`` places ticks in the middle of their bands.
+
+        **Default value:** ``0.5``
+    domain : boolean
+        A boolean flag indicating if the domain (the axis baseline) should be included as
+        part of the axis.
+
+        **Default value:** ``true``
+    domainColor : :class:`Color`
+        Color of axis domain line.
+
+        **Default value:** ``"gray"``.
+    domainOpacity : float
+        Opacity of the axis domain line.
+    domainWidth : float
+        Stroke width of axis domain line
+
+        **Default value:** ``1``
+    grid : boolean
+        A boolean flag indicating if grid lines should be included as part of the axis
+
+        **Default value:** ``true`` for `continuous scales
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__ that are not
+        binned; otherwise, ``false``.
+    gridColor : :class:`Color`
+        Color of gridlines.
+
+        **Default value:** ``"lightGray"``.
+    gridDash : List(float)
+        The offset (in pixels) into which to begin drawing with the grid dash array.
+    gridOpacity : float
+        The stroke opacity of grid (value between [0,1])
+
+        **Default value:** ``1``
+    gridWidth : float
+        The grid width, in pixels.
+
+        **Default value:** ``1``
+    labelAlign : :class:`Align`
+        Horizontal text alignment of axis tick labels, overriding the default setting for
+        the current axis orientation.
+    labelAngle : float
+        The rotation angle of the axis labels.
+
+        **Default value:** ``-90`` for nominal and ordinal fields; ``0`` otherwise.
+    labelBaseline : :class:`TextBaseline`
+        Vertical text baseline of axis tick labels, overriding the default setting for the
+        current axis orientation. Can be ``"top"``, ``"middle"``, ``"bottom"``, or
+        ``"alphabetic"``.
+    labelBound : anyOf(float, boolean)
+        Indicates if labels should be hidden if they exceed the axis range. If ``false``
+        (the default) no bounds overlap analysis is performed. If ``true``, labels will be
+        hidden if they exceed the axis range by more than 1 pixel. If this property is a
+        number, it specifies the pixel tolerance: the maximum amount by which a label
+        bounding box may exceed the axis range.
+
+        **Default value:** ``false``.
+    labelColor : :class:`Color`
+        The color of the tick label, can be in hex color code or regular color name.
+    labelFlush : anyOf(boolean, float)
+        Indicates if the first and last axis labels should be aligned flush with the scale
+        range. Flush alignment for a horizontal axis will left-align the first label and
+        right-align the last label. For vertical axes, bottom and top text baselines are
+        applied instead. If this property is a number, it also indicates the number of
+        pixels by which to offset the first and last labels; for example, a value of 2 will
+        flush-align the first and last labels and also push them 2 pixels outward from the
+        center of the axis. The additional adjustment can sometimes help the labels better
+        visually group with corresponding axis ticks.
+
+        **Default value:** ``true`` for axis of a continuous x-scale. Otherwise, ``false``.
+    labelFlushOffset : float
+        Indicates the number of pixels by which to offset flush-adjusted labels. For
+        example, a value of ``2`` will push flush-adjusted labels 2 pixels outward from the
+        center of the axis. Offsets can help the labels better visually group with
+        corresponding axis ticks.
+
+        **Default value:** ``0``.
+    labelFont : string
+        The font of the tick label.
+    labelFontSize : float
+        The font size of the label, in pixels.
+    labelFontWeight : :class:`FontWeight`
+        Font weight of axis tick labels.
+    labelLimit : float
+        Maximum allowed pixel width of axis tick labels.
+
+        **Default value:** ``180``
+    labelOpacity : float
+        The opacity of the labels.
+    labelOverlap : :class:`LabelOverlap`
+        The strategy to use for resolving overlap of axis labels. If ``false`` (the
+        default), no overlap reduction is attempted. If set to ``true`` or ``"parity"``, a
+        strategy of removing every other label is used (this works well for standard linear
+        axes). If set to ``"greedy"``, a linear scan of the labels is performed, removing
+        any labels that overlaps with the last visible label (this often works better for
+        log-scaled axes).
+
+        **Default value:** ``true`` for non-nominal fields with non-log scales; ``"greedy"``
+        for log scales; otherwise ``false``.
+    labelPadding : float
+        The padding, in pixels, between axis and text labels.
+
+        **Default value:** ``2``
+    labels : boolean
+        A boolean flag indicating if labels should be included as part of the axis.
+
+        **Default value:** ``true``.
+    maxExtent : float
+        The maximum extent in pixels that axis ticks and labels should use. This determines
+        a maximum offset value for axis titles.
+
+        **Default value:** ``undefined``.
+    minExtent : float
+        The minimum extent in pixels that axis ticks and labels should use. This determines
+        a minimum offset value for axis titles.
+
+        **Default value:** ``30`` for y-axis; ``undefined`` for x-axis.
+    shortTimeLabels : boolean
+        Whether month names and weekday names should be abbreviated.
+
+        **Default value:**  ``false``
+    tickColor : :class:`Color`
+        The color of the axis's tick.
+
+        **Default value:** ``"gray"``
+    tickExtra : boolean
+        Boolean flag indicating if an extra axis tick should be added for the initial
+        position of the axis. This flag is useful for styling axes for ``band`` scales such
+        that ticks are placed on band boundaries rather in the middle of a band. Use in
+        conjunction with ``"bandPostion": 1`` and an axis ``"padding"`` value of ``0``.
+    tickOffset : float
+        Position offset in pixels to apply to ticks, labels, and gridlines.
+    tickOpacity : float
+        Opacity of the ticks.
+    tickRound : boolean
+        Boolean flag indicating if pixel position values should be rounded to the nearest
+        integer.
+
+        **Default value:** ``true``
+    tickSize : float
+        The size in pixels of axis ticks.
+
+        **Default value:** ``5``
+    tickWidth : float
+        The width, in pixels, of ticks.
+
+        **Default value:** ``1``
+    ticks : boolean
+        Boolean value that determines whether the axis should include ticks.
+
+        **Default value:** ``true``
+    titleAlign : :class:`Align`
+        Horizontal text alignment of axis titles.
+    titleAngle : float
+        Angle in degrees of axis titles.
+    titleBaseline : :class:`TextBaseline`
+        Vertical text baseline for axis titles.
+    titleColor : :class:`Color`
+        Color of the title, can be in hex color code or regular color name.
+    titleFont : string
+        Font of the title. (e.g., ``"Helvetica Neue"`` ).
+    titleFontSize : float
+        Font size of the title.
+    titleFontWeight : :class:`FontWeight`
+        Font weight of the title.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    titleLimit : float
+        Maximum allowed pixel width of axis titles.
+    titleOpacity : float
+        Opacity of the axis title.
+    titlePadding : float
+        The padding, in pixels, between title and axis.
+    titleX : float
+        X-coordinate of the axis title relative to the axis group.
+    titleY : float
+        Y-coordinate of the axis title relative to the axis group.
+    """
+    _schema = {'$ref': '#/definitions/AxisConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, bandPosition=Undefined, domain=Undefined, domainColor=Undefined,
+                 domainOpacity=Undefined, domainWidth=Undefined, grid=Undefined, gridColor=Undefined,
+                 gridDash=Undefined, gridOpacity=Undefined, gridWidth=Undefined, labelAlign=Undefined,
+                 labelAngle=Undefined, labelBaseline=Undefined, labelBound=Undefined,
+                 labelColor=Undefined, labelFlush=Undefined, labelFlushOffset=Undefined,
+                 labelFont=Undefined, labelFontSize=Undefined, labelFontWeight=Undefined,
+                 labelLimit=Undefined, labelOpacity=Undefined, labelOverlap=Undefined,
+                 labelPadding=Undefined, labels=Undefined, maxExtent=Undefined, minExtent=Undefined,
+                 shortTimeLabels=Undefined, tickColor=Undefined, tickExtra=Undefined,
+                 tickOffset=Undefined, tickOpacity=Undefined, tickRound=Undefined, tickSize=Undefined,
+                 tickWidth=Undefined, ticks=Undefined, titleAlign=Undefined, titleAngle=Undefined,
+                 titleBaseline=Undefined, titleColor=Undefined, titleFont=Undefined,
+                 titleFontSize=Undefined, titleFontWeight=Undefined, titleLimit=Undefined,
+                 titleOpacity=Undefined, titlePadding=Undefined, titleX=Undefined, titleY=Undefined,
+                 **kwds):
+        super(AxisConfig, self).__init__(bandPosition=bandPosition, domain=domain,
+                                         domainColor=domainColor, domainOpacity=domainOpacity,
+                                         domainWidth=domainWidth, grid=grid, gridColor=gridColor,
+                                         gridDash=gridDash, gridOpacity=gridOpacity,
+                                         gridWidth=gridWidth, labelAlign=labelAlign,
+                                         labelAngle=labelAngle, labelBaseline=labelBaseline,
+                                         labelBound=labelBound, labelColor=labelColor,
+                                         labelFlush=labelFlush, labelFlushOffset=labelFlushOffset,
+                                         labelFont=labelFont, labelFontSize=labelFontSize,
+                                         labelFontWeight=labelFontWeight, labelLimit=labelLimit,
+                                         labelOpacity=labelOpacity, labelOverlap=labelOverlap,
+                                         labelPadding=labelPadding, labels=labels, maxExtent=maxExtent,
+                                         minExtent=minExtent, shortTimeLabels=shortTimeLabels,
+                                         tickColor=tickColor, tickExtra=tickExtra,
+                                         tickOffset=tickOffset, tickOpacity=tickOpacity,
+                                         tickRound=tickRound, tickSize=tickSize, tickWidth=tickWidth,
+                                         ticks=ticks, titleAlign=titleAlign, titleAngle=titleAngle,
+                                         titleBaseline=titleBaseline, titleColor=titleColor,
+                                         titleFont=titleFont, titleFontSize=titleFontSize,
+                                         titleFontWeight=titleFontWeight, titleLimit=titleLimit,
+                                         titleOpacity=titleOpacity, titlePadding=titlePadding,
+                                         titleX=titleX, titleY=titleY, **kwds)
+
+
+class AxisOrient(VegaLiteSchema):
+    """AxisOrient schema wrapper
+
+    enum('top', 'bottom', 'left', 'right')
+    """
+    _schema = {'$ref': '#/definitions/AxisOrient'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(AxisOrient, self).__init__(*args)
+
+
+class AxisResolveMap(VegaLiteSchema):
+    """AxisResolveMap schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    x : :class:`ResolveMode`
+
+    y : :class:`ResolveMode`
+
+    """
+    _schema = {'$ref': '#/definitions/AxisResolveMap'}
+    _rootschema = Root._schema
+
+    def __init__(self, x=Undefined, y=Undefined, **kwds):
+        super(AxisResolveMap, self).__init__(x=x, y=y, **kwds)
+
+
+class BarConfig(VegaLiteSchema):
+    """BarConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    align : :class:`Align`
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
+    angle : float
+        The rotation angle of the text, in degrees.
+    baseline : :class:`TextBaseline`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+
+        **Default value:** ``"middle"``
+    binSpacing : float
+        Offset between bars for binned field.  Ideal value for this is either 0 (Preferred
+        by statisticians) or 1 (Vega-Lite Default, D3 example style).
+
+        **Default value:** ``1``
+    color : string
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.
+
+        **Default value:** :raw-html:`<span style="color: #4682b4;">&#9632;</span>`
+        ``"#4682b4"``
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    continuousBandSize : float
+        The default size of the bars on continuous scales.
+
+        **Default value:** ``5``
+    cornerRadius : float
+        The radius in pixels of rounded rectangle corners.
+
+        **Default value:** ``0``
+    cursor : :class:`Cursor`
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
+    dir : :class:`Dir`
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
+
+        **Default value:** ``"ltr"``
+    discreteBandSize : float
+        The default size of the bars with discrete dimensions.  If unspecified, the default
+        size is  ``bandSize-1``,
+        which provides 1 pixel offset between bars.
+    dx : float
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    dy : float
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    ellipsis : string
+        The ellipsis string for text truncated in response to the limit parameter.
+
+        **Default value:** ``"…"``
+    fill : :class:`Color`
+        Default Fill Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    fillOpacity : float
+        The fill opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    filled : boolean
+        Whether the mark's color should be used as fill color instead of stroke color.
+
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.
+
+        **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and ``area`` marks.
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    font : string
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
+    fontSize : float
+        The font size, in pixels.
+    fontStyle : :class:`FontStyle`
+        The font style (e.g., ``"italic"`` ).
+    fontWeight : :class:`FontWeight`
+        The font weight.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    href : string
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    interpolate : :class:`Interpolate`
+        The line interpolation method to use for line and area marks. One of the following:
+
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
+    limit : float
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    opacity : float
+        The overall opacity (value between [0,1]).
+
+        **Default value:** ``0.7`` for non-aggregate plots with ``point``, ``tick``,
+        ``circle``, or ``square`` marks or layered ``bar`` charts and ``1`` otherwise.
+    orient : :class:`Orient`
+        The orientation of a non-stacked bar, tick, area, and line charts.
+        The value is either horizontal (default) or vertical.
+
+
+        * For bar, rule and tick, this determines whether the size of the bar and tick
+        should be applied to x or y dimension.
+        * For area, this property determines the orient property of the Vega output.
+        * For line and trail marks, this property determines the sort order of the points in
+          the line
+        if ``config.sortLineBy`` is not specified.
+        For stacked charts, this is always determined by the orientation of the stack;
+        therefore explicitly specified value will be ignored.
+    radius : float
+        Polar coordinate radial offset, in pixels, of the text label from the origin
+        determined by the ``x`` and ``y`` properties.
+    shape : string
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.
+
+        **Default value:** ``"circle"``
+    size : float
+        Default size for marks.
+
+
+        * For ``point`` / ``circle`` / ``square``, this represents the pixel area of the
+          marks. For example: in the case of circles, the radius is determined in part by
+          the square root of the size value.
+        * For ``bar``, this represents the band size of the bar, in pixels.
+        * For ``text``, this represents the font size, in pixels.
+
+        **Default value:** ``30`` for point, circle, square marks; ``rangeStep`` - 1 for bar
+        marks with discrete dimensions; ``5`` for bar marks with continuous dimensions;
+        ``11`` for text marks.
+    stroke : :class:`Color`
+        Default Stroke Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    strokeCap : :class:`StrokeCap`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
+
+        **Default value:** ``"square"``
+    strokeDash : List(float)
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
+    strokeDashOffset : float
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
+    strokeJoin : :class:`StrokeJoin`
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
+
+        **Default value:** ``"miter"``
+    strokeMiterLimit : float
+        The miter limit at which to bevel a line join.
+    strokeOpacity : float
+        The stroke opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    strokeWidth : float
+        The stroke width, in pixels.
+    tension : float
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
+    text : string
+        Placeholder text if the ``text`` channel is not specified
+    theta : float
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
+    tooltip : anyOf(string, :class:`TooltipContent`)
+        The tooltip text string to show upon mouse hover or an object defining which fields
+        should the tooltip be derived from.
+
+
+        * If ``tooltip`` is ``{"content": "encoding"}``, then all fields from ``encoding``
+          will be used.
+        * If ``tooltip`` is ``{"content": "data"}``, then all fields that appear in the
+          highlighted data point will be used.
+    """
+    _schema = {'$ref': '#/definitions/BarConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                 color=Undefined, continuousBandSize=Undefined, cornerRadius=Undefined,
+                 cursor=Undefined, dir=Undefined, discreteBandSize=Undefined, dx=Undefined,
+                 dy=Undefined, ellipsis=Undefined, fill=Undefined, fillOpacity=Undefined,
+                 filled=Undefined, font=Undefined, fontSize=Undefined, fontStyle=Undefined,
+                 fontWeight=Undefined, href=Undefined, interpolate=Undefined, limit=Undefined,
+                 opacity=Undefined, orient=Undefined, radius=Undefined, shape=Undefined, size=Undefined,
+                 stroke=Undefined, strokeCap=Undefined, strokeDash=Undefined,
+                 strokeDashOffset=Undefined, strokeJoin=Undefined, strokeMiterLimit=Undefined,
+                 strokeOpacity=Undefined, strokeWidth=Undefined, tension=Undefined, text=Undefined,
+                 theta=Undefined, tooltip=Undefined, **kwds):
+        super(BarConfig, self).__init__(align=align, angle=angle, baseline=baseline,
+                                        binSpacing=binSpacing, color=color,
+                                        continuousBandSize=continuousBandSize,
+                                        cornerRadius=cornerRadius, cursor=cursor, dir=dir,
+                                        discreteBandSize=discreteBandSize, dx=dx, dy=dy,
+                                        ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity,
+                                        filled=filled, font=font, fontSize=fontSize,
+                                        fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                                        interpolate=interpolate, limit=limit, opacity=opacity,
+                                        orient=orient, radius=radius, shape=shape, size=size,
+                                        stroke=stroke, strokeCap=strokeCap, strokeDash=strokeDash,
+                                        strokeDashOffset=strokeDashOffset, strokeJoin=strokeJoin,
+                                        strokeMiterLimit=strokeMiterLimit, strokeOpacity=strokeOpacity,
+                                        strokeWidth=strokeWidth, tension=tension, text=text,
+                                        theta=theta, tooltip=tooltip, **kwds)
+
+
+class VgTitleConfig(VegaLiteSchema):
+    """VgTitleConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    align : :class:`Align`
+
+    anchor : :class:`TitleAnchor`
+        The anchor position for placing the title. One of ``"start"``, ``"middle"``, or
+        ``"end"``. For example, with an orientation of top these anchor positions map to a
+        left-, center-, or right-aligned title.
+    angle : float
+        Angle in degrees of title text.
+    baseline : :class:`TextBaseline`
+        Vertical text baseline for title text. One of ``"top"``, ``"middle"``, ``"bottom"``,
+        or ``"alphabetic"``.
+    color : :class:`Color`
+        Text color for title text.
+    font : string
+        Font name for title text.
+    fontSize : float
+        Font size in pixels for title text.
+
+        **Default value:** ``10``.
+    fontWeight : :class:`FontWeight`
+        Font weight for title text.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    frame : :class:`TitleFrame`
+        The reference frame for the anchor position, one of ``"bounds"`` (to anchor relative
+        to the full bounding box) or ``"group"`` (to anchor relative to the group width or
+        height).
+    limit : float
+        The maximum allowed length in pixels of legend labels.
+    offset : float
+        The orthogonal offset in pixels by which to displace the title from its position
+        along the edge of the chart.
+    orient : :class:`TitleOrient`
+        Default title orientation ( ``"top"``, ``"bottom"``, ``"left"``, or ``"right"`` )
+    """
+    _schema = {'$ref': '#/definitions/VgTitleConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, align=Undefined, anchor=Undefined, angle=Undefined, baseline=Undefined,
+                 color=Undefined, font=Undefined, fontSize=Undefined, fontWeight=Undefined,
+                 frame=Undefined, limit=Undefined, offset=Undefined, orient=Undefined, **kwds):
+        super(VgTitleConfig, self).__init__(align=align, anchor=anchor, angle=angle, baseline=baseline,
+                                            color=color, font=font, fontSize=fontSize,
+                                            fontWeight=fontWeight, frame=frame, limit=limit,
+                                            offset=offset, orient=orient, **kwds)
+
+
+class Baseline(VegaLiteSchema):
+    """Baseline schema wrapper
+
+    enum('top', 'middle', 'bottom')
+    """
+    _schema = {'$ref': '#/definitions/Baseline'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Baseline, self).__init__(*args)
+
+
+class BinParams(VegaLiteSchema):
+    """BinParams schema wrapper
+
+    Mapping(required=[])
+    Binning properties or boolean flag for determining whether to bin data or not.
+
+    Attributes
+    ----------
+
+    anchor : float
+        A value in the binned domain at which to anchor the bins, shifting the bin
+        boundaries if necessary to ensure that a boundary aligns with the anchor value.
+
+        **Default Value:** the minimum bin extent value
+    base : float
+        The number base to use for automatic bin determination (default is base 10).
+
+        **Default value:** ``10``
+    divide : List(float)
+        Scale factors indicating allowable subdivisions. The default value is [5, 2], which
+        indicates that for base 10 numbers (the default base), the method may consider
+        dividing bin sizes by 5 and/or 2. For example, for an initial step size of 10, the
+        method can check if bin sizes of 2 (= 10/5), 5 (= 10/2), or 1 (= 10/(5*2)) might
+        also satisfy the given constraints.
+
+        **Default value:** ``[5, 2]``
+    extent : List(float)
+        A two-element ( ``[min, max]`` ) array indicating the range of desired bin values.
+    maxbins : float
+        Maximum number of bins.
+
+        **Default value:** ``6`` for ``row``, ``column`` and ``shape`` channels; ``10`` for
+        other channels
+    minstep : float
+        A minimum allowable step size (particularly useful for integer values).
+    nice : boolean
+        If true (the default), attempts to make the bin boundaries use human-friendly
+        boundaries, such as multiples of ten.
+    step : float
+        An exact step size to use between bins.
+
+        **Note:** If provided, options such as maxbins will be ignored.
+    steps : List(float)
+        An array of allowable step sizes to choose from.
+    """
+    _schema = {'$ref': '#/definitions/BinParams'}
+    _rootschema = Root._schema
+
+    def __init__(self, anchor=Undefined, base=Undefined, divide=Undefined, extent=Undefined,
+                 maxbins=Undefined, minstep=Undefined, nice=Undefined, step=Undefined, steps=Undefined,
+                 **kwds):
+        super(BinParams, self).__init__(anchor=anchor, base=base, divide=divide, extent=extent,
+                                        maxbins=maxbins, minstep=minstep, nice=nice, step=step,
+                                        steps=steps, **kwds)
+
+
+class BinTransform(VegaLiteSchema):
+    """BinTransform schema wrapper
+
+    Mapping(required=[bin, field, as])
+
+    Attributes
+    ----------
+
+    bin : anyOf(boolean, :class:`BinParams`)
+        An object indicating bin properties, or simply ``true`` for using default bin
+        parameters.
+    field : string
+        The data field to bin.
+    as : anyOf(string, List(string))
+        The output fields at which to write the start and end bin values.
+    """
+    _schema = {'$ref': '#/definitions/BinTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, bin=Undefined, field=Undefined, **kwds):
+        super(BinTransform, self).__init__(bin=bin, field=field, **kwds)
+
+
+class BoxPlot(VegaLiteSchema):
+    """BoxPlot schema wrapper
+
+    enum('boxplot')
+    """
+    _schema = {'$ref': '#/definitions/BoxPlot'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(BoxPlot, self).__init__(*args)
+
+
+class BoxPlotConfig(VegaLiteSchema):
+    """BoxPlotConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    box : anyOf(boolean, :class:`MarkConfig`)
+
+    extent : anyOf(enum('min-max'), float)
+        The extent of the whiskers. Available options include:
+
+
+        * ``"min-max"`` : min and max are the lower and upper whiskers respectively.
+        * A number representing multiple of the interquartile range (Q3-Q1).  This number
+          will be multiplied by the IQR. the product will be added to the third quartile to
+          get the upper whisker and subtracted from the first quartile to get the lower
+          whisker.
+
+        **Default value:** ``1.5``.
+    median : anyOf(boolean, :class:`MarkConfig`)
+
+    outliers : anyOf(boolean, :class:`MarkConfig`)
+
+    rule : anyOf(boolean, :class:`MarkConfig`)
+
+    size : float
+        Size of the box and median tick of a box plot
+    ticks : anyOf(boolean, :class:`MarkConfig`)
+
+    """
+    _schema = {'$ref': '#/definitions/BoxPlotConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, box=Undefined, extent=Undefined, median=Undefined, outliers=Undefined,
+                 rule=Undefined, size=Undefined, ticks=Undefined, **kwds):
+        super(BoxPlotConfig, self).__init__(box=box, extent=extent, median=median, outliers=outliers,
+                                            rule=rule, size=size, ticks=ticks, **kwds)
+
+
+class BoxPlotDef(VegaLiteSchema):
+    """BoxPlotDef schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : :class:`BoxPlot`
+        The mark type. This could a primitive mark type
+        (one of ``"bar"``, ``"circle"``, ``"square"``, ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"geoshape"``, ``"rule"``, and ``"text"`` )
+        or a composite mark type ( ``"boxplot"``, ``"errorband"``, ``"errorbar"`` ).
+    box : anyOf(boolean, :class:`MarkConfig`)
+
+    clip : boolean
+        Whether a composite mark be clipped to the enclosing group’s width and height.
+    color : string
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.
+
+        **Default value:** :raw-html:`<span style="color: #4682b4;">&#9632;</span>`
+        ``"#4682b4"``
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    extent : anyOf(enum('min-max'), float)
+        The extent of the whiskers. Available options include:
+
+
+        * ``"min-max"`` : min and max are the lower and upper whiskers respectively.
+        * A number representing multiple of the interquartile range (Q3-Q1).  This number
+          will be multiplied by the IQR. the product will be added to the third quartile to
+          get the upper whisker and subtracted from the first quartile to get the lower
+          whisker.
+
+        **Default value:** ``1.5``.
+    median : anyOf(boolean, :class:`MarkConfig`)
+
+    opacity : float
+        The opacity (value between [0,1]) of the mark.
+    orient : :class:`Orient`
+        Orientation of the box plot.  This is normally automatically determined based on
+        types of fields on x and y channels. However, an explicit ``orient`` be specified
+        when the orientation is ambiguous.
+
+        **Default value:** ``"vertical"``.
+    outliers : anyOf(boolean, :class:`MarkConfig`)
+
+    rule : anyOf(boolean, :class:`MarkConfig`)
+
+    size : float
+        Size of the box and median tick of a box plot
+    ticks : anyOf(boolean, :class:`MarkConfig`)
+
+    """
+    _schema = {'$ref': '#/definitions/BoxPlotDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, box=Undefined, clip=Undefined, color=Undefined, extent=Undefined,
+                 median=Undefined, opacity=Undefined, orient=Undefined, outliers=Undefined,
+                 rule=Undefined, size=Undefined, ticks=Undefined, **kwds):
+        super(BoxPlotDef, self).__init__(type=type, box=box, clip=clip, color=color, extent=extent,
+                                         median=median, opacity=opacity, orient=orient,
+                                         outliers=outliers, rule=rule, size=size, ticks=ticks, **kwds)
+
+
+class BrushConfig(VegaLiteSchema):
+    """BrushConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    fill : string
+        The fill color of the interval mark.
+
+        **Default value:** ``#333333``
+    fillOpacity : float
+        The fill opacity of the interval mark (a value between 0 and 1).
+
+        **Default value:** ``0.125``
+    stroke : string
+        The stroke color of the interval mark.
+
+        **Default value:** ``#ffffff``
+    strokeDash : List(float)
+        An array of alternating stroke and space lengths,
+        for creating dashed or dotted lines.
+    strokeDashOffset : float
+        The offset (in pixels) with which to begin drawing the stroke dash array.
+    strokeOpacity : float
+        The stroke opacity of the interval mark (a value between 0 and 1).
+    strokeWidth : float
+        The stroke width of the interval mark.
+    """
+    _schema = {'$ref': '#/definitions/BrushConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, fill=Undefined, fillOpacity=Undefined, stroke=Undefined, strokeDash=Undefined,
+                 strokeDashOffset=Undefined, strokeOpacity=Undefined, strokeWidth=Undefined, **kwds):
+        super(BrushConfig, self).__init__(fill=fill, fillOpacity=fillOpacity, stroke=stroke,
+                                          strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                                          strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, **kwds)
+
+
+class CalculateTransform(VegaLiteSchema):
+    """CalculateTransform schema wrapper
+
+    Mapping(required=[calculate, as])
+
+    Attributes
+    ----------
+
+    calculate : string
+        A `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`__
+        string. Use the variable ``datum`` to refer to the current data object.
+    as : string
+        The field for storing the computed formula value.
+    """
+    _schema = {'$ref': '#/definitions/CalculateTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, calculate=Undefined, **kwds):
+        super(CalculateTransform, self).__init__(calculate=calculate, **kwds)
+
+
+class Color(VegaLiteSchema):
+    """Color schema wrapper
+
+    string
+    """
+    _schema = {'$ref': '#/definitions/Color'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Color, self).__init__(*args)
+
+
+class CompositeMark(VegaLiteSchema):
+    """CompositeMark schema wrapper
+
+    anyOf(:class:`BoxPlot`, :class:`ErrorBar`, :class:`ErrorBand`)
+    """
+    _schema = {'$ref': '#/definitions/CompositeMark'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(CompositeMark, self).__init__(*args, **kwds)
+
+
+class CompositeMarkDef(VegaLiteSchema):
+    """CompositeMarkDef schema wrapper
+
+    anyOf(:class:`BoxPlotDef`, :class:`ErrorBarDef`, :class:`ErrorBandDef`)
+    """
+    _schema = {'$ref': '#/definitions/CompositeMarkDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(CompositeMarkDef, self).__init__(*args, **kwds)
+
+
+class CompositeUnitSpec(VegaLiteSchema):
+    """CompositeUnitSpec schema wrapper
+
+    Mapping(required=[mark])
+
+    Attributes
+    ----------
+
+    mark : :class:`AnyMark`
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and ``"text"`` ) or a `mark
+        definition object <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`Encoding`
+        A key-value mapping between encoding channels and definition of fields.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    projection : :class:`Projection`
+        An object defining properties of geographic projection, which will be applied to
+        ``shape`` path for ``"geoshape"`` marks
+        and to ``latitude`` and ``"longitude"`` channels for other marks.
+    selection : Mapping(required=[])
+        A key-value mapping between selection names and definitions.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    """
+    _schema = {'$ref': '#/definitions/CompositeUnitSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, mark=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, projection=Undefined, selection=Undefined,
+                 title=Undefined, transform=Undefined, width=Undefined, **kwds):
+        super(CompositeUnitSpec, self).__init__(mark=mark, data=data, description=description,
+                                                encoding=encoding, height=height, name=name,
+                                                projection=projection, selection=selection, title=title,
+                                                transform=transform, width=width, **kwds)
+
+
+class ConditionalFieldDef(VegaLiteSchema):
+    """ConditionalFieldDef schema wrapper
+
+    anyOf(:class:`ConditionalPredicateFieldDef`, :class:`ConditionalSelectionFieldDef`)
+    """
+    _schema = {'$ref': '#/definitions/ConditionalFieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(ConditionalFieldDef, self).__init__(*args, **kwds)
+
+
+class ConditionalMarkPropFieldDef(VegaLiteSchema):
+    """ConditionalMarkPropFieldDef schema wrapper
+
+    anyOf(:class:`ConditionalPredicateMarkPropFieldDef`,
+    :class:`ConditionalSelectionMarkPropFieldDef`)
+    """
+    _schema = {'$ref': '#/definitions/ConditionalMarkPropFieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(ConditionalMarkPropFieldDef, self).__init__(*args, **kwds)
+
+
+class ConditionalTextFieldDef(VegaLiteSchema):
+    """ConditionalTextFieldDef schema wrapper
+
+    anyOf(:class:`ConditionalPredicateTextFieldDef`, :class:`ConditionalSelectionTextFieldDef`)
+    """
+    _schema = {'$ref': '#/definitions/ConditionalTextFieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(ConditionalTextFieldDef, self).__init__(*args, **kwds)
+
+
+class ConditionalValueDef(VegaLiteSchema):
+    """ConditionalValueDef schema wrapper
+
+    anyOf(:class:`ConditionalPredicateValueDef`, :class:`ConditionalSelectionValueDef`)
+    """
+    _schema = {'$ref': '#/definitions/ConditionalValueDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(ConditionalValueDef, self).__init__(*args, **kwds)
+
+
+class ConditionalPredicateFieldDef(VegaLiteSchema):
+    """ConditionalPredicateFieldDef schema wrapper
+
+    Mapping(required=[test, type])
+
+    Attributes
+    ----------
+
+    test : :class:`LogicalOperandPredicate`
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/ConditionalPredicate<FieldDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, test=Undefined, type=Undefined, aggregate=Undefined, bin=Undefined,
+                 field=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
+        super(ConditionalPredicateFieldDef, self).__init__(test=test, type=type, aggregate=aggregate,
+                                                           bin=bin, field=field, timeUnit=timeUnit,
+                                                           title=title, **kwds)
+
+
+class ConditionalPredicateMarkPropFieldDef(VegaLiteSchema):
+    """ConditionalPredicateMarkPropFieldDef schema wrapper
+
+    Mapping(required=[test, type])
+
+    Attributes
+    ----------
+
+    test : :class:`LogicalOperandPredicate`
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/ConditionalPredicate<MarkPropFieldDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, test=Undefined, type=Undefined, aggregate=Undefined, bin=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, **kwds):
+        super(ConditionalPredicateMarkPropFieldDef, self).__init__(test=test, type=type,
+                                                                   aggregate=aggregate, bin=bin,
+                                                                   field=field, legend=legend,
+                                                                   scale=scale, sort=sort,
+                                                                   timeUnit=timeUnit, title=title,
+                                                                   **kwds)
+
+
+class ConditionalPredicateTextFieldDef(VegaLiteSchema):
+    """ConditionalPredicateTextFieldDef schema wrapper
+
+    Mapping(required=[test, type])
+
+    Attributes
+    ----------
+
+    test : :class:`LogicalOperandPredicate`
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    format : string
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`__ for a
+        text field. If not defined, this will be determined automatically.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/ConditionalPredicate<TextFieldDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, test=Undefined, type=Undefined, aggregate=Undefined, bin=Undefined,
+                 field=Undefined, format=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
+        super(ConditionalPredicateTextFieldDef, self).__init__(test=test, type=type,
+                                                               aggregate=aggregate, bin=bin,
+                                                               field=field, format=format,
+                                                               timeUnit=timeUnit, title=title, **kwds)
+
+
+class ConditionalPredicateValueDef(VegaLiteSchema):
+    """ConditionalPredicateValueDef schema wrapper
+
+    Mapping(required=[test, value])
+
+    Attributes
+    ----------
+
+    test : :class:`LogicalOperandPredicate`
+
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _schema = {'$ref': '#/definitions/ConditionalPredicate<ValueDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, test=Undefined, value=Undefined, **kwds):
+        super(ConditionalPredicateValueDef, self).__init__(test=test, value=value, **kwds)
+
+
+class ConditionalSelectionFieldDef(VegaLiteSchema):
+    """ConditionalSelectionFieldDef schema wrapper
+
+    Mapping(required=[selection, type])
+
+    Attributes
+    ----------
+
+    selection : :class:`SelectionOperand`
+        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`__, or a
+        series of `composed selections
+        <https://vega.github.io/vega-lite/docs/selection.html#compose>`__.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/ConditionalSelection<FieldDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, selection=Undefined, type=Undefined, aggregate=Undefined, bin=Undefined,
+                 field=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
+        super(ConditionalSelectionFieldDef, self).__init__(selection=selection, type=type,
+                                                           aggregate=aggregate, bin=bin, field=field,
+                                                           timeUnit=timeUnit, title=title, **kwds)
+
+
+class ConditionalSelectionMarkPropFieldDef(VegaLiteSchema):
+    """ConditionalSelectionMarkPropFieldDef schema wrapper
+
+    Mapping(required=[selection, type])
+
+    Attributes
+    ----------
+
+    selection : :class:`SelectionOperand`
+        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`__, or a
+        series of `composed selections
+        <https://vega.github.io/vega-lite/docs/selection.html#compose>`__.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/ConditionalSelection<MarkPropFieldDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, selection=Undefined, type=Undefined, aggregate=Undefined, bin=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, **kwds):
+        super(ConditionalSelectionMarkPropFieldDef, self).__init__(selection=selection, type=type,
+                                                                   aggregate=aggregate, bin=bin,
+                                                                   field=field, legend=legend,
+                                                                   scale=scale, sort=sort,
+                                                                   timeUnit=timeUnit, title=title,
+                                                                   **kwds)
+
+
+class ConditionalSelectionTextFieldDef(VegaLiteSchema):
+    """ConditionalSelectionTextFieldDef schema wrapper
+
+    Mapping(required=[selection, type])
+
+    Attributes
+    ----------
+
+    selection : :class:`SelectionOperand`
+        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`__, or a
+        series of `composed selections
+        <https://vega.github.io/vega-lite/docs/selection.html#compose>`__.
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    format : string
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`__ for a
+        text field. If not defined, this will be determined automatically.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/ConditionalSelection<TextFieldDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, selection=Undefined, type=Undefined, aggregate=Undefined, bin=Undefined,
+                 field=Undefined, format=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
+        super(ConditionalSelectionTextFieldDef, self).__init__(selection=selection, type=type,
+                                                               aggregate=aggregate, bin=bin,
+                                                               field=field, format=format,
+                                                               timeUnit=timeUnit, title=title, **kwds)
+
+
+class ConditionalSelectionValueDef(VegaLiteSchema):
+    """ConditionalSelectionValueDef schema wrapper
+
+    Mapping(required=[selection, value])
+
+    Attributes
+    ----------
+
+    selection : :class:`SelectionOperand`
+        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`__, or a
+        series of `composed selections
+        <https://vega.github.io/vega-lite/docs/selection.html#compose>`__.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _schema = {'$ref': '#/definitions/ConditionalSelection<ValueDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, selection=Undefined, value=Undefined, **kwds):
+        super(ConditionalSelectionValueDef, self).__init__(selection=selection, value=value, **kwds)
+
+
+class Config(VegaLiteSchema):
+    """Config schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    area : :class:`AreaConfig`
+        Area-Specific Config
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    axis : :class:`AxisConfig`
+        Axis configuration, which determines default properties for all ``x`` and ``y``
+        `axes <https://vega.github.io/vega-lite/docs/axis.html>`__. For a full list of axis
+        configuration options, please see the `corresponding section of the axis
+        documentation <https://vega.github.io/vega-lite/docs/axis.html#config>`__.
+    axisBand : :class:`AxisConfig`
+        Specific axis config for axes with "band" scales.
+    axisBottom : :class:`AxisConfig`
+        Specific axis config for x-axis along the bottom edge of the chart.
+    axisLeft : :class:`AxisConfig`
+        Specific axis config for y-axis along the left edge of the chart.
+    axisRight : :class:`AxisConfig`
+        Specific axis config for y-axis along the right edge of the chart.
+    axisTop : :class:`AxisConfig`
+        Specific axis config for x-axis along the top edge of the chart.
+    axisX : :class:`AxisConfig`
+        X-axis specific config.
+    axisY : :class:`AxisConfig`
+        Y-axis specific config.
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    bar : :class:`BarConfig`
+        Bar-Specific Config
+    boxplot : :class:`BoxPlotConfig`
+        Box Config
+    circle : :class:`MarkConfig`
+        Circle-Specific Config
+    countTitle : string
+        Default axis and legend title for count fields.
+
+        **Default value:** ``'Number of Records'``.
+    errorband : :class:`ErrorBandConfig`
+        ErrorBand Config
+    errorbar : :class:`ErrorBarConfig`
+        ErrorBar Config
+    fieldTitle : enum('verbal', 'functional', 'plain')
+        Defines how Vega-Lite generates title for fields.  There are three possible styles:
+
+
+        * ``"verbal"`` (Default) - displays function in a verbal style (e.g., "Sum of
+          field", "Year-month of date", "field (binned)").
+        * ``"function"`` - displays function using parentheses and capitalized texts (e.g.,
+          "SUM(field)", "YEARMONTH(date)", "BIN(field)").
+        * ``"plain"`` - displays only the field name without functions (e.g., "field",
+          "date", "field").
+    geoshape : :class:`MarkConfig`
+        Geoshape-Specific Config
+    header : :class:`HeaderConfig`
+        Header configuration, which determines default properties for all `header
+        <https://vega.github.io/vega-lite/docs/header.html>`__. For a full list of header
+        configuration options, please see the `corresponding section of in the header
+        documentation <https://vega.github.io/vega-lite/docs/header.html#config>`__.
+    invalidValues : enum('filter', None)
+        Defines how Vega-Lite should handle invalid values ( ``null`` and ``NaN`` ).
+
+
+        * If set to ``"filter"`` (default), all data items with null values will be skipped
+          (for line, trail, and area marks) or filtered (for other marks).
+        * If ``null``, all data items are included. In this case, invalid values will be
+          interpreted as zeroes.
+    legend : :class:`LegendConfig`
+        Legend configuration, which determines default properties for all `legends
+        <https://vega.github.io/vega-lite/docs/legend.html>`__. For a full list of legend
+        configuration options, please see the `corresponding section of in the legend
+        documentation <https://vega.github.io/vega-lite/docs/legend.html#config>`__.
+    line : :class:`LineConfig`
+        Line-Specific Config
+    mark : :class:`MarkConfig`
+        Mark Config
+    numberFormat : string
+        D3 Number format for guide labels and text marks. For example "s" for SI units. Use
+        `D3's number format pattern <https://github.com/d3/d3-format#locale_format>`__.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    point : :class:`MarkConfig`
+        Point-Specific Config
+    projection : :class:`ProjectionConfig`
+        Projection configuration, which determines default properties for all `projections
+        <https://vega.github.io/vega-lite/docs/projection.html>`__. For a full list of
+        projection configuration options, please see the `corresponding section of the
+        projection documentation
+        <https://vega.github.io/vega-lite/docs/projection.html#config>`__.
+    range : :class:`RangeConfig`
+        An object hash that defines default range arrays or schemes for using with scales.
+        For a full list of scale range configuration options, please see the `corresponding
+        section of the scale documentation
+        <https://vega.github.io/vega-lite/docs/scale.html#config>`__.
+    rect : :class:`MarkConfig`
+        Rect-Specific Config
+    rule : :class:`MarkConfig`
+        Rule-Specific Config
+    scale : :class:`ScaleConfig`
+        Scale configuration determines default properties for all `scales
+        <https://vega.github.io/vega-lite/docs/scale.html>`__. For a full list of scale
+        configuration options, please see the `corresponding section of the scale
+        documentation <https://vega.github.io/vega-lite/docs/scale.html#config>`__.
+    selection : :class:`SelectionConfig`
+        An object hash for defining default properties for each type of selections.
+    square : :class:`MarkConfig`
+        Square-Specific Config
+    stack : :class:`StackOffset`
+        Default stack offset for stackable mark.
+    style : :class:`StyleConfigIndex`
+        An object hash that defines key-value mappings to determine default properties for
+        marks with a given `style
+        <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.  The keys represent
+        styles names; the values have to be valid `mark configuration objects
+        <https://vega.github.io/vega-lite/docs/mark.html#config>`__.
+    text : :class:`TextConfig`
+        Text-Specific Config
+    tick : :class:`TickConfig`
+        Tick-Specific Config
+    timeFormat : string
+        Default time format for raw time values (without time units) in text marks, legend
+        labels and header labels.
+
+        **Default value:** ``"%b %d, %Y"``
+        **Note:** Axes automatically determine format each label automatically so this
+        config would not affect axes.
+    title : :class:`TitleConfig`
+        Title configuration, which determines default properties for all `titles
+        <https://vega.github.io/vega-lite/docs/title.html>`__. For a full list of title
+        configuration options, please see the `corresponding section of the title
+        documentation <https://vega.github.io/vega-lite/docs/title.html#config>`__.
+    trail : :class:`LineConfig`
+        Trail-Specific Config
+    view : :class:`ViewConfig`
+        Default properties for `single view plots
+        <https://vega.github.io/vega-lite/docs/spec.html#single>`__.
+    """
+    _schema = {'$ref': '#/definitions/Config'}
+    _rootschema = Root._schema
+
+    def __init__(self, area=Undefined, autosize=Undefined, axis=Undefined, axisBand=Undefined,
+                 axisBottom=Undefined, axisLeft=Undefined, axisRight=Undefined, axisTop=Undefined,
+                 axisX=Undefined, axisY=Undefined, background=Undefined, bar=Undefined,
+                 boxplot=Undefined, circle=Undefined, countTitle=Undefined, errorband=Undefined,
+                 errorbar=Undefined, fieldTitle=Undefined, geoshape=Undefined, header=Undefined,
+                 invalidValues=Undefined, legend=Undefined, line=Undefined, mark=Undefined,
+                 numberFormat=Undefined, padding=Undefined, point=Undefined, projection=Undefined,
+                 range=Undefined, rect=Undefined, rule=Undefined, scale=Undefined, selection=Undefined,
+                 square=Undefined, stack=Undefined, style=Undefined, text=Undefined, tick=Undefined,
+                 timeFormat=Undefined, title=Undefined, trail=Undefined, view=Undefined, **kwds):
+        super(Config, self).__init__(area=area, autosize=autosize, axis=axis, axisBand=axisBand,
+                                     axisBottom=axisBottom, axisLeft=axisLeft, axisRight=axisRight,
+                                     axisTop=axisTop, axisX=axisX, axisY=axisY, background=background,
+                                     bar=bar, boxplot=boxplot, circle=circle, countTitle=countTitle,
+                                     errorband=errorband, errorbar=errorbar, fieldTitle=fieldTitle,
+                                     geoshape=geoshape, header=header, invalidValues=invalidValues,
+                                     legend=legend, line=line, mark=mark, numberFormat=numberFormat,
+                                     padding=padding, point=point, projection=projection, range=range,
+                                     rect=rect, rule=rule, scale=scale, selection=selection,
+                                     square=square, stack=stack, style=style, text=text, tick=tick,
+                                     timeFormat=timeFormat, title=title, trail=trail, view=view, **kwds)
+
+
+class CsvDataFormat(VegaLiteSchema):
+    """CsvDataFormat schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    parse : anyOf(:class:`Parse`, None)
+        If set to ``null``, disable type inference based on the spec and only use type
+        inference based on the data.
+        Alternatively, a parsing directive object can be provided for explicit data types.
+        Each property of the object corresponds to a field name, and the value to the
+        desired data type (one of ``"number"``, ``"boolean"``, ``"date"``, or null (do not
+        parse the field)).
+        For example, ``"parse": {"modified_on": "date"}`` parses the ``modified_on`` field
+        in each input record a Date value.
+
+        For ``"date"``, we parse data based using Javascript's `Date.parse()
+        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse>`__.
+        For Specific date formats can be provided (e.g., ``{foo: 'date:"%m%d%Y"'}`` ), using
+        the `d3-time-format syntax <https://github.com/d3/d3-time-format#locale_format>`__.
+        UTC date format parsing is supported similarly (e.g., ``{foo: 'utc:"%m%d%Y"'}`` ).
+        See more about `UTC time
+        <https://vega.github.io/vega-lite/docs/timeunit.html#utc>`__
+    type : enum('csv', 'tsv')
+        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``, ``"dsv"``.
+        The default format type is determined by the extension of the file URL.
+        If no extension is detected, ``"json"`` will be used by default.
+    """
+    _schema = {'$ref': '#/definitions/CsvDataFormat'}
+    _rootschema = Root._schema
+
+    def __init__(self, parse=Undefined, type=Undefined, **kwds):
+        super(CsvDataFormat, self).__init__(parse=parse, type=type, **kwds)
+
+
+class Cursor(VegaLiteSchema):
+    """Cursor schema wrapper
+
+    enum('auto', 'default', 'none', 'context-menu', 'help', 'pointer', 'progress', 'wait',
+    'cell', 'crosshair', 'text', 'vertical-text', 'alias', 'copy', 'move', 'no-drop',
+    'not-allowed', 'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize', 'se-resize',
+    'sw-resize', 'w-resize', 'ew-resize', 'ns-resize', 'nesw-resize', 'nwse-resize',
+    'col-resize', 'row-resize', 'all-scroll', 'zoom-in', 'zoom-out', 'grab', 'grabbing')
+    """
+    _schema = {'$ref': '#/definitions/Cursor'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Cursor, self).__init__(*args)
+
+
+class Data(VegaLiteSchema):
+    """Data schema wrapper
+
+    anyOf(:class:`UrlData`, :class:`InlineData`, :class:`NamedData`)
+    """
+    _schema = {'$ref': '#/definitions/Data'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(Data, self).__init__(*args, **kwds)
+
+
+class DataFormat(VegaLiteSchema):
+    """DataFormat schema wrapper
+
+    anyOf(:class:`CsvDataFormat`, :class:`DsvDataFormat`, :class:`JsonDataFormat`,
+    :class:`TopoDataFormat`)
+    """
+    _schema = {'$ref': '#/definitions/DataFormat'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(DataFormat, self).__init__(*args, **kwds)
+
+
+class Datasets(VegaLiteSchema):
+    """Datasets schema wrapper
+
+    Mapping(required=[])
+    """
+    _schema = {'$ref': '#/definitions/Datasets'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(Datasets, self).__init__(**kwds)
+
+
+class DateTime(VegaLiteSchema):
+    """DateTime schema wrapper
+
+    Mapping(required=[])
+    Object for defining datetime in Vega-Lite Filter.
+    If both month and quarter are provided, month has higher precedence.
+    ``day`` cannot be combined with other date.
+    We accept string for month and day names.
+
+    Attributes
+    ----------
+
+    date : float
+        Integer value representing the date from 1-31.
+    day : anyOf(:class:`Day`, string)
+        Value representing the day of a week.  This can be one of: (1) integer value --
+        ``1`` represents Monday; (2) case-insensitive day name (e.g., ``"Monday"`` );  (3)
+        case-insensitive, 3-character short day name (e.g., ``"Mon"`` ).   :raw-html:`<br/>`
+        **Warning:** A DateTime definition object with ``day`` ** should not be combined
+        with ``year``, ``quarter``, ``month``, or ``date``.
+    hours : float
+        Integer value representing the hour of a day from 0-23.
+    milliseconds : float
+        Integer value representing the millisecond segment of time.
+    minutes : float
+        Integer value representing the minute segment of time from 0-59.
+    month : anyOf(:class:`Month`, string)
+        One of: (1) integer value representing the month from ``1`` - ``12``. ``1``
+        represents January;  (2) case-insensitive month name (e.g., ``"January"`` );  (3)
+        case-insensitive, 3-character short month name (e.g., ``"Jan"`` ).
+    quarter : float
+        Integer value representing the quarter of the year (from 1-4).
+    seconds : float
+        Integer value representing the second segment (0-59) of a time value
+    utc : boolean
+        A boolean flag indicating if date time is in utc time. If false, the date time is in
+        local time
+    year : float
+        Integer value representing the year.
+    """
+    _schema = {'$ref': '#/definitions/DateTime'}
+    _rootschema = Root._schema
+
+    def __init__(self, date=Undefined, day=Undefined, hours=Undefined, milliseconds=Undefined,
+                 minutes=Undefined, month=Undefined, quarter=Undefined, seconds=Undefined,
+                 utc=Undefined, year=Undefined, **kwds):
+        super(DateTime, self).__init__(date=date, day=day, hours=hours, milliseconds=milliseconds,
+                                       minutes=minutes, month=month, quarter=quarter, seconds=seconds,
+                                       utc=utc, year=year, **kwds)
+
+
+class Day(VegaLiteSchema):
+    """Day schema wrapper
+
+    float
+    """
+    _schema = {'$ref': '#/definitions/Day'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Day, self).__init__(*args)
+
+
+class DictInlineDataset(VegaLiteSchema):
+    """DictInlineDataset schema wrapper
+
+    Mapping(required=[])
+    """
+    _schema = {'$ref': '#/definitions/Dict<InlineDataset>'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(DictInlineDataset, self).__init__(**kwds)
+
+
+class Dir(VegaLiteSchema):
+    """Dir schema wrapper
+
+    enum('ltr', 'rtl')
+    """
+    _schema = {'$ref': '#/definitions/Dir'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Dir, self).__init__(*args)
+
+
+class DsvDataFormat(VegaLiteSchema):
+    """DsvDataFormat schema wrapper
+
+    Mapping(required=[delimiter])
+
+    Attributes
+    ----------
+
+    delimiter : string
+        The delimiter between records. The delimiter must be a single character (i.e., a
+        single 16-bit code unit); so, ASCII delimiters are fine, but emoji delimiters are
+        not.
+    parse : anyOf(:class:`Parse`, None)
+        If set to ``null``, disable type inference based on the spec and only use type
+        inference based on the data.
+        Alternatively, a parsing directive object can be provided for explicit data types.
+        Each property of the object corresponds to a field name, and the value to the
+        desired data type (one of ``"number"``, ``"boolean"``, ``"date"``, or null (do not
+        parse the field)).
+        For example, ``"parse": {"modified_on": "date"}`` parses the ``modified_on`` field
+        in each input record a Date value.
+
+        For ``"date"``, we parse data based using Javascript's `Date.parse()
+        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse>`__.
+        For Specific date formats can be provided (e.g., ``{foo: 'date:"%m%d%Y"'}`` ), using
+        the `d3-time-format syntax <https://github.com/d3/d3-time-format#locale_format>`__.
+        UTC date format parsing is supported similarly (e.g., ``{foo: 'utc:"%m%d%Y"'}`` ).
+        See more about `UTC time
+        <https://vega.github.io/vega-lite/docs/timeunit.html#utc>`__
+    type : enum('dsv')
+        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``, ``"dsv"``.
+        The default format type is determined by the extension of the file URL.
+        If no extension is detected, ``"json"`` will be used by default.
+    """
+    _schema = {'$ref': '#/definitions/DsvDataFormat'}
+    _rootschema = Root._schema
+
+    def __init__(self, delimiter=Undefined, parse=Undefined, type=Undefined, **kwds):
+        super(DsvDataFormat, self).__init__(delimiter=delimiter, parse=parse, type=type, **kwds)
+
+
+class Encoding(VegaLiteSchema):
+    """Encoding schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    color : anyOf(:class:`MarkPropFieldDefWithCondition`,
+    :class:`MarkPropValueDefWithCondition`)
+        Color of the marks – either fill or stroke color based on  the ``filled`` property
+        of mark definition.
+        By default, ``color`` represents fill color for ``"area"``, ``"bar"``, ``"tick"``,
+        ``"text"``, ``"trail"``, ``"circle"``, and ``"square"`` / stroke color for
+        ``"line"`` and ``"point"``.
+
+        **Default value:** If undefined, the default color depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
+
+        *Note:*
+        1) For fine-grained control over both fill and stroke colors of the marks, please
+        use the ``fill`` and ``stroke`` channels.  If either ``fill`` or ``stroke`` channel
+        is specified, ``color`` channel will be ignored.
+        2) See the scale documentation for more information about customizing `color scheme
+        <https://vega.github.io/vega-lite/docs/scale.html#scheme>`__.
+    detail : anyOf(:class:`FieldDef`, List(:class:`FieldDef`))
+        Additional levels of detail for grouping data in aggregate views and
+        in line, trail, and area marks without mapping data to a specific visual channel.
+    fill : anyOf(:class:`MarkPropFieldDefWithCondition`, :class:`MarkPropValueDefWithCondition`)
+        Fill color of the marks.
+        **Default value:** If undefined, the default color depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
+
+        *Note:* When using ``fill`` channel, ``color`` channel will be ignored. To customize
+        both fill and stroke, please use ``fill`` and ``stroke`` channels (not ``fill`` and
+        ``color`` ).
+    href : anyOf(:class:`FieldDefWithCondition`, :class:`ValueDefWithCondition`)
+        A URL to load upon mouse click.
+    key : :class:`FieldDef`
+        A data field to use as a unique key for data binding. When a visualization’s data is
+        updated, the key value will be used to match data elements to existing mark
+        instances. Use a key channel to enable object constancy for transitions over dynamic
+        data.
+    latitude : :class:`FieldDef`
+        Latitude position of geographically projected marks.
+    latitude2 : :class:`FieldDef`
+        Latitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
+        ``"rect"``, and  ``"rule"``.
+    longitude : :class:`FieldDef`
+        Longitude position of geographically projected marks.
+    longitude2 : :class:`FieldDef`
+        Longitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
+        ``"rect"``, and  ``"rule"``.
+    opacity : anyOf(:class:`MarkPropFieldDefWithCondition`,
+    :class:`MarkPropValueDefWithCondition`)
+        Opacity of the marks – either can be a value or a range.
+
+        **Default value:** If undefined, the default opacity depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``opacity`` property.
+    order : anyOf(:class:`OrderFieldDef`, List(:class:`OrderFieldDef`), :class:`ValueDef`)
+        Order of the marks.
+
+
+        * For stacked marks, this ``order`` channel encodes `stack order
+          <https://vega.github.io/vega-lite/docs/stack.html#order>`__.
+        * For line and trail marks, this ``order`` channel encodes order of data points in
+          the lines. This can be useful for creating `a connected scatterplot
+          <https://vega.github.io/vega-lite/examples/connected_scatterplot.html>`__.
+          Setting ``order`` to ``{"value": null}`` makes the line marks use the original
+          order in the data sources.
+        * Otherwise, this ``order`` channel encodes layer order of the marks.
+
+        **Note** : In aggregate plots, ``order`` field should be ``aggregate`` d to avoid
+        creating additional aggregation grouping.
+    shape : anyOf(:class:`MarkPropFieldDefWithCondition`,
+    :class:`MarkPropValueDefWithCondition`)
+        For ``point`` marks the supported values are
+        ``"circle"`` (default), ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``,
+        or ``"triangle-down"``, or else a custom SVG path string.
+        For ``geoshape`` marks it should be a field definition of the geojson data
+
+        **Default value:** If undefined, the default shape depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#point-config>`__ 's ``shape``
+        property.
+    size : anyOf(:class:`MarkPropFieldDefWithCondition`, :class:`MarkPropValueDefWithCondition`)
+        Size of the mark.
+
+
+        * For ``"point"``, ``"square"`` and ``"circle"``, – the symbol size, or pixel area
+          of the mark.
+        * For ``"bar"`` and ``"tick"`` – the bar and tick's size.
+        * For ``"text"`` – the text's font size.
+        * Size is unsupported for ``"line"``, ``"area"``, and ``"rect"``. (Use ``"trail"``
+          instead of line with varying size)
+    stroke : anyOf(:class:`MarkPropFieldDefWithCondition`,
+    :class:`MarkPropValueDefWithCondition`)
+        Stroke color of the marks.
+        **Default value:** If undefined, the default color depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
+
+        *Note:* When using ``stroke`` channel, ``color`` channel will be ignored. To
+        customize both stroke and fill, please use ``stroke`` and ``fill`` channels (not
+        ``stroke`` and ``color`` ).
+    text : anyOf(:class:`TextFieldDefWithCondition`, :class:`TextValueDefWithCondition`)
+        Text of the ``text`` mark.
+    tooltip : anyOf(:class:`TextFieldDefWithCondition`, :class:`TextValueDefWithCondition`,
+    List(:class:`TextFieldDef`))
+        The tooltip text to show upon mouse hover.
+    x : anyOf(:class:`PositionFieldDef`, :class:`ValueDef`)
+        X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"``.
+    x2 : anyOf(:class:`FieldDef`, :class:`ValueDef`)
+        X2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
+    y : anyOf(:class:`PositionFieldDef`, :class:`ValueDef`)
+        Y coordinates of the marks, or height of vertical ``"bar"`` and ``"area"``.
+    y2 : anyOf(:class:`FieldDef`, :class:`ValueDef`)
+        Y2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
+    """
+    _schema = {'$ref': '#/definitions/Encoding'}
+    _rootschema = Root._schema
+
+    def __init__(self, color=Undefined, detail=Undefined, fill=Undefined, href=Undefined, key=Undefined,
+                 latitude=Undefined, latitude2=Undefined, longitude=Undefined, longitude2=Undefined,
+                 opacity=Undefined, order=Undefined, shape=Undefined, size=Undefined, stroke=Undefined,
+                 text=Undefined, tooltip=Undefined, x=Undefined, x2=Undefined, y=Undefined,
+                 y2=Undefined, **kwds):
+        super(Encoding, self).__init__(color=color, detail=detail, fill=fill, href=href, key=key,
+                                       latitude=latitude, latitude2=latitude2, longitude=longitude,
+                                       longitude2=longitude2, opacity=opacity, order=order, shape=shape,
+                                       size=size, stroke=stroke, text=text, tooltip=tooltip, x=x, x2=x2,
+                                       y=y, y2=y2, **kwds)
+
+
+class EncodingSortField(VegaLiteSchema):
+    """EncodingSortField schema wrapper
+
+    Mapping(required=[op])
+    A sort definition for sorting a discrete scale in an encoding field definition.
+
+    Attributes
+    ----------
+
+    op : :class:`AggregateOp`
+        An `aggregate operation
+        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__ to perform on the
+        field prior to sorting (e.g., ``"count"``, ``"mean"`` and ``"median"`` ).
+        This property is required in cases where the sort field and the data reference field
+        do not match.
+        The input data objects will be aggregated, grouped by the encoded data field.
+
+        For a full list of operations, please see the documentation for `aggregate
+        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__.
+    field : anyOf(string, :class:`RepeatRef`)
+        The data `field <https://vega.github.io/vega-lite/docs/field.html>`__ to sort by.
+
+        **Default value:** If unspecified, defaults to the field specified in the outer data
+        reference.
+    order : :class:`SortOrder`
+        The sort order. One of ``"ascending"`` (default), ``"descending"``, or ``null`` (no
+        not sort).
+    """
+    _schema = {'$ref': '#/definitions/EncodingSortField'}
+    _rootschema = Root._schema
+
+    def __init__(self, op=Undefined, field=Undefined, order=Undefined, **kwds):
+        super(EncodingSortField, self).__init__(op=op, field=field, order=order, **kwds)
+
+
+class EncodingWithFacet(VegaLiteSchema):
+    """EncodingWithFacet schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    color : anyOf(:class:`MarkPropFieldDefWithCondition`,
+    :class:`MarkPropValueDefWithCondition`)
+        Color of the marks – either fill or stroke color based on  the ``filled`` property
+        of mark definition.
+        By default, ``color`` represents fill color for ``"area"``, ``"bar"``, ``"tick"``,
+        ``"text"``, ``"trail"``, ``"circle"``, and ``"square"`` / stroke color for
+        ``"line"`` and ``"point"``.
+
+        **Default value:** If undefined, the default color depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
+
+        *Note:*
+        1) For fine-grained control over both fill and stroke colors of the marks, please
+        use the ``fill`` and ``stroke`` channels.  If either ``fill`` or ``stroke`` channel
+        is specified, ``color`` channel will be ignored.
+        2) See the scale documentation for more information about customizing `color scheme
+        <https://vega.github.io/vega-lite/docs/scale.html#scheme>`__.
+    column : :class:`FacetFieldDef`
+        Horizontal facets for trellis plots.
+    detail : anyOf(:class:`FieldDef`, List(:class:`FieldDef`))
+        Additional levels of detail for grouping data in aggregate views and
+        in line, trail, and area marks without mapping data to a specific visual channel.
+    fill : anyOf(:class:`MarkPropFieldDefWithCondition`, :class:`MarkPropValueDefWithCondition`)
+        Fill color of the marks.
+        **Default value:** If undefined, the default color depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
+
+        *Note:* When using ``fill`` channel, ``color`` channel will be ignored. To customize
+        both fill and stroke, please use ``fill`` and ``stroke`` channels (not ``fill`` and
+        ``color`` ).
+    href : anyOf(:class:`FieldDefWithCondition`, :class:`ValueDefWithCondition`)
+        A URL to load upon mouse click.
+    key : :class:`FieldDef`
+        A data field to use as a unique key for data binding. When a visualization’s data is
+        updated, the key value will be used to match data elements to existing mark
+        instances. Use a key channel to enable object constancy for transitions over dynamic
+        data.
+    latitude : :class:`FieldDef`
+        Latitude position of geographically projected marks.
+    latitude2 : :class:`FieldDef`
+        Latitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
+        ``"rect"``, and  ``"rule"``.
+    longitude : :class:`FieldDef`
+        Longitude position of geographically projected marks.
+    longitude2 : :class:`FieldDef`
+        Longitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
+        ``"rect"``, and  ``"rule"``.
+    opacity : anyOf(:class:`MarkPropFieldDefWithCondition`,
+    :class:`MarkPropValueDefWithCondition`)
+        Opacity of the marks – either can be a value or a range.
+
+        **Default value:** If undefined, the default opacity depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``opacity`` property.
+    order : anyOf(:class:`OrderFieldDef`, List(:class:`OrderFieldDef`), :class:`ValueDef`)
+        Order of the marks.
+
+
+        * For stacked marks, this ``order`` channel encodes `stack order
+          <https://vega.github.io/vega-lite/docs/stack.html#order>`__.
+        * For line and trail marks, this ``order`` channel encodes order of data points in
+          the lines. This can be useful for creating `a connected scatterplot
+          <https://vega.github.io/vega-lite/examples/connected_scatterplot.html>`__.
+          Setting ``order`` to ``{"value": null}`` makes the line marks use the original
+          order in the data sources.
+        * Otherwise, this ``order`` channel encodes layer order of the marks.
+
+        **Note** : In aggregate plots, ``order`` field should be ``aggregate`` d to avoid
+        creating additional aggregation grouping.
+    row : :class:`FacetFieldDef`
+        Vertical facets for trellis plots.
+    shape : anyOf(:class:`MarkPropFieldDefWithCondition`,
+    :class:`MarkPropValueDefWithCondition`)
+        For ``point`` marks the supported values are
+        ``"circle"`` (default), ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``,
+        or ``"triangle-down"``, or else a custom SVG path string.
+        For ``geoshape`` marks it should be a field definition of the geojson data
+
+        **Default value:** If undefined, the default shape depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#point-config>`__ 's ``shape``
+        property.
+    size : anyOf(:class:`MarkPropFieldDefWithCondition`, :class:`MarkPropValueDefWithCondition`)
+        Size of the mark.
+
+
+        * For ``"point"``, ``"square"`` and ``"circle"``, – the symbol size, or pixel area
+          of the mark.
+        * For ``"bar"`` and ``"tick"`` – the bar and tick's size.
+        * For ``"text"`` – the text's font size.
+        * Size is unsupported for ``"line"``, ``"area"``, and ``"rect"``. (Use ``"trail"``
+          instead of line with varying size)
+    stroke : anyOf(:class:`MarkPropFieldDefWithCondition`,
+    :class:`MarkPropValueDefWithCondition`)
+        Stroke color of the marks.
+        **Default value:** If undefined, the default color depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
+
+        *Note:* When using ``stroke`` channel, ``color`` channel will be ignored. To
+        customize both stroke and fill, please use ``stroke`` and ``fill`` channels (not
+        ``stroke`` and ``color`` ).
+    text : anyOf(:class:`TextFieldDefWithCondition`, :class:`TextValueDefWithCondition`)
+        Text of the ``text`` mark.
+    tooltip : anyOf(:class:`TextFieldDefWithCondition`, :class:`TextValueDefWithCondition`,
+    List(:class:`TextFieldDef`))
+        The tooltip text to show upon mouse hover.
+    x : anyOf(:class:`PositionFieldDef`, :class:`ValueDef`)
+        X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"``.
+    x2 : anyOf(:class:`FieldDef`, :class:`ValueDef`)
+        X2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
+    y : anyOf(:class:`PositionFieldDef`, :class:`ValueDef`)
+        Y coordinates of the marks, or height of vertical ``"bar"`` and ``"area"``.
+    y2 : anyOf(:class:`FieldDef`, :class:`ValueDef`)
+        Y2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
+    """
+    _schema = {'$ref': '#/definitions/EncodingWithFacet'}
+    _rootschema = Root._schema
+
+    def __init__(self, color=Undefined, column=Undefined, detail=Undefined, fill=Undefined,
+                 href=Undefined, key=Undefined, latitude=Undefined, latitude2=Undefined,
+                 longitude=Undefined, longitude2=Undefined, opacity=Undefined, order=Undefined,
+                 row=Undefined, shape=Undefined, size=Undefined, stroke=Undefined, text=Undefined,
+                 tooltip=Undefined, x=Undefined, x2=Undefined, y=Undefined, y2=Undefined, **kwds):
+        super(EncodingWithFacet, self).__init__(color=color, column=column, detail=detail, fill=fill,
+                                                href=href, key=key, latitude=latitude,
+                                                latitude2=latitude2, longitude=longitude,
+                                                longitude2=longitude2, opacity=opacity, order=order,
+                                                row=row, shape=shape, size=size, stroke=stroke,
+                                                text=text, tooltip=tooltip, x=x, x2=x2, y=y, y2=y2,
+                                                **kwds)
+
+
+class ErrorBand(VegaLiteSchema):
+    """ErrorBand schema wrapper
+
+    enum('errorband')
+    """
+    _schema = {'$ref': '#/definitions/ErrorBand'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(ErrorBand, self).__init__(*args)
+
+
+class ErrorBandConfig(VegaLiteSchema):
+    """ErrorBandConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    band : anyOf(boolean, :class:`MarkConfig`)
+
+    borders : anyOf(boolean, :class:`MarkConfig`)
+
+    extent : :class:`ErrorBarExtent`
+        The extent of the band. Available options include:
+
+
+        * ``"ci"`` : Extend the band to the confidence interval of the mean.
+        * ``"stderr"`` : The size of band are set to the value of standard error, extending
+          from the mean.
+        * ``"stdev"`` : The size of band are set to the value of standard deviation,
+          extending from the mean.
+        * ``"iqr"`` : Extend the band to the q1 and q3.
+
+        **Default value:** ``"stderr"``.
+    interpolate : :class:`Interpolate`
+        The line interpolation method for the error band. One of the following:
+
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
+    tension : float
+        The tension parameter for the interpolation type of the error band.
+    """
+    _schema = {'$ref': '#/definitions/ErrorBandConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, band=Undefined, borders=Undefined, extent=Undefined, interpolate=Undefined,
+                 tension=Undefined, **kwds):
+        super(ErrorBandConfig, self).__init__(band=band, borders=borders, extent=extent,
+                                              interpolate=interpolate, tension=tension, **kwds)
+
+
+class ErrorBandDef(VegaLiteSchema):
+    """ErrorBandDef schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : :class:`ErrorBand`
+        The mark type. This could a primitive mark type
+        (one of ``"bar"``, ``"circle"``, ``"square"``, ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"geoshape"``, ``"rule"``, and ``"text"`` )
+        or a composite mark type ( ``"boxplot"``, ``"errorband"``, ``"errorbar"`` ).
+    band : anyOf(boolean, :class:`MarkConfig`)
+
+    borders : anyOf(boolean, :class:`MarkConfig`)
+
+    clip : boolean
+        Whether a composite mark be clipped to the enclosing group’s width and height.
+    color : string
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.
+
+        **Default value:** :raw-html:`<span style="color: #4682b4;">&#9632;</span>`
+        ``"#4682b4"``
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    extent : :class:`ErrorBarExtent`
+        The extent of the band. Available options include:
+
+
+        * ``"ci"`` : Extend the band to the confidence interval of the mean.
+        * ``"stderr"`` : The size of band are set to the value of standard error, extending
+          from the mean.
+        * ``"stdev"`` : The size of band are set to the value of standard deviation,
+          extending from the mean.
+        * ``"iqr"`` : Extend the band to the q1 and q3.
+
+        **Default value:** ``"stderr"``.
+    interpolate : :class:`Interpolate`
+        The line interpolation method for the error band. One of the following:
+
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
+    opacity : float
+        The opacity (value between [0,1]) of the mark.
+    orient : :class:`Orient`
+        Orientation of the error band. This is normally automatically determined, but can be
+        specified when the orientation is ambiguous and cannot be automatically determined.
+    tension : float
+        The tension parameter for the interpolation type of the error band.
+    """
+    _schema = {'$ref': '#/definitions/ErrorBandDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, band=Undefined, borders=Undefined, clip=Undefined,
+                 color=Undefined, extent=Undefined, interpolate=Undefined, opacity=Undefined,
+                 orient=Undefined, tension=Undefined, **kwds):
+        super(ErrorBandDef, self).__init__(type=type, band=band, borders=borders, clip=clip,
+                                           color=color, extent=extent, interpolate=interpolate,
+                                           opacity=opacity, orient=orient, tension=tension, **kwds)
+
+
+class ErrorBar(VegaLiteSchema):
+    """ErrorBar schema wrapper
+
+    enum('errorbar')
+    """
+    _schema = {'$ref': '#/definitions/ErrorBar'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(ErrorBar, self).__init__(*args)
+
+
+class ErrorBarConfig(VegaLiteSchema):
+    """ErrorBarConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    extent : :class:`ErrorBarExtent`
+        The extent of the rule. Available options include:
+
+
+        * ``"ci"`` : Extend the rule to the confidence interval of the mean.
+        * ``"stderr"`` : The size of rule are set to the value of standard error, extending
+          from the mean.
+        * ``"stdev"`` : The size of rule are set to the value of standard deviation,
+          extending from the mean.
+        * ``"iqr"`` : Extend the rule to the q1 and q3.
+
+        **Default value:** ``"stderr"``.
+    rule : anyOf(boolean, :class:`MarkConfig`)
+
+    ticks : anyOf(boolean, :class:`MarkConfig`)
+
+    """
+    _schema = {'$ref': '#/definitions/ErrorBarConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, extent=Undefined, rule=Undefined, ticks=Undefined, **kwds):
+        super(ErrorBarConfig, self).__init__(extent=extent, rule=rule, ticks=ticks, **kwds)
+
+
+class ErrorBarDef(VegaLiteSchema):
+    """ErrorBarDef schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : :class:`ErrorBar`
+        The mark type. This could a primitive mark type
+        (one of ``"bar"``, ``"circle"``, ``"square"``, ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"geoshape"``, ``"rule"``, and ``"text"`` )
+        or a composite mark type ( ``"boxplot"``, ``"errorband"``, ``"errorbar"`` ).
+    clip : boolean
+        Whether a composite mark be clipped to the enclosing group’s width and height.
+    color : string
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.
+
+        **Default value:** :raw-html:`<span style="color: #4682b4;">&#9632;</span>`
+        ``"#4682b4"``
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    extent : :class:`ErrorBarExtent`
+        The extent of the rule. Available options include:
+
+
+        * ``"ci"`` : Extend the rule to the confidence interval of the mean.
+        * ``"stderr"`` : The size of rule are set to the value of standard error, extending
+          from the mean.
+        * ``"stdev"`` : The size of rule are set to the value of standard deviation,
+          extending from the mean.
+        * ``"iqr"`` : Extend the rule to the q1 and q3.
+
+        **Default value:** ``"stderr"``.
+    opacity : float
+        The opacity (value between [0,1]) of the mark.
+    orient : :class:`Orient`
+        Orientation of the error bar.  This is normally automatically determined, but can be
+        specified when the orientation is ambiguous and cannot be automatically determined.
+    rule : anyOf(boolean, :class:`MarkConfig`)
+
+    ticks : anyOf(boolean, :class:`MarkConfig`)
+
+    """
+    _schema = {'$ref': '#/definitions/ErrorBarDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, clip=Undefined, color=Undefined, extent=Undefined,
+                 opacity=Undefined, orient=Undefined, rule=Undefined, ticks=Undefined, **kwds):
+        super(ErrorBarDef, self).__init__(type=type, clip=clip, color=color, extent=extent,
+                                          opacity=opacity, orient=orient, rule=rule, ticks=ticks, **kwds)
+
+
+class ErrorBarExtent(VegaLiteSchema):
+    """ErrorBarExtent schema wrapper
+
+    enum('ci', 'iqr', 'stderr', 'stdev')
+    """
+    _schema = {'$ref': '#/definitions/ErrorBarExtent'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(ErrorBarExtent, self).__init__(*args)
+
+
+class LayerSpec(VegaLiteSchema):
+    """LayerSpec schema wrapper
+
+    Mapping(required=[layer])
+    Layer Spec with encoding and projection
+
+    Attributes
+    ----------
+
+    layer : List(anyOf(:class:`LayerSpec`, :class:`CompositeUnitSpec`))
+        Layer or single view specifications to be layered.
+
+        **Note** : Specifications inside ``layer`` cannot use ``row`` and ``column``
+        channels as layering facet specifications is not allowed. Instead, use the `facet
+        operator <https://vega.github.io/vega-lite/docs/facet.html>`__ and place a layer
+        inside a facet.
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`Encoding`
+        A shared key-value mapping between encoding channels and definition of fields in the
+        underlying layers.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    projection : :class:`Projection`
+        An object defining properties of the geographic projection shared by underlying
+        layers.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for layers.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    """
+    _schema = {'$ref': '#/definitions/LayerSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, layer=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, projection=Undefined, resolve=Undefined,
+                 title=Undefined, transform=Undefined, width=Undefined, **kwds):
+        super(LayerSpec, self).__init__(layer=layer, data=data, description=description,
+                                        encoding=encoding, height=height, name=name,
+                                        projection=projection, resolve=resolve, title=title,
+                                        transform=transform, width=width, **kwds)
+
+
+class FacetFieldDef(VegaLiteSchema):
+    """FacetFieldDef schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    header : :class:`Header`
+        An object defining properties of a facet's header.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/FacetFieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 header=Undefined, sort=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
+        super(FacetFieldDef, self).__init__(type=type, aggregate=aggregate, bin=bin, field=field,
+                                            header=header, sort=sort, timeUnit=timeUnit, title=title,
+                                            **kwds)
+
+
+class FacetMapping(VegaLiteSchema):
+    """FacetMapping schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    column : :class:`FacetFieldDef`
+        Horizontal facets for trellis plots.
+    row : :class:`FacetFieldDef`
+        Vertical facets for trellis plots.
+    """
+    _schema = {'$ref': '#/definitions/FacetMapping'}
+    _rootschema = Root._schema
+
+    def __init__(self, column=Undefined, row=Undefined, **kwds):
+        super(FacetMapping, self).__init__(column=column, row=row, **kwds)
+
+
+class FacetedUnitSpec(VegaLiteSchema):
+    """FacetedUnitSpec schema wrapper
+
+    Mapping(required=[mark])
+
+    Attributes
+    ----------
+
+    mark : :class:`AnyMark`
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and ``"text"`` ) or a `mark
+        definition object <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`EncodingWithFacet`
+        A key-value mapping between encoding channels and definition of fields.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    projection : :class:`Projection`
+        An object defining properties of geographic projection, which will be applied to
+        ``shape`` path for ``"geoshape"`` marks
+        and to ``latitude`` and ``"longitude"`` channels for other marks.
+    selection : Mapping(required=[])
+        A key-value mapping between selection names and definitions.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    """
+    _schema = {'$ref': '#/definitions/FacetedUnitSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, mark=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, projection=Undefined, selection=Undefined,
+                 title=Undefined, transform=Undefined, width=Undefined, **kwds):
+        super(FacetedUnitSpec, self).__init__(mark=mark, data=data, description=description,
+                                              encoding=encoding, height=height, name=name,
+                                              projection=projection, selection=selection, title=title,
+                                              transform=transform, width=width, **kwds)
+
+
+class FieldDefWithCondition(VegaLiteSchema):
+    """FieldDefWithCondition schema wrapper
+
+    Mapping(required=[type])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/FieldDefWithCondition'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
+        super(FieldDefWithCondition, self).__init__(type=type, aggregate=aggregate, bin=bin,
+                                                    condition=condition, field=field, timeUnit=timeUnit,
+                                                    title=title, **kwds)
+
+
+class MarkPropFieldDefWithCondition(VegaLiteSchema):
+    """MarkPropFieldDefWithCondition schema wrapper
+
+    Mapping(required=[type])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/MarkPropFieldDefWithCondition'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, **kwds):
+        super(MarkPropFieldDefWithCondition, self).__init__(type=type, aggregate=aggregate, bin=bin,
+                                                            condition=condition, field=field,
+                                                            legend=legend, scale=scale, sort=sort,
+                                                            timeUnit=timeUnit, title=title, **kwds)
+
+
+class TextFieldDefWithCondition(VegaLiteSchema):
+    """TextFieldDefWithCondition schema wrapper
+
+    Mapping(required=[type])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    format : string
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`__ for a
+        text field. If not defined, this will be determined automatically.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/TextFieldDefWithCondition'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, format=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
+        super(TextFieldDefWithCondition, self).__init__(type=type, aggregate=aggregate, bin=bin,
+                                                        condition=condition, field=field, format=format,
+                                                        timeUnit=timeUnit, title=title, **kwds)
+
+
+class FieldDef(VegaLiteSchema):
+    """FieldDef schema wrapper
+
+    Mapping(required=[type])
+    Field Def without scale (and without bin: "binned" support).
+
+    Attributes
+    ----------
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/FieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 timeUnit=Undefined, title=Undefined, **kwds):
+        super(FieldDef, self).__init__(type=type, aggregate=aggregate, bin=bin, field=field,
+                                       timeUnit=timeUnit, title=title, **kwds)
+
+
+class FieldEqualPredicate(VegaLiteSchema):
+    """FieldEqualPredicate schema wrapper
+
+    Mapping(required=[equal, field])
+
+    Attributes
+    ----------
+
+    equal : anyOf(string, float, boolean, :class:`DateTime`)
+        The value that the field should be equal to.
+    field : string
+        Field to be filtered.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldEqualPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, equal=Undefined, field=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldEqualPredicate, self).__init__(equal=equal, field=field, timeUnit=timeUnit, **kwds)
+
+
+class FieldGTEPredicate(VegaLiteSchema):
+    """FieldGTEPredicate schema wrapper
+
+    Mapping(required=[field, gte])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    gte : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be greater than or equals to.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldGTEPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, gte=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldGTEPredicate, self).__init__(field=field, gte=gte, timeUnit=timeUnit, **kwds)
+
+
+class FieldGTPredicate(VegaLiteSchema):
+    """FieldGTPredicate schema wrapper
+
+    Mapping(required=[field, gt])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    gt : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be greater than.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldGTPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, gt=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldGTPredicate, self).__init__(field=field, gt=gt, timeUnit=timeUnit, **kwds)
+
+
+class FieldLTEPredicate(VegaLiteSchema):
+    """FieldLTEPredicate schema wrapper
+
+    Mapping(required=[field, lte])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    lte : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be less than or equals to.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldLTEPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, lte=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldLTEPredicate, self).__init__(field=field, lte=lte, timeUnit=timeUnit, **kwds)
+
+
+class FieldLTPredicate(VegaLiteSchema):
+    """FieldLTPredicate schema wrapper
+
+    Mapping(required=[field, lt])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    lt : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be less than.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldLTPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, lt=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldLTPredicate, self).__init__(field=field, lt=lt, timeUnit=timeUnit, **kwds)
+
+
+class FieldOneOfPredicate(VegaLiteSchema):
+    """FieldOneOfPredicate schema wrapper
+
+    Mapping(required=[field, oneOf])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    oneOf : anyOf(List(string), List(float), List(boolean), List(:class:`DateTime`))
+        A set of values that the ``field`` 's value should be a member of,
+        for a data item included in the filtered data.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldOneOfPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, oneOf=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldOneOfPredicate, self).__init__(field=field, oneOf=oneOf, timeUnit=timeUnit, **kwds)
+
+
+class FieldRangePredicate(VegaLiteSchema):
+    """FieldRangePredicate schema wrapper
+
+    Mapping(required=[field, range])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    range : List(anyOf(float, :class:`DateTime`, None))
+        An array of inclusive minimum and maximum values
+        for a field value of a data item to be included in the filtered data.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldRangePredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, range=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldRangePredicate, self).__init__(field=field, range=range, timeUnit=timeUnit, **kwds)
+
+
+class FieldValidPredicate(VegaLiteSchema):
+    """FieldValidPredicate schema wrapper
+
+    Mapping(required=[field, valid])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    valid : boolean
+        If set to true the field's value has to be valid, meaning both not ``null`` and not
+        `NaN
+        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN>`__.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldValidPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, valid=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldValidPredicate, self).__init__(field=field, valid=valid, timeUnit=timeUnit, **kwds)
+
+
+class FilterTransform(VegaLiteSchema):
+    """FilterTransform schema wrapper
+
+    Mapping(required=[filter])
+
+    Attributes
+    ----------
+
+    filter : :class:`LogicalOperandPredicate`
+        The ``filter`` property must be one of the predicate definitions:
+
+        1) an `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`__
+        string,
+        where ``datum`` can be used to refer to the current data object
+
+        2) one of the field predicates: `equal
+        <https://vega.github.io/vega-lite/docs/filter.html#equal-predicate>`__,
+        `lt <https://vega.github.io/vega-lite/docs/filter.html#lt-predicate>`__,
+        `lte <https://vega.github.io/vega-lite/docs/filter.html#lte-predicate>`__,
+        `gt <https://vega.github.io/vega-lite/docs/filter.html#gt-predicate>`__,
+        `gte <https://vega.github.io/vega-lite/docs/filter.html#gte-predicate>`__,
+        `range <https://vega.github.io/vega-lite/docs/filter.html#range-predicate>`__,
+        or `oneOf <https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate>`__.
+
+        3) a `selection predicate
+        <https://vega.github.io/vega-lite/docs/filter.html#selection-predicate>`__
+
+        4) a logical operand that combines (1), (2), or (3).
+    """
+    _schema = {'$ref': '#/definitions/FilterTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, filter=Undefined, **kwds):
+        super(FilterTransform, self).__init__(filter=filter, **kwds)
+
+
+class FlattenTransform(VegaLiteSchema):
+    """FlattenTransform schema wrapper
+
+    Mapping(required=[flatten])
+
+    Attributes
+    ----------
+
+    flatten : List(string)
+        An array of one or more data fields containing arrays to flatten.
+        If multiple fields are specified, their array values should have a parallel
+        structure, ideally with the same length.
+        If the lengths of parallel arrays do not match,
+        the longest array will be used with ``null`` values added for missing entries.
+    as : List(string)
+        The output field names for extracted array values.
+
+        **Default value:** The field name of the corresponding array field
+    """
+    _schema = {'$ref': '#/definitions/FlattenTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, flatten=Undefined, **kwds):
+        super(FlattenTransform, self).__init__(flatten=flatten, **kwds)
+
+
+class FoldTransform(VegaLiteSchema):
+    """FoldTransform schema wrapper
+
+    Mapping(required=[fold])
+
+    Attributes
+    ----------
+
+    fold : List(string)
+        An array of data fields indicating the properties to fold.
+    as : List([string, string])
+        The output field names for the key and value properties produced by the fold
+        transform.
+        **Default value:** ``["key", "value"]``
+    """
+    _schema = {'$ref': '#/definitions/FoldTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, fold=Undefined, **kwds):
+        super(FoldTransform, self).__init__(fold=fold, **kwds)
+
+
+class FontStyle(VegaLiteSchema):
+    """FontStyle schema wrapper
+
+    enum('normal', 'italic')
+    """
+    _schema = {'$ref': '#/definitions/FontStyle'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(FontStyle, self).__init__(*args)
+
+
+class FontWeight(VegaLiteSchema):
+    """FontWeight schema wrapper
+
+    enum('normal', 'bold', 'lighter', 'bolder', 100, 200, 300, 400, 500, 600, 700, 800, 900)
+    """
+    _schema = {'$ref': '#/definitions/FontWeight'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(FontWeight, self).__init__(*args)
+
+
+class GenericBinMixinsbooleanBinParams(VegaLiteSchema):
+    """GenericBinMixinsbooleanBinParams schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    bin : anyOf(boolean, :class:`BinParams`)
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    """
+    _schema = {'$ref': '#/definitions/GenericBinMixins<(boolean|BinParams)>'}
+    _rootschema = Root._schema
+
+    def __init__(self, bin=Undefined, **kwds):
+        super(GenericBinMixinsbooleanBinParams, self).__init__(bin=bin, **kwds)
+
+
+class GenericBinMixinsbooleanBinParamsbinned(VegaLiteSchema):
+    """GenericBinMixinsbooleanBinParamsbinned schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    """
+    _schema = {'$ref': '#/definitions/GenericBinMixins<(boolean|BinParams|"binned")>'}
+    _rootschema = Root._schema
+
+    def __init__(self, bin=Undefined, **kwds):
+        super(GenericBinMixinsbooleanBinParamsbinned, self).__init__(bin=bin, **kwds)
+
+
+class FacetSpec(VegaLiteSchema):
+    """FacetSpec schema wrapper
+
+    Mapping(required=[facet, spec])
+
+    Attributes
+    ----------
+
+    facet : :class:`FacetMapping`
+        An object that describes mappings between ``row`` and ``column`` channels and their
+        field definitions.
+    spec : anyOf(:class:`LayerSpec`, :class:`FacetedUnitSpec`)
+        A specification of the view that gets faceted.
+    align : anyOf(:class:`VgLayoutAlign`, :class:`RowColVgLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for facets.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/FacetSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, facet=Undefined, spec=Undefined, align=Undefined, bounds=Undefined,
+                 center=Undefined, data=Undefined, description=Undefined, name=Undefined,
+                 resolve=Undefined, spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
+        super(FacetSpec, self).__init__(facet=facet, spec=spec, align=align, bounds=bounds,
+                                        center=center, data=data, description=description, name=name,
+                                        resolve=resolve, spacing=spacing, title=title,
+                                        transform=transform, **kwds)
+
+
+class HConcatSpec(VegaLiteSchema):
+    """HConcatSpec schema wrapper
+
+    Mapping(required=[hconcat])
+
+    Attributes
+    ----------
+
+    hconcat : List(:class:`Spec`)
+        A list of views that should be concatenated and put into a row.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : boolean
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        **Default value:** ``false``
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for horizontally concatenated charts.
+    spacing : float
+        The spacing in pixels between sub-views of the concat operator.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/HConcatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, hconcat=Undefined, bounds=Undefined, center=Undefined, data=Undefined,
+                 description=Undefined, name=Undefined, resolve=Undefined, spacing=Undefined,
+                 title=Undefined, transform=Undefined, **kwds):
+        super(HConcatSpec, self).__init__(hconcat=hconcat, bounds=bounds, center=center, data=data,
+                                          description=description, name=name, resolve=resolve,
+                                          spacing=spacing, title=title, transform=transform, **kwds)
+
+
+class RepeatSpec(VegaLiteSchema):
+    """RepeatSpec schema wrapper
+
+    Mapping(required=[repeat, spec])
+
+    Attributes
+    ----------
+
+    repeat : :class:`Repeat`
+        An object that describes what fields should be repeated into views that are laid out
+        as a ``row`` or ``column``.
+    spec : :class:`Spec`
+
+    align : anyOf(:class:`VgLayoutAlign`, :class:`RowColVgLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale and legend resolutions for repeated charts.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/RepeatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, repeat=Undefined, spec=Undefined, align=Undefined, bounds=Undefined,
+                 center=Undefined, data=Undefined, description=Undefined, name=Undefined,
+                 resolve=Undefined, spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
+        super(RepeatSpec, self).__init__(repeat=repeat, spec=spec, align=align, bounds=bounds,
+                                         center=center, data=data, description=description, name=name,
+                                         resolve=resolve, spacing=spacing, title=title,
+                                         transform=transform, **kwds)
+
+
+class Spec(VegaLiteSchema):
+    """Spec schema wrapper
+
+    anyOf(:class:`FacetedUnitSpec`, :class:`LayerSpec`, :class:`FacetSpec`, :class:`RepeatSpec`,
+    :class:`VConcatSpec`, :class:`HConcatSpec`)
+    """
+    _schema = {'$ref': '#/definitions/Spec'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(Spec, self).__init__(*args, **kwds)
+
+
+class CompositeUnitSpecAlias(VegaLiteSchema):
+    """CompositeUnitSpecAlias schema wrapper
+
+    Mapping(required=[mark])
+
+    Attributes
+    ----------
+
+    mark : :class:`AnyMark`
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and ``"text"`` ) or a `mark
+        definition object <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`Encoding`
+        A key-value mapping between encoding channels and definition of fields.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    projection : :class:`Projection`
+        An object defining properties of geographic projection, which will be applied to
+        ``shape`` path for ``"geoshape"`` marks
+        and to ``latitude`` and ``"longitude"`` channels for other marks.
+    selection : Mapping(required=[])
+        A key-value mapping between selection names and definitions.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    """
+    _schema = {'$ref': '#/definitions/CompositeUnitSpecAlias'}
+    _rootschema = Root._schema
+
+    def __init__(self, mark=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, projection=Undefined, selection=Undefined,
+                 title=Undefined, transform=Undefined, width=Undefined, **kwds):
+        super(CompositeUnitSpecAlias, self).__init__(mark=mark, data=data, description=description,
+                                                     encoding=encoding, height=height, name=name,
+                                                     projection=projection, selection=selection,
+                                                     title=title, transform=transform, width=width,
+                                                     **kwds)
+
+
+class FacetedCompositeUnitSpecAlias(VegaLiteSchema):
+    """FacetedCompositeUnitSpecAlias schema wrapper
+
+    Mapping(required=[mark])
+
+    Attributes
+    ----------
+
+    mark : :class:`AnyMark`
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and ``"text"`` ) or a `mark
+        definition object <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`EncodingWithFacet`
+        A key-value mapping between encoding channels and definition of fields.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    projection : :class:`Projection`
+        An object defining properties of geographic projection, which will be applied to
+        ``shape`` path for ``"geoshape"`` marks
+        and to ``latitude`` and ``"longitude"`` channels for other marks.
+    selection : Mapping(required=[])
+        A key-value mapping between selection names and definitions.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    """
+    _schema = {'$ref': '#/definitions/FacetedCompositeUnitSpecAlias'}
+    _rootschema = Root._schema
+
+    def __init__(self, mark=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, projection=Undefined, selection=Undefined,
+                 title=Undefined, transform=Undefined, width=Undefined, **kwds):
+        super(FacetedCompositeUnitSpecAlias, self).__init__(mark=mark, data=data,
+                                                            description=description, encoding=encoding,
+                                                            height=height, name=name,
+                                                            projection=projection, selection=selection,
+                                                            title=title, transform=transform,
+                                                            width=width, **kwds)
+
+
+class VConcatSpec(VegaLiteSchema):
+    """VConcatSpec schema wrapper
+
+    Mapping(required=[vconcat])
+
+    Attributes
+    ----------
+
+    vconcat : List(:class:`Spec`)
+        A list of views that should be concatenated and put into a column.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : boolean
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        **Default value:** ``false``
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for vertically concatenated charts.
+    spacing : float
+        The spacing in pixels between sub-views of the concat operator.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/VConcatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, vconcat=Undefined, bounds=Undefined, center=Undefined, data=Undefined,
+                 description=Undefined, name=Undefined, resolve=Undefined, spacing=Undefined,
+                 title=Undefined, transform=Undefined, **kwds):
+        super(VConcatSpec, self).__init__(vconcat=vconcat, bounds=bounds, center=center, data=data,
+                                          description=description, name=name, resolve=resolve,
+                                          spacing=spacing, title=title, transform=transform, **kwds)
+
+
+class Header(VegaLiteSchema):
+    """Header schema wrapper
+
+    Mapping(required=[])
+    Headers of row / column channels for faceted plots.
+
+    Attributes
+    ----------
+
+    format : string
+        The formatting pattern for labels. This is D3's `number format pattern
+        <https://github.com/d3/d3-format#locale_format>`__ for quantitative fields and D3's
+        `time format pattern <https://github.com/d3/d3-time-format#locale_format>`__ for
+        time field.
+
+        See the `format documentation <https://vega.github.io/vega-lite/docs/format.html>`__
+        for more information.
+
+        **Default value:**  derived from `numberFormat
+        <https://vega.github.io/vega-lite/docs/config.html#format>`__ config for
+        quantitative fields and from `timeFormat
+        <https://vega.github.io/vega-lite/docs/config.html#format>`__ config for temporal
+        fields.
+    labelAngle : float
+        The rotation angle of the header labels.
+
+        **Default value:** ``0`` for column header, ``-90`` for row header.
+    labelColor : string
+        The color of the header label, can be in hex color code or regular color name.
+    labelFont : string
+        The font of the header label.
+    labelFontSize : float
+        The font size of the header label, in pixels.
+    labelLimit : float
+        The maximum length of the header label in pixels. The text value will be
+        automatically truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    labelPadding : float
+        The orthogonal distance in pixels by which to displace the title from its position
+        along the edge of the chart.
+
+        **Default value:** ``10``
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    titleAnchor : string
+        The anchor position for placing the title. One of ``"start"``, ``"middle"``, or
+        ``"end"``. For example, with an orientation of top these anchor positions map to a
+        left-, center-, or right-aligned title.
+
+        **Default value:** ``"middle"`` for `single
+        <https://vega.github.io/vega-lite/docs/spec.html>`__ and `layered
+        <https://vega.github.io/vega-lite/docs/layer.html>`__ views.
+        ``"start"`` for other composite views.
+
+        **Note:** `For now <https://github.com/vega/vega-lite/issues/2875>`__, ``anchor`` is
+        only customizable only for `single
+        <https://vega.github.io/vega-lite/docs/spec.html>`__ and `layered
+        <https://vega.github.io/vega-lite/docs/layer.html>`__ views.  For other composite
+        views, ``anchor`` is always ``"start"``.
+    titleAngle : float
+        The rotation angle of the header title.
+
+        **Default value:** ``0``.
+    titleBaseline : :class:`TextBaseline`
+        Vertical text baseline for the header title. One of ``"top"``, ``"bottom"``,
+        ``"middle"``.
+
+        **Default value:** ``"middle"``
+    titleColor : string
+        Color of the header title, can be in hex color code or regular color name.
+    titleFont : string
+        Font of the header title. (e.g., ``"Helvetica Neue"`` ).
+    titleFontSize : float
+        Font size of the header title.
+    titleFontWeight : :class:`FontWeight`
+        Font weight of the header title.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    titleLimit : float
+        The maximum length of the header title in pixels. The text value will be
+        automatically truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    titlePadding : float
+        The orthogonal distance in pixels by which to displace the title from its position
+        along the edge of the chart.
+
+        **Default value:** ``10``
+    """
+    _schema = {'$ref': '#/definitions/Header'}
+    _rootschema = Root._schema
+
+    def __init__(self, format=Undefined, labelAngle=Undefined, labelColor=Undefined,
+                 labelFont=Undefined, labelFontSize=Undefined, labelLimit=Undefined,
+                 labelPadding=Undefined, title=Undefined, titleAnchor=Undefined, titleAngle=Undefined,
+                 titleBaseline=Undefined, titleColor=Undefined, titleFont=Undefined,
+                 titleFontSize=Undefined, titleFontWeight=Undefined, titleLimit=Undefined,
+                 titlePadding=Undefined, **kwds):
+        super(Header, self).__init__(format=format, labelAngle=labelAngle, labelColor=labelColor,
+                                     labelFont=labelFont, labelFontSize=labelFontSize,
+                                     labelLimit=labelLimit, labelPadding=labelPadding, title=title,
+                                     titleAnchor=titleAnchor, titleAngle=titleAngle,
+                                     titleBaseline=titleBaseline, titleColor=titleColor,
+                                     titleFont=titleFont, titleFontSize=titleFontSize,
+                                     titleFontWeight=titleFontWeight, titleLimit=titleLimit,
+                                     titlePadding=titlePadding, **kwds)
+
+
+class HeaderConfig(VegaLiteSchema):
+    """HeaderConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    labelAngle : float
+        The rotation angle of the header labels.
+
+        **Default value:** ``0`` for column header, ``-90`` for row header.
+    labelColor : string
+        The color of the header label, can be in hex color code or regular color name.
+    labelFont : string
+        The font of the header label.
+    labelFontSize : float
+        The font size of the header label, in pixels.
+    labelLimit : float
+        The maximum length of the header label in pixels. The text value will be
+        automatically truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    labelPadding : float
+        The orthogonal distance in pixels by which to displace the title from its position
+        along the edge of the chart.
+
+        **Default value:** ``10``
+    titleAnchor : string
+        The anchor position for placing the title. One of ``"start"``, ``"middle"``, or
+        ``"end"``. For example, with an orientation of top these anchor positions map to a
+        left-, center-, or right-aligned title.
+
+        **Default value:** ``"middle"`` for `single
+        <https://vega.github.io/vega-lite/docs/spec.html>`__ and `layered
+        <https://vega.github.io/vega-lite/docs/layer.html>`__ views.
+        ``"start"`` for other composite views.
+
+        **Note:** `For now <https://github.com/vega/vega-lite/issues/2875>`__, ``anchor`` is
+        only customizable only for `single
+        <https://vega.github.io/vega-lite/docs/spec.html>`__ and `layered
+        <https://vega.github.io/vega-lite/docs/layer.html>`__ views.  For other composite
+        views, ``anchor`` is always ``"start"``.
+    titleAngle : float
+        The rotation angle of the header title.
+
+        **Default value:** ``0``.
+    titleBaseline : :class:`TextBaseline`
+        Vertical text baseline for the header title. One of ``"top"``, ``"bottom"``,
+        ``"middle"``.
+
+        **Default value:** ``"middle"``
+    titleColor : string
+        Color of the header title, can be in hex color code or regular color name.
+    titleFont : string
+        Font of the header title. (e.g., ``"Helvetica Neue"`` ).
+    titleFontSize : float
+        Font size of the header title.
+    titleFontWeight : :class:`FontWeight`
+        Font weight of the header title.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    titleLimit : float
+        The maximum length of the header title in pixels. The text value will be
+        automatically truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    titlePadding : float
+        The orthogonal distance in pixels by which to displace the title from its position
+        along the edge of the chart.
+
+        **Default value:** ``10``
+    """
+    _schema = {'$ref': '#/definitions/HeaderConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, labelAngle=Undefined, labelColor=Undefined, labelFont=Undefined,
+                 labelFontSize=Undefined, labelLimit=Undefined, labelPadding=Undefined,
+                 titleAnchor=Undefined, titleAngle=Undefined, titleBaseline=Undefined,
+                 titleColor=Undefined, titleFont=Undefined, titleFontSize=Undefined,
+                 titleFontWeight=Undefined, titleLimit=Undefined, titlePadding=Undefined, **kwds):
+        super(HeaderConfig, self).__init__(labelAngle=labelAngle, labelColor=labelColor,
+                                           labelFont=labelFont, labelFontSize=labelFontSize,
+                                           labelLimit=labelLimit, labelPadding=labelPadding,
+                                           titleAnchor=titleAnchor, titleAngle=titleAngle,
+                                           titleBaseline=titleBaseline, titleColor=titleColor,
+                                           titleFont=titleFont, titleFontSize=titleFontSize,
+                                           titleFontWeight=titleFontWeight, titleLimit=titleLimit,
+                                           titlePadding=titlePadding, **kwds)
+
+
+class ImputeMethod(VegaLiteSchema):
+    """ImputeMethod schema wrapper
+
+    enum('value', 'median', 'max', 'min', 'mean')
+    """
+    _schema = {'$ref': '#/definitions/ImputeMethod'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(ImputeMethod, self).__init__(*args)
+
+
+class ImputeParams(VegaLiteSchema):
+    """ImputeParams schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    frame : List(anyOf(None, float))
+        A frame specification as a two-element array used to control the window over which
+        the specified method is applied. The array entries should either be a number
+        indicating the offset from the current data object, or null to indicate unbounded
+        rows preceding or following the current data object.  For example, the value ``[-5,
+        5]`` indicates that the window should include five objects preceding and five
+        objects following the current object.
+
+        **Default value:** :  ``[null, null]`` indicating that the window includes all
+        objects.
+    keyvals : anyOf(List(Mapping(required=[])), :class:`ImputeSequence`)
+        Defines the key values that should be considered for imputation.
+        An array of key values or an object defining a `number sequence
+        <https://vega.github.io/vega-lite/docs/impute.html#sequence-def>`__.
+
+        If provided, this will be used in addition to the key values observed within the
+        input data.  If not provided, the values will be derived from all unique values of
+        the ``key`` field. For ``impute`` in ``encoding``, the key field is the x-field if
+        the y-field is imputed, or vice versa.
+
+        If there is no impute grouping, this property *must* be specified.
+    method : :class:`ImputeMethod`
+        The imputation method to use for the field value of imputed data objects.
+        One of ``value``, ``mean``, ``median``, ``max`` or ``min``.
+
+        **Default value:**  ``"value"``
+    value : Mapping(required=[])
+        The field value to use when the imputation ``method`` is ``"value"``.
+    """
+    _schema = {'$ref': '#/definitions/ImputeParams'}
+    _rootschema = Root._schema
+
+    def __init__(self, frame=Undefined, keyvals=Undefined, method=Undefined, value=Undefined, **kwds):
+        super(ImputeParams, self).__init__(frame=frame, keyvals=keyvals, method=method, value=value,
+                                           **kwds)
+
+
+class ImputeSequence(VegaLiteSchema):
+    """ImputeSequence schema wrapper
+
+    Mapping(required=[stop])
+
+    Attributes
+    ----------
+
+    stop : float
+        The ending value(exclusive) of the sequence.
+    start : float
+        The starting value of the sequence.
+        **Default value:** ``0``
+    step : float
+        The step value between sequence entries.
+        **Default value:** ``1`` or ``-1`` if ``stop < start``
+    """
+    _schema = {'$ref': '#/definitions/ImputeSequence'}
+    _rootschema = Root._schema
+
+    def __init__(self, stop=Undefined, start=Undefined, step=Undefined, **kwds):
+        super(ImputeSequence, self).__init__(stop=stop, start=start, step=step, **kwds)
+
+
+class ImputeTransform(VegaLiteSchema):
+    """ImputeTransform schema wrapper
+
+    Mapping(required=[impute, key])
+
+    Attributes
+    ----------
+
+    impute : string
+        The data field for which the missing values should be imputed.
+    key : string
+        A key field that uniquely identifies data objects within a group.
+        Missing key values (those occurring in the data but not in the current group) will
+        be imputed.
+    frame : List(anyOf(None, float))
+        A frame specification as a two-element array used to control the window over which
+        the specified method is applied. The array entries should either be a number
+        indicating the offset from the current data object, or null to indicate unbounded
+        rows preceding or following the current data object.  For example, the value ``[-5,
+        5]`` indicates that the window should include five objects preceding and five
+        objects following the current object.
+
+        **Default value:** :  ``[null, null]`` indicating that the window includes all
+        objects.
+    groupby : List(string)
+        An optional array of fields by which to group the values.
+        Imputation will then be performed on a per-group basis.
+    keyvals : anyOf(List(Mapping(required=[])), :class:`ImputeSequence`)
+        Defines the key values that should be considered for imputation.
+        An array of key values or an object defining a `number sequence
+        <https://vega.github.io/vega-lite/docs/impute.html#sequence-def>`__.
+
+        If provided, this will be used in addition to the key values observed within the
+        input data.  If not provided, the values will be derived from all unique values of
+        the ``key`` field. For ``impute`` in ``encoding``, the key field is the x-field if
+        the y-field is imputed, or vice versa.
+
+        If there is no impute grouping, this property *must* be specified.
+    method : :class:`ImputeMethod`
+        The imputation method to use for the field value of imputed data objects.
+        One of ``value``, ``mean``, ``median``, ``max`` or ``min``.
+
+        **Default value:**  ``"value"``
+    value : Mapping(required=[])
+        The field value to use when the imputation ``method`` is ``"value"``.
+    """
+    _schema = {'$ref': '#/definitions/ImputeTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, impute=Undefined, key=Undefined, frame=Undefined, groupby=Undefined,
+                 keyvals=Undefined, method=Undefined, value=Undefined, **kwds):
+        super(ImputeTransform, self).__init__(impute=impute, key=key, frame=frame, groupby=groupby,
+                                              keyvals=keyvals, method=method, value=value, **kwds)
+
+
+class InlineData(VegaLiteSchema):
+    """InlineData schema wrapper
+
+    Mapping(required=[values])
+
+    Attributes
+    ----------
+
+    values : :class:`InlineDataset`
+        The full data set, included inline. This can be an array of objects or primitive
+        values, an object, or a string.
+        Arrays of primitive values are ingested as objects with a ``data`` property. Strings
+        are parsed according to the specified format type.
+    format : :class:`DataFormat`
+        An object that specifies the format for parsing the data.
+    name : string
+        Provide a placeholder name and bind data at runtime.
+    """
+    _schema = {'$ref': '#/definitions/InlineData'}
+    _rootschema = Root._schema
+
+    def __init__(self, values=Undefined, format=Undefined, name=Undefined, **kwds):
+        super(InlineData, self).__init__(values=values, format=format, name=name, **kwds)
+
+
+class InlineDataset(VegaLiteSchema):
+    """InlineDataset schema wrapper
+
+    anyOf(List(float), List(string), List(boolean), List(Mapping(required=[])), string,
+    Mapping(required=[]))
+    """
+    _schema = {'$ref': '#/definitions/InlineDataset'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(InlineDataset, self).__init__(*args, **kwds)
+
+
+class Interpolate(VegaLiteSchema):
+    """Interpolate schema wrapper
+
+    enum('linear', 'linear-closed', 'step', 'step-before', 'step-after', 'basis', 'basis-open',
+    'basis-closed', 'cardinal', 'cardinal-open', 'cardinal-closed', 'bundle', 'monotone')
+    """
+    _schema = {'$ref': '#/definitions/Interpolate'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Interpolate, self).__init__(*args)
+
+
+class IntervalSelection(VegaLiteSchema):
+    """IntervalSelection schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('interval')
+
+    bind : enum('scales')
+        Establishes a two-way binding between the interval selection and the scales
+        used within the same view. This allows a user to interactively pan and
+        zoom the view.
+    empty : enum('all', 'none')
+        By default, all data values are considered to lie within an empty selection.
+        When set to ``none``, empty selections contain no data values.
+    encodings : List(:class:`SingleDefChannel`)
+        An array of encoding channels. The corresponding data field values
+        must match for a data tuple to fall within the selection.
+    fields : List(string)
+        An array of field names whose values must match for a data tuple to
+        fall within the selection.
+    mark : :class:`BrushConfig`
+        An interval selection also adds a rectangle mark to depict the
+        extents of the interval. The ``mark`` property can be used to customize the
+        appearance of the mark.
+    on : :class:`VgEventStream`
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
+        selector) that triggers the selection.
+        For interval selections, the event stream must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
+    resolve : :class:`SelectionResolution`
+        With layered and multi-view displays, a strategy that determines how
+        selections' data queries are resolved when applied in a filter transform,
+        conditional encoding rule, or scale domain.
+    translate : anyOf(string, boolean)
+        When truthy, allows a user to interactively move an interval selection
+        back-and-forth. Can be ``true``, ``false`` (to disable panning), or a
+        `Vega event stream definition <https://vega.github.io/vega/docs/event-streams/>`__
+        which must include a start and end event to trigger continuous panning.
+
+        **Default value:** ``true``, which corresponds to
+        ``[mousedown, window:mouseup] > window:mousemove!`` which corresponds to
+        clicks and dragging within an interval selection to reposition it.
+    zoom : anyOf(string, boolean)
+        When truthy, allows a user to interactively resize an interval selection.
+        Can be ``true``, ``false`` (to disable zooming), or a `Vega event stream
+        definition <https://vega.github.io/vega/docs/event-streams/>`__. Currently,
+        only ``wheel`` events are supported.
+
+        **Default value:** ``true``, which corresponds to ``wheel!``.
+    """
+    _schema = {'$ref': '#/definitions/IntervalSelection'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, bind=Undefined, empty=Undefined, encodings=Undefined,
+                 fields=Undefined, mark=Undefined, on=Undefined, resolve=Undefined, translate=Undefined,
+                 zoom=Undefined, **kwds):
+        super(IntervalSelection, self).__init__(type=type, bind=bind, empty=empty, encodings=encodings,
+                                                fields=fields, mark=mark, on=on, resolve=resolve,
+                                                translate=translate, zoom=zoom, **kwds)
+
+
+class IntervalSelectionConfig(VegaLiteSchema):
+    """IntervalSelectionConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    bind : enum('scales')
+        Establishes a two-way binding between the interval selection and the scales
+        used within the same view. This allows a user to interactively pan and
+        zoom the view.
+    empty : enum('all', 'none')
+        By default, all data values are considered to lie within an empty selection.
+        When set to ``none``, empty selections contain no data values.
+    encodings : List(:class:`SingleDefChannel`)
+        An array of encoding channels. The corresponding data field values
+        must match for a data tuple to fall within the selection.
+    fields : List(string)
+        An array of field names whose values must match for a data tuple to
+        fall within the selection.
+    mark : :class:`BrushConfig`
+        An interval selection also adds a rectangle mark to depict the
+        extents of the interval. The ``mark`` property can be used to customize the
+        appearance of the mark.
+    on : :class:`VgEventStream`
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
+        selector) that triggers the selection.
+        For interval selections, the event stream must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
+    resolve : :class:`SelectionResolution`
+        With layered and multi-view displays, a strategy that determines how
+        selections' data queries are resolved when applied in a filter transform,
+        conditional encoding rule, or scale domain.
+    translate : anyOf(string, boolean)
+        When truthy, allows a user to interactively move an interval selection
+        back-and-forth. Can be ``true``, ``false`` (to disable panning), or a
+        `Vega event stream definition <https://vega.github.io/vega/docs/event-streams/>`__
+        which must include a start and end event to trigger continuous panning.
+
+        **Default value:** ``true``, which corresponds to
+        ``[mousedown, window:mouseup] > window:mousemove!`` which corresponds to
+        clicks and dragging within an interval selection to reposition it.
+    zoom : anyOf(string, boolean)
+        When truthy, allows a user to interactively resize an interval selection.
+        Can be ``true``, ``false`` (to disable zooming), or a `Vega event stream
+        definition <https://vega.github.io/vega/docs/event-streams/>`__. Currently,
+        only ``wheel`` events are supported.
+
+        **Default value:** ``true``, which corresponds to ``wheel!``.
+    """
+    _schema = {'$ref': '#/definitions/IntervalSelectionConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, bind=Undefined, empty=Undefined, encodings=Undefined, fields=Undefined,
+                 mark=Undefined, on=Undefined, resolve=Undefined, translate=Undefined, zoom=Undefined,
+                 **kwds):
+        super(IntervalSelectionConfig, self).__init__(bind=bind, empty=empty, encodings=encodings,
+                                                      fields=fields, mark=mark, on=on, resolve=resolve,
+                                                      translate=translate, zoom=zoom, **kwds)
+
+
+class JsonDataFormat(VegaLiteSchema):
+    """JsonDataFormat schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    parse : anyOf(:class:`Parse`, None)
+        If set to ``null``, disable type inference based on the spec and only use type
+        inference based on the data.
+        Alternatively, a parsing directive object can be provided for explicit data types.
+        Each property of the object corresponds to a field name, and the value to the
+        desired data type (one of ``"number"``, ``"boolean"``, ``"date"``, or null (do not
+        parse the field)).
+        For example, ``"parse": {"modified_on": "date"}`` parses the ``modified_on`` field
+        in each input record a Date value.
+
+        For ``"date"``, we parse data based using Javascript's `Date.parse()
+        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse>`__.
+        For Specific date formats can be provided (e.g., ``{foo: 'date:"%m%d%Y"'}`` ), using
+        the `d3-time-format syntax <https://github.com/d3/d3-time-format#locale_format>`__.
+        UTC date format parsing is supported similarly (e.g., ``{foo: 'utc:"%m%d%Y"'}`` ).
+        See more about `UTC time
+        <https://vega.github.io/vega-lite/docs/timeunit.html#utc>`__
+    property : string
+        The JSON property containing the desired data.
+        This parameter can be used when the loaded JSON file may have surrounding structure
+        or meta-data.
+        For example ``"property": "values.features"`` is equivalent to retrieving
+        ``json.values.features``
+        from the loaded JSON object.
+    type : enum('json')
+        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``, ``"dsv"``.
+        The default format type is determined by the extension of the file URL.
+        If no extension is detected, ``"json"`` will be used by default.
+    """
+    _schema = {'$ref': '#/definitions/JsonDataFormat'}
+    _rootschema = Root._schema
+
+    def __init__(self, parse=Undefined, property=Undefined, type=Undefined, **kwds):
+        super(JsonDataFormat, self).__init__(parse=parse, property=property, type=type, **kwds)
+
+
+class LabelOverlap(VegaLiteSchema):
+    """LabelOverlap schema wrapper
+
+    anyOf(boolean, enum('parity'), enum('greedy'))
+    """
+    _schema = {'$ref': '#/definitions/LabelOverlap'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(LabelOverlap, self).__init__(*args, **kwds)
+
+
+class Legend(VegaLiteSchema):
+    """Legend schema wrapper
+
+    Mapping(required=[])
+    Properties of a legend or boolean flag for determining whether to show it.
+
+    Attributes
+    ----------
+
+    clipHeight : float
+        The height in pixels to clip symbol legend entries and limit their size.
+    columnPadding : float
+        The horizontal padding in pixels between symbol legend entries.
+
+        **Default value:** ``10``.
+    columns : float
+        The number of columns in which to arrange symbol legend entries. A value of ``0`` or
+        lower indicates a single row with one column per entry.
+    cornerRadius : float
+        Corner radius for the full legend.
+    direction : :class:`Orientation`
+        The direction of the legend, one of ``"vertical"`` (default) or ``"horizontal"``.
+    fillColor : :class:`Color`
+        Background fill color for the full legend.
+    format : string
+        The formatting pattern for labels. This is D3's `number format pattern
+        <https://github.com/d3/d3-format#locale_format>`__ for quantitative fields and D3's
+        `time format pattern <https://github.com/d3/d3-time-format#locale_format>`__ for
+        time field.
+
+        See the `format documentation <https://vega.github.io/vega-lite/docs/format.html>`__
+        for more information.
+
+        **Default value:**  derived from `numberFormat
+        <https://vega.github.io/vega-lite/docs/config.html#format>`__ config for
+        quantitative fields and from `timeFormat
+        <https://vega.github.io/vega-lite/docs/config.html#format>`__ config for temporal
+        fields.
+    gradientLength : float
+        The length in pixels of the primary axis of a color gradient. This value corresponds
+        to the height of a vertical gradient or the width of a horizontal gradient.
+
+        **Default value:** ``200``.
+    gradientOpacity : float
+        Opacity of the color gradient.
+    gradientStrokeColor : :class:`Color`
+        The color of the gradient stroke, can be in hex color code or regular color name.
+
+        **Default value:** ``"lightGray"``.
+    gradientStrokeWidth : float
+        The width of the gradient stroke, in pixels.
+
+        **Default value:** ``0``.
+    gradientThickness : float
+        The thickness in pixels of the color gradient. This value corresponds to the width
+        of a vertical gradient or the height of a horizontal gradient.
+
+        **Default value:** ``16``.
+    gridAlign : :class:`VgLayoutAlign`
+        The alignment to apply to symbol legends rows and columns. The supported string
+        values are ``"all"``, ``"each"`` (the default), and ``none``. For more information,
+        see the `grid layout documentation <https://vega.github.io/vega/docs/layout>`__.
+
+        **Default value:** ``"each"``.
+    labelAlign : :class:`Align`
+        The alignment of the legend label, can be left, center, or right.
+    labelBaseline : :class:`TextBaseline`
+        The position of the baseline of legend label, can be ``"top"``, ``"middle"``,
+        ``"bottom"``, or ``"alphabetic"``.
+
+        **Default value:** ``"middle"``.
+    labelColor : :class:`Color`
+        The color of the legend label, can be in hex color code or regular color name.
+    labelFont : string
+        The font of the legend label.
+    labelFontSize : float
+        The font size of legend label.
+
+        **Default value:** ``10``.
+    labelFontWeight : :class:`FontWeight`
+        The font weight of legend label.
+    labelLimit : float
+        Maximum allowed pixel width of axis tick labels.
+
+        **Default value:** ``160``.
+    labelOffset : float
+        The offset of the legend label.
+    labelOpacity : float
+        Opacity of labels.
+    labelOverlap : :class:`LabelOverlap`
+        The strategy to use for resolving overlap of labels in gradient legends. If
+        ``false``, no overlap reduction is attempted. If set to ``true`` (default) or
+        ``"parity"``, a strategy of removing every other label is used. If set to
+        ``"greedy"``, a linear scan of the labels is performed, removing any label that
+        overlaps with the last visible label (this often works better for log-scaled axes).
+
+        **Default value:** ``true``.
+    labelPadding : float
+        Padding in pixels between the legend and legend labels.
+    offset : float
+        The offset in pixels by which to displace the legend from the data rectangle and
+        axes.
+
+        **Default value:** ``18``.
+    orient : :class:`LegendOrient`
+        The orientation of the legend, which determines how the legend is positioned within
+        the scene. One of "left", "right", "top-left", "top-right", "bottom-left",
+        "bottom-right", "none".
+
+        **Default value:** ``"right"``
+    padding : float
+        The padding between the border and content of the legend group.
+
+        **Default value:** ``0``.
+    rowPadding : float
+        The vertical padding in pixels between symbol legend entries.
+
+        **Default value:** ``2``.
+    strokeColor : :class:`Color`
+        Border stroke color for the full legend.
+    strokeWidth : float
+        Border stroke width for the full legend.
+    symbolFillColor : :class:`Color`
+        The color of the legend symbol,
+    symbolOffset : float
+        Horizontal pixel offset for legend symbols.
+
+        **Default value:** ``0``.
+    symbolOpacity : float
+        Opacity of the legend symbols.
+    symbolSize : float
+        The size of the legend symbol, in pixels.
+
+        **Default value:** ``100``.
+    symbolStrokeColor : :class:`Color`
+        Stroke color for legend symbols.
+    symbolStrokeWidth : float
+        The width of the symbol's stroke.
+
+        **Default value:** ``1.5``.
+    symbolType : :class:`SymbolShape`
+        Default shape type (such as "circle") for legend symbols.
+        Can be one of ```"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
+        ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
+        ``"triangle-left"``.
+
+
+        * In addition to a set of built-in shapes, custom shapes can be defined using `SVG
+          path strings <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__.
+        *
+        * **Default value:** ``"circle"``.
+        *
+    tickCount : float
+        The desired number of tick values for quantitative legends.
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    titleAlign : :class:`Align`
+        Horizontal text alignment for legend titles.
+
+        **Default value:** ``"left"``.
+    titleBaseline : :class:`TextBaseline`
+        Vertical text baseline for legend titles.
+
+        **Default value:** ``"top"``.
+    titleColor : :class:`Color`
+        The color of the legend title, can be in hex color code or regular color name.
+    titleFont : string
+        The font of the legend title.
+    titleFontSize : float
+        The font size of the legend title.
+    titleFontWeight : :class:`FontWeight`
+        The font weight of the legend title.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    titleLimit : float
+        Maximum allowed pixel width of axis titles.
+
+        **Default value:** ``180``.
+    titleOpacity : float
+        Opacity of the legend title.
+    titlePadding : float
+        The padding, in pixels, between title and legend.
+
+        **Default value:** ``5``.
+    type : enum('symbol', 'gradient')
+        The type of the legend. Use ``"symbol"`` to create a discrete legend and
+        ``"gradient"`` for a continuous color gradient.
+
+        **Default value:** ``"gradient"`` for non-binned quantitative fields and temporal
+        fields; ``"symbol"`` otherwise.
+    values : List(anyOf(float, string, boolean, :class:`DateTime`))
+        Explicitly set the visible legend values.
+    zindex : float
+        A non-positive integer indicating z-index of the legend.
+        If zindex is 0, legend should be drawn behind all chart elements.
+        To put them in front, use zindex = 1.
+    """
+    _schema = {'$ref': '#/definitions/Legend'}
+    _rootschema = Root._schema
+
+    def __init__(self, clipHeight=Undefined, columnPadding=Undefined, columns=Undefined,
+                 cornerRadius=Undefined, direction=Undefined, fillColor=Undefined, format=Undefined,
+                 gradientLength=Undefined, gradientOpacity=Undefined, gradientStrokeColor=Undefined,
+                 gradientStrokeWidth=Undefined, gradientThickness=Undefined, gridAlign=Undefined,
+                 labelAlign=Undefined, labelBaseline=Undefined, labelColor=Undefined,
+                 labelFont=Undefined, labelFontSize=Undefined, labelFontWeight=Undefined,
+                 labelLimit=Undefined, labelOffset=Undefined, labelOpacity=Undefined,
+                 labelOverlap=Undefined, labelPadding=Undefined, offset=Undefined, orient=Undefined,
+                 padding=Undefined, rowPadding=Undefined, strokeColor=Undefined, strokeWidth=Undefined,
+                 symbolFillColor=Undefined, symbolOffset=Undefined, symbolOpacity=Undefined,
+                 symbolSize=Undefined, symbolStrokeColor=Undefined, symbolStrokeWidth=Undefined,
+                 symbolType=Undefined, tickCount=Undefined, title=Undefined, titleAlign=Undefined,
+                 titleBaseline=Undefined, titleColor=Undefined, titleFont=Undefined,
+                 titleFontSize=Undefined, titleFontWeight=Undefined, titleLimit=Undefined,
+                 titleOpacity=Undefined, titlePadding=Undefined, type=Undefined, values=Undefined,
+                 zindex=Undefined, **kwds):
+        super(Legend, self).__init__(clipHeight=clipHeight, columnPadding=columnPadding,
+                                     columns=columns, cornerRadius=cornerRadius, direction=direction,
+                                     fillColor=fillColor, format=format, gradientLength=gradientLength,
+                                     gradientOpacity=gradientOpacity,
+                                     gradientStrokeColor=gradientStrokeColor,
+                                     gradientStrokeWidth=gradientStrokeWidth,
+                                     gradientThickness=gradientThickness, gridAlign=gridAlign,
+                                     labelAlign=labelAlign, labelBaseline=labelBaseline,
+                                     labelColor=labelColor, labelFont=labelFont,
+                                     labelFontSize=labelFontSize, labelFontWeight=labelFontWeight,
+                                     labelLimit=labelLimit, labelOffset=labelOffset,
+                                     labelOpacity=labelOpacity, labelOverlap=labelOverlap,
+                                     labelPadding=labelPadding, offset=offset, orient=orient,
+                                     padding=padding, rowPadding=rowPadding, strokeColor=strokeColor,
+                                     strokeWidth=strokeWidth, symbolFillColor=symbolFillColor,
+                                     symbolOffset=symbolOffset, symbolOpacity=symbolOpacity,
+                                     symbolSize=symbolSize, symbolStrokeColor=symbolStrokeColor,
+                                     symbolStrokeWidth=symbolStrokeWidth, symbolType=symbolType,
+                                     tickCount=tickCount, title=title, titleAlign=titleAlign,
+                                     titleBaseline=titleBaseline, titleColor=titleColor,
+                                     titleFont=titleFont, titleFontSize=titleFontSize,
+                                     titleFontWeight=titleFontWeight, titleLimit=titleLimit,
+                                     titleOpacity=titleOpacity, titlePadding=titlePadding, type=type,
+                                     values=values, zindex=zindex, **kwds)
+
+
+class LegendConfig(VegaLiteSchema):
+    """LegendConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    clipHeight : float
+        The height in pixels to clip symbol legend entries and limit their size.
+    columnPadding : float
+        The horizontal padding in pixels between symbol legend entries.
+
+        **Default value:** ``10``.
+    columns : float
+        The number of columns in which to arrange symbol legend entries. A value of ``0`` or
+        lower indicates a single row with one column per entry.
+    cornerRadius : float
+        Corner radius for the full legend.
+    fillColor : :class:`Color`
+        Background fill color for the full legend.
+    gradientDirection : :class:`Orientation`
+        The default direction ( ``"horizontal"`` or ``"vertical"`` ) for gradient legends.
+
+        **Default value:** ``"vertical"``.
+    gradientLabelLimit : float
+        The maximum allowed length in pixels of color ramp gradient labels.
+    gradientLabelOffset : float
+        Vertical offset in pixels for color ramp gradient labels.
+
+        **Default value:** ``2``.
+    gradientLength : float
+        The length in pixels of the primary axis of a color gradient. This value corresponds
+        to the height of a vertical gradient or the width of a horizontal gradient.
+
+        **Default value:** ``200``.
+    gradientOpacity : float
+        Opacity of the color gradient.
+    gradientStrokeColor : :class:`Color`
+        The color of the gradient stroke, can be in hex color code or regular color name.
+
+        **Default value:** ``"lightGray"``.
+    gradientStrokeWidth : float
+        The width of the gradient stroke, in pixels.
+
+        **Default value:** ``0``.
+    gradientThickness : float
+        The thickness in pixels of the color gradient. This value corresponds to the width
+        of a vertical gradient or the height of a horizontal gradient.
+
+        **Default value:** ``16``.
+    gridAlign : :class:`VgLayoutAlign`
+        The alignment to apply to symbol legends rows and columns. The supported string
+        values are ``"all"``, ``"each"`` (the default), and ``none``. For more information,
+        see the `grid layout documentation <https://vega.github.io/vega/docs/layout>`__.
+
+        **Default value:** ``"each"``.
+    labelAlign : :class:`Align`
+        The alignment of the legend label, can be left, center, or right.
+    labelBaseline : :class:`TextBaseline`
+        The position of the baseline of legend label, can be ``"top"``, ``"middle"``,
+        ``"bottom"``, or ``"alphabetic"``.
+
+        **Default value:** ``"middle"``.
+    labelColor : :class:`Color`
+        The color of the legend label, can be in hex color code or regular color name.
+    labelFont : string
+        The font of the legend label.
+    labelFontSize : float
+        The font size of legend label.
+
+        **Default value:** ``10``.
+    labelFontWeight : :class:`FontWeight`
+        The font weight of legend label.
+    labelLimit : float
+        Maximum allowed pixel width of axis tick labels.
+
+        **Default value:** ``160``.
+    labelOffset : float
+        The offset of the legend label.
+    labelOpacity : float
+        Opacity of labels.
+    labelOverlap : :class:`LabelOverlap`
+        The strategy to use for resolving overlap of labels in gradient legends. If
+        ``false``, no overlap reduction is attempted. If set to ``true`` (default) or
+        ``"parity"``, a strategy of removing every other label is used. If set to
+        ``"greedy"``, a linear scan of the labels is performed, removing any label that
+        overlaps with the last visible label (this often works better for log-scaled axes).
+
+        **Default value:** ``"greedy"`` for ``log scales otherwise`` true`.
+        *
+    labelPadding : float
+        Padding in pixels between the legend and legend labels.
+    offset : float
+        The offset in pixels by which to displace the legend from the data rectangle and
+        axes.
+
+        **Default value:** ``18``.
+    orient : :class:`LegendOrient`
+        The orientation of the legend, which determines how the legend is positioned within
+        the scene. One of "left", "right", "top-left", "top-right", "bottom-left",
+        "bottom-right", "none".
+
+        **Default value:** ``"right"``
+    padding : float
+        The padding between the border and content of the legend group.
+
+        **Default value:** ``0``.
+    rowPadding : float
+        The vertical padding in pixels between symbol legend entries.
+
+        **Default value:** ``2``.
+    shortTimeLabels : boolean
+        Whether month names and weekday names should be abbreviated.
+
+        **Default value:**  ``false``
+    strokeColor : :class:`Color`
+        Border stroke color for the full legend.
+    strokeDash : List(float)
+        Border stroke dash pattern for the full legend.
+    strokeWidth : float
+        Border stroke width for the full legend.
+    symbolBaseFillColor : :class:`Color`
+        Default fill color for legend symbols. Only applied if there is no ``"fill"`` scale
+        color encoding for the legend.
+
+        **Default value:** ``"transparent"``.
+    symbolBaseStrokeColor : :class:`Color`
+        Default stroke color for legend symbols. Only applied if there is no ``"fill"``
+        scale color encoding for the legend.
+
+        **Default value:** ``"gray"``.
+    symbolDirection : :class:`Orientation`
+        The default direction ( ``"horizontal"`` or ``"vertical"`` ) for symbol legends.
+
+        **Default value:** ``"vertical"``.
+    symbolFillColor : :class:`Color`
+        The color of the legend symbol,
+    symbolOffset : float
+        Horizontal pixel offset for legend symbols.
+
+        **Default value:** ``0``.
+    symbolOpacity : float
+        Opacity of the legend symbols.
+    symbolSize : float
+        The size of the legend symbol, in pixels.
+
+        **Default value:** ``100``.
+    symbolStrokeColor : :class:`Color`
+        Stroke color for legend symbols.
+    symbolStrokeWidth : float
+        The width of the symbol's stroke.
+
+        **Default value:** ``1.5``.
+    symbolType : :class:`SymbolShape`
+        Default shape type (such as "circle") for legend symbols.
+        Can be one of ```"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
+        ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
+        ``"triangle-left"``.
+
+
+        * In addition to a set of built-in shapes, custom shapes can be defined using `SVG
+          path strings <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__.
+        *
+        * **Default value:** ``"circle"``.
+        *
+    titleAlign : :class:`Align`
+        Horizontal text alignment for legend titles.
+
+        **Default value:** ``"left"``.
+    titleBaseline : :class:`TextBaseline`
+        Vertical text baseline for legend titles.
+
+        **Default value:** ``"top"``.
+    titleColor : :class:`Color`
+        The color of the legend title, can be in hex color code or regular color name.
+    titleFont : string
+        The font of the legend title.
+    titleFontSize : float
+        The font size of the legend title.
+    titleFontWeight : :class:`FontWeight`
+        The font weight of the legend title.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    titleLimit : float
+        Maximum allowed pixel width of axis titles.
+
+        **Default value:** ``180``.
+    titleOpacity : float
+        Opacity of the legend title.
+    titlePadding : float
+        The padding, in pixels, between title and legend.
+
+        **Default value:** ``5``.
+    """
+    _schema = {'$ref': '#/definitions/LegendConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, clipHeight=Undefined, columnPadding=Undefined, columns=Undefined,
+                 cornerRadius=Undefined, fillColor=Undefined, gradientDirection=Undefined,
+                 gradientLabelLimit=Undefined, gradientLabelOffset=Undefined, gradientLength=Undefined,
+                 gradientOpacity=Undefined, gradientStrokeColor=Undefined,
+                 gradientStrokeWidth=Undefined, gradientThickness=Undefined, gridAlign=Undefined,
+                 labelAlign=Undefined, labelBaseline=Undefined, labelColor=Undefined,
+                 labelFont=Undefined, labelFontSize=Undefined, labelFontWeight=Undefined,
+                 labelLimit=Undefined, labelOffset=Undefined, labelOpacity=Undefined,
+                 labelOverlap=Undefined, labelPadding=Undefined, offset=Undefined, orient=Undefined,
+                 padding=Undefined, rowPadding=Undefined, shortTimeLabels=Undefined,
+                 strokeColor=Undefined, strokeDash=Undefined, strokeWidth=Undefined,
+                 symbolBaseFillColor=Undefined, symbolBaseStrokeColor=Undefined,
+                 symbolDirection=Undefined, symbolFillColor=Undefined, symbolOffset=Undefined,
+                 symbolOpacity=Undefined, symbolSize=Undefined, symbolStrokeColor=Undefined,
+                 symbolStrokeWidth=Undefined, symbolType=Undefined, titleAlign=Undefined,
+                 titleBaseline=Undefined, titleColor=Undefined, titleFont=Undefined,
+                 titleFontSize=Undefined, titleFontWeight=Undefined, titleLimit=Undefined,
+                 titleOpacity=Undefined, titlePadding=Undefined, **kwds):
+        super(LegendConfig, self).__init__(clipHeight=clipHeight, columnPadding=columnPadding,
+                                           columns=columns, cornerRadius=cornerRadius,
+                                           fillColor=fillColor, gradientDirection=gradientDirection,
+                                           gradientLabelLimit=gradientLabelLimit,
+                                           gradientLabelOffset=gradientLabelOffset,
+                                           gradientLength=gradientLength,
+                                           gradientOpacity=gradientOpacity,
+                                           gradientStrokeColor=gradientStrokeColor,
+                                           gradientStrokeWidth=gradientStrokeWidth,
+                                           gradientThickness=gradientThickness, gridAlign=gridAlign,
+                                           labelAlign=labelAlign, labelBaseline=labelBaseline,
+                                           labelColor=labelColor, labelFont=labelFont,
+                                           labelFontSize=labelFontSize, labelFontWeight=labelFontWeight,
+                                           labelLimit=labelLimit, labelOffset=labelOffset,
+                                           labelOpacity=labelOpacity, labelOverlap=labelOverlap,
+                                           labelPadding=labelPadding, offset=offset, orient=orient,
+                                           padding=padding, rowPadding=rowPadding,
+                                           shortTimeLabels=shortTimeLabels, strokeColor=strokeColor,
+                                           strokeDash=strokeDash, strokeWidth=strokeWidth,
+                                           symbolBaseFillColor=symbolBaseFillColor,
+                                           symbolBaseStrokeColor=symbolBaseStrokeColor,
+                                           symbolDirection=symbolDirection,
+                                           symbolFillColor=symbolFillColor, symbolOffset=symbolOffset,
+                                           symbolOpacity=symbolOpacity, symbolSize=symbolSize,
+                                           symbolStrokeColor=symbolStrokeColor,
+                                           symbolStrokeWidth=symbolStrokeWidth, symbolType=symbolType,
+                                           titleAlign=titleAlign, titleBaseline=titleBaseline,
+                                           titleColor=titleColor, titleFont=titleFont,
+                                           titleFontSize=titleFontSize, titleFontWeight=titleFontWeight,
+                                           titleLimit=titleLimit, titleOpacity=titleOpacity,
+                                           titlePadding=titlePadding, **kwds)
+
+
+class LegendOrient(VegaLiteSchema):
+    """LegendOrient schema wrapper
+
+    enum('none', 'left', 'right', 'top', 'bottom', 'top-left', 'top-right', 'bottom-left',
+    'bottom-right')
+    """
+    _schema = {'$ref': '#/definitions/LegendOrient'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(LegendOrient, self).__init__(*args)
+
+
+class LegendResolveMap(VegaLiteSchema):
+    """LegendResolveMap schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    color : :class:`ResolveMode`
+
+    fill : :class:`ResolveMode`
+
+    opacity : :class:`ResolveMode`
+
+    shape : :class:`ResolveMode`
+
+    size : :class:`ResolveMode`
+
+    stroke : :class:`ResolveMode`
+
+    """
+    _schema = {'$ref': '#/definitions/LegendResolveMap'}
+    _rootschema = Root._schema
+
+    def __init__(self, color=Undefined, fill=Undefined, opacity=Undefined, shape=Undefined,
+                 size=Undefined, stroke=Undefined, **kwds):
+        super(LegendResolveMap, self).__init__(color=color, fill=fill, opacity=opacity, shape=shape,
+                                               size=size, stroke=stroke, **kwds)
+
+
+class LineConfig(VegaLiteSchema):
+    """LineConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    align : :class:`Align`
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
+    angle : float
+        The rotation angle of the text, in degrees.
+    baseline : :class:`TextBaseline`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+
+        **Default value:** ``"middle"``
+    color : string
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.
+
+        **Default value:** :raw-html:`<span style="color: #4682b4;">&#9632;</span>`
+        ``"#4682b4"``
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    cornerRadius : float
+        The radius in pixels of rounded rectangle corners.
+
+        **Default value:** ``0``
+    cursor : :class:`Cursor`
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
+    dir : :class:`Dir`
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
+
+        **Default value:** ``"ltr"``
+    dx : float
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    dy : float
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    ellipsis : string
+        The ellipsis string for text truncated in response to the limit parameter.
+
+        **Default value:** ``"…"``
+    fill : :class:`Color`
+        Default Fill Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    fillOpacity : float
+        The fill opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    filled : boolean
+        Whether the mark's color should be used as fill color instead of stroke color.
+
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.
+
+        **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and ``area`` marks.
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    font : string
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
+    fontSize : float
+        The font size, in pixels.
+    fontStyle : :class:`FontStyle`
+        The font style (e.g., ``"italic"`` ).
+    fontWeight : :class:`FontWeight`
+        The font weight.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    href : string
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    interpolate : :class:`Interpolate`
+        The line interpolation method to use for line and area marks. One of the following:
+
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
+    limit : float
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    opacity : float
+        The overall opacity (value between [0,1]).
+
+        **Default value:** ``0.7`` for non-aggregate plots with ``point``, ``tick``,
+        ``circle``, or ``square`` marks or layered ``bar`` charts and ``1`` otherwise.
+    orient : :class:`Orient`
+        The orientation of a non-stacked bar, tick, area, and line charts.
+        The value is either horizontal (default) or vertical.
+
+
+        * For bar, rule and tick, this determines whether the size of the bar and tick
+        should be applied to x or y dimension.
+        * For area, this property determines the orient property of the Vega output.
+        * For line and trail marks, this property determines the sort order of the points in
+          the line
+        if ``config.sortLineBy`` is not specified.
+        For stacked charts, this is always determined by the orientation of the stack;
+        therefore explicitly specified value will be ignored.
+    point : anyOf(boolean, :class:`OverlayMarkDef`, enum('transparent'))
+        A flag for overlaying points on top of line or area marks, or an object defining the
+        properties of the overlayed points.
+
+
+        If this property is ``"transparent"``, transparent points will be used (for
+        enhancing tooltips and selections).
+
+        If this property is an empty object ( ``{}`` ) or ``true``, filled points with
+        default properties will be used.
+
+        If this property is ``false``, no points would be automatically added to line or
+        area marks.
+
+        **Default value:** ``false``.
+    radius : float
+        Polar coordinate radial offset, in pixels, of the text label from the origin
+        determined by the ``x`` and ``y`` properties.
+    shape : string
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.
+
+        **Default value:** ``"circle"``
+    size : float
+        Default size for marks.
+
+
+        * For ``point`` / ``circle`` / ``square``, this represents the pixel area of the
+          marks. For example: in the case of circles, the radius is determined in part by
+          the square root of the size value.
+        * For ``bar``, this represents the band size of the bar, in pixels.
+        * For ``text``, this represents the font size, in pixels.
+
+        **Default value:** ``30`` for point, circle, square marks; ``rangeStep`` - 1 for bar
+        marks with discrete dimensions; ``5`` for bar marks with continuous dimensions;
+        ``11`` for text marks.
+    stroke : :class:`Color`
+        Default Stroke Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    strokeCap : :class:`StrokeCap`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
+
+        **Default value:** ``"square"``
+    strokeDash : List(float)
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
+    strokeDashOffset : float
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
+    strokeJoin : :class:`StrokeJoin`
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
+
+        **Default value:** ``"miter"``
+    strokeMiterLimit : float
+        The miter limit at which to bevel a line join.
+    strokeOpacity : float
+        The stroke opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    strokeWidth : float
+        The stroke width, in pixels.
+    tension : float
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
+    text : string
+        Placeholder text if the ``text`` channel is not specified
+    theta : float
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
+    tooltip : anyOf(string, :class:`TooltipContent`)
+        The tooltip text string to show upon mouse hover or an object defining which fields
+        should the tooltip be derived from.
+
+
+        * If ``tooltip`` is ``{"content": "encoding"}``, then all fields from ``encoding``
+          will be used.
+        * If ``tooltip`` is ``{"content": "data"}``, then all fields that appear in the
+          highlighted data point will be used.
+    """
+    _schema = {'$ref': '#/definitions/LineConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, align=Undefined, angle=Undefined, baseline=Undefined, color=Undefined,
+                 cornerRadius=Undefined, cursor=Undefined, dir=Undefined, dx=Undefined, dy=Undefined,
+                 ellipsis=Undefined, fill=Undefined, fillOpacity=Undefined, filled=Undefined,
+                 font=Undefined, fontSize=Undefined, fontStyle=Undefined, fontWeight=Undefined,
+                 href=Undefined, interpolate=Undefined, limit=Undefined, opacity=Undefined,
+                 orient=Undefined, point=Undefined, radius=Undefined, shape=Undefined, size=Undefined,
+                 stroke=Undefined, strokeCap=Undefined, strokeDash=Undefined,
+                 strokeDashOffset=Undefined, strokeJoin=Undefined, strokeMiterLimit=Undefined,
+                 strokeOpacity=Undefined, strokeWidth=Undefined, tension=Undefined, text=Undefined,
+                 theta=Undefined, tooltip=Undefined, **kwds):
+        super(LineConfig, self).__init__(align=align, angle=angle, baseline=baseline, color=color,
+                                         cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx,
+                                         dy=dy, ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity,
+                                         filled=filled, font=font, fontSize=fontSize,
+                                         fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                                         interpolate=interpolate, limit=limit, opacity=opacity,
+                                         orient=orient, point=point, radius=radius, shape=shape,
+                                         size=size, stroke=stroke, strokeCap=strokeCap,
+                                         strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                                         strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                                         strokeOpacity=strokeOpacity, strokeWidth=strokeWidth,
+                                         tension=tension, text=text, theta=theta, tooltip=tooltip,
+                                         **kwds)
+
+
+class LocalMultiTimeUnit(VegaLiteSchema):
+    """LocalMultiTimeUnit schema wrapper
+
+    enum('yearquarter', 'yearquartermonth', 'yearmonth', 'yearmonthdate', 'yearmonthdatehours',
+    'yearmonthdatehoursminutes', 'yearmonthdatehoursminutesseconds', 'quartermonth',
+    'monthdate', 'hoursminutes', 'hoursminutesseconds', 'minutesseconds', 'secondsmilliseconds')
+    """
+    _schema = {'$ref': '#/definitions/LocalMultiTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(LocalMultiTimeUnit, self).__init__(*args)
+
+
+class LocalSingleTimeUnit(VegaLiteSchema):
+    """LocalSingleTimeUnit schema wrapper
+
+    enum('year', 'quarter', 'month', 'day', 'date', 'hours', 'minutes', 'seconds',
+    'milliseconds')
+    """
+    _schema = {'$ref': '#/definitions/LocalSingleTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(LocalSingleTimeUnit, self).__init__(*args)
+
+
+class LogicalAndPredicate(VegaLiteSchema):
+    """LogicalAndPredicate schema wrapper
+
+    Mapping(required=[and])
+
+    Attributes
+    ----------
+
+    and : List(:class:`LogicalOperandPredicate`)
+
+    """
+    _schema = {'$ref': '#/definitions/LogicalAnd<Predicate>'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(LogicalAndPredicate, self).__init__(**kwds)
+
+
+class SelectionAnd(VegaLiteSchema):
+    """SelectionAnd schema wrapper
+
+    Mapping(required=[and])
+
+    Attributes
+    ----------
+
+    and : List(:class:`SelectionOperand`)
+
+    """
+    _schema = {'$ref': '#/definitions/SelectionAnd'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(SelectionAnd, self).__init__(**kwds)
+
+
+class LogicalNotPredicate(VegaLiteSchema):
+    """LogicalNotPredicate schema wrapper
+
+    Mapping(required=[not])
+
+    Attributes
+    ----------
+
+    not : :class:`LogicalOperandPredicate`
+
+    """
+    _schema = {'$ref': '#/definitions/LogicalNot<Predicate>'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(LogicalNotPredicate, self).__init__(**kwds)
+
+
+class SelectionNot(VegaLiteSchema):
+    """SelectionNot schema wrapper
+
+    Mapping(required=[not])
+
+    Attributes
+    ----------
+
+    not : :class:`SelectionOperand`
+
+    """
+    _schema = {'$ref': '#/definitions/SelectionNot'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(SelectionNot, self).__init__(**kwds)
+
+
+class LogicalOperandPredicate(VegaLiteSchema):
+    """LogicalOperandPredicate schema wrapper
+
+    anyOf(:class:`LogicalNotPredicate`, :class:`LogicalAndPredicate`,
+    :class:`LogicalOrPredicate`, :class:`Predicate`)
+    """
+    _schema = {'$ref': '#/definitions/LogicalOperand<Predicate>'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(LogicalOperandPredicate, self).__init__(*args, **kwds)
+
+
+class SelectionOperand(VegaLiteSchema):
+    """SelectionOperand schema wrapper
+
+    anyOf(:class:`SelectionNot`, :class:`SelectionAnd`, :class:`SelectionOr`, string)
+    """
+    _schema = {'$ref': '#/definitions/SelectionOperand'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(SelectionOperand, self).__init__(*args, **kwds)
+
+
+class LogicalOrPredicate(VegaLiteSchema):
+    """LogicalOrPredicate schema wrapper
+
+    Mapping(required=[or])
+
+    Attributes
+    ----------
+
+    or : List(:class:`LogicalOperandPredicate`)
+
+    """
+    _schema = {'$ref': '#/definitions/LogicalOr<Predicate>'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(LogicalOrPredicate, self).__init__(**kwds)
+
+
+class SelectionOr(VegaLiteSchema):
+    """SelectionOr schema wrapper
+
+    Mapping(required=[or])
+
+    Attributes
+    ----------
+
+    or : List(:class:`SelectionOperand`)
+
+    """
+    _schema = {'$ref': '#/definitions/SelectionOr'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(SelectionOr, self).__init__(**kwds)
+
+
+class LookupData(VegaLiteSchema):
+    """LookupData schema wrapper
+
+    Mapping(required=[data, key])
+
+    Attributes
+    ----------
+
+    data : :class:`Data`
+        Secondary data source to lookup in.
+    key : string
+        Key in data to lookup.
+    fields : List(string)
+        Fields in foreign data to lookup.
+        If not specified, the entire object is queried.
+    """
+    _schema = {'$ref': '#/definitions/LookupData'}
+    _rootschema = Root._schema
+
+    def __init__(self, data=Undefined, key=Undefined, fields=Undefined, **kwds):
+        super(LookupData, self).__init__(data=data, key=key, fields=fields, **kwds)
+
+
+class LookupTransform(VegaLiteSchema):
+    """LookupTransform schema wrapper
+
+    Mapping(required=[lookup, from])
+
+    Attributes
+    ----------
+
+    lookup : string
+        Key in primary data source.
+    default : string
+        The default value to use if lookup fails.
+
+        **Default value:** ``null``
+    as : anyOf(string, List(string))
+        The field or fields for storing the computed formula value.
+        If ``from.fields`` is specified, the transform will use the same names for ``as``.
+        If ``from.fields`` is not specified, ``as`` has to be a string and we put the whole
+        object into the data under the specified name.
+    from : :class:`LookupData`
+        Secondary data reference.
+    """
+    _schema = {'$ref': '#/definitions/LookupTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, lookup=Undefined, default=Undefined, **kwds):
+        super(LookupTransform, self).__init__(lookup=lookup, default=default, **kwds)
+
+
+class Mark(VegaLiteSchema):
+    """Mark schema wrapper
+
+    enum('area', 'bar', 'line', 'trail', 'point', 'text', 'tick', 'rect', 'rule', 'circle',
+    'square', 'geoshape')
+    All types of primitive marks.
+    """
+    _schema = {'$ref': '#/definitions/Mark'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Mark, self).__init__(*args)
+
+
+class MarkConfig(VegaLiteSchema):
+    """MarkConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    align : :class:`Align`
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
+    angle : float
+        The rotation angle of the text, in degrees.
+    baseline : :class:`TextBaseline`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+
+        **Default value:** ``"middle"``
+    color : string
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.
+
+        **Default value:** :raw-html:`<span style="color: #4682b4;">&#9632;</span>`
+        ``"#4682b4"``
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    cornerRadius : float
+        The radius in pixels of rounded rectangle corners.
+
+        **Default value:** ``0``
+    cursor : :class:`Cursor`
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
+    dir : :class:`Dir`
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
+
+        **Default value:** ``"ltr"``
+    dx : float
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    dy : float
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    ellipsis : string
+        The ellipsis string for text truncated in response to the limit parameter.
+
+        **Default value:** ``"…"``
+    fill : :class:`Color`
+        Default Fill Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    fillOpacity : float
+        The fill opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    filled : boolean
+        Whether the mark's color should be used as fill color instead of stroke color.
+
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.
+
+        **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and ``area`` marks.
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    font : string
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
+    fontSize : float
+        The font size, in pixels.
+    fontStyle : :class:`FontStyle`
+        The font style (e.g., ``"italic"`` ).
+    fontWeight : :class:`FontWeight`
+        The font weight.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    href : string
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    interpolate : :class:`Interpolate`
+        The line interpolation method to use for line and area marks. One of the following:
+
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
+    limit : float
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    opacity : float
+        The overall opacity (value between [0,1]).
+
+        **Default value:** ``0.7`` for non-aggregate plots with ``point``, ``tick``,
+        ``circle``, or ``square`` marks or layered ``bar`` charts and ``1`` otherwise.
+    orient : :class:`Orient`
+        The orientation of a non-stacked bar, tick, area, and line charts.
+        The value is either horizontal (default) or vertical.
+
+
+        * For bar, rule and tick, this determines whether the size of the bar and tick
+        should be applied to x or y dimension.
+        * For area, this property determines the orient property of the Vega output.
+        * For line and trail marks, this property determines the sort order of the points in
+          the line
+        if ``config.sortLineBy`` is not specified.
+        For stacked charts, this is always determined by the orientation of the stack;
+        therefore explicitly specified value will be ignored.
+    radius : float
+        Polar coordinate radial offset, in pixels, of the text label from the origin
+        determined by the ``x`` and ``y`` properties.
+    shape : string
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.
+
+        **Default value:** ``"circle"``
+    size : float
+        Default size for marks.
+
+
+        * For ``point`` / ``circle`` / ``square``, this represents the pixel area of the
+          marks. For example: in the case of circles, the radius is determined in part by
+          the square root of the size value.
+        * For ``bar``, this represents the band size of the bar, in pixels.
+        * For ``text``, this represents the font size, in pixels.
+
+        **Default value:** ``30`` for point, circle, square marks; ``rangeStep`` - 1 for bar
+        marks with discrete dimensions; ``5`` for bar marks with continuous dimensions;
+        ``11`` for text marks.
+    stroke : :class:`Color`
+        Default Stroke Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    strokeCap : :class:`StrokeCap`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
+
+        **Default value:** ``"square"``
+    strokeDash : List(float)
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
+    strokeDashOffset : float
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
+    strokeJoin : :class:`StrokeJoin`
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
+
+        **Default value:** ``"miter"``
+    strokeMiterLimit : float
+        The miter limit at which to bevel a line join.
+    strokeOpacity : float
+        The stroke opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    strokeWidth : float
+        The stroke width, in pixels.
+    tension : float
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
+    text : string
+        Placeholder text if the ``text`` channel is not specified
+    theta : float
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
+    tooltip : anyOf(string, :class:`TooltipContent`)
+        The tooltip text string to show upon mouse hover or an object defining which fields
+        should the tooltip be derived from.
+
+
+        * If ``tooltip`` is ``{"content": "encoding"}``, then all fields from ``encoding``
+          will be used.
+        * If ``tooltip`` is ``{"content": "data"}``, then all fields that appear in the
+          highlighted data point will be used.
+    """
+    _schema = {'$ref': '#/definitions/MarkConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, align=Undefined, angle=Undefined, baseline=Undefined, color=Undefined,
+                 cornerRadius=Undefined, cursor=Undefined, dir=Undefined, dx=Undefined, dy=Undefined,
+                 ellipsis=Undefined, fill=Undefined, fillOpacity=Undefined, filled=Undefined,
+                 font=Undefined, fontSize=Undefined, fontStyle=Undefined, fontWeight=Undefined,
+                 href=Undefined, interpolate=Undefined, limit=Undefined, opacity=Undefined,
+                 orient=Undefined, radius=Undefined, shape=Undefined, size=Undefined, stroke=Undefined,
+                 strokeCap=Undefined, strokeDash=Undefined, strokeDashOffset=Undefined,
+                 strokeJoin=Undefined, strokeMiterLimit=Undefined, strokeOpacity=Undefined,
+                 strokeWidth=Undefined, tension=Undefined, text=Undefined, theta=Undefined,
+                 tooltip=Undefined, **kwds):
+        super(MarkConfig, self).__init__(align=align, angle=angle, baseline=baseline, color=color,
+                                         cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx,
+                                         dy=dy, ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity,
+                                         filled=filled, font=font, fontSize=fontSize,
+                                         fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                                         interpolate=interpolate, limit=limit, opacity=opacity,
+                                         orient=orient, radius=radius, shape=shape, size=size,
+                                         stroke=stroke, strokeCap=strokeCap, strokeDash=strokeDash,
+                                         strokeDashOffset=strokeDashOffset, strokeJoin=strokeJoin,
+                                         strokeMiterLimit=strokeMiterLimit, strokeOpacity=strokeOpacity,
+                                         strokeWidth=strokeWidth, tension=tension, text=text,
+                                         theta=theta, tooltip=tooltip, **kwds)
+
+
+class MarkDef(VegaLiteSchema):
+    """MarkDef schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : :class:`Mark`
+        The mark type.
+        One of ``"bar"``, ``"circle"``, ``"square"``, ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"geoshape"``, ``"rule"``, and ``"text"``.
+    align : :class:`Align`
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
+    angle : float
+        The rotation angle of the text, in degrees.
+    baseline : :class:`TextBaseline`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+
+        **Default value:** ``"middle"``
+    binSpacing : float
+        Offset between bars for binned field.  Ideal value for this is either 0 (Preferred
+        by statisticians) or 1 (Vega-Lite Default, D3 example style).
+
+        **Default value:** ``1``
+    clip : boolean
+        Whether a mark be clipped to the enclosing group’s width and height.
+    color : string
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.
+
+        **Default value:** :raw-html:`<span style="color: #4682b4;">&#9632;</span>`
+        ``"#4682b4"``
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    cornerRadius : float
+        The radius in pixels of rounded rectangle corners.
+
+        **Default value:** ``0``
+    cursor : :class:`Cursor`
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
+    dir : :class:`Dir`
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
+
+        **Default value:** ``"ltr"``
+    dx : float
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    dy : float
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    ellipsis : string
+        The ellipsis string for text truncated in response to the limit parameter.
+
+        **Default value:** ``"…"``
+    fill : :class:`Color`
+        Default Fill Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    fillOpacity : float
+        The fill opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    filled : boolean
+        Whether the mark's color should be used as fill color instead of stroke color.
+
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.
+
+        **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and ``area`` marks.
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    font : string
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
+    fontSize : float
+        The font size, in pixels.
+    fontStyle : :class:`FontStyle`
+        The font style (e.g., ``"italic"`` ).
+    fontWeight : :class:`FontWeight`
+        The font weight.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    href : string
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    interpolate : :class:`Interpolate`
+        The line interpolation method to use for line and area marks. One of the following:
+
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
+    limit : float
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    line : anyOf(boolean, :class:`OverlayMarkDef`)
+        A flag for overlaying line on top of area marks, or an object defining the
+        properties of the overlayed lines.
+
+
+        If this value is an empty object ( ``{}`` ) or ``true``, lines with default
+        properties will be used.
+
+        If this value is ``false``, no lines would be automatically added to area marks.
+
+        **Default value:** ``false``.
+    opacity : float
+        The overall opacity (value between [0,1]).
+
+        **Default value:** ``0.7`` for non-aggregate plots with ``point``, ``tick``,
+        ``circle``, or ``square`` marks or layered ``bar`` charts and ``1`` otherwise.
+    orient : :class:`Orient`
+        The orientation of a non-stacked bar, tick, area, and line charts.
+        The value is either horizontal (default) or vertical.
+
+
+        * For bar, rule and tick, this determines whether the size of the bar and tick
+        should be applied to x or y dimension.
+        * For area, this property determines the orient property of the Vega output.
+        * For line and trail marks, this property determines the sort order of the points in
+          the line
+        if ``config.sortLineBy`` is not specified.
+        For stacked charts, this is always determined by the orientation of the stack;
+        therefore explicitly specified value will be ignored.
+    point : anyOf(boolean, :class:`OverlayMarkDef`, enum('transparent'))
+        A flag for overlaying points on top of line or area marks, or an object defining the
+        properties of the overlayed points.
+
+
+        If this property is ``"transparent"``, transparent points will be used (for
+        enhancing tooltips and selections).
+
+        If this property is an empty object ( ``{}`` ) or ``true``, filled points with
+        default properties will be used.
+
+        If this property is ``false``, no points would be automatically added to line or
+        area marks.
+
+        **Default value:** ``false``.
+    radius : float
+        Polar coordinate radial offset, in pixels, of the text label from the origin
+        determined by the ``x`` and ``y`` properties.
+    shape : string
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.
+
+        **Default value:** ``"circle"``
+    size : float
+        Default size for marks.
+
+
+        * For ``point`` / ``circle`` / ``square``, this represents the pixel area of the
+          marks. For example: in the case of circles, the radius is determined in part by
+          the square root of the size value.
+        * For ``bar``, this represents the band size of the bar, in pixels.
+        * For ``text``, this represents the font size, in pixels.
+
+        **Default value:** ``30`` for point, circle, square marks; ``rangeStep`` - 1 for bar
+        marks with discrete dimensions; ``5`` for bar marks with continuous dimensions;
+        ``11`` for text marks.
+    stroke : :class:`Color`
+        Default Stroke Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    strokeCap : :class:`StrokeCap`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
+
+        **Default value:** ``"square"``
+    strokeDash : List(float)
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
+    strokeDashOffset : float
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
+    strokeJoin : :class:`StrokeJoin`
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
+
+        **Default value:** ``"miter"``
+    strokeMiterLimit : float
+        The miter limit at which to bevel a line join.
+    strokeOpacity : float
+        The stroke opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    strokeWidth : float
+        The stroke width, in pixels.
+    style : anyOf(string, List(string))
+        A string or array of strings indicating the name of custom styles to apply to the
+        mark. A style is a named collection of mark property defaults defined within the
+        `style configuration
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__. If style is an
+        array, later styles will override earlier styles. Any `mark properties
+        <https://vega.github.io/vega-lite/docs/encoding.html#mark-prop>`__ explicitly
+        defined within the ``encoding`` will override a style default.
+
+        **Default value:** The mark's name.  For example, a bar mark will have style
+        ``"bar"`` by default.
+        **Note:** Any specified style will augment the default style. For example, a bar
+        mark with ``"style": "foo"`` will receive from ``config.style.bar`` and
+        ``config.style.foo`` (the specified style ``"foo"`` has higher precedence).
+    tension : float
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
+    text : string
+        Placeholder text if the ``text`` channel is not specified
+    theta : float
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
+    thickness : float
+        Thickness of the tick mark.
+
+        **Default value:**  ``1``
+    tooltip : anyOf(string, :class:`TooltipContent`)
+        The tooltip text string to show upon mouse hover or an object defining which fields
+        should the tooltip be derived from.
+
+
+        * If ``tooltip`` is ``{"content": "encoding"}``, then all fields from ``encoding``
+          will be used.
+        * If ``tooltip`` is ``{"content": "data"}``, then all fields that appear in the
+          highlighted data point will be used.
+    x2Offset : float
+        Offset for x2-position.
+    xOffset : float
+        Offset for x-position.
+    y2Offset : float
+        Offset for y2-position.
+    yOffset : float
+        Offset for y-position.
+    """
+    _schema = {'$ref': '#/definitions/MarkDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, align=Undefined, angle=Undefined, baseline=Undefined,
+                 binSpacing=Undefined, clip=Undefined, color=Undefined, cornerRadius=Undefined,
+                 cursor=Undefined, dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined,
+                 fill=Undefined, fillOpacity=Undefined, filled=Undefined, font=Undefined,
+                 fontSize=Undefined, fontStyle=Undefined, fontWeight=Undefined, href=Undefined,
+                 interpolate=Undefined, limit=Undefined, line=Undefined, opacity=Undefined,
+                 orient=Undefined, point=Undefined, radius=Undefined, shape=Undefined, size=Undefined,
+                 stroke=Undefined, strokeCap=Undefined, strokeDash=Undefined,
+                 strokeDashOffset=Undefined, strokeJoin=Undefined, strokeMiterLimit=Undefined,
+                 strokeOpacity=Undefined, strokeWidth=Undefined, style=Undefined, tension=Undefined,
+                 text=Undefined, theta=Undefined, thickness=Undefined, tooltip=Undefined,
+                 x2Offset=Undefined, xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        super(MarkDef, self).__init__(type=type, align=align, angle=angle, baseline=baseline,
+                                      binSpacing=binSpacing, clip=clip, color=color,
+                                      cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                                      ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity,
+                                      filled=filled, font=font, fontSize=fontSize, fontStyle=fontStyle,
+                                      fontWeight=fontWeight, href=href, interpolate=interpolate,
+                                      limit=limit, line=line, opacity=opacity, orient=orient,
+                                      point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                                      strokeCap=strokeCap, strokeDash=strokeDash,
+                                      strokeDashOffset=strokeDashOffset, strokeJoin=strokeJoin,
+                                      strokeMiterLimit=strokeMiterLimit, strokeOpacity=strokeOpacity,
+                                      strokeWidth=strokeWidth, style=style, tension=tension, text=text,
+                                      theta=theta, thickness=thickness, tooltip=tooltip,
+                                      x2Offset=x2Offset, xOffset=xOffset, y2Offset=y2Offset,
+                                      yOffset=yOffset, **kwds)
+
+
+class Month(VegaLiteSchema):
+    """Month schema wrapper
+
+    float
+    """
+    _schema = {'$ref': '#/definitions/Month'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Month, self).__init__(*args)
+
+
+class MultiSelection(VegaLiteSchema):
+    """MultiSelection schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('multi')
+
+    empty : enum('all', 'none')
+        By default, all data values are considered to lie within an empty selection.
+        When set to ``none``, empty selections contain no data values.
+    encodings : List(:class:`SingleDefChannel`)
+        An array of encoding channels. The corresponding data field values
+        must match for a data tuple to fall within the selection.
+    fields : List(string)
+        An array of field names whose values must match for a data tuple to
+        fall within the selection.
+    nearest : boolean
+        When true, an invisible voronoi diagram is computed to accelerate discrete
+        selection. The data value *nearest* the mouse cursor is added to the selection.
+
+        See the `nearest transform <https://vega.github.io/vega-lite/docs/nearest.html>`__
+        documentation for more information.
+    on : :class:`VgEventStream`
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
+        selector) that triggers the selection.
+        For interval selections, the event stream must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
+    resolve : :class:`SelectionResolution`
+        With layered and multi-view displays, a strategy that determines how
+        selections' data queries are resolved when applied in a filter transform,
+        conditional encoding rule, or scale domain.
+    toggle : anyOf(string, boolean)
+        Controls whether data values should be toggled or only ever inserted into
+        multi selections. Can be ``true``, ``false`` (for insertion only), or a
+        `Vega expression <https://vega.github.io/vega/docs/expressions/>`__.
+
+        **Default value:** ``true``, which corresponds to ``event.shiftKey`` (i.e.,
+        data values are toggled when a user interacts with the shift-key pressed).
+
+        See the `toggle transform <https://vega.github.io/vega-lite/docs/toggle.html>`__
+        documentation for more information.
+    """
+    _schema = {'$ref': '#/definitions/MultiSelection'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, empty=Undefined, encodings=Undefined, fields=Undefined,
+                 nearest=Undefined, on=Undefined, resolve=Undefined, toggle=Undefined, **kwds):
+        super(MultiSelection, self).__init__(type=type, empty=empty, encodings=encodings, fields=fields,
+                                             nearest=nearest, on=on, resolve=resolve, toggle=toggle,
+                                             **kwds)
+
+
+class MultiSelectionConfig(VegaLiteSchema):
+    """MultiSelectionConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    empty : enum('all', 'none')
+        By default, all data values are considered to lie within an empty selection.
+        When set to ``none``, empty selections contain no data values.
+    encodings : List(:class:`SingleDefChannel`)
+        An array of encoding channels. The corresponding data field values
+        must match for a data tuple to fall within the selection.
+    fields : List(string)
+        An array of field names whose values must match for a data tuple to
+        fall within the selection.
+    nearest : boolean
+        When true, an invisible voronoi diagram is computed to accelerate discrete
+        selection. The data value *nearest* the mouse cursor is added to the selection.
+
+        See the `nearest transform <https://vega.github.io/vega-lite/docs/nearest.html>`__
+        documentation for more information.
+    on : :class:`VgEventStream`
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
+        selector) that triggers the selection.
+        For interval selections, the event stream must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
+    resolve : :class:`SelectionResolution`
+        With layered and multi-view displays, a strategy that determines how
+        selections' data queries are resolved when applied in a filter transform,
+        conditional encoding rule, or scale domain.
+    toggle : anyOf(string, boolean)
+        Controls whether data values should be toggled or only ever inserted into
+        multi selections. Can be ``true``, ``false`` (for insertion only), or a
+        `Vega expression <https://vega.github.io/vega/docs/expressions/>`__.
+
+        **Default value:** ``true``, which corresponds to ``event.shiftKey`` (i.e.,
+        data values are toggled when a user interacts with the shift-key pressed).
+
+        See the `toggle transform <https://vega.github.io/vega-lite/docs/toggle.html>`__
+        documentation for more information.
+    """
+    _schema = {'$ref': '#/definitions/MultiSelectionConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, empty=Undefined, encodings=Undefined, fields=Undefined, nearest=Undefined,
+                 on=Undefined, resolve=Undefined, toggle=Undefined, **kwds):
+        super(MultiSelectionConfig, self).__init__(empty=empty, encodings=encodings, fields=fields,
+                                                   nearest=nearest, on=on, resolve=resolve,
+                                                   toggle=toggle, **kwds)
+
+
+class MultiTimeUnit(VegaLiteSchema):
+    """MultiTimeUnit schema wrapper
+
+    anyOf(:class:`LocalMultiTimeUnit`, :class:`UtcMultiTimeUnit`)
+    """
+    _schema = {'$ref': '#/definitions/MultiTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(MultiTimeUnit, self).__init__(*args, **kwds)
+
+
+class NamedData(VegaLiteSchema):
+    """NamedData schema wrapper
+
+    Mapping(required=[name])
+
+    Attributes
+    ----------
+
+    name : string
+        Provide a placeholder name and bind data at runtime.
+    format : :class:`DataFormat`
+        An object that specifies the format for parsing the data.
+    """
+    _schema = {'$ref': '#/definitions/NamedData'}
+    _rootschema = Root._schema
+
+    def __init__(self, name=Undefined, format=Undefined, **kwds):
+        super(NamedData, self).__init__(name=name, format=format, **kwds)
+
+
+class NiceTime(VegaLiteSchema):
+    """NiceTime schema wrapper
+
+    enum('second', 'minute', 'hour', 'day', 'week', 'month', 'year')
+    """
+    _schema = {'$ref': '#/definitions/NiceTime'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(NiceTime, self).__init__(*args)
+
+
+class OrderFieldDef(VegaLiteSchema):
+    """OrderFieldDef schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    sort : :class:`SortOrder`
+        The sort order. One of ``"ascending"`` (default) or ``"descending"``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/OrderFieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 sort=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
+        super(OrderFieldDef, self).__init__(type=type, aggregate=aggregate, bin=bin, field=field,
+                                            sort=sort, timeUnit=timeUnit, title=title, **kwds)
+
+
+class Orient(VegaLiteSchema):
+    """Orient schema wrapper
+
+    enum('horizontal', 'vertical')
+    """
+    _schema = {'$ref': '#/definitions/Orient'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Orient, self).__init__(*args)
+
+
+class Orientation(VegaLiteSchema):
+    """Orientation schema wrapper
+
+    enum('horizontal', 'vertical')
+    """
+    _schema = {'$ref': '#/definitions/Orientation'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Orientation, self).__init__(*args)
+
+
+class OverlayMarkDef(VegaLiteSchema):
+    """OverlayMarkDef schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    align : :class:`Align`
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
+    angle : float
+        The rotation angle of the text, in degrees.
+    baseline : :class:`TextBaseline`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+
+        **Default value:** ``"middle"``
+    clip : boolean
+        Whether a mark be clipped to the enclosing group’s width and height.
+    color : string
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.
+
+        **Default value:** :raw-html:`<span style="color: #4682b4;">&#9632;</span>`
+        ``"#4682b4"``
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    cornerRadius : float
+        The radius in pixels of rounded rectangle corners.
+
+        **Default value:** ``0``
+    cursor : :class:`Cursor`
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
+    dir : :class:`Dir`
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
+
+        **Default value:** ``"ltr"``
+    dx : float
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    dy : float
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    ellipsis : string
+        The ellipsis string for text truncated in response to the limit parameter.
+
+        **Default value:** ``"…"``
+    fill : :class:`Color`
+        Default Fill Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    fillOpacity : float
+        The fill opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    filled : boolean
+        Whether the mark's color should be used as fill color instead of stroke color.
+
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.
+
+        **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and ``area`` marks.
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    font : string
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
+    fontSize : float
+        The font size, in pixels.
+    fontStyle : :class:`FontStyle`
+        The font style (e.g., ``"italic"`` ).
+    fontWeight : :class:`FontWeight`
+        The font weight.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    href : string
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    interpolate : :class:`Interpolate`
+        The line interpolation method to use for line and area marks. One of the following:
+
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
+    limit : float
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    opacity : float
+        The overall opacity (value between [0,1]).
+
+        **Default value:** ``0.7`` for non-aggregate plots with ``point``, ``tick``,
+        ``circle``, or ``square`` marks or layered ``bar`` charts and ``1`` otherwise.
+    orient : :class:`Orient`
+        The orientation of a non-stacked bar, tick, area, and line charts.
+        The value is either horizontal (default) or vertical.
+
+
+        * For bar, rule and tick, this determines whether the size of the bar and tick
+        should be applied to x or y dimension.
+        * For area, this property determines the orient property of the Vega output.
+        * For line and trail marks, this property determines the sort order of the points in
+          the line
+        if ``config.sortLineBy`` is not specified.
+        For stacked charts, this is always determined by the orientation of the stack;
+        therefore explicitly specified value will be ignored.
+    radius : float
+        Polar coordinate radial offset, in pixels, of the text label from the origin
+        determined by the ``x`` and ``y`` properties.
+    shape : string
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.
+
+        **Default value:** ``"circle"``
+    size : float
+        Default size for marks.
+
+
+        * For ``point`` / ``circle`` / ``square``, this represents the pixel area of the
+          marks. For example: in the case of circles, the radius is determined in part by
+          the square root of the size value.
+        * For ``bar``, this represents the band size of the bar, in pixels.
+        * For ``text``, this represents the font size, in pixels.
+
+        **Default value:** ``30`` for point, circle, square marks; ``rangeStep`` - 1 for bar
+        marks with discrete dimensions; ``5`` for bar marks with continuous dimensions;
+        ``11`` for text marks.
+    stroke : :class:`Color`
+        Default Stroke Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    strokeCap : :class:`StrokeCap`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
+
+        **Default value:** ``"square"``
+    strokeDash : List(float)
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
+    strokeDashOffset : float
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
+    strokeJoin : :class:`StrokeJoin`
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
+
+        **Default value:** ``"miter"``
+    strokeMiterLimit : float
+        The miter limit at which to bevel a line join.
+    strokeOpacity : float
+        The stroke opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    strokeWidth : float
+        The stroke width, in pixels.
+    style : anyOf(string, List(string))
+        A string or array of strings indicating the name of custom styles to apply to the
+        mark. A style is a named collection of mark property defaults defined within the
+        `style configuration
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__. If style is an
+        array, later styles will override earlier styles. Any `mark properties
+        <https://vega.github.io/vega-lite/docs/encoding.html#mark-prop>`__ explicitly
+        defined within the ``encoding`` will override a style default.
+
+        **Default value:** The mark's name.  For example, a bar mark will have style
+        ``"bar"`` by default.
+        **Note:** Any specified style will augment the default style. For example, a bar
+        mark with ``"style": "foo"`` will receive from ``config.style.bar`` and
+        ``config.style.foo`` (the specified style ``"foo"`` has higher precedence).
+    tension : float
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
+    text : string
+        Placeholder text if the ``text`` channel is not specified
+    theta : float
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
+    tooltip : anyOf(string, :class:`TooltipContent`)
+        The tooltip text string to show upon mouse hover or an object defining which fields
+        should the tooltip be derived from.
+
+
+        * If ``tooltip`` is ``{"content": "encoding"}``, then all fields from ``encoding``
+          will be used.
+        * If ``tooltip`` is ``{"content": "data"}``, then all fields that appear in the
+          highlighted data point will be used.
+    x2Offset : float
+        Offset for x2-position.
+    xOffset : float
+        Offset for x-position.
+    y2Offset : float
+        Offset for y2-position.
+    yOffset : float
+        Offset for y-position.
+    """
+    _schema = {'$ref': '#/definitions/OverlayMarkDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, align=Undefined, angle=Undefined, baseline=Undefined, clip=Undefined,
+                 color=Undefined, cornerRadius=Undefined, cursor=Undefined, dir=Undefined, dx=Undefined,
+                 dy=Undefined, ellipsis=Undefined, fill=Undefined, fillOpacity=Undefined,
+                 filled=Undefined, font=Undefined, fontSize=Undefined, fontStyle=Undefined,
+                 fontWeight=Undefined, href=Undefined, interpolate=Undefined, limit=Undefined,
+                 opacity=Undefined, orient=Undefined, radius=Undefined, shape=Undefined, size=Undefined,
+                 stroke=Undefined, strokeCap=Undefined, strokeDash=Undefined,
+                 strokeDashOffset=Undefined, strokeJoin=Undefined, strokeMiterLimit=Undefined,
+                 strokeOpacity=Undefined, strokeWidth=Undefined, style=Undefined, tension=Undefined,
+                 text=Undefined, theta=Undefined, tooltip=Undefined, x2Offset=Undefined,
+                 xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        super(OverlayMarkDef, self).__init__(align=align, angle=angle, baseline=baseline, clip=clip,
+                                             color=color, cornerRadius=cornerRadius, cursor=cursor,
+                                             dir=dir, dx=dx, dy=dy, ellipsis=ellipsis, fill=fill,
+                                             fillOpacity=fillOpacity, filled=filled, font=font,
+                                             fontSize=fontSize, fontStyle=fontStyle,
+                                             fontWeight=fontWeight, href=href, interpolate=interpolate,
+                                             limit=limit, opacity=opacity, orient=orient, radius=radius,
+                                             shape=shape, size=size, stroke=stroke, strokeCap=strokeCap,
+                                             strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                                             strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                                             strokeOpacity=strokeOpacity, strokeWidth=strokeWidth,
+                                             style=style, tension=tension, text=text, theta=theta,
+                                             tooltip=tooltip, x2Offset=x2Offset, xOffset=xOffset,
+                                             y2Offset=y2Offset, yOffset=yOffset, **kwds)
+
+
+class Padding(VegaLiteSchema):
+    """Padding schema wrapper
+
+    anyOf(float, Mapping(required=[]))
+    """
+    _schema = {'$ref': '#/definitions/Padding'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(Padding, self).__init__(*args, **kwds)
+
+
+class Parse(VegaLiteSchema):
+    """Parse schema wrapper
+
+    Mapping(required=[])
+    """
+    _schema = {'$ref': '#/definitions/Parse'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(Parse, self).__init__(**kwds)
+
+
+class ParseValue(VegaLiteSchema):
+    """ParseValue schema wrapper
+
+    anyOf(None, string, enum('string'), enum('boolean'), enum('date'), enum('number'))
+    """
+    _schema = {'$ref': '#/definitions/ParseValue'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(ParseValue, self).__init__(*args, **kwds)
+
+
+class PartsMixinsBoxPlotPart(VegaLiteSchema):
+    """PartsMixinsBoxPlotPart schema wrapper
+
+    Mapping(required=[])
+    Make all properties in T optional
+
+    Attributes
+    ----------
+
+    box : anyOf(boolean, :class:`MarkConfig`)
+
+    median : anyOf(boolean, :class:`MarkConfig`)
+
+    outliers : anyOf(boolean, :class:`MarkConfig`)
+
+    rule : anyOf(boolean, :class:`MarkConfig`)
+
+    ticks : anyOf(boolean, :class:`MarkConfig`)
+
+    """
+    _schema = {'$ref': '#/definitions/PartsMixins<BoxPlotPart>'}
+    _rootschema = Root._schema
+
+    def __init__(self, box=Undefined, median=Undefined, outliers=Undefined, rule=Undefined,
+                 ticks=Undefined, **kwds):
+        super(PartsMixinsBoxPlotPart, self).__init__(box=box, median=median, outliers=outliers,
+                                                     rule=rule, ticks=ticks, **kwds)
+
+
+class PartsMixinsErrorBandPart(VegaLiteSchema):
+    """PartsMixinsErrorBandPart schema wrapper
+
+    Mapping(required=[])
+    Make all properties in T optional
+
+    Attributes
+    ----------
+
+    band : anyOf(boolean, :class:`MarkConfig`)
+
+    borders : anyOf(boolean, :class:`MarkConfig`)
+
+    """
+    _schema = {'$ref': '#/definitions/PartsMixins<ErrorBandPart>'}
+    _rootschema = Root._schema
+
+    def __init__(self, band=Undefined, borders=Undefined, **kwds):
+        super(PartsMixinsErrorBandPart, self).__init__(band=band, borders=borders, **kwds)
+
+
+class PartsMixinsErrorBarPart(VegaLiteSchema):
+    """PartsMixinsErrorBarPart schema wrapper
+
+    Mapping(required=[])
+    Make all properties in T optional
+
+    Attributes
+    ----------
+
+    rule : anyOf(boolean, :class:`MarkConfig`)
+
+    ticks : anyOf(boolean, :class:`MarkConfig`)
+
+    """
+    _schema = {'$ref': '#/definitions/PartsMixins<ErrorBarPart>'}
+    _rootschema = Root._schema
+
+    def __init__(self, rule=Undefined, ticks=Undefined, **kwds):
+        super(PartsMixinsErrorBarPart, self).__init__(rule=rule, ticks=ticks, **kwds)
+
+
+class PositionFieldDef(VegaLiteSchema):
+    """PositionFieldDef schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    axis : anyOf(:class:`Axis`, None)
+        An object defining properties of axis's gridlines, ticks and labels.
+        If ``null``, the axis for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `axis properties
+        <https://vega.github.io/vega-lite/docs/axis.html>`__ are applied.
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    impute : :class:`ImputeParams`
+        An object defining the properties of the Impute Operation to be applied.
+        The field value of the other positional channel is taken as ``key`` of the
+        ``Impute`` Operation.
+        The field of the ``color`` channel if specified is used as ``groupby`` of the
+        ``Impute`` Operation.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    stack : anyOf(:class:`StackOffset`, None)
+        Type of stacking offset if the field should be stacked.
+        ``stack`` is only applicable for ``x`` and ``y`` channels with continuous domains.
+        For example, ``stack`` of ``y`` can be used to customize stacking for a vertical bar
+        chart.
+
+        ``stack`` can be one of the following values:
+
+
+        * `"zero"`: stacking with baseline offset at zero value of the scale (for creating
+          typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and
+          `area <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
+        * ``"normalize"`` - stacking with normalized domain (for creating `normalized
+          stacked bar and area charts
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
+          :raw-html:`<br/>`
+        - ``"center"`` - stacking with center baseline (for `streamgraph
+        <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
+        * ``null`` - No-stacking. This will produce layered `bar
+          <https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart>`__ and area
+          chart.
+
+        **Default value:** ``zero`` for plots with all of the following conditions are true:
+        (1) the mark is ``bar`` or ``area`` ;
+        (2) the stacked measure channel (x or y) has a linear scale;
+        (3) At least one of non-position channels mapped to an unaggregated field that is
+        different from x and y.  Otherwise, ``null`` by default.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/PositionFieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, axis=Undefined, bin=Undefined,
+                 field=Undefined, impute=Undefined, scale=Undefined, sort=Undefined, stack=Undefined,
+                 timeUnit=Undefined, title=Undefined, **kwds):
+        super(PositionFieldDef, self).__init__(type=type, aggregate=aggregate, axis=axis, bin=bin,
+                                               field=field, impute=impute, scale=scale, sort=sort,
+                                               stack=stack, timeUnit=timeUnit, title=title, **kwds)
+
+
+class Predicate(VegaLiteSchema):
+    """Predicate schema wrapper
+
+    anyOf(:class:`FieldEqualPredicate`, :class:`FieldRangePredicate`,
+    :class:`FieldOneOfPredicate`, :class:`FieldLTPredicate`, :class:`FieldGTPredicate`,
+    :class:`FieldLTEPredicate`, :class:`FieldGTEPredicate`, :class:`FieldValidPredicate`,
+    :class:`SelectionPredicate`, string)
+    """
+    _schema = {'$ref': '#/definitions/Predicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(Predicate, self).__init__(*args, **kwds)
+
+
+class Projection(VegaLiteSchema):
+    """Projection schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    center : List(float)
+        Sets the projection’s center to the specified center, a two-element array of
+        longitude and latitude in degrees.
+
+        **Default value:** ``[0, 0]``
+    clipAngle : float
+        Sets the projection’s clipping circle radius to the specified angle in degrees. If
+        ``null``, switches to `antimeridian <http://bl.ocks.org/mbostock/3788999>`__ cutting
+        rather than small-circle clipping.
+    clipExtent : List(List(float))
+        Sets the projection’s viewport clip extent to the specified bounds in pixels. The
+        extent bounds are specified as an array ``[[x0, y0], [x1, y1]]``, where ``x0`` is
+        the left-side of the viewport, ``y0`` is the top, ``x1`` is the right and ``y1`` is
+        the bottom. If ``null``, no viewport clipping is performed.
+    coefficient : float
+
+    distance : float
+
+    fraction : float
+
+    lobes : float
+
+    parallel : float
+
+    precision : string
+        Sets the threshold for the projection’s `adaptive resampling
+        <http://bl.ocks.org/mbostock/3795544>`__ to the specified value in pixels. This
+        value corresponds to the `Douglas–Peucker distance
+        <http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm>`__.
+        If precision is not specified, returns the projection’s current resampling precision
+        which defaults to ``√0.5 ≅ 0.70710…``.
+    radius : float
+
+    ratio : float
+
+    rotate : List(float)
+        Sets the projection’s three-axis rotation to the specified angles, which must be a
+        two- or three-element array of numbers [ ``lambda``, ``phi``, ``gamma`` ] specifying
+        the rotation angles in degrees about each spherical axis. (These correspond to yaw,
+        pitch and roll.)
+
+        **Default value:** ``[0, 0, 0]``
+    spacing : float
+
+    tilt : float
+
+    type : :class:`ProjectionType`
+        The cartographic projection to use. This value is case-insensitive, for example
+        ``"albers"`` and ``"Albers"`` indicate the same projection type. You can find all
+        valid projection types `in the documentation
+        <https://vega.github.io/vega-lite/docs/projection.html#projection-types>`__.
+
+        **Default value:** ``mercator``
+    """
+    _schema = {'$ref': '#/definitions/Projection'}
+    _rootschema = Root._schema
+
+    def __init__(self, center=Undefined, clipAngle=Undefined, clipExtent=Undefined,
+                 coefficient=Undefined, distance=Undefined, fraction=Undefined, lobes=Undefined,
+                 parallel=Undefined, precision=Undefined, radius=Undefined, ratio=Undefined,
+                 rotate=Undefined, spacing=Undefined, tilt=Undefined, type=Undefined, **kwds):
+        super(Projection, self).__init__(center=center, clipAngle=clipAngle, clipExtent=clipExtent,
+                                         coefficient=coefficient, distance=distance, fraction=fraction,
+                                         lobes=lobes, parallel=parallel, precision=precision,
+                                         radius=radius, ratio=ratio, rotate=rotate, spacing=spacing,
+                                         tilt=tilt, type=type, **kwds)
+
+
+class ProjectionConfig(VegaLiteSchema):
+    """ProjectionConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    center : List(float)
+        Sets the projection’s center to the specified center, a two-element array of
+        longitude and latitude in degrees.
+
+        **Default value:** ``[0, 0]``
+    clipAngle : float
+        Sets the projection’s clipping circle radius to the specified angle in degrees. If
+        ``null``, switches to `antimeridian <http://bl.ocks.org/mbostock/3788999>`__ cutting
+        rather than small-circle clipping.
+    clipExtent : List(List(float))
+        Sets the projection’s viewport clip extent to the specified bounds in pixels. The
+        extent bounds are specified as an array ``[[x0, y0], [x1, y1]]``, where ``x0`` is
+        the left-side of the viewport, ``y0`` is the top, ``x1`` is the right and ``y1`` is
+        the bottom. If ``null``, no viewport clipping is performed.
+    coefficient : float
+
+    distance : float
+
+    fraction : float
+
+    lobes : float
+
+    parallel : float
+
+    precision : string
+        Sets the threshold for the projection’s `adaptive resampling
+        <http://bl.ocks.org/mbostock/3795544>`__ to the specified value in pixels. This
+        value corresponds to the `Douglas–Peucker distance
+        <http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm>`__.
+        If precision is not specified, returns the projection’s current resampling precision
+        which defaults to ``√0.5 ≅ 0.70710…``.
+    radius : float
+
+    ratio : float
+
+    rotate : List(float)
+        Sets the projection’s three-axis rotation to the specified angles, which must be a
+        two- or three-element array of numbers [ ``lambda``, ``phi``, ``gamma`` ] specifying
+        the rotation angles in degrees about each spherical axis. (These correspond to yaw,
+        pitch and roll.)
+
+        **Default value:** ``[0, 0, 0]``
+    spacing : float
+
+    tilt : float
+
+    type : :class:`ProjectionType`
+        The cartographic projection to use. This value is case-insensitive, for example
+        ``"albers"`` and ``"Albers"`` indicate the same projection type. You can find all
+        valid projection types `in the documentation
+        <https://vega.github.io/vega-lite/docs/projection.html#projection-types>`__.
+
+        **Default value:** ``mercator``
+    """
+    _schema = {'$ref': '#/definitions/ProjectionConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, center=Undefined, clipAngle=Undefined, clipExtent=Undefined,
+                 coefficient=Undefined, distance=Undefined, fraction=Undefined, lobes=Undefined,
+                 parallel=Undefined, precision=Undefined, radius=Undefined, ratio=Undefined,
+                 rotate=Undefined, spacing=Undefined, tilt=Undefined, type=Undefined, **kwds):
+        super(ProjectionConfig, self).__init__(center=center, clipAngle=clipAngle,
+                                               clipExtent=clipExtent, coefficient=coefficient,
+                                               distance=distance, fraction=fraction, lobes=lobes,
+                                               parallel=parallel, precision=precision, radius=radius,
+                                               ratio=ratio, rotate=rotate, spacing=spacing, tilt=tilt,
+                                               type=type, **kwds)
+
+
+class ProjectionType(VegaLiteSchema):
+    """ProjectionType schema wrapper
+
+    enum('albers', 'albersUsa', 'azimuthalEqualArea', 'azimuthalEquidistant', 'conicConformal',
+    'conicEqualArea', 'conicEquidistant', 'equirectangular', 'gnomonic', 'mercator',
+    'orthographic', 'stereographic', 'transverseMercator')
+    """
+    _schema = {'$ref': '#/definitions/ProjectionType'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(ProjectionType, self).__init__(*args)
+
+
+class RangeConfig(VegaLiteSchema):
+    """RangeConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    category : anyOf(List(string), :class:`VgScheme`)
+        Default range for *nominal* (categorical) fields.
+    diverging : anyOf(List(string), :class:`VgScheme`)
+        Default range for diverging *quantitative* fields.
+    heatmap : anyOf(List(string), :class:`VgScheme`)
+        Default range for *quantitative* heatmaps.
+    ordinal : anyOf(List(string), :class:`VgScheme`)
+        Default range for *ordinal* fields.
+    ramp : anyOf(List(string), :class:`VgScheme`)
+        Default range for *quantitative* and *temporal* fields.
+    symbol : List(string)
+        Default range palette for the ``shape`` channel.
+    """
+    _schema = {'$ref': '#/definitions/RangeConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, category=Undefined, diverging=Undefined, heatmap=Undefined, ordinal=Undefined,
+                 ramp=Undefined, symbol=Undefined, **kwds):
+        super(RangeConfig, self).__init__(category=category, diverging=diverging, heatmap=heatmap,
+                                          ordinal=ordinal, ramp=ramp, symbol=symbol, **kwds)
+
+
+class RangeConfigValue(VegaLiteSchema):
+    """RangeConfigValue schema wrapper
+
+    anyOf(List(anyOf(float, string)), :class:`VgScheme`, Mapping(required=[step]))
+    """
+    _schema = {'$ref': '#/definitions/RangeConfigValue'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(RangeConfigValue, self).__init__(*args, **kwds)
+
+
+class Repeat(VegaLiteSchema):
+    """Repeat schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    column : List(string)
+        Horizontal repeated views.
+    row : List(string)
+        Vertical repeated views.
+    """
+    _schema = {'$ref': '#/definitions/Repeat'}
+    _rootschema = Root._schema
+
+    def __init__(self, column=Undefined, row=Undefined, **kwds):
+        super(Repeat, self).__init__(column=column, row=row, **kwds)
+
+
+class RepeatRef(VegaLiteSchema):
+    """RepeatRef schema wrapper
+
+    Mapping(required=[repeat])
+    Reference to a repeated value.
+
+    Attributes
+    ----------
+
+    repeat : enum('row', 'column')
+
+    """
+    _schema = {'$ref': '#/definitions/RepeatRef'}
+    _rootschema = Root._schema
+
+    def __init__(self, repeat=Undefined, **kwds):
+        super(RepeatRef, self).__init__(repeat=repeat, **kwds)
+
+
+class Resolve(VegaLiteSchema):
+    """Resolve schema wrapper
+
+    Mapping(required=[])
+    Defines how scales, axes, and legends from different specs should be combined. Resolve is a
+    mapping from ``scale``, ``axis``, and ``legend`` to a mapping from channels to resolutions.
+
+    Attributes
+    ----------
+
+    axis : :class:`AxisResolveMap`
+
+    legend : :class:`LegendResolveMap`
+
+    scale : :class:`ScaleResolveMap`
+
+    """
+    _schema = {'$ref': '#/definitions/Resolve'}
+    _rootschema = Root._schema
+
+    def __init__(self, axis=Undefined, legend=Undefined, scale=Undefined, **kwds):
+        super(Resolve, self).__init__(axis=axis, legend=legend, scale=scale, **kwds)
+
+
+class ResolveMode(VegaLiteSchema):
+    """ResolveMode schema wrapper
+
+    enum('independent', 'shared')
+    """
+    _schema = {'$ref': '#/definitions/ResolveMode'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(ResolveMode, self).__init__(*args)
+
+
+class RowColVgLayoutAlign(VegaLiteSchema):
+    """RowColVgLayoutAlign schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    column : :class:`VgLayoutAlign`
+
+    row : :class:`VgLayoutAlign`
+
+    """
+    _schema = {'$ref': '#/definitions/RowCol<VgLayoutAlign>'}
+    _rootschema = Root._schema
+
+    def __init__(self, column=Undefined, row=Undefined, **kwds):
+        super(RowColVgLayoutAlign, self).__init__(column=column, row=row, **kwds)
+
+
+class RowColboolean(VegaLiteSchema):
+    """RowColboolean schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    column : boolean
+
+    row : boolean
+
+    """
+    _schema = {'$ref': '#/definitions/RowCol<boolean>'}
+    _rootschema = Root._schema
+
+    def __init__(self, column=Undefined, row=Undefined, **kwds):
+        super(RowColboolean, self).__init__(column=column, row=row, **kwds)
+
+
+class RowColnumber(VegaLiteSchema):
+    """RowColnumber schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    column : float
+
+    row : float
+
+    """
+    _schema = {'$ref': '#/definitions/RowCol<number>'}
+    _rootschema = Root._schema
+
+    def __init__(self, column=Undefined, row=Undefined, **kwds):
+        super(RowColnumber, self).__init__(column=column, row=row, **kwds)
+
+
+class SampleTransform(VegaLiteSchema):
+    """SampleTransform schema wrapper
+
+    Mapping(required=[sample])
+
+    Attributes
+    ----------
+
+    sample : float
+        The maximum number of data objects to include in the sample.
+
+        **Default value:** ``1000``
+    """
+    _schema = {'$ref': '#/definitions/SampleTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, sample=Undefined, **kwds):
+        super(SampleTransform, self).__init__(sample=sample, **kwds)
+
+
+class Scale(VegaLiteSchema):
+    """Scale schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    base : float
+        The logarithm base of the ``log`` scale (default ``10`` ).
+    clamp : boolean
+        If ``true``, values that exceed the data domain are clamped to either the minimum or
+        maximum range value
+
+        **Default value:** derived from the `scale config
+        <https://vega.github.io/vega-lite/docs/config.html#scale-config>`__ 's ``clamp`` (
+        ``true`` by default).
+    domain : anyOf(List(float), List(string), List(boolean), List(:class:`DateTime`),
+    enum('unaggregated'), :class:`SelectionDomain`)
+        Customized domain values.
+
+        For *quantitative* fields, ``domain`` can take the form of a two-element array with
+        minimum and maximum values.  `Piecewise scales
+        <https://vega.github.io/vega-lite/docs/scale.html#piecewise>`__ can be created by
+        providing a ``domain`` with more than two entries.
+        If the input field is aggregated, ``domain`` can also be a string value
+        ``"unaggregated"``, indicating that the domain should include the raw data values
+        prior to the aggregation.
+
+        For *temporal* fields, ``domain`` can be a two-element array minimum and maximum
+        values, in the form of either timestamps or the `DateTime definition objects
+        <https://vega.github.io/vega-lite/docs/types.html#datetime>`__.
+
+        For *ordinal* and *nominal* fields, ``domain`` can be an array that lists valid
+        input values.
+
+        The ``selection`` property can be used to `interactively determine
+        <https://vega.github.io/vega-lite/docs/selection.html#scale-domains>`__ the scale
+        domain.
+    exponent : float
+        The exponent of the ``pow`` scale.
+    interpolate : anyOf(:class:`ScaleInterpolate`, :class:`ScaleInterpolateParams`)
+        The interpolation method for range values. By default, a general interpolator for
+        numbers, dates, strings and colors (in HCL space) is used. For color ranges, this
+        property allows interpolation in alternative color spaces. Legal values include
+        ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and
+        ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces).
+        If object-valued, this property accepts an object with a string-valued *type*
+        property and an optional numeric *gamma* property applicable to rgb and cubehelix
+        interpolators. For more, see the `d3-interpolate documentation
+        <https://github.com/d3/d3-interpolate>`__.
+
+
+        * **Default value:** ``hcl``
+
+        **Note:** Sequential scales do not support ``interpolate`` as they have a fixed
+        interpolator.  Since Vega-Lite uses sequential scales for quantitative fields by
+        default, you have to set the scale ``type`` to other quantitative scale type such as
+        ``"linear"`` to customize ``interpolate``.
+    nice : anyOf(boolean, float, :class:`NiceTime`, Mapping(required=[interval, step]))
+        Extending the domain so that it starts and ends on nice round values. This method
+        typically modifies the scale’s domain, and may only extend the bounds to the nearest
+        round value. Nicing is useful if the domain is computed from data and may be
+        irregular. For example, for a domain of *[0.201479…, 0.996679…]*, a nice domain
+        might be *[0.2, 1.0]*.
+
+        For quantitative scales such as linear, ``nice`` can be either a boolean flag or a
+        number. If ``nice`` is a number, it will represent a desired tick count. This allows
+        greater control over the step size used to extend the bounds, guaranteeing that the
+        returned ticks will exactly cover the domain.
+
+        For temporal fields with time and utc scales, the ``nice`` value can be a string
+        indicating the desired time interval. Legal values are ``"millisecond"``,
+        ``"second"``, ``"minute"``, ``"hour"``, ``"day"``, ``"week"``, ``"month"``, and
+        ``"year"``. Alternatively, ``time`` and ``utc`` scales can accept an object-valued
+        interval specifier of the form ``{"interval": "month", "step": 3}``, which includes
+        a desired number of interval steps. Here, the domain would snap to quarter (Jan,
+        Apr, Jul, Oct) boundaries.
+
+        **Default value:** ``true`` for unbinned *quantitative* fields; ``false`` otherwise.
+    padding : float
+        For * `continuous <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__ *
+        scales, expands the scale domain to accommodate the specified number of pixels on
+        each of the scale range. The scale range must represent pixels for this parameter to
+        function as intended. Padding adjustment is performed prior to all other
+        adjustments, including the effects of the zero, nice, domainMin, and domainMax
+        properties.
+
+        For * `band <https://vega.github.io/vega-lite/docs/scale.html#band>`__ * scales,
+        shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value.
+
+        For * `point <https://vega.github.io/vega-lite/docs/scale.html#point>`__ * scales,
+        alias for ``paddingOuter``.
+
+        **Default value:** For *continuous* scales, derived from the `scale config
+        <https://vega.github.io/vega-lite/docs/scale.html#config>`__ 's
+        ``continuousPadding``.
+        For *band and point* scales, see ``paddingInner`` and ``paddingOuter``.
+    paddingInner : float
+        The inner padding (spacing) within each band step of band scales, as a fraction of
+        the step size. This value must lie in the range [0,1].
+
+        For point scale, this property is invalid as point scales do not have internal band
+        widths (only step sizes between bands).
+
+        **Default value:** derived from the `scale config
+        <https://vega.github.io/vega-lite/docs/scale.html#config>`__ 's
+        ``bandPaddingInner``.
+    paddingOuter : float
+        The outer padding (spacing) at the ends of the range of band and point scales,
+        as a fraction of the step size. This value must lie in the range [0,1].
+
+        **Default value:** derived from the `scale config
+        <https://vega.github.io/vega-lite/docs/scale.html#config>`__ 's ``bandPaddingOuter``
+        for band scales and ``pointPadding`` for point scales.
+    range : anyOf(List(float), List(string), string)
+        The range of the scale. One of:
+
+
+        A string indicating a `pre-defined named scale range
+        <https://vega.github.io/vega-lite/docs/scale.html#range-config>`__ (e.g., example,
+        ``"symbol"``, or ``"diverging"`` ).
+
+        For `continuous scales
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, two-element array
+        indicating  minimum and maximum values, or an array with more than two entries for
+        specifying a `piecewise scale
+        <https://vega.github.io/vega-lite/docs/scale.html#piecewise>`__.
+
+        For `discrete <https://vega.github.io/vega-lite/docs/scale.html#discrete>`__ and
+        `discretizing <https://vega.github.io/vega-lite/docs/scale.html#discretizing>`__
+        scales, an array of desired output values.
+
+        **Notes:**
+
+        1) For `sequential <https://vega.github.io/vega-lite/docs/scale.html#sequential>`__,
+        `ordinal <https://vega.github.io/vega-lite/docs/scale.html#ordinal>`__, and
+        discretizing color scales, you can also specify a color `scheme
+        <https://vega.github.io/vega-lite/docs/scale.html#scheme>`__ instead of ``range``.
+
+        2) Any directly specified ``range`` for ``x`` and ``y`` channels will be ignored.
+        Range can be customized via the view's corresponding `size
+        <https://vega.github.io/vega-lite/docs/size.html>`__ ( ``width`` and ``height`` ) or
+        via `range steps and paddings properties <#range-step>`__ for `band <#band>`__ and
+        `point <#point>`__ scales.
+    rangeStep : anyOf(float, None)
+        The distance between the starts of adjacent bands or points in `band
+        <https://vega.github.io/vega-lite/docs/scale.html#band>`__ and `point
+        <https://vega.github.io/vega-lite/docs/scale.html#point>`__ scales.
+
+        If ``rangeStep`` is ``null`` or if the view contains the scale's corresponding `size
+        <https://vega.github.io/vega-lite/docs/size.html>`__ ( ``width`` for ``x`` scales
+        and ``height`` for ``y`` scales), ``rangeStep`` will be automatically determined to
+        fit the size of the view.
+
+        **Default value:**  derived the `scale config
+        <https://vega.github.io/vega-lite/docs/config.html#scale-config>`__ 's
+        ``textXRangeStep`` ( ``90`` by default) for x-scales of ``text`` marks and
+        ``rangeStep`` ( ``21`` by default) for x-scales of other marks and y-scales.
+
+        **Warning** : If ``rangeStep`` is ``null`` and the cardinality of the scale's domain
+        is higher than ``width`` or ``height``, the rangeStep might become less than one
+        pixel and the mark might not appear correctly.
+    round : boolean
+        If ``true``, rounds numeric output values to integers. This can be helpful for
+        snapping to the pixel grid.
+
+        **Default value:** ``false``.
+    scheme : anyOf(string, :class:`SchemeParams`)
+        A string indicating a color `scheme
+        <https://vega.github.io/vega-lite/docs/scale.html#scheme>`__ name (e.g.,
+        ``"category10"`` or ``"viridis"`` ) or a `scheme parameter object
+        <https://vega.github.io/vega-lite/docs/scale.html#scheme-params>`__.
+
+        Discrete color schemes may be used with `discrete
+        <https://vega.github.io/vega-lite/docs/scale.html#discrete>`__ or `discretizing
+        <https://vega.github.io/vega-lite/docs/scale.html#discretizing>`__ scales.
+        Continuous color schemes are intended for use with `sequential
+        <https://vega.github.io/vega-lite/docs/scales.html#sequential>`__ scales.
+
+        For the full list of supported schemes, please refer to the `Vega Scheme
+        <https://vega.github.io/vega/docs/schemes/#reference>`__ reference.
+    type : :class:`ScaleType`
+        The type of scale.  Vega-Lite supports the following categories of scale types:
+
+        1) `Continuous Scales
+        <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__ -- mapping
+        continuous domains to continuous output ranges ( `"linear"
+        <https://vega.github.io/vega-lite/docs/scale.html#linear>`__, `"pow"
+        <https://vega.github.io/vega-lite/docs/scale.html#pow>`__, `"sqrt"
+        <https://vega.github.io/vega-lite/docs/scale.html#sqrt>`__, `"log"
+        <https://vega.github.io/vega-lite/docs/scale.html#log>`__, `"time"
+        <https://vega.github.io/vega-lite/docs/scale.html#time>`__, `"utc"
+        <https://vega.github.io/vega-lite/docs/scale.html#utc>`__, `"sequential"
+        <https://vega.github.io/vega-lite/docs/scale.html#sequential>`__ ).
+
+        2) `Discrete Scales <https://vega.github.io/vega-lite/docs/scale.html#discrete>`__
+        -- mapping discrete domains to discrete ( `"ordinal"
+        <https://vega.github.io/vega-lite/docs/scale.html#ordinal>`__ ) or continuous (
+        `"band" <https://vega.github.io/vega-lite/docs/scale.html#band>`__ and `"point"
+        <https://vega.github.io/vega-lite/docs/scale.html#point>`__ ) output ranges.
+
+        3) `Discretizing Scales
+        <https://vega.github.io/vega-lite/docs/scale.html#discretizing>`__ -- mapping
+        continuous domains to discrete output ranges ( `"bin-linear"
+        <https://vega.github.io/vega-lite/docs/scale.html#bin-linear>`__, `"bin-ordinal"
+        <https://vega.github.io/vega-lite/docs/scale.html#bin-ordinal>`__, `"quantile"
+        <https://vega.github.io/vega-lite/docs/scale.html#quantile>`__, `"quantize"
+        <https://vega.github.io/vega-lite/docs/scale.html#quantize>`__ and `"threshold"
+        <https://vega.github.io/vega-lite/docs/scale.html#threshold>`__.
+
+        **Default value:** please see the `scale type table
+        <https://vega.github.io/vega-lite/docs/scale.html#type>`__.
+    zero : boolean
+        If ``true``, ensures that a zero baseline value is included in the scale domain.
+
+        **Default value:** ``true`` for x and y channels if the quantitative field is not
+        binned and no custom ``domain`` is provided; ``false`` otherwise.
+
+        **Note:** Log, time, and utc scales do not support ``zero``.
+    """
+    _schema = {'$ref': '#/definitions/Scale'}
+    _rootschema = Root._schema
+
+    def __init__(self, base=Undefined, clamp=Undefined, domain=Undefined, exponent=Undefined,
+                 interpolate=Undefined, nice=Undefined, padding=Undefined, paddingInner=Undefined,
+                 paddingOuter=Undefined, range=Undefined, rangeStep=Undefined, round=Undefined,
+                 scheme=Undefined, type=Undefined, zero=Undefined, **kwds):
+        super(Scale, self).__init__(base=base, clamp=clamp, domain=domain, exponent=exponent,
+                                    interpolate=interpolate, nice=nice, padding=padding,
+                                    paddingInner=paddingInner, paddingOuter=paddingOuter, range=range,
+                                    rangeStep=rangeStep, round=round, scheme=scheme, type=type,
+                                    zero=zero, **kwds)
+
+
+class ScaleConfig(VegaLiteSchema):
+    """ScaleConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    bandPaddingInner : float
+        Default inner padding for ``x`` and ``y`` band-ordinal scales.
+
+        **Default value:** ``0.1``
+    bandPaddingOuter : float
+        Default outer padding for ``x`` and ``y`` band-ordinal scales.
+        If not specified, by default, band scale's paddingOuter is paddingInner/2.
+    clamp : boolean
+        If true, values that exceed the data domain are clamped to either the minimum or
+        maximum range value
+    continuousPadding : float
+        Default padding for continuous scales.
+
+        **Default:** ``5`` for continuous x-scale of a vertical bar and continuous y-scale
+        of a horizontal bar.; ``0`` otherwise.
+    maxBandSize : float
+        The default max value for mapping quantitative fields to bar's size/bandSize.
+
+        If undefined (default), we will use the scale's ``rangeStep`` - 1.
+    maxFontSize : float
+        The default max value for mapping quantitative fields to text's size/fontSize.
+
+        **Default value:** ``40``
+    maxOpacity : float
+        Default max opacity for mapping a field to opacity.
+
+        **Default value:** ``0.8``
+    maxSize : float
+        Default max value for point size scale.
+    maxStrokeWidth : float
+        Default max strokeWidth for the scale of strokeWidth for rule and line marks and of
+        size for trail marks.
+
+        **Default value:** ``4``
+    minBandSize : float
+        The default min value for mapping quantitative fields to bar and tick's
+        size/bandSize scale with zero=false.
+
+        **Default value:** ``2``
+    minFontSize : float
+        The default min value for mapping quantitative fields to tick's size/fontSize scale
+        with zero=false
+
+        **Default value:** ``8``
+    minOpacity : float
+        Default minimum opacity for mapping a field to opacity.
+
+        **Default value:** ``0.3``
+    minSize : float
+        Default minimum value for point size scale with zero=false.
+
+        **Default value:** ``9``
+    minStrokeWidth : float
+        Default minimum strokeWidth for the scale of strokeWidth for rule and line marks and
+        of size for trail marks with zero=false.
+
+        **Default value:** ``1``
+    pointPadding : float
+        Default outer padding for ``x`` and ``y`` point-ordinal scales.
+
+        **Default value:** ``0.5``
+    quantileCount : float
+        Default range cardinality for `quantile
+        <https://vega.github.io/vega-lite/docs/scale.html#quantile>`__ scale.
+
+        **Default value:** ``4``
+    quantizeCount : float
+        Default range cardinality for `quantize
+        <https://vega.github.io/vega-lite/docs/scale.html#quantize>`__ scale.
+
+        **Default value:** ``4``
+    rangeStep : anyOf(float, None)
+        Default range step for band and point scales of (1) the ``y`` channel
+        and (2) the ``x`` channel when the mark is not ``text``.
+
+        **Default value:** ``21``
+    round : boolean
+        If true, rounds numeric output values to integers.
+        This can be helpful for snapping to the pixel grid.
+        (Only available for ``x``, ``y``, and ``size`` scales.)
+    textXRangeStep : float
+        Default range step for ``x`` band and point scales of text marks.
+
+        **Default value:** ``90``
+    useUnaggregatedDomain : boolean
+        Use the source data range before aggregation as scale domain instead of aggregated
+        data for aggregate axis.
+
+        This is equivalent to setting ``domain`` to ``"unaggregate"`` for aggregated
+        *quantitative* fields by default.
+
+        This property only works with aggregate functions that produce values within the raw
+        data domain ( ``"mean"``, ``"average"``, ``"median"``, ``"q1"``, ``"q3"``,
+        ``"min"``, ``"max"`` ). For other aggregations that produce values outside of the
+        raw data domain (e.g. ``"count"``, ``"sum"`` ), this property is ignored.
+
+        **Default value:** ``false``
+    """
+    _schema = {'$ref': '#/definitions/ScaleConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, bandPaddingInner=Undefined, bandPaddingOuter=Undefined, clamp=Undefined,
+                 continuousPadding=Undefined, maxBandSize=Undefined, maxFontSize=Undefined,
+                 maxOpacity=Undefined, maxSize=Undefined, maxStrokeWidth=Undefined,
+                 minBandSize=Undefined, minFontSize=Undefined, minOpacity=Undefined, minSize=Undefined,
+                 minStrokeWidth=Undefined, pointPadding=Undefined, quantileCount=Undefined,
+                 quantizeCount=Undefined, rangeStep=Undefined, round=Undefined,
+                 textXRangeStep=Undefined, useUnaggregatedDomain=Undefined, **kwds):
+        super(ScaleConfig, self).__init__(bandPaddingInner=bandPaddingInner,
+                                          bandPaddingOuter=bandPaddingOuter, clamp=clamp,
+                                          continuousPadding=continuousPadding, maxBandSize=maxBandSize,
+                                          maxFontSize=maxFontSize, maxOpacity=maxOpacity,
+                                          maxSize=maxSize, maxStrokeWidth=maxStrokeWidth,
+                                          minBandSize=minBandSize, minFontSize=minFontSize,
+                                          minOpacity=minOpacity, minSize=minSize,
+                                          minStrokeWidth=minStrokeWidth, pointPadding=pointPadding,
+                                          quantileCount=quantileCount, quantizeCount=quantizeCount,
+                                          rangeStep=rangeStep, round=round,
+                                          textXRangeStep=textXRangeStep,
+                                          useUnaggregatedDomain=useUnaggregatedDomain, **kwds)
+
+
+class ScaleInterpolate(VegaLiteSchema):
+    """ScaleInterpolate schema wrapper
+
+    enum('rgb', 'lab', 'hcl', 'hsl', 'hsl-long', 'hcl-long', 'cubehelix', 'cubehelix-long')
+    """
+    _schema = {'$ref': '#/definitions/ScaleInterpolate'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(ScaleInterpolate, self).__init__(*args)
+
+
+class ScaleInterpolateParams(VegaLiteSchema):
+    """ScaleInterpolateParams schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('rgb', 'cubehelix', 'cubehelix-long')
+
+    gamma : float
+
+    """
+    _schema = {'$ref': '#/definitions/ScaleInterpolateParams'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, gamma=Undefined, **kwds):
+        super(ScaleInterpolateParams, self).__init__(type=type, gamma=gamma, **kwds)
+
+
+class ScaleResolveMap(VegaLiteSchema):
+    """ScaleResolveMap schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    color : :class:`ResolveMode`
+
+    fill : :class:`ResolveMode`
+
+    opacity : :class:`ResolveMode`
+
+    shape : :class:`ResolveMode`
+
+    size : :class:`ResolveMode`
+
+    stroke : :class:`ResolveMode`
+
+    x : :class:`ResolveMode`
+
+    y : :class:`ResolveMode`
+
+    """
+    _schema = {'$ref': '#/definitions/ScaleResolveMap'}
+    _rootschema = Root._schema
+
+    def __init__(self, color=Undefined, fill=Undefined, opacity=Undefined, shape=Undefined,
+                 size=Undefined, stroke=Undefined, x=Undefined, y=Undefined, **kwds):
+        super(ScaleResolveMap, self).__init__(color=color, fill=fill, opacity=opacity, shape=shape,
+                                              size=size, stroke=stroke, x=x, y=y, **kwds)
+
+
+class ScaleType(VegaLiteSchema):
+    """ScaleType schema wrapper
+
+    enum('linear', 'bin-linear', 'log', 'pow', 'sqrt', 'time', 'utc', 'sequential', 'quantile',
+    'quantize', 'threshold', 'ordinal', 'bin-ordinal', 'point', 'band')
+    """
+    _schema = {'$ref': '#/definitions/ScaleType'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(ScaleType, self).__init__(*args)
+
+
+class SchemeParams(VegaLiteSchema):
+    """SchemeParams schema wrapper
+
+    Mapping(required=[name])
+
+    Attributes
+    ----------
+
+    name : string
+        A color scheme name for sequential/ordinal scales (e.g., ``"category10"`` or
+        ``"viridis"`` ).
+
+        For the full list of supported schemes, please refer to the `Vega Scheme
+        <https://vega.github.io/vega/docs/schemes/#reference>`__ reference.
+    count : float
+        The number of colors to use in the scheme. This can be useful for scale types such
+        as ``"quantize"``, which use the length of the scale range to determine the number
+        of discrete bins for the scale domain.
+    extent : List(float)
+        For sequential and diverging schemes only, determines the extent of the color range
+        to use. For example ``[0.2, 1]`` will rescale the color scheme such that color
+        values in the range *[0, 0.2)* are excluded from the scheme.
+    """
+    _schema = {'$ref': '#/definitions/SchemeParams'}
+    _rootschema = Root._schema
+
+    def __init__(self, name=Undefined, count=Undefined, extent=Undefined, **kwds):
+        super(SchemeParams, self).__init__(name=name, count=count, extent=extent, **kwds)
+
+
+class SelectionConfig(VegaLiteSchema):
+    """SelectionConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    interval : :class:`IntervalSelectionConfig`
+        The default definition for an `interval
+        <https://vega.github.io/vega-lite/docs/selection.html#type>`__ selection. All
+        properties and transformations
+        for an interval selection definition (except ``type`` ) may be specified here.
+
+        For instance, setting ``interval`` to ``{"translate": false}`` disables the ability
+        to move
+        interval selections by default.
+    multi : :class:`MultiSelectionConfig`
+        The default definition for a `multi
+        <https://vega.github.io/vega-lite/docs/selection.html#type>`__ selection. All
+        properties and transformations
+        for a multi selection definition (except ``type`` ) may be specified here.
+
+        For instance, setting ``multi`` to ``{"toggle": "event.altKey"}`` adds additional
+        values to
+        multi selections when clicking with the alt-key pressed by default.
+    single : :class:`SingleSelectionConfig`
+        The default definition for a `single
+        <https://vega.github.io/vega-lite/docs/selection.html#type>`__ selection. All
+        properties and transformations
+        for a single selection definition (except ``type`` ) may be specified here.
+
+        For instance, setting ``single`` to ``{"on": "dblclick"}`` populates single
+        selections on double-click by default.
+    """
+    _schema = {'$ref': '#/definitions/SelectionConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, interval=Undefined, multi=Undefined, single=Undefined, **kwds):
+        super(SelectionConfig, self).__init__(interval=interval, multi=multi, single=single, **kwds)
+
+
+class SelectionDef(VegaLiteSchema):
+    """SelectionDef schema wrapper
+
+    anyOf(:class:`SingleSelection`, :class:`MultiSelection`, :class:`IntervalSelection`)
+    """
+    _schema = {'$ref': '#/definitions/SelectionDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(SelectionDef, self).__init__(*args, **kwds)
+
+
+class SelectionDomain(VegaLiteSchema):
+    """SelectionDomain schema wrapper
+
+    anyOf(Mapping(required=[selection]), Mapping(required=[selection]))
+    """
+    _schema = {'$ref': '#/definitions/SelectionDomain'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(SelectionDomain, self).__init__(*args, **kwds)
+
+
+class SelectionPredicate(VegaLiteSchema):
+    """SelectionPredicate schema wrapper
+
+    Mapping(required=[selection])
+
+    Attributes
+    ----------
+
+    selection : :class:`SelectionOperand`
+        Filter using a selection name.
+    """
+    _schema = {'$ref': '#/definitions/SelectionPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, selection=Undefined, **kwds):
+        super(SelectionPredicate, self).__init__(selection=selection, **kwds)
+
+
+class SelectionResolution(VegaLiteSchema):
+    """SelectionResolution schema wrapper
+
+    enum('global', 'union', 'intersect')
+    """
+    _schema = {'$ref': '#/definitions/SelectionResolution'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(SelectionResolution, self).__init__(*args)
+
+
+class SingleDefChannel(VegaLiteSchema):
+    """SingleDefChannel schema wrapper
+
+    enum('x', 'y', 'x2', 'y2', 'longitude', 'latitude', 'longitude2', 'latitude2', 'row',
+    'column', 'color', 'fill', 'stroke', 'size', 'shape', 'opacity', 'text', 'tooltip', 'href',
+    'key')
+    """
+    _schema = {'$ref': '#/definitions/SingleDefChannel'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(SingleDefChannel, self).__init__(*args)
+
+
+class SingleSelection(VegaLiteSchema):
+    """SingleSelection schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('single')
+
+    bind : anyOf(:class:`VgBinding`, Mapping(required=[]))
+        Establish a two-way binding between a single selection and input elements
+        (also known as dynamic query widgets). A binding takes the form of
+        Vega's `input element binding definition
+        <https://vega.github.io/vega/docs/signals/#bind>`__
+        or can be a mapping between projected field/encodings and binding definitions.
+
+        See the `bind transform <https://vega.github.io/vega-lite/docs/bind.html>`__
+        documentation for more information.
+    empty : enum('all', 'none')
+        By default, all data values are considered to lie within an empty selection.
+        When set to ``none``, empty selections contain no data values.
+    encodings : List(:class:`SingleDefChannel`)
+        An array of encoding channels. The corresponding data field values
+        must match for a data tuple to fall within the selection.
+    fields : List(string)
+        An array of field names whose values must match for a data tuple to
+        fall within the selection.
+    nearest : boolean
+        When true, an invisible voronoi diagram is computed to accelerate discrete
+        selection. The data value *nearest* the mouse cursor is added to the selection.
+
+        See the `nearest transform <https://vega.github.io/vega-lite/docs/nearest.html>`__
+        documentation for more information.
+    on : :class:`VgEventStream`
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
+        selector) that triggers the selection.
+        For interval selections, the event stream must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
+    resolve : :class:`SelectionResolution`
+        With layered and multi-view displays, a strategy that determines how
+        selections' data queries are resolved when applied in a filter transform,
+        conditional encoding rule, or scale domain.
+    """
+    _schema = {'$ref': '#/definitions/SingleSelection'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, bind=Undefined, empty=Undefined, encodings=Undefined,
+                 fields=Undefined, nearest=Undefined, on=Undefined, resolve=Undefined, **kwds):
+        super(SingleSelection, self).__init__(type=type, bind=bind, empty=empty, encodings=encodings,
+                                              fields=fields, nearest=nearest, on=on, resolve=resolve,
+                                              **kwds)
+
+
+class SingleSelectionConfig(VegaLiteSchema):
+    """SingleSelectionConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    bind : anyOf(:class:`VgBinding`, Mapping(required=[]))
+        Establish a two-way binding between a single selection and input elements
+        (also known as dynamic query widgets). A binding takes the form of
+        Vega's `input element binding definition
+        <https://vega.github.io/vega/docs/signals/#bind>`__
+        or can be a mapping between projected field/encodings and binding definitions.
+
+        See the `bind transform <https://vega.github.io/vega-lite/docs/bind.html>`__
+        documentation for more information.
+    empty : enum('all', 'none')
+        By default, all data values are considered to lie within an empty selection.
+        When set to ``none``, empty selections contain no data values.
+    encodings : List(:class:`SingleDefChannel`)
+        An array of encoding channels. The corresponding data field values
+        must match for a data tuple to fall within the selection.
+    fields : List(string)
+        An array of field names whose values must match for a data tuple to
+        fall within the selection.
+    nearest : boolean
+        When true, an invisible voronoi diagram is computed to accelerate discrete
+        selection. The data value *nearest* the mouse cursor is added to the selection.
+
+        See the `nearest transform <https://vega.github.io/vega-lite/docs/nearest.html>`__
+        documentation for more information.
+    on : :class:`VgEventStream`
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
+        selector) that triggers the selection.
+        For interval selections, the event stream must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
+    resolve : :class:`SelectionResolution`
+        With layered and multi-view displays, a strategy that determines how
+        selections' data queries are resolved when applied in a filter transform,
+        conditional encoding rule, or scale domain.
+    """
+    _schema = {'$ref': '#/definitions/SingleSelectionConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, bind=Undefined, empty=Undefined, encodings=Undefined, fields=Undefined,
+                 nearest=Undefined, on=Undefined, resolve=Undefined, **kwds):
+        super(SingleSelectionConfig, self).__init__(bind=bind, empty=empty, encodings=encodings,
+                                                    fields=fields, nearest=nearest, on=on,
+                                                    resolve=resolve, **kwds)
+
+
+class SingleTimeUnit(VegaLiteSchema):
+    """SingleTimeUnit schema wrapper
+
+    anyOf(:class:`LocalSingleTimeUnit`, :class:`UtcSingleTimeUnit`)
+    """
+    _schema = {'$ref': '#/definitions/SingleTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(SingleTimeUnit, self).__init__(*args, **kwds)
+
+
+class Sort(VegaLiteSchema):
+    """Sort schema wrapper
+
+    anyOf(List(float), List(string), List(boolean), List(:class:`DateTime`), :class:`SortOrder`,
+    :class:`EncodingSortField`, None)
+    """
+    _schema = {'$ref': '#/definitions/Sort'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(Sort, self).__init__(*args, **kwds)
+
+
+class SortField(VegaLiteSchema):
+    """SortField schema wrapper
+
+    Mapping(required=[field])
+    A sort definition for transform
+
+    Attributes
+    ----------
+
+    field : string
+        The name of the field to sort.
+    order : :class:`VgComparatorOrder`
+        Whether to sort the field in ascending or descending order.
+    """
+    _schema = {'$ref': '#/definitions/SortField'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, order=Undefined, **kwds):
+        super(SortField, self).__init__(field=field, order=order, **kwds)
+
+
+class SortOrder(VegaLiteSchema):
+    """SortOrder schema wrapper
+
+    anyOf(:class:`VgComparatorOrder`, None)
+    """
+    _schema = {'$ref': '#/definitions/SortOrder'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(SortOrder, self).__init__(*args, **kwds)
+
+
+class StackOffset(VegaLiteSchema):
+    """StackOffset schema wrapper
+
+    enum('zero', 'center', 'normalize')
+    """
+    _schema = {'$ref': '#/definitions/StackOffset'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(StackOffset, self).__init__(*args)
+
+
+class StackTransform(VegaLiteSchema):
+    """StackTransform schema wrapper
+
+    Mapping(required=[stack, groupby, as])
+
+    Attributes
+    ----------
+
+    groupby : List(string)
+        The data fields to group by.
+    stack : string
+        The field which is stacked.
+    offset : enum('zero', 'center', 'normalize')
+        Mode for stacking marks.
+        **Default value:** ``"zero"``
+    sort : List(:class:`SortField`)
+        Field that determines the order of leaves in the stacked charts.
+    as : anyOf(string, List(string))
+        Output field names. This can be either a string or an array of strings with
+        two elements denoting the name for the fields for stack start and stack end
+        respectively.
+        If a single string(eg."val") is provided, the end field will be "val_end".
+    """
+    _schema = {'$ref': '#/definitions/StackTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, groupby=Undefined, stack=Undefined, offset=Undefined, sort=Undefined, **kwds):
+        super(StackTransform, self).__init__(groupby=groupby, stack=stack, offset=offset, sort=sort,
+                                             **kwds)
+
+
+class StrokeCap(VegaLiteSchema):
+    """StrokeCap schema wrapper
+
+    enum('butt', 'round', 'square')
+    """
+    _schema = {'$ref': '#/definitions/StrokeCap'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(StrokeCap, self).__init__(*args)
+
+
+class StrokeJoin(VegaLiteSchema):
+    """StrokeJoin schema wrapper
+
+    enum('miter', 'round', 'bevel')
+    """
+    _schema = {'$ref': '#/definitions/StrokeJoin'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(StrokeJoin, self).__init__(*args)
+
+
+class StyleConfigIndex(VegaLiteSchema):
+    """StyleConfigIndex schema wrapper
+
+    Mapping(required=[])
+    """
+    _schema = {'$ref': '#/definitions/StyleConfigIndex'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(StyleConfigIndex, self).__init__(**kwds)
+
+
+class SymbolShape(VegaLiteSchema):
+    """SymbolShape schema wrapper
+
+    string
+    """
+    _schema = {'$ref': '#/definitions/SymbolShape'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(SymbolShape, self).__init__(*args)
+
+
+class TextBaseline(VegaLiteSchema):
+    """TextBaseline schema wrapper
+
+    anyOf(enum('alphabetic'), :class:`Baseline`)
+    """
+    _schema = {'$ref': '#/definitions/TextBaseline'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(TextBaseline, self).__init__(*args, **kwds)
+
+
+class TextConfig(VegaLiteSchema):
+    """TextConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    align : :class:`Align`
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
+    angle : float
+        The rotation angle of the text, in degrees.
+    baseline : :class:`TextBaseline`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+
+        **Default value:** ``"middle"``
+    color : string
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.
+
+        **Default value:** :raw-html:`<span style="color: #4682b4;">&#9632;</span>`
+        ``"#4682b4"``
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    cornerRadius : float
+        The radius in pixels of rounded rectangle corners.
+
+        **Default value:** ``0``
+    cursor : :class:`Cursor`
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
+    dir : :class:`Dir`
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
+
+        **Default value:** ``"ltr"``
+    dx : float
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    dy : float
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    ellipsis : string
+        The ellipsis string for text truncated in response to the limit parameter.
+
+        **Default value:** ``"…"``
+    fill : :class:`Color`
+        Default Fill Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    fillOpacity : float
+        The fill opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    filled : boolean
+        Whether the mark's color should be used as fill color instead of stroke color.
+
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.
+
+        **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and ``area`` marks.
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    font : string
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
+    fontSize : float
+        The font size, in pixels.
+    fontStyle : :class:`FontStyle`
+        The font style (e.g., ``"italic"`` ).
+    fontWeight : :class:`FontWeight`
+        The font weight.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    href : string
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    interpolate : :class:`Interpolate`
+        The line interpolation method to use for line and area marks. One of the following:
+
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
+    limit : float
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    opacity : float
+        The overall opacity (value between [0,1]).
+
+        **Default value:** ``0.7`` for non-aggregate plots with ``point``, ``tick``,
+        ``circle``, or ``square`` marks or layered ``bar`` charts and ``1`` otherwise.
+    orient : :class:`Orient`
+        The orientation of a non-stacked bar, tick, area, and line charts.
+        The value is either horizontal (default) or vertical.
+
+
+        * For bar, rule and tick, this determines whether the size of the bar and tick
+        should be applied to x or y dimension.
+        * For area, this property determines the orient property of the Vega output.
+        * For line and trail marks, this property determines the sort order of the points in
+          the line
+        if ``config.sortLineBy`` is not specified.
+        For stacked charts, this is always determined by the orientation of the stack;
+        therefore explicitly specified value will be ignored.
+    radius : float
+        Polar coordinate radial offset, in pixels, of the text label from the origin
+        determined by the ``x`` and ``y`` properties.
+    shape : string
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.
+
+        **Default value:** ``"circle"``
+    shortTimeLabels : boolean
+        Whether month names and weekday names should be abbreviated.
+    size : float
+        Default size for marks.
+
+
+        * For ``point`` / ``circle`` / ``square``, this represents the pixel area of the
+          marks. For example: in the case of circles, the radius is determined in part by
+          the square root of the size value.
+        * For ``bar``, this represents the band size of the bar, in pixels.
+        * For ``text``, this represents the font size, in pixels.
+
+        **Default value:** ``30`` for point, circle, square marks; ``rangeStep`` - 1 for bar
+        marks with discrete dimensions; ``5`` for bar marks with continuous dimensions;
+        ``11`` for text marks.
+    stroke : :class:`Color`
+        Default Stroke Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    strokeCap : :class:`StrokeCap`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
+
+        **Default value:** ``"square"``
+    strokeDash : List(float)
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
+    strokeDashOffset : float
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
+    strokeJoin : :class:`StrokeJoin`
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
+
+        **Default value:** ``"miter"``
+    strokeMiterLimit : float
+        The miter limit at which to bevel a line join.
+    strokeOpacity : float
+        The stroke opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    strokeWidth : float
+        The stroke width, in pixels.
+    tension : float
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
+    text : string
+        Placeholder text if the ``text`` channel is not specified
+    theta : float
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
+    tooltip : anyOf(string, :class:`TooltipContent`)
+        The tooltip text string to show upon mouse hover or an object defining which fields
+        should the tooltip be derived from.
+
+
+        * If ``tooltip`` is ``{"content": "encoding"}``, then all fields from ``encoding``
+          will be used.
+        * If ``tooltip`` is ``{"content": "data"}``, then all fields that appear in the
+          highlighted data point will be used.
+    """
+    _schema = {'$ref': '#/definitions/TextConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, align=Undefined, angle=Undefined, baseline=Undefined, color=Undefined,
+                 cornerRadius=Undefined, cursor=Undefined, dir=Undefined, dx=Undefined, dy=Undefined,
+                 ellipsis=Undefined, fill=Undefined, fillOpacity=Undefined, filled=Undefined,
+                 font=Undefined, fontSize=Undefined, fontStyle=Undefined, fontWeight=Undefined,
+                 href=Undefined, interpolate=Undefined, limit=Undefined, opacity=Undefined,
+                 orient=Undefined, radius=Undefined, shape=Undefined, shortTimeLabels=Undefined,
+                 size=Undefined, stroke=Undefined, strokeCap=Undefined, strokeDash=Undefined,
+                 strokeDashOffset=Undefined, strokeJoin=Undefined, strokeMiterLimit=Undefined,
+                 strokeOpacity=Undefined, strokeWidth=Undefined, tension=Undefined, text=Undefined,
+                 theta=Undefined, tooltip=Undefined, **kwds):
+        super(TextConfig, self).__init__(align=align, angle=angle, baseline=baseline, color=color,
+                                         cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx,
+                                         dy=dy, ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity,
+                                         filled=filled, font=font, fontSize=fontSize,
+                                         fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                                         interpolate=interpolate, limit=limit, opacity=opacity,
+                                         orient=orient, radius=radius, shape=shape,
+                                         shortTimeLabels=shortTimeLabels, size=size, stroke=stroke,
+                                         strokeCap=strokeCap, strokeDash=strokeDash,
+                                         strokeDashOffset=strokeDashOffset, strokeJoin=strokeJoin,
+                                         strokeMiterLimit=strokeMiterLimit, strokeOpacity=strokeOpacity,
+                                         strokeWidth=strokeWidth, tension=tension, text=text,
+                                         theta=theta, tooltip=tooltip, **kwds)
+
+
+class TextFieldDef(VegaLiteSchema):
+    """TextFieldDef schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'))
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        To indicate that the data for the ``x`` (or ``y`` ) channel are already binned, you
+        can set the ``bin`` property of the ``x`` (or ``y`` ) channel to ``"binned"`` and
+        map the bin-start field to ``x`` (or ``y`` ) and the bin-end field to ``x2`` (or
+        ``y2`` ). The scale and axis will be formatted similar to binning in Vega-lite.  To
+        adjust the axis ticks based on the bin step, you can also set the axis's `tickStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    format : string
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`__ for a
+        text field. If not defined, this will be determined automatically.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/TextFieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, field=Undefined,
+                 format=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
+        super(TextFieldDef, self).__init__(type=type, aggregate=aggregate, bin=bin, field=field,
+                                           format=format, timeUnit=timeUnit, title=title, **kwds)
+
+
+class TickConfig(VegaLiteSchema):
+    """TickConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    align : :class:`Align`
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
+    angle : float
+        The rotation angle of the text, in degrees.
+    bandSize : float
+        The width of the ticks.
+
+        **Default value:**  2/3 of rangeStep.
+    baseline : :class:`TextBaseline`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+
+        **Default value:** ``"middle"``
+    color : string
+        Default color.  Note that ``fill`` and ``stroke`` have higher precedence than
+        ``color`` and will override ``color``.
+
+        **Default value:** :raw-html:`<span style="color: #4682b4;">&#9632;</span>`
+        ``"#4682b4"``
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    cornerRadius : float
+        The radius in pixels of rounded rectangle corners.
+
+        **Default value:** ``0``
+    cursor : :class:`Cursor`
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
+    dir : :class:`Dir`
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
+
+        **Default value:** ``"ltr"``
+    dx : float
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    dy : float
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    ellipsis : string
+        The ellipsis string for text truncated in response to the limit parameter.
+
+        **Default value:** ``"…"``
+    fill : :class:`Color`
+        Default Fill Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    fillOpacity : float
+        The fill opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    filled : boolean
+        Whether the mark's color should be used as fill color instead of stroke color.
+
+        **Default value:** ``true`` for all marks except ``point`` and ``false`` for
+        ``point``.
+
+        **Applicable for:** ``bar``, ``point``, ``circle``, ``square``, and ``area`` marks.
+
+        **Note:** This property cannot be used in a `style config
+        <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
+    font : string
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
+    fontSize : float
+        The font size, in pixels.
+    fontStyle : :class:`FontStyle`
+        The font style (e.g., ``"italic"`` ).
+    fontWeight : :class:`FontWeight`
+        The font weight.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    href : string
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    interpolate : :class:`Interpolate`
+        The line interpolation method to use for line and area marks. One of the following:
+
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
+    limit : float
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    opacity : float
+        The overall opacity (value between [0,1]).
+
+        **Default value:** ``0.7`` for non-aggregate plots with ``point``, ``tick``,
+        ``circle``, or ``square`` marks or layered ``bar`` charts and ``1`` otherwise.
+    orient : :class:`Orient`
+        The orientation of a non-stacked bar, tick, area, and line charts.
+        The value is either horizontal (default) or vertical.
+
+
+        * For bar, rule and tick, this determines whether the size of the bar and tick
+        should be applied to x or y dimension.
+        * For area, this property determines the orient property of the Vega output.
+        * For line and trail marks, this property determines the sort order of the points in
+          the line
+        if ``config.sortLineBy`` is not specified.
+        For stacked charts, this is always determined by the orientation of the stack;
+        therefore explicitly specified value will be ignored.
+    radius : float
+        Polar coordinate radial offset, in pixels, of the text label from the origin
+        determined by the ``x`` and ``y`` properties.
+    shape : string
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.
+
+        **Default value:** ``"circle"``
+    size : float
+        Default size for marks.
+
+
+        * For ``point`` / ``circle`` / ``square``, this represents the pixel area of the
+          marks. For example: in the case of circles, the radius is determined in part by
+          the square root of the size value.
+        * For ``bar``, this represents the band size of the bar, in pixels.
+        * For ``text``, this represents the font size, in pixels.
+
+        **Default value:** ``30`` for point, circle, square marks; ``rangeStep`` - 1 for bar
+        marks with discrete dimensions; ``5`` for bar marks with continuous dimensions;
+        ``11`` for text marks.
+    stroke : :class:`Color`
+        Default Stroke Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    strokeCap : :class:`StrokeCap`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
+
+        **Default value:** ``"square"``
+    strokeDash : List(float)
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
+    strokeDashOffset : float
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
+    strokeJoin : :class:`StrokeJoin`
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
+
+        **Default value:** ``"miter"``
+    strokeMiterLimit : float
+        The miter limit at which to bevel a line join.
+    strokeOpacity : float
+        The stroke opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    strokeWidth : float
+        The stroke width, in pixels.
+    tension : float
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
+    text : string
+        Placeholder text if the ``text`` channel is not specified
+    theta : float
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
+    thickness : float
+        Thickness of the tick mark.
+
+        **Default value:**  ``1``
+    tooltip : anyOf(string, :class:`TooltipContent`)
+        The tooltip text string to show upon mouse hover or an object defining which fields
+        should the tooltip be derived from.
+
+
+        * If ``tooltip`` is ``{"content": "encoding"}``, then all fields from ``encoding``
+          will be used.
+        * If ``tooltip`` is ``{"content": "data"}``, then all fields that appear in the
+          highlighted data point will be used.
+    """
+    _schema = {'$ref': '#/definitions/TickConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, align=Undefined, angle=Undefined, bandSize=Undefined, baseline=Undefined,
+                 color=Undefined, cornerRadius=Undefined, cursor=Undefined, dir=Undefined, dx=Undefined,
+                 dy=Undefined, ellipsis=Undefined, fill=Undefined, fillOpacity=Undefined,
+                 filled=Undefined, font=Undefined, fontSize=Undefined, fontStyle=Undefined,
+                 fontWeight=Undefined, href=Undefined, interpolate=Undefined, limit=Undefined,
+                 opacity=Undefined, orient=Undefined, radius=Undefined, shape=Undefined, size=Undefined,
+                 stroke=Undefined, strokeCap=Undefined, strokeDash=Undefined,
+                 strokeDashOffset=Undefined, strokeJoin=Undefined, strokeMiterLimit=Undefined,
+                 strokeOpacity=Undefined, strokeWidth=Undefined, tension=Undefined, text=Undefined,
+                 theta=Undefined, thickness=Undefined, tooltip=Undefined, **kwds):
+        super(TickConfig, self).__init__(align=align, angle=angle, bandSize=bandSize, baseline=baseline,
+                                         color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir,
+                                         dx=dx, dy=dy, ellipsis=ellipsis, fill=fill,
+                                         fillOpacity=fillOpacity, filled=filled, font=font,
+                                         fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight,
+                                         href=href, interpolate=interpolate, limit=limit,
+                                         opacity=opacity, orient=orient, radius=radius, shape=shape,
+                                         size=size, stroke=stroke, strokeCap=strokeCap,
+                                         strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                                         strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                                         strokeOpacity=strokeOpacity, strokeWidth=strokeWidth,
+                                         tension=tension, text=text, theta=theta, thickness=thickness,
+                                         tooltip=tooltip, **kwds)
+
+
+class TimeUnit(VegaLiteSchema):
+    """TimeUnit schema wrapper
+
+    anyOf(:class:`SingleTimeUnit`, :class:`MultiTimeUnit`)
+    """
+    _schema = {'$ref': '#/definitions/TimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(TimeUnit, self).__init__(*args, **kwds)
+
+
+class TimeUnitTransform(VegaLiteSchema):
+    """TimeUnitTransform schema wrapper
+
+    Mapping(required=[timeUnit, field, as])
+
+    Attributes
+    ----------
+
+    field : string
+        The data field to apply time unit.
+    timeUnit : :class:`TimeUnit`
+        The timeUnit.
+    as : string
+        The output field to write the timeUnit value.
+    """
+    _schema = {'$ref': '#/definitions/TimeUnitTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, timeUnit=Undefined, **kwds):
+        super(TimeUnitTransform, self).__init__(field=field, timeUnit=timeUnit, **kwds)
+
+
+class TitleAnchor(VegaLiteSchema):
+    """TitleAnchor schema wrapper
+
+    enum('start', 'middle', 'end')
+    """
+    _schema = {'$ref': '#/definitions/TitleAnchor'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(TitleAnchor, self).__init__(*args)
+
+
+class TitleConfig(VegaLiteSchema):
+    """TitleConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    align : :class:`Align`
+
+    anchor : :class:`TitleAnchor`
+        The anchor position for placing the title. One of ``"start"``, ``"middle"``, or
+        ``"end"``. For example, with an orientation of top these anchor positions map to a
+        left-, center-, or right-aligned title.
+    angle : float
+        Angle in degrees of title text.
+    baseline : :class:`TextBaseline`
+        Vertical text baseline for title text. One of ``"top"``, ``"middle"``, ``"bottom"``,
+        or ``"alphabetic"``.
+    color : :class:`Color`
+        Text color for title text.
+    font : string
+        Font name for title text.
+    fontSize : float
+        Font size in pixels for title text.
+
+        **Default value:** ``10``.
+    fontWeight : :class:`FontWeight`
+        Font weight for title text.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    frame : :class:`TitleFrame`
+        The reference frame for the anchor position, one of ``"bounds"`` (to anchor relative
+        to the full bounding box) or ``"group"`` (to anchor relative to the group width or
+        height).
+    limit : float
+        The maximum allowed length in pixels of legend labels.
+    offset : float
+        The orthogonal offset in pixels by which to displace the title from its position
+        along the edge of the chart.
+    orient : :class:`TitleOrient`
+        Default title orientation ( ``"top"``, ``"bottom"``, ``"left"``, or ``"right"`` )
+    """
+    _schema = {'$ref': '#/definitions/TitleConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, align=Undefined, anchor=Undefined, angle=Undefined, baseline=Undefined,
+                 color=Undefined, font=Undefined, fontSize=Undefined, fontWeight=Undefined,
+                 frame=Undefined, limit=Undefined, offset=Undefined, orient=Undefined, **kwds):
+        super(TitleConfig, self).__init__(align=align, anchor=anchor, angle=angle, baseline=baseline,
+                                          color=color, font=font, fontSize=fontSize,
+                                          fontWeight=fontWeight, frame=frame, limit=limit,
+                                          offset=offset, orient=orient, **kwds)
+
+
+class TitleFrame(VegaLiteSchema):
+    """TitleFrame schema wrapper
+
+    enum('bounds', 'group')
+    """
+    _schema = {'$ref': '#/definitions/TitleFrame'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(TitleFrame, self).__init__(*args)
+
+
+class TitleOrient(VegaLiteSchema):
+    """TitleOrient schema wrapper
+
+    enum('none', 'left', 'right', 'top', 'bottom')
+    """
+    _schema = {'$ref': '#/definitions/TitleOrient'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(TitleOrient, self).__init__(*args)
+
+
+class TitleParams(VegaLiteSchema):
+    """TitleParams schema wrapper
+
+    Mapping(required=[text])
+
+    Attributes
+    ----------
+
+    text : string
+        The title text.
+    align : :class:`Align`
+
+    anchor : :class:`TitleAnchor`
+        The anchor position for placing the title. One of ``"start"``, ``"middle"``, or
+        ``"end"``. For example, with an orientation of top these anchor positions map to a
+        left-, center-, or right-aligned title.
+
+        **Default value:** ``"middle"`` for `single
+        <https://vega.github.io/vega-lite/docs/spec.html>`__ and `layered
+        <https://vega.github.io/vega-lite/docs/layer.html>`__ views.
+        ``"start"`` for other composite views.
+
+        **Note:** `For now <https://github.com/vega/vega-lite/issues/2875>`__, ``anchor`` is
+        only customizable only for `single
+        <https://vega.github.io/vega-lite/docs/spec.html>`__ and `layered
+        <https://vega.github.io/vega-lite/docs/layer.html>`__ views.  For other composite
+        views, ``anchor`` is always ``"start"``.
+    angle : float
+        Angle in degrees of title text.
+    baseline : :class:`TextBaseline`
+        Vertical text baseline for title text. One of ``"top"``, ``"middle"``, ``"bottom"``,
+        or ``"alphabetic"``.
+    color : :class:`Color`
+        Text color for title text.
+    font : string
+        Font name for title text.
+    fontSize : float
+        Font size in pixels for title text.
+
+        **Default value:** ``10``.
+    fontWeight : :class:`FontWeight`
+        Font weight for title text.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    frame : :class:`TitleFrame`
+        The reference frame for the anchor position, one of ``"bounds"`` (to anchor relative
+        to the full bounding box) or ``"group"`` (to anchor relative to the group width or
+        height).
+    limit : float
+        The maximum allowed length in pixels of legend labels.
+    offset : float
+        The orthogonal offset in pixels by which to displace the title from its position
+        along the edge of the chart.
+    orient : :class:`TitleOrient`
+        Default title orientation ( ``"top"``, ``"bottom"``, ``"left"``, or ``"right"`` )
+    style : anyOf(string, List(string))
+        A `mark style property <https://vega.github.io/vega-lite/docs/config.html#style>`__
+        to apply to the title text mark.
+
+        **Default value:** ``"group-title"``.
+    zindex : float
+        The integer z-index indicating the layering of the title group relative to other
+        axis, mark and legend groups.
+
+        **Default value:** ``0``.
+    """
+    _schema = {'$ref': '#/definitions/TitleParams'}
+    _rootschema = Root._schema
+
+    def __init__(self, text=Undefined, align=Undefined, anchor=Undefined, angle=Undefined,
+                 baseline=Undefined, color=Undefined, font=Undefined, fontSize=Undefined,
+                 fontWeight=Undefined, frame=Undefined, limit=Undefined, offset=Undefined,
+                 orient=Undefined, style=Undefined, zindex=Undefined, **kwds):
+        super(TitleParams, self).__init__(text=text, align=align, anchor=anchor, angle=angle,
+                                          baseline=baseline, color=color, font=font, fontSize=fontSize,
+                                          fontWeight=fontWeight, frame=frame, limit=limit,
+                                          offset=offset, orient=orient, style=style, zindex=zindex,
+                                          **kwds)
+
+
+class TooltipContent(VegaLiteSchema):
+    """TooltipContent schema wrapper
+
+    Mapping(required=[content])
+
+    Attributes
+    ----------
+
+    content : enum('encoding', 'data')
+
+    """
+    _schema = {'$ref': '#/definitions/TooltipContent'}
+    _rootschema = Root._schema
+
+    def __init__(self, content=Undefined, **kwds):
+        super(TooltipContent, self).__init__(content=content, **kwds)
+
+
+class TopLevelLayerSpec(VegaLiteSchema):
+    """TopLevelLayerSpec schema wrapper
+
+    Mapping(required=[layer])
+
+    Attributes
+    ----------
+
+    layer : List(anyOf(:class:`LayerSpec`, :class:`CompositeUnitSpec`))
+        Layer or single view specifications to be layered.
+
+        **Note** : Specifications inside ``layer`` cannot use ``row`` and ``column``
+        channels as layering facet specifications is not allowed. Instead, use the `facet
+        operator <https://vega.github.io/vega-lite/docs/facet.html>`__ and place a layer
+        inside a facet.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    data : :class:`Data`
+        An object describing the data source
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`Encoding`
+        A shared key-value mapping between encoding channels and definition of fields in the
+        underlying layers.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    projection : :class:`Projection`
+        An object defining properties of the geographic projection shared by underlying
+        layers.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for layers.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    usermeta : Mapping(required=[])
+        Optional metadata that will be passed to Vega.
+        This object is completely ignored by Vega and Vega-Lite and can be used for custom
+        metadata.
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v3.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
+    """
+    _schema = {'$ref': '#/definitions/TopLevelLayerSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, layer=Undefined, autosize=Undefined, background=Undefined, config=Undefined,
+                 data=Undefined, datasets=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, padding=Undefined, projection=Undefined,
+                 resolve=Undefined, title=Undefined, transform=Undefined, usermeta=Undefined,
+                 width=Undefined, **kwds):
+        super(TopLevelLayerSpec, self).__init__(layer=layer, autosize=autosize, background=background,
+                                                config=config, data=data, datasets=datasets,
+                                                description=description, encoding=encoding,
+                                                height=height, name=name, padding=padding,
+                                                projection=projection, resolve=resolve, title=title,
+                                                transform=transform, usermeta=usermeta, width=width,
+                                                **kwds)
+
+
+class TopLevelHConcatSpec(VegaLiteSchema):
+    """TopLevelHConcatSpec schema wrapper
+
+    Mapping(required=[hconcat])
+
+    Attributes
+    ----------
+
+    hconcat : List(:class:`Spec`)
+        A list of views that should be concatenated and put into a row.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : boolean
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        **Default value:** ``false``
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    data : :class:`Data`
+        An object describing the data source
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for horizontally concatenated charts.
+    spacing : float
+        The spacing in pixels between sub-views of the concat operator.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    usermeta : Mapping(required=[])
+        Optional metadata that will be passed to Vega.
+        This object is completely ignored by Vega and Vega-Lite and can be used for custom
+        metadata.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v3.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
+    """
+    _schema = {'$ref': '#/definitions/TopLevelHConcatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, hconcat=Undefined, autosize=Undefined, background=Undefined, bounds=Undefined,
+                 center=Undefined, config=Undefined, data=Undefined, datasets=Undefined,
+                 description=Undefined, name=Undefined, padding=Undefined, resolve=Undefined,
+                 spacing=Undefined, title=Undefined, transform=Undefined, usermeta=Undefined, **kwds):
+        super(TopLevelHConcatSpec, self).__init__(hconcat=hconcat, autosize=autosize,
+                                                  background=background, bounds=bounds, center=center,
+                                                  config=config, data=data, datasets=datasets,
+                                                  description=description, name=name, padding=padding,
+                                                  resolve=resolve, spacing=spacing, title=title,
+                                                  transform=transform, usermeta=usermeta, **kwds)
+
+
+class TopLevelRepeatSpec(VegaLiteSchema):
+    """TopLevelRepeatSpec schema wrapper
+
+    Mapping(required=[repeat, spec])
+
+    Attributes
+    ----------
+
+    repeat : :class:`Repeat`
+        An object that describes what fields should be repeated into views that are laid out
+        as a ``row`` or ``column``.
+    spec : :class:`Spec`
+
+    align : anyOf(:class:`VgLayoutAlign`, :class:`RowColVgLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    data : :class:`Data`
+        An object describing the data source
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    resolve : :class:`Resolve`
+        Scale and legend resolutions for repeated charts.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    usermeta : Mapping(required=[])
+        Optional metadata that will be passed to Vega.
+        This object is completely ignored by Vega and Vega-Lite and can be used for custom
+        metadata.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v3.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
+    """
+    _schema = {'$ref': '#/definitions/TopLevelRepeatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, repeat=Undefined, spec=Undefined, align=Undefined, autosize=Undefined,
+                 background=Undefined, bounds=Undefined, center=Undefined, config=Undefined,
+                 data=Undefined, datasets=Undefined, description=Undefined, name=Undefined,
+                 padding=Undefined, resolve=Undefined, spacing=Undefined, title=Undefined,
+                 transform=Undefined, usermeta=Undefined, **kwds):
+        super(TopLevelRepeatSpec, self).__init__(repeat=repeat, spec=spec, align=align,
+                                                 autosize=autosize, background=background,
+                                                 bounds=bounds, center=center, config=config, data=data,
+                                                 datasets=datasets, description=description, name=name,
+                                                 padding=padding, resolve=resolve, spacing=spacing,
+                                                 title=title, transform=transform, usermeta=usermeta,
+                                                 **kwds)
+
+
+class TopLevelVConcatSpec(VegaLiteSchema):
+    """TopLevelVConcatSpec schema wrapper
+
+    Mapping(required=[vconcat])
+
+    Attributes
+    ----------
+
+    vconcat : List(:class:`Spec`)
+        A list of views that should be concatenated and put into a column.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : boolean
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        **Default value:** ``false``
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    data : :class:`Data`
+        An object describing the data source
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for vertically concatenated charts.
+    spacing : float
+        The spacing in pixels between sub-views of the concat operator.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    usermeta : Mapping(required=[])
+        Optional metadata that will be passed to Vega.
+        This object is completely ignored by Vega and Vega-Lite and can be used for custom
+        metadata.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v3.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
+    """
+    _schema = {'$ref': '#/definitions/TopLevelVConcatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, vconcat=Undefined, autosize=Undefined, background=Undefined, bounds=Undefined,
+                 center=Undefined, config=Undefined, data=Undefined, datasets=Undefined,
+                 description=Undefined, name=Undefined, padding=Undefined, resolve=Undefined,
+                 spacing=Undefined, title=Undefined, transform=Undefined, usermeta=Undefined, **kwds):
+        super(TopLevelVConcatSpec, self).__init__(vconcat=vconcat, autosize=autosize,
+                                                  background=background, bounds=bounds, center=center,
+                                                  config=config, data=data, datasets=datasets,
+                                                  description=description, name=name, padding=padding,
+                                                  resolve=resolve, spacing=spacing, title=title,
+                                                  transform=transform, usermeta=usermeta, **kwds)
+
+
+class TopLevelFacetSpec(VegaLiteSchema):
+    """TopLevelFacetSpec schema wrapper
+
+    Mapping(required=[data, facet, spec])
+
+    Attributes
+    ----------
+
+    data : :class:`Data`
+        An object describing the data source
+    facet : :class:`FacetMapping`
+        An object that describes mappings between ``row`` and ``column`` channels and their
+        field definitions.
+    spec : anyOf(:class:`LayerSpec`, :class:`FacetedUnitSpec`)
+        A specification of the view that gets faceted.
+    align : anyOf(:class:`VgLayoutAlign`, :class:`RowColVgLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for facets.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    usermeta : Mapping(required=[])
+        Optional metadata that will be passed to Vega.
+        This object is completely ignored by Vega and Vega-Lite and can be used for custom
+        metadata.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v3.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
+    """
+    _schema = {'$ref': '#/definitions/TopLevelFacetSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, data=Undefined, facet=Undefined, spec=Undefined, align=Undefined,
+                 autosize=Undefined, background=Undefined, bounds=Undefined, center=Undefined,
+                 config=Undefined, datasets=Undefined, description=Undefined, name=Undefined,
+                 padding=Undefined, resolve=Undefined, spacing=Undefined, title=Undefined,
+                 transform=Undefined, usermeta=Undefined, **kwds):
+        super(TopLevelFacetSpec, self).__init__(data=data, facet=facet, spec=spec, align=align,
+                                                autosize=autosize, background=background, bounds=bounds,
+                                                center=center, config=config, datasets=datasets,
+                                                description=description, name=name, padding=padding,
+                                                resolve=resolve, spacing=spacing, title=title,
+                                                transform=transform, usermeta=usermeta, **kwds)
+
+
+class TopLevelFacetedUnitSpec(VegaLiteSchema):
+    """TopLevelFacetedUnitSpec schema wrapper
+
+    Mapping(required=[data, mark])
+
+    Attributes
+    ----------
+
+    data : :class:`Data`
+        An object describing the data source
+    mark : :class:`AnyMark`
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and ``"text"`` ) or a `mark
+        definition object <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`EncodingWithFacet`
+        A key-value mapping between encoding channels and definition of fields.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    projection : :class:`Projection`
+        An object defining properties of geographic projection, which will be applied to
+        ``shape`` path for ``"geoshape"`` marks
+        and to ``latitude`` and ``"longitude"`` channels for other marks.
+    selection : Mapping(required=[])
+        A key-value mapping between selection names and definitions.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    usermeta : Mapping(required=[])
+        Optional metadata that will be passed to Vega.
+        This object is completely ignored by Vega and Vega-Lite and can be used for custom
+        metadata.
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v3.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
+    """
+    _schema = {'$ref': '#/definitions/TopLevelFacetedUnitSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, data=Undefined, mark=Undefined, autosize=Undefined, background=Undefined,
+                 config=Undefined, datasets=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, padding=Undefined, projection=Undefined,
+                 selection=Undefined, title=Undefined, transform=Undefined, usermeta=Undefined,
+                 width=Undefined, **kwds):
+        super(TopLevelFacetedUnitSpec, self).__init__(data=data, mark=mark, autosize=autosize,
+                                                      background=background, config=config,
+                                                      datasets=datasets, description=description,
+                                                      encoding=encoding, height=height, name=name,
+                                                      padding=padding, projection=projection,
+                                                      selection=selection, title=title,
+                                                      transform=transform, usermeta=usermeta,
+                                                      width=width, **kwds)
+
+
+class TopLevelSpec(VegaLiteSchema):
+    """TopLevelSpec schema wrapper
+
+    anyOf(:class:`TopLevelFacetedUnitSpec`, :class:`TopLevelFacetSpec`,
+    :class:`TopLevelLayerSpec`, :class:`TopLevelRepeatSpec`, :class:`TopLevelVConcatSpec`,
+    :class:`TopLevelHConcatSpec`)
+    """
+    _schema = {'$ref': '#/definitions/TopLevelSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(TopLevelSpec, self).__init__(*args, **kwds)
+
+
+class TopoDataFormat(VegaLiteSchema):
+    """TopoDataFormat schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    feature : string
+        The name of the TopoJSON object set to convert to a GeoJSON feature collection.
+        For example, in a map of the world, there may be an object set named
+        ``"countries"``.
+        Using the feature property, we can extract this set and generate a GeoJSON feature
+        object for each country.
+    mesh : string
+        The name of the TopoJSON object set to convert to mesh.
+        Similar to the ``feature`` option, ``mesh`` extracts a named TopoJSON object set.
+        Unlike the ``feature`` option, the corresponding geo data is returned as a single,
+        unified mesh instance, not as individual GeoJSON features.
+        Extracting a mesh is useful for more efficiently drawing borders or other geographic
+        elements that you do not need to associate with specific regions such as individual
+        countries, states or counties.
+    parse : anyOf(:class:`Parse`, None)
+        If set to ``null``, disable type inference based on the spec and only use type
+        inference based on the data.
+        Alternatively, a parsing directive object can be provided for explicit data types.
+        Each property of the object corresponds to a field name, and the value to the
+        desired data type (one of ``"number"``, ``"boolean"``, ``"date"``, or null (do not
+        parse the field)).
+        For example, ``"parse": {"modified_on": "date"}`` parses the ``modified_on`` field
+        in each input record a Date value.
+
+        For ``"date"``, we parse data based using Javascript's `Date.parse()
+        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse>`__.
+        For Specific date formats can be provided (e.g., ``{foo: 'date:"%m%d%Y"'}`` ), using
+        the `d3-time-format syntax <https://github.com/d3/d3-time-format#locale_format>`__.
+        UTC date format parsing is supported similarly (e.g., ``{foo: 'utc:"%m%d%Y"'}`` ).
+        See more about `UTC time
+        <https://vega.github.io/vega-lite/docs/timeunit.html#utc>`__
+    type : enum('topojson')
+        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``, ``"dsv"``.
+        The default format type is determined by the extension of the file URL.
+        If no extension is detected, ``"json"`` will be used by default.
+    """
+    _schema = {'$ref': '#/definitions/TopoDataFormat'}
+    _rootschema = Root._schema
+
+    def __init__(self, feature=Undefined, mesh=Undefined, parse=Undefined, type=Undefined, **kwds):
+        super(TopoDataFormat, self).__init__(feature=feature, mesh=mesh, parse=parse, type=type, **kwds)
+
+
+class Transform(VegaLiteSchema):
+    """Transform schema wrapper
+
+    anyOf(:class:`FilterTransform`, :class:`CalculateTransform`, :class:`LookupTransform`,
+    :class:`BinTransform`, :class:`TimeUnitTransform`, :class:`ImputeTransform`,
+    :class:`AggregateTransform`, :class:`WindowTransform`, :class:`StackTransform`,
+    :class:`FlattenTransform`, :class:`FoldTransform`, :class:`SampleTransform`)
+    """
+    _schema = {'$ref': '#/definitions/Transform'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(Transform, self).__init__(*args, **kwds)
+
+
+class Type(VegaLiteSchema):
+    """Type schema wrapper
+
+    enum('quantitative', 'ordinal', 'temporal', 'nominal', 'geojson')
+    Constants and utilities for data type
+     Data type based on level of measurement
+    """
+    _schema = {'$ref': '#/definitions/Type'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Type, self).__init__(*args)
+
+
+class UrlData(VegaLiteSchema):
+    """UrlData schema wrapper
+
+    Mapping(required=[url])
+
+    Attributes
+    ----------
+
+    url : string
+        An URL from which to load the data set. Use the ``format.type`` property
+        to ensure the loaded data is correctly parsed.
+    format : :class:`DataFormat`
+        An object that specifies the format for parsing the data.
+    name : string
+        Provide a placeholder name and bind data at runtime.
+    """
+    _schema = {'$ref': '#/definitions/UrlData'}
+    _rootschema = Root._schema
+
+    def __init__(self, url=Undefined, format=Undefined, name=Undefined, **kwds):
+        super(UrlData, self).__init__(url=url, format=format, name=name, **kwds)
+
+
+class UtcMultiTimeUnit(VegaLiteSchema):
+    """UtcMultiTimeUnit schema wrapper
+
+    enum('utcyearquarter', 'utcyearquartermonth', 'utcyearmonth', 'utcyearmonthdate',
+    'utcyearmonthdatehours', 'utcyearmonthdatehoursminutes',
+    'utcyearmonthdatehoursminutesseconds', 'utcquartermonth', 'utcmonthdate', 'utchoursminutes',
+    'utchoursminutesseconds', 'utcminutesseconds', 'utcsecondsmilliseconds')
+    """
+    _schema = {'$ref': '#/definitions/UtcMultiTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(UtcMultiTimeUnit, self).__init__(*args)
+
+
+class UtcSingleTimeUnit(VegaLiteSchema):
+    """UtcSingleTimeUnit schema wrapper
+
+    enum('utcyear', 'utcquarter', 'utcmonth', 'utcday', 'utcdate', 'utchours', 'utcminutes',
+    'utcseconds', 'utcmilliseconds')
+    """
+    _schema = {'$ref': '#/definitions/UtcSingleTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(UtcSingleTimeUnit, self).__init__(*args)
+
+
+class ValueDef(VegaLiteSchema):
+    """ValueDef schema wrapper
+
+    Mapping(required=[value])
+    Definition object for a constant value of an encoding channel.
+
+    Attributes
+    ----------
+
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _schema = {'$ref': '#/definitions/ValueDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, value=Undefined, **kwds):
+        super(ValueDef, self).__init__(value=value, **kwds)
+
+
+class ValueDefWithCondition(VegaLiteSchema):
+    """ValueDefWithCondition schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _schema = {'$ref': '#/definitions/ValueDefWithCondition'}
+    _rootschema = Root._schema
+
+    def __init__(self, condition=Undefined, value=Undefined, **kwds):
+        super(ValueDefWithCondition, self).__init__(condition=condition, value=value, **kwds)
+
+
+class MarkPropValueDefWithCondition(VegaLiteSchema):
+    """MarkPropValueDefWithCondition schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _schema = {'$ref': '#/definitions/MarkPropValueDefWithCondition'}
+    _rootschema = Root._schema
+
+    def __init__(self, condition=Undefined, value=Undefined, **kwds):
+        super(MarkPropValueDefWithCondition, self).__init__(condition=condition, value=value, **kwds)
+
+
+class TextValueDefWithCondition(VegaLiteSchema):
+    """TextValueDefWithCondition schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalTextFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean, None)
+        A constant value in visual domain.
+    """
+    _schema = {'$ref': '#/definitions/TextValueDefWithCondition'}
+    _rootschema = Root._schema
+
+    def __init__(self, condition=Undefined, value=Undefined, **kwds):
+        super(TextValueDefWithCondition, self).__init__(condition=condition, value=value, **kwds)
+
+
+class VgBinding(VegaLiteSchema):
+    """VgBinding schema wrapper
+
+    anyOf(:class:`VgCheckboxBinding`, :class:`VgRadioBinding`, :class:`VgSelectBinding`,
+    :class:`VgRangeBinding`, :class:`VgGenericBinding`)
+    """
+    _schema = {'$ref': '#/definitions/VgBinding'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(VgBinding, self).__init__(*args, **kwds)
+
+
+class VgCheckboxBinding(VegaLiteSchema):
+    """VgCheckboxBinding schema wrapper
+
+    Mapping(required=[input])
+
+    Attributes
+    ----------
+
+    input : enum('checkbox')
+
+    element : string
+
+    """
+    _schema = {'$ref': '#/definitions/VgCheckboxBinding'}
+    _rootschema = Root._schema
+
+    def __init__(self, input=Undefined, element=Undefined, **kwds):
+        super(VgCheckboxBinding, self).__init__(input=input, element=element, **kwds)
+
+
+class VgComparatorOrder(VegaLiteSchema):
+    """VgComparatorOrder schema wrapper
+
+    enum('ascending', 'descending')
+    """
+    _schema = {'$ref': '#/definitions/VgComparatorOrder'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(VgComparatorOrder, self).__init__(*args)
+
+
+class VgEventStream(VegaLiteSchema):
+    """VgEventStream schema wrapper
+
+    Mapping(required=[])
+    """
+    _schema = {'$ref': '#/definitions/VgEventStream'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(VgEventStream, self).__init__(**kwds)
+
+
+class VgGenericBinding(VegaLiteSchema):
+    """VgGenericBinding schema wrapper
+
+    Mapping(required=[input])
+
+    Attributes
+    ----------
+
+    input : string
+
+    element : string
+
+    """
+    _schema = {'$ref': '#/definitions/VgGenericBinding'}
+    _rootschema = Root._schema
+
+    def __init__(self, input=Undefined, element=Undefined, **kwds):
+        super(VgGenericBinding, self).__init__(input=input, element=element, **kwds)
+
+
+class VgLayoutAlign(VegaLiteSchema):
+    """VgLayoutAlign schema wrapper
+
+    enum('none', 'each', 'all')
+    """
+    _schema = {'$ref': '#/definitions/VgLayoutAlign'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(VgLayoutAlign, self).__init__(*args)
+
+
+class VgMarkConfig(VegaLiteSchema):
+    """VgMarkConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    align : :class:`Align`
+        The horizontal alignment of the text. One of ``"left"``, ``"right"``, ``"center"``.
+    angle : float
+        The rotation angle of the text, in degrees.
+    baseline : :class:`TextBaseline`
+        The vertical alignment of the text. One of ``"top"``, ``"middle"``, ``"bottom"``.
+
+        **Default value:** ``"middle"``
+    cornerRadius : float
+        The radius in pixels of rounded rectangle corners.
+
+        **Default value:** ``0``
+    cursor : :class:`Cursor`
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
+    dir : :class:`Dir`
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
+
+        **Default value:** ``"ltr"``
+    dx : float
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    dy : float
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
+    ellipsis : string
+        The ellipsis string for text truncated in response to the limit parameter.
+
+        **Default value:** ``"…"``
+    fill : :class:`Color`
+        Default Fill Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    fillOpacity : float
+        The fill opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    font : string
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
+    fontSize : float
+        The font size, in pixels.
+    fontStyle : :class:`FontStyle`
+        The font style (e.g., ``"italic"`` ).
+    fontWeight : :class:`FontWeight`
+        The font weight.
+        This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a number ( ``100``,
+        ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and ``"bold"`` = ``700``
+        ).
+    href : string
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    interpolate : :class:`Interpolate`
+        The line interpolation method to use for line and area marks. One of the following:
+
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
+    limit : float
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
+
+        **Default value:** ``0``, indicating no limit
+    opacity : float
+        The overall opacity (value between [0,1]).
+
+        **Default value:** ``0.7`` for non-aggregate plots with ``point``, ``tick``,
+        ``circle``, or ``square`` marks or layered ``bar`` charts and ``1`` otherwise.
+    orient : :class:`Orient`
+        The orientation of a non-stacked bar, tick, area, and line charts.
+        The value is either horizontal (default) or vertical.
+
+
+        * For bar, rule and tick, this determines whether the size of the bar and tick
+        should be applied to x or y dimension.
+        * For area, this property determines the orient property of the Vega output.
+        * For line and trail marks, this property determines the sort order of the points in
+          the line
+        if ``config.sortLineBy`` is not specified.
+        For stacked charts, this is always determined by the orientation of the stack;
+        therefore explicitly specified value will be ignored.
+    radius : float
+        Polar coordinate radial offset, in pixels, of the text label from the origin
+        determined by the ``x`` and ``y`` properties.
+    shape : string
+        The default symbol shape to use. One of: ``"circle"`` (default), ``"square"``,
+        ``"cross"``, ``"diamond"``, ``"triangle-up"``, or ``"triangle-down"``, or a custom
+        SVG path.
+
+        **Default value:** ``"circle"``
+    size : float
+        The pixel area each the point/circle/square.
+        For example: in the case of circles, the radius is determined in part by the square
+        root of the size value.
+
+        **Default value:** ``30``
+    stroke : :class:`Color`
+        Default Stroke Color.  This has higher precedence than ``config.color``
+
+        **Default value:** (None)
+    strokeCap : :class:`StrokeCap`
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
+
+        **Default value:** ``"square"``
+    strokeDash : List(float)
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
+    strokeDashOffset : float
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
+    strokeJoin : :class:`StrokeJoin`
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
+
+        **Default value:** ``"miter"``
+    strokeMiterLimit : float
+        The miter limit at which to bevel a line join.
+    strokeOpacity : float
+        The stroke opacity (value between [0,1]).
+
+        **Default value:** ``1``
+    strokeWidth : float
+        The stroke width, in pixels.
+    tension : float
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
+    text : string
+        Placeholder text if the ``text`` channel is not specified
+    theta : float
+        Polar coordinate angle, in radians, of the text label from the origin determined by
+        the ``x`` and ``y`` properties. Values for ``theta`` follow the same convention of
+        ``arc`` mark ``startAngle`` and ``endAngle`` properties: angles are measured in
+        radians, with ``0`` indicating "north".
+    tooltip : Mapping(required=[])
+        The tooltip text to show upon mouse hover.
+    """
+    _schema = {'$ref': '#/definitions/VgMarkConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, align=Undefined, angle=Undefined, baseline=Undefined, cornerRadius=Undefined,
+                 cursor=Undefined, dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined,
+                 fill=Undefined, fillOpacity=Undefined, font=Undefined, fontSize=Undefined,
+                 fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                 limit=Undefined, opacity=Undefined, orient=Undefined, radius=Undefined,
+                 shape=Undefined, size=Undefined, stroke=Undefined, strokeCap=Undefined,
+                 strokeDash=Undefined, strokeDashOffset=Undefined, strokeJoin=Undefined,
+                 strokeMiterLimit=Undefined, strokeOpacity=Undefined, strokeWidth=Undefined,
+                 tension=Undefined, text=Undefined, theta=Undefined, tooltip=Undefined, **kwds):
+        super(VgMarkConfig, self).__init__(align=align, angle=angle, baseline=baseline,
+                                           cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx,
+                                           dy=dy, ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity,
+                                           font=font, fontSize=fontSize, fontStyle=fontStyle,
+                                           fontWeight=fontWeight, href=href, interpolate=interpolate,
+                                           limit=limit, opacity=opacity, orient=orient, radius=radius,
+                                           shape=shape, size=size, stroke=stroke, strokeCap=strokeCap,
+                                           strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                                           strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                                           strokeOpacity=strokeOpacity, strokeWidth=strokeWidth,
+                                           tension=tension, text=text, theta=theta, tooltip=tooltip,
+                                           **kwds)
+
+
+class VgProjectionType(VegaLiteSchema):
+    """VgProjectionType schema wrapper
+
+    enum('albers', 'albersUsa', 'azimuthalEqualArea', 'azimuthalEquidistant', 'conicConformal',
+    'conicEqualArea', 'conicEquidistant', 'equirectangular', 'gnomonic', 'mercator',
+    'orthographic', 'stereographic', 'transverseMercator')
+    """
+    _schema = {'$ref': '#/definitions/VgProjectionType'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(VgProjectionType, self).__init__(*args)
+
+
+class VgRadioBinding(VegaLiteSchema):
+    """VgRadioBinding schema wrapper
+
+    Mapping(required=[input, options])
+
+    Attributes
+    ----------
+
+    input : enum('radio')
+
+    options : List(string)
+
+    element : string
+
+    """
+    _schema = {'$ref': '#/definitions/VgRadioBinding'}
+    _rootschema = Root._schema
+
+    def __init__(self, input=Undefined, options=Undefined, element=Undefined, **kwds):
+        super(VgRadioBinding, self).__init__(input=input, options=options, element=element, **kwds)
+
+
+class VgRangeBinding(VegaLiteSchema):
+    """VgRangeBinding schema wrapper
+
+    Mapping(required=[input])
+
+    Attributes
+    ----------
+
+    input : enum('range')
+
+    element : string
+
+    max : float
+
+    min : float
+
+    step : float
+
+    """
+    _schema = {'$ref': '#/definitions/VgRangeBinding'}
+    _rootschema = Root._schema
+
+    def __init__(self, input=Undefined, element=Undefined, max=Undefined, min=Undefined, step=Undefined,
+                 **kwds):
+        super(VgRangeBinding, self).__init__(input=input, element=element, max=max, min=min, step=step,
+                                             **kwds)
+
+
+class VgScheme(VegaLiteSchema):
+    """VgScheme schema wrapper
+
+    Mapping(required=[scheme])
+
+    Attributes
+    ----------
+
+    scheme : string
+
+    count : float
+
+    extent : List(float)
+
+    """
+    _schema = {'$ref': '#/definitions/VgScheme'}
+    _rootschema = Root._schema
+
+    def __init__(self, scheme=Undefined, count=Undefined, extent=Undefined, **kwds):
+        super(VgScheme, self).__init__(scheme=scheme, count=count, extent=extent, **kwds)
+
+
+class VgSelectBinding(VegaLiteSchema):
+    """VgSelectBinding schema wrapper
+
+    Mapping(required=[input, options])
+
+    Attributes
+    ----------
+
+    input : enum('select')
+
+    options : List(string)
+
+    element : string
+
+    """
+    _schema = {'$ref': '#/definitions/VgSelectBinding'}
+    _rootschema = Root._schema
+
+    def __init__(self, input=Undefined, options=Undefined, element=Undefined, **kwds):
+        super(VgSelectBinding, self).__init__(input=input, options=options, element=element, **kwds)
+
+
+class ViewConfig(VegaLiteSchema):
+    """ViewConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    clip : boolean
+        Whether the view should be clipped.
+    fill : string
+        The fill color.
+
+        **Default value:** (none)
+    fillOpacity : float
+        The fill opacity (value between [0,1]).
+
+        **Default value:** (none)
+    height : float
+        The default height of the single plot or each plot in a trellis plot when the
+        visualization has a continuous (non-ordinal) y-scale with ``rangeStep`` = ``null``.
+
+        **Default value:** ``200``
+    stroke : string
+        The stroke color.
+
+        **Default value:** (none)
+    strokeDash : List(float)
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
+
+        **Default value:** (none)
+    strokeDashOffset : float
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
+
+        **Default value:** (none)
+    strokeJoin : :class:`StrokeJoin`
+        The stroke line join method. One of miter (default), round or bevel.
+
+        **Default value:** 'miter'
+    strokeMiterLimit : float
+        The stroke line join method. One of miter (default), round or bevel.
+
+        **Default value:** 'miter'
+    strokeOpacity : float
+        The stroke opacity (value between [0,1]).
+
+        **Default value:** (none)
+    strokeWidth : float
+        The stroke width, in pixels.
+
+        **Default value:** (none)
+    width : float
+        The default width of the single plot or each plot in a trellis plot when the
+        visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with
+        ``rangeStep`` = ``null``.
+
+        **Default value:** ``200``
+    """
+    _schema = {'$ref': '#/definitions/ViewConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, clip=Undefined, fill=Undefined, fillOpacity=Undefined, height=Undefined,
+                 stroke=Undefined, strokeDash=Undefined, strokeDashOffset=Undefined,
+                 strokeJoin=Undefined, strokeMiterLimit=Undefined, strokeOpacity=Undefined,
+                 strokeWidth=Undefined, width=Undefined, **kwds):
+        super(ViewConfig, self).__init__(clip=clip, fill=fill, fillOpacity=fillOpacity, height=height,
+                                         stroke=stroke, strokeDash=strokeDash,
+                                         strokeDashOffset=strokeDashOffset, strokeJoin=strokeJoin,
+                                         strokeMiterLimit=strokeMiterLimit, strokeOpacity=strokeOpacity,
+                                         strokeWidth=strokeWidth, width=width, **kwds)
+
+
+class WindowFieldDef(VegaLiteSchema):
+    """WindowFieldDef schema wrapper
+
+    Mapping(required=[op, as])
+
+    Attributes
+    ----------
+
+    op : anyOf(:class:`AggregateOp`, :class:`WindowOnlyOp`)
+        The window or aggregation operations to apply within a window, including ``rank``,
+        ``lead``, ``sum``, ``average`` or ``count``. See the list of all supported
+        operations `here <https://vega.github.io/vega-lite/docs/window.html#ops>`__.
+    field : string
+        The data field for which to compute the aggregate or window function. This can be
+        omitted for window functions that do not operate over a field such as ``count``,
+        ``rank``, ``dense_rank``.
+    param : float
+        Parameter values for the window functions. Parameter values can be omitted for
+        operations that do not accept a parameter.
+
+        See the list of all supported operations and their parameters `here
+        <https://vega.github.io/vega-lite/docs/transforms/window.html>`__.
+    as : string
+        The output name for the window operation.
+    """
+    _schema = {'$ref': '#/definitions/WindowFieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, op=Undefined, field=Undefined, param=Undefined, **kwds):
+        super(WindowFieldDef, self).__init__(op=op, field=field, param=param, **kwds)
+
+
+class WindowOnlyOp(VegaLiteSchema):
+    """WindowOnlyOp schema wrapper
+
+    enum('row_number', 'rank', 'dense_rank', 'percent_rank', 'cume_dist', 'ntile', 'lag',
+    'lead', 'first_value', 'last_value', 'nth_value')
+    """
+    _schema = {'$ref': '#/definitions/WindowOnlyOp'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(WindowOnlyOp, self).__init__(*args)
+
+
+class WindowTransform(VegaLiteSchema):
+    """WindowTransform schema wrapper
+
+    Mapping(required=[window])
+
+    Attributes
+    ----------
+
+    window : List(:class:`WindowFieldDef`)
+        The definition of the fields in the window, and what calculations to use.
+    frame : List(anyOf(None, float))
+        A frame specification as a two-element array indicating how the sliding window
+        should proceed. The array entries should either be a number indicating the offset
+        from the current data object, or null to indicate unbounded rows preceding or
+        following the current data object. The default value is ``[null, 0]``, indicating
+        that the sliding window includes the current object and all preceding objects. The
+        value ``[-5, 5]`` indicates that the window should include five objects preceding
+        and five objects following the current object. Finally, ``[null, null]`` indicates
+        that the window frame should always include all data objects. The only operators
+        affected are the aggregation operations and the ``first_value``, ``last_value``, and
+        ``nth_value`` window operations. The other window operations are not affected by
+        this.
+
+        **Default value:** :  ``[null, 0]`` (includes the current object and all preceding
+        objects)
+    groupby : List(string)
+        The data fields for partitioning the data objects into separate windows. If
+        unspecified, all data points will be in a single group.
+    ignorePeers : boolean
+        Indicates if the sliding window frame should ignore peer values. (Peer values are
+        those considered identical by the sort criteria). The default is false, causing the
+        window frame to expand to include all peer values. If set to true, the window frame
+        will be defined by offset values only. This setting only affects those operations
+        that depend on the window frame, namely aggregation operations and the first_value,
+        last_value, and nth_value window operations.
+
+        **Default value:** ``false``
+    sort : List(:class:`SortField`)
+        A sort field definition for sorting data objects within a window. If two data
+        objects are considered equal by the comparator, they are considered “peer” values of
+        equal rank. If sort is not specified, the order is undefined: data objects are
+        processed in the order they are observed and none are considered peers (the
+        ignorePeers parameter is ignored and treated as if set to ``true`` ).
+    """
+    _schema = {'$ref': '#/definitions/WindowTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, window=Undefined, frame=Undefined, groupby=Undefined, ignorePeers=Undefined,
+                 sort=Undefined, **kwds):
+        super(WindowTransform, self).__init__(window=window, frame=frame, groupby=groupby,
+                                              ignorePeers=ignorePeers, sort=sort, **kwds)
+

--- a/altair/vegalite/v3/schema/mixins.py
+++ b/altair/vegalite/v3/schema/mixins.py
@@ -1,0 +1,750 @@
+# -*- coding: utf-8 -*-
+#
+# The contents of this file are automatically written by
+# tools/generate_schema_wrapper.py. Do not modify directly.
+from . import core
+from altair.utils import use_signature
+from altair.utils.schemapi import Undefined
+
+
+class MarkMethodMixin(object):
+    """A mixin class that defines mark methods"""
+
+    def mark_area(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                  clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                  dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                  fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                  fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                  limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined, point=Undefined,
+                  radius=Undefined, shape=Undefined, size=Undefined, stroke=Undefined,
+                  strokeCap=Undefined, strokeDash=Undefined, strokeDashOffset=Undefined,
+                  strokeJoin=Undefined, strokeMiterLimit=Undefined, strokeOpacity=Undefined,
+                  strokeWidth=Undefined, style=Undefined, tension=Undefined, text=Undefined,
+                  theta=Undefined, thickness=Undefined, tooltip=Undefined, x2Offset=Undefined,
+                  xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'area'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="area", **kwds)
+        else:
+            copy.mark = "area"
+        return copy
+
+    def mark_bar(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                 clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                 dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                 fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                 fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                 limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined, point=Undefined,
+                 radius=Undefined, shape=Undefined, size=Undefined, stroke=Undefined,
+                 strokeCap=Undefined, strokeDash=Undefined, strokeDashOffset=Undefined,
+                 strokeJoin=Undefined, strokeMiterLimit=Undefined, strokeOpacity=Undefined,
+                 strokeWidth=Undefined, style=Undefined, tension=Undefined, text=Undefined,
+                 theta=Undefined, thickness=Undefined, tooltip=Undefined, x2Offset=Undefined,
+                 xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'bar'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="bar", **kwds)
+        else:
+            copy.mark = "bar"
+        return copy
+
+    def mark_line(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                  clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                  dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                  fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                  fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                  limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined, point=Undefined,
+                  radius=Undefined, shape=Undefined, size=Undefined, stroke=Undefined,
+                  strokeCap=Undefined, strokeDash=Undefined, strokeDashOffset=Undefined,
+                  strokeJoin=Undefined, strokeMiterLimit=Undefined, strokeOpacity=Undefined,
+                  strokeWidth=Undefined, style=Undefined, tension=Undefined, text=Undefined,
+                  theta=Undefined, thickness=Undefined, tooltip=Undefined, x2Offset=Undefined,
+                  xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'line'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="line", **kwds)
+        else:
+            copy.mark = "line"
+        return copy
+
+    def mark_trail(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                   clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                   dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                   fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                   fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                   limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined,
+                   point=Undefined, radius=Undefined, shape=Undefined, size=Undefined, stroke=Undefined,
+                   strokeCap=Undefined, strokeDash=Undefined, strokeDashOffset=Undefined,
+                   strokeJoin=Undefined, strokeMiterLimit=Undefined, strokeOpacity=Undefined,
+                   strokeWidth=Undefined, style=Undefined, tension=Undefined, text=Undefined,
+                   theta=Undefined, thickness=Undefined, tooltip=Undefined, x2Offset=Undefined,
+                   xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'trail'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="trail", **kwds)
+        else:
+            copy.mark = "trail"
+        return copy
+
+    def mark_point(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                   clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                   dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                   fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                   fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                   limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined,
+                   point=Undefined, radius=Undefined, shape=Undefined, size=Undefined, stroke=Undefined,
+                   strokeCap=Undefined, strokeDash=Undefined, strokeDashOffset=Undefined,
+                   strokeJoin=Undefined, strokeMiterLimit=Undefined, strokeOpacity=Undefined,
+                   strokeWidth=Undefined, style=Undefined, tension=Undefined, text=Undefined,
+                   theta=Undefined, thickness=Undefined, tooltip=Undefined, x2Offset=Undefined,
+                   xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'point'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="point", **kwds)
+        else:
+            copy.mark = "point"
+        return copy
+
+    def mark_text(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                  clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                  dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                  fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                  fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                  limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined, point=Undefined,
+                  radius=Undefined, shape=Undefined, size=Undefined, stroke=Undefined,
+                  strokeCap=Undefined, strokeDash=Undefined, strokeDashOffset=Undefined,
+                  strokeJoin=Undefined, strokeMiterLimit=Undefined, strokeOpacity=Undefined,
+                  strokeWidth=Undefined, style=Undefined, tension=Undefined, text=Undefined,
+                  theta=Undefined, thickness=Undefined, tooltip=Undefined, x2Offset=Undefined,
+                  xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'text'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="text", **kwds)
+        else:
+            copy.mark = "text"
+        return copy
+
+    def mark_tick(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                  clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                  dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                  fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                  fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                  limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined, point=Undefined,
+                  radius=Undefined, shape=Undefined, size=Undefined, stroke=Undefined,
+                  strokeCap=Undefined, strokeDash=Undefined, strokeDashOffset=Undefined,
+                  strokeJoin=Undefined, strokeMiterLimit=Undefined, strokeOpacity=Undefined,
+                  strokeWidth=Undefined, style=Undefined, tension=Undefined, text=Undefined,
+                  theta=Undefined, thickness=Undefined, tooltip=Undefined, x2Offset=Undefined,
+                  xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'tick'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="tick", **kwds)
+        else:
+            copy.mark = "tick"
+        return copy
+
+    def mark_rect(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                  clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                  dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                  fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                  fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                  limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined, point=Undefined,
+                  radius=Undefined, shape=Undefined, size=Undefined, stroke=Undefined,
+                  strokeCap=Undefined, strokeDash=Undefined, strokeDashOffset=Undefined,
+                  strokeJoin=Undefined, strokeMiterLimit=Undefined, strokeOpacity=Undefined,
+                  strokeWidth=Undefined, style=Undefined, tension=Undefined, text=Undefined,
+                  theta=Undefined, thickness=Undefined, tooltip=Undefined, x2Offset=Undefined,
+                  xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'rect'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="rect", **kwds)
+        else:
+            copy.mark = "rect"
+        return copy
+
+    def mark_rule(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                  clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                  dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                  fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                  fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                  limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined, point=Undefined,
+                  radius=Undefined, shape=Undefined, size=Undefined, stroke=Undefined,
+                  strokeCap=Undefined, strokeDash=Undefined, strokeDashOffset=Undefined,
+                  strokeJoin=Undefined, strokeMiterLimit=Undefined, strokeOpacity=Undefined,
+                  strokeWidth=Undefined, style=Undefined, tension=Undefined, text=Undefined,
+                  theta=Undefined, thickness=Undefined, tooltip=Undefined, x2Offset=Undefined,
+                  xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'rule'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="rule", **kwds)
+        else:
+            copy.mark = "rule"
+        return copy
+
+    def mark_circle(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                    clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                    dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                    fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                    fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                    limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined,
+                    point=Undefined, radius=Undefined, shape=Undefined, size=Undefined,
+                    stroke=Undefined, strokeCap=Undefined, strokeDash=Undefined,
+                    strokeDashOffset=Undefined, strokeJoin=Undefined, strokeMiterLimit=Undefined,
+                    strokeOpacity=Undefined, strokeWidth=Undefined, style=Undefined, tension=Undefined,
+                    text=Undefined, theta=Undefined, thickness=Undefined, tooltip=Undefined,
+                    x2Offset=Undefined, xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'circle'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="circle", **kwds)
+        else:
+            copy.mark = "circle"
+        return copy
+
+    def mark_square(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                    clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                    dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                    fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                    fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                    limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined,
+                    point=Undefined, radius=Undefined, shape=Undefined, size=Undefined,
+                    stroke=Undefined, strokeCap=Undefined, strokeDash=Undefined,
+                    strokeDashOffset=Undefined, strokeJoin=Undefined, strokeMiterLimit=Undefined,
+                    strokeOpacity=Undefined, strokeWidth=Undefined, style=Undefined, tension=Undefined,
+                    text=Undefined, theta=Undefined, thickness=Undefined, tooltip=Undefined,
+                    x2Offset=Undefined, xOffset=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'square'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="square", **kwds)
+        else:
+            copy.mark = "square"
+        return copy
+
+    def mark_geoshape(self, align=Undefined, angle=Undefined, baseline=Undefined, binSpacing=Undefined,
+                      clip=Undefined, color=Undefined, cornerRadius=Undefined, cursor=Undefined,
+                      dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined, fill=Undefined,
+                      fillOpacity=Undefined, filled=Undefined, font=Undefined, fontSize=Undefined,
+                      fontStyle=Undefined, fontWeight=Undefined, href=Undefined, interpolate=Undefined,
+                      limit=Undefined, line=Undefined, opacity=Undefined, orient=Undefined,
+                      point=Undefined, radius=Undefined, shape=Undefined, size=Undefined,
+                      stroke=Undefined, strokeCap=Undefined, strokeDash=Undefined,
+                      strokeDashOffset=Undefined, strokeJoin=Undefined, strokeMiterLimit=Undefined,
+                      strokeOpacity=Undefined, strokeWidth=Undefined, style=Undefined,
+                      tension=Undefined, text=Undefined, theta=Undefined, thickness=Undefined,
+                      tooltip=Undefined, x2Offset=Undefined, xOffset=Undefined, y2Offset=Undefined,
+                      yOffset=Undefined, **kwds):
+        """Set the chart's mark to 'geoshape'
+    
+        For information on additional arguments, see ``alt.MarkDef``
+        """
+        kwds = dict(align=align, angle=angle, baseline=baseline, binSpacing=binSpacing, clip=clip,
+                    color=color, cornerRadius=cornerRadius, cursor=cursor, dir=dir, dx=dx, dy=dy,
+                    ellipsis=ellipsis, fill=fill, fillOpacity=fillOpacity, filled=filled, font=font,
+                    fontSize=fontSize, fontStyle=fontStyle, fontWeight=fontWeight, href=href,
+                    interpolate=interpolate, limit=limit, line=line, opacity=opacity, orient=orient,
+                    point=point, radius=radius, shape=shape, size=size, stroke=stroke,
+                    strokeCap=strokeCap, strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                    strokeJoin=strokeJoin, strokeMiterLimit=strokeMiterLimit,
+                    strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, style=style, tension=tension,
+                    text=text, theta=theta, thickness=thickness, tooltip=tooltip, x2Offset=x2Offset,
+                    xOffset=xOffset, y2Offset=y2Offset, yOffset=yOffset, **kwds)
+        copy = self.copy(deep=True, ignore=['data'])
+        if any(val is not Undefined for val in kwds.values()):
+            copy.mark = core.MarkDef(type="geoshape", **kwds)
+        else:
+            copy.mark = "geoshape"
+        return copy
+
+
+class ConfigMethodMixin(object):
+    """A mixin class that defines config methods"""
+
+    @use_signature(core.Config)
+    def configure(self, *args, **kwargs):
+        copy = self.copy()
+        copy.config = core.Config(*args, **kwargs)
+        return copy
+
+    @use_signature(core.AreaConfig)
+    def configure_area(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["area"] = core.AreaConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.AxisConfig)
+    def configure_axis(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["axis"] = core.AxisConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.AxisConfig)
+    def configure_axisBand(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["axisBand"] = core.AxisConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.AxisConfig)
+    def configure_axisBottom(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["axisBottom"] = core.AxisConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.AxisConfig)
+    def configure_axisLeft(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["axisLeft"] = core.AxisConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.AxisConfig)
+    def configure_axisRight(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["axisRight"] = core.AxisConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.AxisConfig)
+    def configure_axisTop(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["axisTop"] = core.AxisConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.AxisConfig)
+    def configure_axisX(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["axisX"] = core.AxisConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.AxisConfig)
+    def configure_axisY(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["axisY"] = core.AxisConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.BarConfig)
+    def configure_bar(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["bar"] = core.BarConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.BoxPlotConfig)
+    def configure_boxplot(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["boxplot"] = core.BoxPlotConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.MarkConfig)
+    def configure_circle(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["circle"] = core.MarkConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.ErrorBandConfig)
+    def configure_errorband(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["errorband"] = core.ErrorBandConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.ErrorBarConfig)
+    def configure_errorbar(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["errorbar"] = core.ErrorBarConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.MarkConfig)
+    def configure_geoshape(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["geoshape"] = core.MarkConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.HeaderConfig)
+    def configure_header(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["header"] = core.HeaderConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.LegendConfig)
+    def configure_legend(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["legend"] = core.LegendConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.LineConfig)
+    def configure_line(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["line"] = core.LineConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.MarkConfig)
+    def configure_mark(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["mark"] = core.MarkConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.MarkConfig)
+    def configure_point(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["point"] = core.MarkConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.ProjectionConfig)
+    def configure_projection(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["projection"] = core.ProjectionConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.RangeConfig)
+    def configure_range(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["range"] = core.RangeConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.MarkConfig)
+    def configure_rect(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["rect"] = core.MarkConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.MarkConfig)
+    def configure_rule(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["rule"] = core.MarkConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.ScaleConfig)
+    def configure_scale(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["scale"] = core.ScaleConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.SelectionConfig)
+    def configure_selection(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["selection"] = core.SelectionConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.MarkConfig)
+    def configure_square(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["square"] = core.MarkConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.TextConfig)
+    def configure_text(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["text"] = core.TextConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.TickConfig)
+    def configure_tick(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["tick"] = core.TickConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.TitleConfig)
+    def configure_title(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["title"] = core.TitleConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.LineConfig)
+    def configure_trail(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["trail"] = core.LineConfig(*args, **kwargs)
+        return copy
+
+    @use_signature(core.ViewConfig)
+    def configure_view(self, *args, **kwargs):
+        copy = self.copy(deep=False)
+        if copy.config is Undefined:
+            copy.config = core.Config()
+        else:
+            copy.config = copy.config.copy(deep=False)
+        copy.config["view"] = core.ViewConfig(*args, **kwargs)
+        return copy

--- a/altair/vegalite/v3/schema/vega-lite-schema.json
+++ b/altair/vegalite/v3/schema/vega-lite-schema.json
@@ -1,0 +1,10155 @@
+{
+  "$ref": "#/definitions/TopLevelSpec",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "definitions": {
+    "Aggregate": {
+      "$ref": "#/definitions/AggregateOp"
+    },
+    "AggregateOp": {
+      "enum": [
+        "argmax",
+        "argmin",
+        "average",
+        "count",
+        "distinct",
+        "max",
+        "mean",
+        "median",
+        "min",
+        "missing",
+        "q1",
+        "q3",
+        "ci0",
+        "ci1",
+        "stderr",
+        "stdev",
+        "stdevp",
+        "sum",
+        "valid",
+        "values",
+        "variance",
+        "variancep"
+      ],
+      "type": "string"
+    },
+    "AggregateTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "description": "Array of objects that define fields to aggregate.",
+          "items": {
+            "$ref": "#/definitions/AggregatedFieldDef"
+          },
+          "type": "array"
+        },
+        "groupby": {
+          "description": "The data fields to group by. If not specified, a single group containing all data objects will be used.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "aggregate"
+      ],
+      "type": "object"
+    },
+    "AggregatedFieldDef": {
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "description": "The output field names to use for each aggregated field.",
+          "type": "string"
+        },
+        "field": {
+          "description": "The data field for which to compute aggregate function. This is required for all aggregation operations except `\"count\"`.",
+          "type": "string"
+        },
+        "op": {
+          "$ref": "#/definitions/AggregateOp",
+          "description": "The aggregation operations to apply to the fields, such as sum, average or count.\nSee the [full list of supported aggregation operations](https://vega.github.io/vega-lite/docs/aggregate.html#ops)\nfor more information."
+        }
+      },
+      "required": [
+        "op",
+        "as"
+      ],
+      "type": "object"
+    },
+    "Align": {
+      "enum": [
+        "left",
+        "center",
+        "right"
+      ],
+      "type": "string"
+    },
+    "AnyMark": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CompositeMark"
+        },
+        {
+          "$ref": "#/definitions/CompositeMarkDef"
+        },
+        {
+          "$ref": "#/definitions/Mark"
+        },
+        {
+          "$ref": "#/definitions/MarkDef"
+        }
+      ]
+    },
+    "AreaConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/Align",
+          "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
+        },
+        "angle": {
+          "description": "The rotation angle of the text, in degrees.",
+          "maximum": 360,
+          "minimum": 0,
+          "type": "number"
+        },
+        "baseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
+        },
+        "color": {
+          "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "string"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners.\n\n__Default value:__ `0`",
+          "type": "number"
+        },
+        "cursor": {
+          "$ref": "#/definitions/Cursor",
+          "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
+        },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of `\"ltr\"` (left-to-right) or `\"rtl\"` (right-to-left). This property determines on which side is truncated in response to the limit parameter.\n\n__Default value:__ `\"ltr\"`"
+        },
+        "dx": {
+          "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "dy": {
+          "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter.\n\n__Default value:__ `\"…\"`",
+          "type": "string"
+        },
+        "fill": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "filled": {
+          "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "boolean"
+        },
+        "font": {
+          "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "fontSize": {
+          "description": "The font size, in pixels.",
+          "type": "number"
+        },
+        "fontStyle": {
+          "$ref": "#/definitions/FontStyle",
+          "description": "The font style (e.g., `\"italic\"`)."
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "href": {
+          "description": "A URL to load upon mouse click. If defined, the mark acts as a hyperlink.",
+          "format": "uri",
+          "type": "string"
+        },
+        "interpolate": {
+          "$ref": "#/definitions/Interpolate",
+          "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "line": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/OverlayMarkDef"
+            }
+          ],
+          "description": "A flag for overlaying line on top of area marks, or an object defining the properties of the overlayed lines.\n\n- If this value is an empty object (`{}`) or `true`, lines with default properties will be used.\n\n- If this value is `false`, no lines would be automatically added to area marks.\n\n__Default value:__ `false`."
+        },
+        "opacity": {
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
+        },
+        "point": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/OverlayMarkDef"
+            },
+            {
+              "enum": [
+                "transparent"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for overlaying points on top of line or area marks, or an object defining the properties of the overlayed points.\n\n- If this property is `\"transparent\"`, transparent points will be used (for enhancing tooltips and selections).\n\n- If this property is an empty object (`{}`) or `true`, filled points with default properties will be used.\n\n- If this property is `false`, no points would be automatically added to line or area marks.\n\n__Default value:__ `false`."
+        },
+        "radius": {
+          "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "shape": {
+          "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
+          "type": "string"
+        },
+        "size": {
+          "description": "Default size for marks.\n- For `point`/`circle`/`square`, this represents the pixel area of the marks. For example: in the case of circles, the radius is determined in part by the square root of the size value.\n- For `bar`, this represents the band size of the bar, in pixels.\n- For `text`, this represents the font size, in pixels.\n\n__Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text marks.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "stroke": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Stroke Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "strokeCap": {
+          "$ref": "#/definitions/StrokeCap",
+          "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"square\"`"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tension": {
+          "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "text": {
+          "description": "Placeholder text if the `text` channel is not specified",
+          "type": "string"
+        },
+        "theta": {
+          "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
+          "type": "number"
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TooltipContent"
+            }
+          ],
+          "description": "The tooltip text string to show upon mouse hover or an object defining which fields should the tooltip be derived from.\n\n- If `tooltip` is `{\"content\": \"encoding\"}`, then all fields from `encoding` will be used.\n- If `tooltip` is `{\"content\": \"data\"}`, then all fields that appear in the highlighted data point will be used."
+        }
+      },
+      "type": "object"
+    },
+    "AutoSizeParams": {
+      "additionalProperties": false,
+      "properties": {
+        "contains": {
+          "description": "Determines how size calculation should be performed, one of `\"content\"` or `\"padding\"`. The default setting (`\"content\"`) interprets the width and height settings as the data rectangle (plotting) dimensions, to which padding is then added. In contrast, the `\"padding\"` setting includes the padding within the view size calculations, such that the width and height settings indicate the **total** intended size of the view.\n\n__Default value__: `\"content\"`",
+          "enum": [
+            "content",
+            "padding"
+          ],
+          "type": "string"
+        },
+        "resize": {
+          "description": "A boolean flag indicating if autosize layout should be re-calculated on every view update.\n\n__Default value__: `false`",
+          "type": "boolean"
+        },
+        "type": {
+          "$ref": "#/definitions/AutosizeType",
+          "description": "The sizing format type. One of `\"pad\"`, `\"fit\"` or `\"none\"`. See the [autosize type](https://vega.github.io/vega-lite/docs/size.html#autosize) documentation for descriptions of each.\n\n__Default value__: `\"pad\"`"
+        }
+      },
+      "type": "object"
+    },
+    "AutosizeType": {
+      "enum": [
+        "pad",
+        "fit",
+        "none"
+      ],
+      "type": "string"
+    },
+    "Axis": {
+      "additionalProperties": false,
+      "properties": {
+        "bandPosition": {
+          "description": "An interpolation fraction indicating where, for `band` scales, axis ticks should be positioned. A value of `0` places ticks at the left edge of their bands. A value of `0.5` places ticks in the middle of their bands.\n\n  __Default value:__ `0.5`",
+          "type": "number"
+        },
+        "domain": {
+          "description": "A boolean flag indicating if the domain (the axis baseline) should be included as part of the axis.\n\n__Default value:__ `true`",
+          "type": "boolean"
+        },
+        "domainColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Color of axis domain line.\n\n__Default value:__ `\"gray\"`."
+        },
+        "domainOpacity": {
+          "description": "Opacity of the axis domain line.",
+          "type": "number"
+        },
+        "domainWidth": {
+          "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
+          "type": "number"
+        },
+        "format": {
+          "description": "The formatting pattern for labels. This is D3's [number format pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for time field.\n\nSee the [format documentation](https://vega.github.io/vega-lite/docs/format.html) for more information.\n\n__Default value:__  derived from [numberFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for quantitative fields and from [timeFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for temporal fields.",
+          "type": "string"
+        },
+        "grid": {
+          "description": "A boolean flag indicating if grid lines should be included as part of the axis\n\n__Default value:__ `true` for [continuous scales](https://vega.github.io/vega-lite/docs/scale.html#continuous) that are not binned; otherwise, `false`.",
+          "type": "boolean"
+        },
+        "gridColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Color of gridlines.\n\n__Default value:__ `\"lightGray\"`."
+        },
+        "gridDash": {
+          "description": "The offset (in pixels) into which to begin drawing with the grid dash array.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "gridOpacity": {
+          "description": "The stroke opacity of grid (value between [0,1])\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "gridWidth": {
+          "description": "The grid width, in pixels.\n\n__Default value:__ `1`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "labelAlign": {
+          "$ref": "#/definitions/Align",
+          "description": "Horizontal text alignment of axis tick labels, overriding the default setting for the current axis orientation."
+        },
+        "labelAngle": {
+          "description": "The rotation angle of the axis labels.\n\n__Default value:__ `-90` for nominal and ordinal fields; `0` otherwise.",
+          "maximum": 360,
+          "minimum": -360,
+          "type": "number"
+        },
+        "labelBaseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "Vertical text baseline of axis tick labels, overriding the default setting for the current axis orientation. Can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
+        },
+        "labelBound": {
+          "description": "Indicates if labels should be hidden if they exceed the axis range. If `false` (the default) no bounds overlap analysis is performed. If `true`, labels will be hidden if they exceed the axis range by more than 1 pixel. If this property is a number, it specifies the pixel tolerance: the maximum amount by which a label bounding box may exceed the axis range.\n\n__Default value:__ `false`.",
+          "type": [
+            "number",
+            "boolean"
+          ]
+        },
+        "labelColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the tick label, can be in hex color code or regular color name."
+        },
+        "labelFlush": {
+          "description": "Indicates if the first and last axis labels should be aligned flush with the scale range. Flush alignment for a horizontal axis will left-align the first label and right-align the last label. For vertical axes, bottom and top text baselines are applied instead. If this property is a number, it also indicates the number of pixels by which to offset the first and last labels; for example, a value of 2 will flush-align the first and last labels and also push them 2 pixels outward from the center of the axis. The additional adjustment can sometimes help the labels better visually group with corresponding axis ticks.\n\n__Default value:__ `true` for axis of a continuous x-scale. Otherwise, `false`.",
+          "type": [
+            "boolean",
+            "number"
+          ]
+        },
+        "labelFlushOffset": {
+          "description": "Indicates the number of pixels by which to offset flush-adjusted labels. For example, a value of `2` will push flush-adjusted labels 2 pixels outward from the center of the axis. Offsets can help the labels better visually group with corresponding axis ticks.\n\n__Default value:__ `0`.",
+          "type": "number"
+        },
+        "labelFont": {
+          "description": "The font of the tick label.",
+          "type": "string"
+        },
+        "labelFontSize": {
+          "description": "The font size of the label, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "labelFontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "Font weight of axis tick labels."
+        },
+        "labelLimit": {
+          "description": "Maximum allowed pixel width of axis tick labels.\n\n__Default value:__ `180`",
+          "type": "number"
+        },
+        "labelOpacity": {
+          "description": "The opacity of the labels.",
+          "type": "number"
+        },
+        "labelOverlap": {
+          "$ref": "#/definitions/LabelOverlap",
+          "description": "The strategy to use for resolving overlap of axis labels. If `false` (the default), no overlap reduction is attempted. If set to `true` or `\"parity\"`, a strategy of removing every other label is used (this works well for standard linear axes). If set to `\"greedy\"`, a linear scan of the labels is performed, removing any labels that overlaps with the last visible label (this often works better for log-scaled axes).\n\n__Default value:__ `true` for non-nominal fields with non-log scales; `\"greedy\"` for log scales; otherwise `false`."
+        },
+        "labelPadding": {
+          "description": "The padding, in pixels, between axis and text labels.\n\n__Default value:__ `2`",
+          "type": "number"
+        },
+        "labels": {
+          "description": "A boolean flag indicating if labels should be included as part of the axis.\n\n__Default value:__ `true`.",
+          "type": "boolean"
+        },
+        "maxExtent": {
+          "description": "The maximum extent in pixels that axis ticks and labels should use. This determines a maximum offset value for axis titles.\n\n__Default value:__ `undefined`.",
+          "type": "number"
+        },
+        "minExtent": {
+          "description": "The minimum extent in pixels that axis ticks and labels should use. This determines a minimum offset value for axis titles.\n\n__Default value:__ `30` for y-axis; `undefined` for x-axis.",
+          "type": "number"
+        },
+        "offset": {
+          "description": "The offset, in pixels, by which to displace the axis from the edge of the enclosing group or data rectangle.\n\n__Default value:__ derived from the [axis config](https://vega.github.io/vega-lite/docs/config.html#facet-scale-config)'s `offset` (`0` by default)",
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/AxisOrient",
+          "description": "The orientation of the axis. One of `\"top\"`, `\"bottom\"`, `\"left\"` or `\"right\"`. The orientation can be used to further specialize the axis type (e.g., a y axis oriented for the right edge of the chart).\n\n__Default value:__ `\"bottom\"` for x-axes and `\"left\"` for y-axes."
+        },
+        "position": {
+          "description": "The anchor position of the axis in pixels. For x-axes with top or bottom orientation, this sets the axis group x coordinate. For y-axes with left or right orientation, this sets the axis group y coordinate.\n\n__Default value__: `0`",
+          "type": "number"
+        },
+        "tickColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the axis's tick.\n\n__Default value:__ `\"gray\"`"
+        },
+        "tickCount": {
+          "description": "A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are \"nice\" (multiples of 2, 5, 10) and lie within the underlying scale's range.",
+          "type": "number"
+        },
+        "tickExtra": {
+          "description": "Boolean flag indicating if an extra axis tick should be added for the initial position of the axis. This flag is useful for styling axes for `band` scales such that ticks are placed on band boundaries rather in the middle of a band. Use in conjunction with `\"bandPostion\": 1` and an axis `\"padding\"` value of `0`.",
+          "type": "boolean"
+        },
+        "tickOffset": {
+          "description": "Position offset in pixels to apply to ticks, labels, and gridlines.",
+          "type": "number"
+        },
+        "tickOpacity": {
+          "description": "Opacity of the ticks.",
+          "type": "number"
+        },
+        "tickRound": {
+          "description": "Boolean flag indicating if pixel position values should be rounded to the nearest integer.\n\n__Default value:__ `true`",
+          "type": "boolean"
+        },
+        "tickSize": {
+          "description": "The size in pixels of axis ticks.\n\n__Default value:__ `5`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tickStep": {
+          "description": "A desired step size for ticks. This property will generate the corresponding `tickCount` and `values`. It can be useful for [data that are binned before importing into Vega-Lite](https://vega.github.io/vega-lite/docs/bin.html#binned).\n\n__Default value__: `undefined`",
+          "type": "number"
+        },
+        "tickWidth": {
+          "description": "The width, in pixels, of ticks.\n\n__Default value:__ `1`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "ticks": {
+          "description": "Boolean value that determines whether the axis should include ticks.\n\n__Default value:__ `true`",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "titleAlign": {
+          "$ref": "#/definitions/Align",
+          "description": "Horizontal text alignment of axis titles."
+        },
+        "titleAngle": {
+          "description": "Angle in degrees of axis titles.",
+          "type": "number"
+        },
+        "titleBaseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "Vertical text baseline for axis titles."
+        },
+        "titleColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Color of the title, can be in hex color code or regular color name."
+        },
+        "titleFont": {
+          "description": "Font of the title. (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "titleFontSize": {
+          "description": "Font size of the title.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "titleFontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "Font weight of the title.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "titleLimit": {
+          "description": "Maximum allowed pixel width of axis titles.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "titleOpacity": {
+          "description": "Opacity of the axis title.",
+          "type": "number"
+        },
+        "titlePadding": {
+          "description": "The padding, in pixels, between title and axis.",
+          "type": "number"
+        },
+        "titleX": {
+          "description": "X-coordinate of the axis title relative to the axis group.",
+          "type": "number"
+        },
+        "titleY": {
+          "description": "Y-coordinate of the axis title relative to the axis group.",
+          "type": "number"
+        },
+        "values": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "type": "boolean"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/DateTime"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Explicitly set the visible axis tick values."
+        },
+        "zindex": {
+          "description": "A non-positive integer indicating z-index of the axis.\nIf zindex is 0, axes should be drawn behind all chart elements.\nTo put them in front, use `\"zindex = 1\"`.\n\n__Default value:__ `1` (in front of the marks) for actual axis and `0` (behind the marks) for grids.",
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "AxisConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "bandPosition": {
+          "description": "An interpolation fraction indicating where, for `band` scales, axis ticks should be positioned. A value of `0` places ticks at the left edge of their bands. A value of `0.5` places ticks in the middle of their bands.\n\n  __Default value:__ `0.5`",
+          "type": "number"
+        },
+        "domain": {
+          "description": "A boolean flag indicating if the domain (the axis baseline) should be included as part of the axis.\n\n__Default value:__ `true`",
+          "type": "boolean"
+        },
+        "domainColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Color of axis domain line.\n\n__Default value:__ `\"gray\"`."
+        },
+        "domainOpacity": {
+          "description": "Opacity of the axis domain line.",
+          "type": "number"
+        },
+        "domainWidth": {
+          "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
+          "type": "number"
+        },
+        "grid": {
+          "description": "A boolean flag indicating if grid lines should be included as part of the axis\n\n__Default value:__ `true` for [continuous scales](https://vega.github.io/vega-lite/docs/scale.html#continuous) that are not binned; otherwise, `false`.",
+          "type": "boolean"
+        },
+        "gridColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Color of gridlines.\n\n__Default value:__ `\"lightGray\"`."
+        },
+        "gridDash": {
+          "description": "The offset (in pixels) into which to begin drawing with the grid dash array.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "gridOpacity": {
+          "description": "The stroke opacity of grid (value between [0,1])\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "gridWidth": {
+          "description": "The grid width, in pixels.\n\n__Default value:__ `1`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "labelAlign": {
+          "$ref": "#/definitions/Align",
+          "description": "Horizontal text alignment of axis tick labels, overriding the default setting for the current axis orientation."
+        },
+        "labelAngle": {
+          "description": "The rotation angle of the axis labels.\n\n__Default value:__ `-90` for nominal and ordinal fields; `0` otherwise.",
+          "maximum": 360,
+          "minimum": -360,
+          "type": "number"
+        },
+        "labelBaseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "Vertical text baseline of axis tick labels, overriding the default setting for the current axis orientation. Can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
+        },
+        "labelBound": {
+          "description": "Indicates if labels should be hidden if they exceed the axis range. If `false` (the default) no bounds overlap analysis is performed. If `true`, labels will be hidden if they exceed the axis range by more than 1 pixel. If this property is a number, it specifies the pixel tolerance: the maximum amount by which a label bounding box may exceed the axis range.\n\n__Default value:__ `false`.",
+          "type": [
+            "number",
+            "boolean"
+          ]
+        },
+        "labelColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the tick label, can be in hex color code or regular color name."
+        },
+        "labelFlush": {
+          "description": "Indicates if the first and last axis labels should be aligned flush with the scale range. Flush alignment for a horizontal axis will left-align the first label and right-align the last label. For vertical axes, bottom and top text baselines are applied instead. If this property is a number, it also indicates the number of pixels by which to offset the first and last labels; for example, a value of 2 will flush-align the first and last labels and also push them 2 pixels outward from the center of the axis. The additional adjustment can sometimes help the labels better visually group with corresponding axis ticks.\n\n__Default value:__ `true` for axis of a continuous x-scale. Otherwise, `false`.",
+          "type": [
+            "boolean",
+            "number"
+          ]
+        },
+        "labelFlushOffset": {
+          "description": "Indicates the number of pixels by which to offset flush-adjusted labels. For example, a value of `2` will push flush-adjusted labels 2 pixels outward from the center of the axis. Offsets can help the labels better visually group with corresponding axis ticks.\n\n__Default value:__ `0`.",
+          "type": "number"
+        },
+        "labelFont": {
+          "description": "The font of the tick label.",
+          "type": "string"
+        },
+        "labelFontSize": {
+          "description": "The font size of the label, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "labelFontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "Font weight of axis tick labels."
+        },
+        "labelLimit": {
+          "description": "Maximum allowed pixel width of axis tick labels.\n\n__Default value:__ `180`",
+          "type": "number"
+        },
+        "labelOpacity": {
+          "description": "The opacity of the labels.",
+          "type": "number"
+        },
+        "labelOverlap": {
+          "$ref": "#/definitions/LabelOverlap",
+          "description": "The strategy to use for resolving overlap of axis labels. If `false` (the default), no overlap reduction is attempted. If set to `true` or `\"parity\"`, a strategy of removing every other label is used (this works well for standard linear axes). If set to `\"greedy\"`, a linear scan of the labels is performed, removing any labels that overlaps with the last visible label (this often works better for log-scaled axes).\n\n__Default value:__ `true` for non-nominal fields with non-log scales; `\"greedy\"` for log scales; otherwise `false`."
+        },
+        "labelPadding": {
+          "description": "The padding, in pixels, between axis and text labels.\n\n__Default value:__ `2`",
+          "type": "number"
+        },
+        "labels": {
+          "description": "A boolean flag indicating if labels should be included as part of the axis.\n\n__Default value:__ `true`.",
+          "type": "boolean"
+        },
+        "maxExtent": {
+          "description": "The maximum extent in pixels that axis ticks and labels should use. This determines a maximum offset value for axis titles.\n\n__Default value:__ `undefined`.",
+          "type": "number"
+        },
+        "minExtent": {
+          "description": "The minimum extent in pixels that axis ticks and labels should use. This determines a minimum offset value for axis titles.\n\n__Default value:__ `30` for y-axis; `undefined` for x-axis.",
+          "type": "number"
+        },
+        "shortTimeLabels": {
+          "description": "Whether month names and weekday names should be abbreviated.\n\n__Default value:__  `false`",
+          "type": "boolean"
+        },
+        "tickColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the axis's tick.\n\n__Default value:__ `\"gray\"`"
+        },
+        "tickExtra": {
+          "description": "Boolean flag indicating if an extra axis tick should be added for the initial position of the axis. This flag is useful for styling axes for `band` scales such that ticks are placed on band boundaries rather in the middle of a band. Use in conjunction with `\"bandPostion\": 1` and an axis `\"padding\"` value of `0`.",
+          "type": "boolean"
+        },
+        "tickOffset": {
+          "description": "Position offset in pixels to apply to ticks, labels, and gridlines.",
+          "type": "number"
+        },
+        "tickOpacity": {
+          "description": "Opacity of the ticks.",
+          "type": "number"
+        },
+        "tickRound": {
+          "description": "Boolean flag indicating if pixel position values should be rounded to the nearest integer.\n\n__Default value:__ `true`",
+          "type": "boolean"
+        },
+        "tickSize": {
+          "description": "The size in pixels of axis ticks.\n\n__Default value:__ `5`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tickWidth": {
+          "description": "The width, in pixels, of ticks.\n\n__Default value:__ `1`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "ticks": {
+          "description": "Boolean value that determines whether the axis should include ticks.\n\n__Default value:__ `true`",
+          "type": "boolean"
+        },
+        "titleAlign": {
+          "$ref": "#/definitions/Align",
+          "description": "Horizontal text alignment of axis titles."
+        },
+        "titleAngle": {
+          "description": "Angle in degrees of axis titles.",
+          "type": "number"
+        },
+        "titleBaseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "Vertical text baseline for axis titles."
+        },
+        "titleColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Color of the title, can be in hex color code or regular color name."
+        },
+        "titleFont": {
+          "description": "Font of the title. (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "titleFontSize": {
+          "description": "Font size of the title.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "titleFontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "Font weight of the title.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "titleLimit": {
+          "description": "Maximum allowed pixel width of axis titles.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "titleOpacity": {
+          "description": "Opacity of the axis title.",
+          "type": "number"
+        },
+        "titlePadding": {
+          "description": "The padding, in pixels, between title and axis.",
+          "type": "number"
+        },
+        "titleX": {
+          "description": "X-coordinate of the axis title relative to the axis group.",
+          "type": "number"
+        },
+        "titleY": {
+          "description": "Y-coordinate of the axis title relative to the axis group.",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "AxisOrient": {
+      "enum": [
+        "top",
+        "bottom",
+        "left",
+        "right"
+      ],
+      "type": "string"
+    },
+    "AxisResolveMap": {
+      "additionalProperties": false,
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "y": {
+          "$ref": "#/definitions/ResolveMode"
+        }
+      },
+      "type": "object"
+    },
+    "BarConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/Align",
+          "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
+        },
+        "angle": {
+          "description": "The rotation angle of the text, in degrees.",
+          "maximum": 360,
+          "minimum": 0,
+          "type": "number"
+        },
+        "baseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
+        },
+        "binSpacing": {
+          "description": "Offset between bars for binned field.  Ideal value for this is either 0 (Preferred by statisticians) or 1 (Vega-Lite Default, D3 example style).\n\n__Default value:__ `1`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "color": {
+          "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "string"
+        },
+        "continuousBandSize": {
+          "description": "The default size of the bars on continuous scales.\n\n__Default value:__ `5`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners.\n\n__Default value:__ `0`",
+          "type": "number"
+        },
+        "cursor": {
+          "$ref": "#/definitions/Cursor",
+          "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
+        },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of `\"ltr\"` (left-to-right) or `\"rtl\"` (right-to-left). This property determines on which side is truncated in response to the limit parameter.\n\n__Default value:__ `\"ltr\"`"
+        },
+        "discreteBandSize": {
+          "description": "The default size of the bars with discrete dimensions.  If unspecified, the default size is  `bandSize-1`,\nwhich provides 1 pixel offset between bars.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "dx": {
+          "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "dy": {
+          "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter.\n\n__Default value:__ `\"…\"`",
+          "type": "string"
+        },
+        "fill": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "filled": {
+          "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "boolean"
+        },
+        "font": {
+          "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "fontSize": {
+          "description": "The font size, in pixels.",
+          "type": "number"
+        },
+        "fontStyle": {
+          "$ref": "#/definitions/FontStyle",
+          "description": "The font style (e.g., `\"italic\"`)."
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "href": {
+          "description": "A URL to load upon mouse click. If defined, the mark acts as a hyperlink.",
+          "format": "uri",
+          "type": "string"
+        },
+        "interpolate": {
+          "$ref": "#/definitions/Interpolate",
+          "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "opacity": {
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
+        },
+        "radius": {
+          "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "shape": {
+          "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
+          "type": "string"
+        },
+        "size": {
+          "description": "Default size for marks.\n- For `point`/`circle`/`square`, this represents the pixel area of the marks. For example: in the case of circles, the radius is determined in part by the square root of the size value.\n- For `bar`, this represents the band size of the bar, in pixels.\n- For `text`, this represents the font size, in pixels.\n\n__Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text marks.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "stroke": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Stroke Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "strokeCap": {
+          "$ref": "#/definitions/StrokeCap",
+          "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"square\"`"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tension": {
+          "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "text": {
+          "description": "Placeholder text if the `text` channel is not specified",
+          "type": "string"
+        },
+        "theta": {
+          "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
+          "type": "number"
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TooltipContent"
+            }
+          ],
+          "description": "The tooltip text string to show upon mouse hover or an object defining which fields should the tooltip be derived from.\n\n- If `tooltip` is `{\"content\": \"encoding\"}`, then all fields from `encoding` will be used.\n- If `tooltip` is `{\"content\": \"data\"}`, then all fields that appear in the highlighted data point will be used."
+        }
+      },
+      "type": "object"
+    },
+    "VgTitleConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/Align"
+        },
+        "anchor": {
+          "$ref": "#/definitions/TitleAnchor",
+          "description": "The anchor position for placing the title. One of `\"start\"`, `\"middle\"`, or `\"end\"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title."
+        },
+        "angle": {
+          "description": "Angle in degrees of title text.",
+          "type": "number"
+        },
+        "baseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "Vertical text baseline for title text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
+        },
+        "color": {
+          "$ref": "#/definitions/Color",
+          "description": "Text color for title text."
+        },
+        "font": {
+          "description": "Font name for title text.",
+          "type": "string"
+        },
+        "fontSize": {
+          "description": "Font size in pixels for title text.\n\n__Default value:__ `10`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "Font weight for title text.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "frame": {
+          "$ref": "#/definitions/TitleFrame",
+          "description": "The reference frame for the anchor position, one of `\"bounds\"` (to anchor relative to the full bounding box) or `\"group\"` (to anchor relative to the group width or height)."
+        },
+        "limit": {
+          "description": "The maximum allowed length in pixels of legend labels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "offset": {
+          "description": "The orthogonal offset in pixels by which to displace the title from its position along the edge of the chart.",
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/TitleOrient",
+          "description": "Default title orientation (`\"top\"`, `\"bottom\"`, `\"left\"`, or `\"right\"`)"
+        }
+      },
+      "type": "object"
+    },
+    "Baseline": {
+      "enum": [
+        "top",
+        "middle",
+        "bottom"
+      ],
+      "type": "string"
+    },
+    "BinParams": {
+      "additionalProperties": false,
+      "description": "Binning properties or boolean flag for determining whether to bin data or not.",
+      "properties": {
+        "anchor": {
+          "description": "A value in the binned domain at which to anchor the bins, shifting the bin boundaries if necessary to ensure that a boundary aligns with the anchor value.\n\n__Default Value:__ the minimum bin extent value",
+          "type": "number"
+        },
+        "base": {
+          "description": "The number base to use for automatic bin determination (default is base 10).\n\n__Default value:__ `10`",
+          "type": "number"
+        },
+        "divide": {
+          "description": "Scale factors indicating allowable subdivisions. The default value is [5, 2], which indicates that for base 10 numbers (the default base), the method may consider dividing bin sizes by 5 and/or 2. For example, for an initial step size of 10, the method can check if bin sizes of 2 (= 10/5), 5 (= 10/2), or 1 (= 10/(5*2)) might also satisfy the given constraints.\n\n__Default value:__ `[5, 2]`",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "extent": {
+          "description": "A two-element (`[min, max]`) array indicating the range of desired bin values.",
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "maxbins": {
+          "description": "Maximum number of bins.\n\n__Default value:__ `6` for `row`, `column` and `shape` channels; `10` for other channels",
+          "minimum": 2,
+          "type": "number"
+        },
+        "minstep": {
+          "description": "A minimum allowable step size (particularly useful for integer values).",
+          "type": "number"
+        },
+        "nice": {
+          "description": "If true (the default), attempts to make the bin boundaries use human-friendly boundaries, such as multiples of ten.",
+          "type": "boolean"
+        },
+        "step": {
+          "description": "An exact step size to use between bins.\n\n__Note:__ If provided, options such as maxbins will be ignored.",
+          "type": "number"
+        },
+        "steps": {
+          "description": "An array of allowable step sizes to choose from.",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "BinTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "The output fields at which to write the start and end bin values."
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            }
+          ],
+          "description": "An object indicating bin properties, or simply `true` for using default bin parameters."
+        },
+        "field": {
+          "description": "The data field to bin.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "bin",
+        "field",
+        "as"
+      ],
+      "type": "object"
+    },
+    "BoxPlot": {
+      "enum": [
+        "boxplot"
+      ],
+      "type": "string"
+    },
+    "BoxPlotConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "box": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "extent": {
+          "anyOf": [
+            {
+              "enum": [
+                "min-max"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "description": "The extent of the whiskers. Available options include:\n- `\"min-max\"`: min and max are the lower and upper whiskers respectively.\n- A number representing multiple of the interquartile range (Q3-Q1).  This number will be multiplied by the IQR. the product will be added to the third quartile to get the upper whisker and subtracted from the first quartile to get the lower whisker.\n\n__Default value:__ `1.5`."
+        },
+        "median": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "outliers": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "rule": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "size": {
+          "description": "Size of the box and median tick of a box plot",
+          "type": "number"
+        },
+        "ticks": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "BoxPlotDef": {
+      "additionalProperties": false,
+      "properties": {
+        "box": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "clip": {
+          "description": "Whether a composite mark be clipped to the enclosing group’s width and height.",
+          "type": "boolean"
+        },
+        "color": {
+          "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "string"
+        },
+        "extent": {
+          "anyOf": [
+            {
+              "enum": [
+                "min-max"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "description": "The extent of the whiskers. Available options include:\n- `\"min-max\"`: min and max are the lower and upper whiskers respectively.\n- A number representing multiple of the interquartile range (Q3-Q1).  This number will be multiplied by the IQR. the product will be added to the third quartile to get the upper whisker and subtracted from the first quartile to get the lower whisker.\n\n__Default value:__ `1.5`."
+        },
+        "median": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "opacity": {
+          "description": "The opacity (value between [0,1]) of the mark.",
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "Orientation of the box plot.  This is normally automatically determined based on types of fields on x and y channels. However, an explicit `orient` be specified when the orientation is ambiguous.\n\n__Default value:__ `\"vertical\"`."
+        },
+        "outliers": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "rule": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "size": {
+          "description": "Size of the box and median tick of a box plot",
+          "type": "number"
+        },
+        "ticks": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/BoxPlot",
+          "description": "The mark type. This could a primitive mark type\n(one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"geoshape\"`, `\"rule\"`, and `\"text\"`)\nor a composite mark type (`\"boxplot\"`, `\"errorband\"`, `\"errorbar\"`)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "BrushConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "fill": {
+          "description": "The fill color of the interval mark.\n\n__Default value:__ `#333333`",
+          "type": "string"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity of the interval mark (a value between 0 and 1).\n\n__Default value:__ `0.125`",
+          "type": "number"
+        },
+        "stroke": {
+          "description": "The stroke color of the interval mark.\n\n__Default value:__ `#ffffff`",
+          "type": "string"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke and space lengths,\nfor creating dashed or dotted lines.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) with which to begin drawing the stroke dash array.",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity of the interval mark (a value between 0 and 1).",
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width of the interval mark.",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "CalculateTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "description": "The field for storing the computed formula value.",
+          "type": "string"
+        },
+        "calculate": {
+          "description": "A [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string. Use the variable `datum` to refer to the current data object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "calculate",
+        "as"
+      ],
+      "type": "object"
+    },
+    "Color": {
+      "type": "string"
+    },
+    "CompositeMark": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/BoxPlot"
+        },
+        {
+          "$ref": "#/definitions/ErrorBar"
+        },
+        {
+          "$ref": "#/definitions/ErrorBand"
+        }
+      ]
+    },
+    "CompositeMarkDef": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/BoxPlotDef"
+        },
+        {
+          "$ref": "#/definitions/ErrorBarDef"
+        },
+        {
+          "$ref": "#/definitions/ErrorBandDef"
+        }
+      ]
+    },
+    "CompositeUnitSpec": {
+      "$ref": "#/definitions/CompositeUnitSpecAlias",
+      "description": "Unit spec that can have a composite mark."
+    },
+    "ConditionalFieldDef": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ConditionalPredicate<FieldDef>"
+        },
+        {
+          "$ref": "#/definitions/ConditionalSelection<FieldDef>"
+        }
+      ]
+    },
+    "ConditionalMarkPropFieldDef": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ConditionalPredicate<MarkPropFieldDef>"
+        },
+        {
+          "$ref": "#/definitions/ConditionalSelection<MarkPropFieldDef>"
+        }
+      ]
+    },
+    "ConditionalTextFieldDef": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ConditionalPredicate<TextFieldDef>"
+        },
+        {
+          "$ref": "#/definitions/ConditionalSelection<TextFieldDef>"
+        }
+      ]
+    },
+    "ConditionalValueDef": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ConditionalPredicate<ValueDef>"
+        },
+        {
+          "$ref": "#/definitions/ConditionalSelection<ValueDef>"
+        }
+      ]
+    },
+    "ConditionalPredicate<FieldDef>": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "test",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<MarkPropFieldDef>": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "legend": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Legend"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object defining properties of the legend.\nIf `null`, the legend for the encoding channel will be removed.\n\n__Default value:__ If undefined, default [legend properties](https://vega.github.io/vega-lite/docs/legend.html) are applied."
+        },
+        "scale": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Scale"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object defining properties of the channel's scale, which is the function that transforms values in the data domain (numbers, dates, strings, etc) to visual values (pixels, colors, sizes) of the encoding channels.\n\nIf `null`, the scale will be [disabled and the data value will be directly encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).\n\n__Default value:__ If undefined, default [scale properties](https://vega.github.io/vega-lite/docs/scale.html) are applied."
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort",
+          "description": "Sort order for the encoded field.\n\nFor continuous fields (quantitative or temporal), `sort` can be either `\"ascending\"` or `\"descending\"`.\n\nFor discrete fields, `sort` can be one of the following:\n- `\"ascending\"` or `\"descending\"` -- for sorting by the values' natural order in Javascript.\n- [A sort field definition](https://vega.github.io/vega-lite/docs/sort.html#sort-field) for sorting by another field.\n- [An array specifying the field values in preferred order](https://vega.github.io/vega-lite/docs/sort.html#sort-array). In this case, the sort order will obey the values in the array, followed by any unspecified values in their original order.  For discrete time field, values in the sort array can be [date-time definition objects](types#datetime). In addition, for time units `\"month\"` and `\"day\"`, the values can be the month or day names (case insensitive) or their 3-letter initials (e.g., `\"Mon\"`, `\"Tue\"`).\n- `null` indicating no sort.\n\n__Default value:__ `\"ascending\"`\n\n__Note:__ `null` is not supported for `row` and `column`."
+        },
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "test",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<TextFieldDef>": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "format": {
+          "description": "The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a text field. If not defined, this will be determined automatically.",
+          "type": "string"
+        },
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "test",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>"
+        },
+        "value": {
+          "description": "A constant value in visual domain (e.g., `\"red\"` / \"#0099ff\" for color, values between `0` to `1` for opacity).",
+          "type": [
+            "number",
+            "string",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalSelection<FieldDef>": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "selection": {
+          "$ref": "#/definitions/SelectionOperand",
+          "description": "A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a series of [composed selections](https://vega.github.io/vega-lite/docs/selection.html#compose)."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "selection",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ConditionalSelection<MarkPropFieldDef>": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "legend": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Legend"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object defining properties of the legend.\nIf `null`, the legend for the encoding channel will be removed.\n\n__Default value:__ If undefined, default [legend properties](https://vega.github.io/vega-lite/docs/legend.html) are applied."
+        },
+        "scale": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Scale"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object defining properties of the channel's scale, which is the function that transforms values in the data domain (numbers, dates, strings, etc) to visual values (pixels, colors, sizes) of the encoding channels.\n\nIf `null`, the scale will be [disabled and the data value will be directly encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).\n\n__Default value:__ If undefined, default [scale properties](https://vega.github.io/vega-lite/docs/scale.html) are applied."
+        },
+        "selection": {
+          "$ref": "#/definitions/SelectionOperand",
+          "description": "A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a series of [composed selections](https://vega.github.io/vega-lite/docs/selection.html#compose)."
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort",
+          "description": "Sort order for the encoded field.\n\nFor continuous fields (quantitative or temporal), `sort` can be either `\"ascending\"` or `\"descending\"`.\n\nFor discrete fields, `sort` can be one of the following:\n- `\"ascending\"` or `\"descending\"` -- for sorting by the values' natural order in Javascript.\n- [A sort field definition](https://vega.github.io/vega-lite/docs/sort.html#sort-field) for sorting by another field.\n- [An array specifying the field values in preferred order](https://vega.github.io/vega-lite/docs/sort.html#sort-array). In this case, the sort order will obey the values in the array, followed by any unspecified values in their original order.  For discrete time field, values in the sort array can be [date-time definition objects](types#datetime). In addition, for time units `\"month\"` and `\"day\"`, the values can be the month or day names (case insensitive) or their 3-letter initials (e.g., `\"Mon\"`, `\"Tue\"`).\n- `null` indicating no sort.\n\n__Default value:__ `\"ascending\"`\n\n__Note:__ `null` is not supported for `row` and `column`."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "selection",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ConditionalSelection<TextFieldDef>": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "format": {
+          "description": "The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a text field. If not defined, this will be determined automatically.",
+          "type": "string"
+        },
+        "selection": {
+          "$ref": "#/definitions/SelectionOperand",
+          "description": "A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a series of [composed selections](https://vega.github.io/vega-lite/docs/selection.html#compose)."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "selection",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ConditionalSelection<ValueDef>": {
+      "additionalProperties": false,
+      "properties": {
+        "selection": {
+          "$ref": "#/definitions/SelectionOperand",
+          "description": "A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a series of [composed selections](https://vega.github.io/vega-lite/docs/selection.html#compose)."
+        },
+        "value": {
+          "description": "A constant value in visual domain (e.g., `\"red\"` / \"#0099ff\" for color, values between `0` to `1` for opacity).",
+          "type": [
+            "number",
+            "string",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "selection",
+        "value"
+      ],
+      "type": "object"
+    },
+    "Config": {
+      "additionalProperties": false,
+      "properties": {
+        "area": {
+          "$ref": "#/definitions/AreaConfig",
+          "description": "Area-Specific Config"
+        },
+        "autosize": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AutosizeType"
+            },
+            {
+              "$ref": "#/definitions/AutoSizeParams"
+            }
+          ],
+          "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
+        },
+        "axis": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Axis configuration, which determines default properties for all `x` and `y` [axes](https://vega.github.io/vega-lite/docs/axis.html). For a full list of axis configuration options, please see the [corresponding section of the axis documentation](https://vega.github.io/vega-lite/docs/axis.html#config)."
+        },
+        "axisBand": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Specific axis config for axes with \"band\" scales."
+        },
+        "axisBottom": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Specific axis config for x-axis along the bottom edge of the chart."
+        },
+        "axisLeft": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Specific axis config for y-axis along the left edge of the chart."
+        },
+        "axisRight": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Specific axis config for y-axis along the right edge of the chart."
+        },
+        "axisTop": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Specific axis config for x-axis along the top edge of the chart."
+        },
+        "axisX": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "X-axis specific config."
+        },
+        "axisY": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Y-axis specific config."
+        },
+        "background": {
+          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "type": "string"
+        },
+        "bar": {
+          "$ref": "#/definitions/BarConfig",
+          "description": "Bar-Specific Config"
+        },
+        "boxplot": {
+          "$ref": "#/definitions/BoxPlotConfig",
+          "description": "Box Config"
+        },
+        "circle": {
+          "$ref": "#/definitions/MarkConfig",
+          "description": "Circle-Specific Config"
+        },
+        "countTitle": {
+          "description": "Default axis and legend title for count fields.\n\n__Default value:__ `'Number of Records'`.",
+          "type": "string"
+        },
+        "errorband": {
+          "$ref": "#/definitions/ErrorBandConfig",
+          "description": "ErrorBand Config"
+        },
+        "errorbar": {
+          "$ref": "#/definitions/ErrorBarConfig",
+          "description": "ErrorBar Config"
+        },
+        "fieldTitle": {
+          "description": "Defines how Vega-Lite generates title for fields.  There are three possible styles:\n- `\"verbal\"` (Default) - displays function in a verbal style (e.g., \"Sum of field\", \"Year-month of date\", \"field (binned)\").\n- `\"function\"` - displays function using parentheses and capitalized texts (e.g., \"SUM(field)\", \"YEARMONTH(date)\", \"BIN(field)\").\n- `\"plain\"` - displays only the field name without functions (e.g., \"field\", \"date\", \"field\").",
+          "enum": [
+            "verbal",
+            "functional",
+            "plain"
+          ],
+          "type": "string"
+        },
+        "geoshape": {
+          "$ref": "#/definitions/MarkConfig",
+          "description": "Geoshape-Specific Config"
+        },
+        "header": {
+          "$ref": "#/definitions/HeaderConfig",
+          "description": "Header configuration, which determines default properties for all [header](https://vega.github.io/vega-lite/docs/header.html). For a full list of header configuration options, please see the [corresponding section of in the header documentation](https://vega.github.io/vega-lite/docs/header.html#config)."
+        },
+        "invalidValues": {
+          "description": "Defines how Vega-Lite should handle invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "legend": {
+          "$ref": "#/definitions/LegendConfig",
+          "description": "Legend configuration, which determines default properties for all [legends](https://vega.github.io/vega-lite/docs/legend.html). For a full list of legend configuration options, please see the [corresponding section of in the legend documentation](https://vega.github.io/vega-lite/docs/legend.html#config)."
+        },
+        "line": {
+          "$ref": "#/definitions/LineConfig",
+          "description": "Line-Specific Config"
+        },
+        "mark": {
+          "$ref": "#/definitions/MarkConfig",
+          "description": "Mark Config"
+        },
+        "numberFormat": {
+          "description": "D3 Number format for guide labels and text marks. For example \"s\" for SI units. Use [D3's number format pattern](https://github.com/d3/d3-format#locale_format).",
+          "type": "string"
+        },
+        "padding": {
+          "$ref": "#/definitions/Padding",
+          "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
+        },
+        "point": {
+          "$ref": "#/definitions/MarkConfig",
+          "description": "Point-Specific Config"
+        },
+        "projection": {
+          "$ref": "#/definitions/ProjectionConfig",
+          "description": "Projection configuration, which determines default properties for all [projections](https://vega.github.io/vega-lite/docs/projection.html). For a full list of projection configuration options, please see the [corresponding section of the projection documentation](https://vega.github.io/vega-lite/docs/projection.html#config)."
+        },
+        "range": {
+          "$ref": "#/definitions/RangeConfig",
+          "description": "An object hash that defines default range arrays or schemes for using with scales.\nFor a full list of scale range configuration options, please see the [corresponding section of the scale documentation](https://vega.github.io/vega-lite/docs/scale.html#config)."
+        },
+        "rect": {
+          "$ref": "#/definitions/MarkConfig",
+          "description": "Rect-Specific Config"
+        },
+        "rule": {
+          "$ref": "#/definitions/MarkConfig",
+          "description": "Rule-Specific Config"
+        },
+        "scale": {
+          "$ref": "#/definitions/ScaleConfig",
+          "description": "Scale configuration determines default properties for all [scales](https://vega.github.io/vega-lite/docs/scale.html). For a full list of scale configuration options, please see the [corresponding section of the scale documentation](https://vega.github.io/vega-lite/docs/scale.html#config)."
+        },
+        "selection": {
+          "$ref": "#/definitions/SelectionConfig",
+          "description": "An object hash for defining default properties for each type of selections."
+        },
+        "square": {
+          "$ref": "#/definitions/MarkConfig",
+          "description": "Square-Specific Config"
+        },
+        "stack": {
+          "$ref": "#/definitions/StackOffset",
+          "description": "Default stack offset for stackable mark."
+        },
+        "style": {
+          "$ref": "#/definitions/StyleConfigIndex",
+          "description": "An object hash that defines key-value mappings to determine default properties for marks with a given [style](https://vega.github.io/vega-lite/docs/mark.html#mark-def).  The keys represent styles names; the values have to be valid [mark configuration objects](https://vega.github.io/vega-lite/docs/mark.html#config)."
+        },
+        "text": {
+          "$ref": "#/definitions/TextConfig",
+          "description": "Text-Specific Config"
+        },
+        "tick": {
+          "$ref": "#/definitions/TickConfig",
+          "description": "Tick-Specific Config"
+        },
+        "timeFormat": {
+          "description": "Default time format for raw time values (without time units) in text marks, legend labels and header labels.\n\n__Default value:__ `\"%b %d, %Y\"`\n__Note:__ Axes automatically determine format each label automatically so this config would not affect axes.",
+          "type": "string"
+        },
+        "title": {
+          "$ref": "#/definitions/TitleConfig",
+          "description": "Title configuration, which determines default properties for all [titles](https://vega.github.io/vega-lite/docs/title.html). For a full list of title configuration options, please see the [corresponding section of the title documentation](https://vega.github.io/vega-lite/docs/title.html#config)."
+        },
+        "trail": {
+          "$ref": "#/definitions/LineConfig",
+          "description": "Trail-Specific Config"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewConfig",
+          "description": "Default properties for [single view plots](https://vega.github.io/vega-lite/docs/spec.html#single)."
+        }
+      },
+      "type": "object"
+    },
+    "CsvDataFormat": {
+      "additionalProperties": false,
+      "properties": {
+        "parse": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Parse"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "If set to `null`, disable type inference based on the spec and only use type inference based on the data.\nAlternatively, a parsing directive object can be provided for explicit data types. Each property of the object corresponds to a field name, and the value to the desired data type (one of `\"number\"`, `\"boolean\"`, `\"date\"`, or null (do not parse the field)).\nFor example, `\"parse\": {\"modified_on\": \"date\"}` parses the `modified_on` field in each input record a Date value.\n\nFor `\"date\"`, we parse data based using Javascript's [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).\nFor Specific date formats can be provided (e.g., `{foo: 'date:\"%m%d%Y\"'}`), using the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC date format parsing is supported similarly (e.g., `{foo: 'utc:\"%m%d%Y\"'}`). See more about [UTC time](https://vega.github.io/vega-lite/docs/timeunit.html#utc)"
+        },
+        "type": {
+          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\nThe default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
+          "enum": [
+            "csv",
+            "tsv"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Cursor": {
+      "enum": [
+        "auto",
+        "default",
+        "none",
+        "context-menu",
+        "help",
+        "pointer",
+        "progress",
+        "wait",
+        "cell",
+        "crosshair",
+        "text",
+        "vertical-text",
+        "alias",
+        "copy",
+        "move",
+        "no-drop",
+        "not-allowed",
+        "e-resize",
+        "n-resize",
+        "ne-resize",
+        "nw-resize",
+        "s-resize",
+        "se-resize",
+        "sw-resize",
+        "w-resize",
+        "ew-resize",
+        "ns-resize",
+        "nesw-resize",
+        "nwse-resize",
+        "col-resize",
+        "row-resize",
+        "all-scroll",
+        "zoom-in",
+        "zoom-out",
+        "grab",
+        "grabbing"
+      ],
+      "type": "string"
+    },
+    "Data": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/UrlData"
+        },
+        {
+          "$ref": "#/definitions/InlineData"
+        },
+        {
+          "$ref": "#/definitions/NamedData"
+        }
+      ]
+    },
+    "DataFormat": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CsvDataFormat"
+        },
+        {
+          "$ref": "#/definitions/DsvDataFormat"
+        },
+        {
+          "$ref": "#/definitions/JsonDataFormat"
+        },
+        {
+          "$ref": "#/definitions/TopoDataFormat"
+        }
+      ]
+    },
+    "Datasets": {
+      "$ref": "#/definitions/Dict<InlineDataset>"
+    },
+    "DateTime": {
+      "additionalProperties": false,
+      "description": "Object for defining datetime in Vega-Lite Filter.\nIf both month and quarter are provided, month has higher precedence.\n`day` cannot be combined with other date.\nWe accept string for month and day names.",
+      "properties": {
+        "date": {
+          "description": "Integer value representing the date from 1-31.",
+          "maximum": 31,
+          "minimum": 1,
+          "type": "number"
+        },
+        "day": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Day"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Value representing the day of a week.  This can be one of: (1) integer value -- `1` represents Monday; (2) case-insensitive day name (e.g., `\"Monday\"`);  (3) case-insensitive, 3-character short day name (e.g., `\"Mon\"`).   <br/> **Warning:** A DateTime definition object with `day`** should not be combined with `year`, `quarter`, `month`, or `date`."
+        },
+        "hours": {
+          "description": "Integer value representing the hour of a day from 0-23.",
+          "maximum": 23,
+          "minimum": 0,
+          "type": "number"
+        },
+        "milliseconds": {
+          "description": "Integer value representing the millisecond segment of time.",
+          "maximum": 999,
+          "minimum": 0,
+          "type": "number"
+        },
+        "minutes": {
+          "description": "Integer value representing the minute segment of time from 0-59.",
+          "maximum": 59,
+          "minimum": 0,
+          "type": "number"
+        },
+        "month": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Month"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "One of: (1) integer value representing the month from `1`-`12`. `1` represents January;  (2) case-insensitive month name (e.g., `\"January\"`);  (3) case-insensitive, 3-character short month name (e.g., `\"Jan\"`)."
+        },
+        "quarter": {
+          "description": "Integer value representing the quarter of the year (from 1-4).",
+          "maximum": 4,
+          "minimum": 1,
+          "type": "number"
+        },
+        "seconds": {
+          "description": "Integer value representing the second segment (0-59) of a time value",
+          "maximum": 59,
+          "minimum": 0,
+          "type": "number"
+        },
+        "utc": {
+          "description": "A boolean flag indicating if date time is in utc time. If false, the date time is in local time",
+          "type": "boolean"
+        },
+        "year": {
+          "description": "Integer value representing the year.",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "Day": {
+      "maximum": 7,
+      "minimum": 1,
+      "type": "number"
+    },
+    "Dict<InlineDataset>": {
+      "additionalProperties": {
+        "$ref": "#/definitions/InlineDataset"
+      },
+      "type": "object"
+    },
+    "Dir": {
+      "enum": [
+        "ltr",
+        "rtl"
+      ],
+      "type": "string"
+    },
+    "DsvDataFormat": {
+      "additionalProperties": false,
+      "properties": {
+        "delimiter": {
+          "description": "The delimiter between records. The delimiter must be a single character (i.e., a single 16-bit code unit); so, ASCII delimiters are fine, but emoji delimiters are not.",
+          "maxLength": 1,
+          "minLength": 1,
+          "type": "string"
+        },
+        "parse": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Parse"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "If set to `null`, disable type inference based on the spec and only use type inference based on the data.\nAlternatively, a parsing directive object can be provided for explicit data types. Each property of the object corresponds to a field name, and the value to the desired data type (one of `\"number\"`, `\"boolean\"`, `\"date\"`, or null (do not parse the field)).\nFor example, `\"parse\": {\"modified_on\": \"date\"}` parses the `modified_on` field in each input record a Date value.\n\nFor `\"date\"`, we parse data based using Javascript's [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).\nFor Specific date formats can be provided (e.g., `{foo: 'date:\"%m%d%Y\"'}`), using the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC date format parsing is supported similarly (e.g., `{foo: 'utc:\"%m%d%Y\"'}`). See more about [UTC time](https://vega.github.io/vega-lite/docs/timeunit.html#utc)"
+        },
+        "type": {
+          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\nThe default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
+          "enum": [
+            "dsv"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "delimiter"
+      ],
+      "type": "object"
+    },
+    "Encoding": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+        },
+        "detail": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FieldDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+        },
+        "fill": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
+        },
+        "href": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/ValueDefWithCondition"
+            }
+          ],
+          "description": "A URL to load upon mouse click."
+        },
+        "key": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
+        },
+        "latitude": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "Latitude position of geographically projected marks."
+        },
+        "latitude2": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        },
+        "longitude": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "Longitude position of geographically projected marks."
+        },
+        "longitude2": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        },
+        "opacity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Opacity of the marks – either can be a value or a range.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+        },
+        "order": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OrderFieldDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/OrderFieldDef"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/ValueDef"
+            }
+          ],
+          "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
+        },
+        "shape": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
+        },
+        "size": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
+        },
+        "stroke": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
+        },
+        "text": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/TextValueDefWithCondition"
+            }
+          ],
+          "description": "Text of the `text` mark."
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/TextValueDefWithCondition"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/TextFieldDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "The tooltip text to show upon mouse hover."
+        },
+        "x": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ValueDef"
+            }
+          ],
+          "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`."
+        },
+        "x2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FieldDef"
+            },
+            {
+              "$ref": "#/definitions/ValueDef"
+            }
+          ],
+          "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        },
+        "y": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ValueDef"
+            }
+          ],
+          "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`."
+        },
+        "y2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FieldDef"
+            },
+            {
+              "$ref": "#/definitions/ValueDef"
+            }
+          ],
+          "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        }
+      },
+      "type": "object"
+    },
+    "EncodingSortField": {
+      "additionalProperties": false,
+      "description": "A sort definition for sorting a discrete scale in an encoding field definition.",
+      "properties": {
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "The data [field](https://vega.github.io/vega-lite/docs/field.html) to sort by.\n\n__Default value:__ If unspecified, defaults to the field specified in the outer data reference."
+        },
+        "op": {
+          "$ref": "#/definitions/AggregateOp",
+          "description": "An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `\"count\"`, `\"mean\"` and `\"median\"`).\nThis property is required in cases where the sort field and the data reference field do not match.\nThe input data objects will be aggregated, grouped by the encoded data field.\n\nFor a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops)."
+        },
+        "order": {
+          "$ref": "#/definitions/SortOrder",
+          "description": "The sort order. One of `\"ascending\"` (default), `\"descending\"`, or `null` (no not sort)."
+        }
+      },
+      "required": [
+        "op"
+      ],
+      "type": "object"
+    },
+    "EncodingWithFacet": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+        },
+        "column": {
+          "$ref": "#/definitions/FacetFieldDef",
+          "description": "Horizontal facets for trellis plots."
+        },
+        "detail": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FieldDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+        },
+        "fill": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
+        },
+        "href": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/ValueDefWithCondition"
+            }
+          ],
+          "description": "A URL to load upon mouse click."
+        },
+        "key": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
+        },
+        "latitude": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "Latitude position of geographically projected marks."
+        },
+        "latitude2": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        },
+        "longitude": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "Longitude position of geographically projected marks."
+        },
+        "longitude2": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        },
+        "opacity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Opacity of the marks – either can be a value or a range.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+        },
+        "order": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OrderFieldDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/OrderFieldDef"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/ValueDef"
+            }
+          ],
+          "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
+        },
+        "row": {
+          "$ref": "#/definitions/FacetFieldDef",
+          "description": "Vertical facets for trellis plots."
+        },
+        "shape": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
+        },
+        "size": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
+        },
+        "stroke": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
+        },
+        "text": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/TextValueDefWithCondition"
+            }
+          ],
+          "description": "Text of the `text` mark."
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/TextValueDefWithCondition"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/TextFieldDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "The tooltip text to show upon mouse hover."
+        },
+        "x": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ValueDef"
+            }
+          ],
+          "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`."
+        },
+        "x2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FieldDef"
+            },
+            {
+              "$ref": "#/definitions/ValueDef"
+            }
+          ],
+          "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        },
+        "y": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ValueDef"
+            }
+          ],
+          "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`."
+        },
+        "y2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FieldDef"
+            },
+            {
+              "$ref": "#/definitions/ValueDef"
+            }
+          ],
+          "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        }
+      },
+      "type": "object"
+    },
+    "ErrorBand": {
+      "enum": [
+        "errorband"
+      ],
+      "type": "string"
+    },
+    "ErrorBandConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "band": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "borders": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "extent": {
+          "$ref": "#/definitions/ErrorBarExtent",
+          "description": "The extent of the band. Available options include:\n- `\"ci\"`: Extend the band to the confidence interval of the mean.\n- `\"stderr\"`: The size of band are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of band are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the band to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
+        },
+        "interpolate": {
+          "$ref": "#/definitions/Interpolate",
+          "description": "The line interpolation method for the error band. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "tension": {
+          "description": "The tension parameter for the interpolation type of the error band.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "ErrorBandDef": {
+      "additionalProperties": false,
+      "properties": {
+        "band": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "borders": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "clip": {
+          "description": "Whether a composite mark be clipped to the enclosing group’s width and height.",
+          "type": "boolean"
+        },
+        "color": {
+          "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "string"
+        },
+        "extent": {
+          "$ref": "#/definitions/ErrorBarExtent",
+          "description": "The extent of the band. Available options include:\n- `\"ci\"`: Extend the band to the confidence interval of the mean.\n- `\"stderr\"`: The size of band are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of band are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the band to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
+        },
+        "interpolate": {
+          "$ref": "#/definitions/Interpolate",
+          "description": "The line interpolation method for the error band. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "opacity": {
+          "description": "The opacity (value between [0,1]) of the mark.",
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "Orientation of the error band. This is normally automatically determined, but can be specified when the orientation is ambiguous and cannot be automatically determined."
+        },
+        "tension": {
+          "description": "The tension parameter for the interpolation type of the error band.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "$ref": "#/definitions/ErrorBand",
+          "description": "The mark type. This could a primitive mark type\n(one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"geoshape\"`, `\"rule\"`, and `\"text\"`)\nor a composite mark type (`\"boxplot\"`, `\"errorband\"`, `\"errorbar\"`)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "ErrorBar": {
+      "enum": [
+        "errorbar"
+      ],
+      "type": "string"
+    },
+    "ErrorBarConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "extent": {
+          "$ref": "#/definitions/ErrorBarExtent",
+          "description": "The extent of the rule. Available options include:\n- `\"ci\"`: Extend the rule to the confidence interval of the mean.\n- `\"stderr\"`: The size of rule are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of rule are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the rule to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
+        },
+        "rule": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "ticks": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ErrorBarDef": {
+      "additionalProperties": false,
+      "properties": {
+        "clip": {
+          "description": "Whether a composite mark be clipped to the enclosing group’s width and height.",
+          "type": "boolean"
+        },
+        "color": {
+          "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "string"
+        },
+        "extent": {
+          "$ref": "#/definitions/ErrorBarExtent",
+          "description": "The extent of the rule. Available options include:\n- `\"ci\"`: Extend the rule to the confidence interval of the mean.\n- `\"stderr\"`: The size of rule are set to the value of standard error, extending from the mean.\n- `\"stdev\"`: The size of rule are set to the value of standard deviation, extending from the mean.\n- `\"iqr\"`: Extend the rule to the q1 and q3.\n\n__Default value:__ `\"stderr\"`."
+        },
+        "opacity": {
+          "description": "The opacity (value between [0,1]) of the mark.",
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "Orientation of the error bar.  This is normally automatically determined, but can be specified when the orientation is ambiguous and cannot be automatically determined."
+        },
+        "rule": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "ticks": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/ErrorBar",
+          "description": "The mark type. This could a primitive mark type\n(one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"geoshape\"`, `\"rule\"`, and `\"text\"`)\nor a composite mark type (`\"boxplot\"`, `\"errorband\"`, `\"errorbar\"`)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "ErrorBarExtent": {
+      "enum": [
+        "ci",
+        "iqr",
+        "stderr",
+        "stdev"
+      ],
+      "type": "string"
+    },
+    "LayerSpec": {
+      "additionalProperties": false,
+      "description": "Layer Spec with encoding and projection",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "$ref": "#/definitions/Encoding",
+          "description": "A shared key-value mapping between encoding channels and definition of fields in the underlying layers."
+        },
+        "height": {
+          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        },
+        "layer": {
+          "description": "Layer or single view specifications to be layered.\n\n__Note__: Specifications inside `layer` cannot use `row` and `column` channels as layering facet specifications is not allowed. Instead, use the [facet operator](https://vega.github.io/vega-lite/docs/facet.html) and place a layer inside a facet.",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LayerSpec"
+              },
+              {
+                "$ref": "#/definitions/CompositeUnitSpec"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of the geographic projection shared by underlying layers."
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale, axis, and legend resolutions for layers."
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "width": {
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "layer"
+      ],
+      "type": "object"
+    },
+    "FacetFieldDef": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "header": {
+          "$ref": "#/definitions/Header",
+          "description": "An object defining properties of a facet's header."
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort",
+          "description": "Sort order for the encoded field.\n\nFor continuous fields (quantitative or temporal), `sort` can be either `\"ascending\"` or `\"descending\"`.\n\nFor discrete fields, `sort` can be one of the following:\n- `\"ascending\"` or `\"descending\"` -- for sorting by the values' natural order in Javascript.\n- [A sort field definition](https://vega.github.io/vega-lite/docs/sort.html#sort-field) for sorting by another field.\n- [An array specifying the field values in preferred order](https://vega.github.io/vega-lite/docs/sort.html#sort-array). In this case, the sort order will obey the values in the array, followed by any unspecified values in their original order.  For discrete time field, values in the sort array can be [date-time definition objects](types#datetime). In addition, for time units `\"month\"` and `\"day\"`, the values can be the month or day names (case insensitive) or their 3-letter initials (e.g., `\"Mon\"`, `\"Tue\"`).\n- `null` indicating no sort.\n\n__Default value:__ `\"ascending\"`\n\n__Note:__ `null` is not supported for `row` and `column`."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "FacetMapping": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "$ref": "#/definitions/FacetFieldDef",
+          "description": "Horizontal facets for trellis plots."
+        },
+        "row": {
+          "$ref": "#/definitions/FacetFieldDef",
+          "description": "Vertical facets for trellis plots."
+        }
+      },
+      "type": "object"
+    },
+    "FacetedUnitSpec": {
+      "$ref": "#/definitions/FacetedCompositeUnitSpecAlias",
+      "description": "Unit spec that can have a composite mark and row or column channels."
+    },
+    "FieldDefWithCondition": {
+      "additionalProperties": false,
+      "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "One or more value definition(s) with a selection predicate.\n\n__Note:__ A field definition's `condition` property can only contain [value definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "MarkPropFieldDefWithCondition": {
+      "additionalProperties": false,
+      "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "One or more value definition(s) with a selection predicate.\n\n__Note:__ A field definition's `condition` property can only contain [value definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "legend": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Legend"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object defining properties of the legend.\nIf `null`, the legend for the encoding channel will be removed.\n\n__Default value:__ If undefined, default [legend properties](https://vega.github.io/vega-lite/docs/legend.html) are applied."
+        },
+        "scale": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Scale"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object defining properties of the channel's scale, which is the function that transforms values in the data domain (numbers, dates, strings, etc) to visual values (pixels, colors, sizes) of the encoding channels.\n\nIf `null`, the scale will be [disabled and the data value will be directly encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).\n\n__Default value:__ If undefined, default [scale properties](https://vega.github.io/vega-lite/docs/scale.html) are applied."
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort",
+          "description": "Sort order for the encoded field.\n\nFor continuous fields (quantitative or temporal), `sort` can be either `\"ascending\"` or `\"descending\"`.\n\nFor discrete fields, `sort` can be one of the following:\n- `\"ascending\"` or `\"descending\"` -- for sorting by the values' natural order in Javascript.\n- [A sort field definition](https://vega.github.io/vega-lite/docs/sort.html#sort-field) for sorting by another field.\n- [An array specifying the field values in preferred order](https://vega.github.io/vega-lite/docs/sort.html#sort-array). In this case, the sort order will obey the values in the array, followed by any unspecified values in their original order.  For discrete time field, values in the sort array can be [date-time definition objects](types#datetime). In addition, for time units `\"month\"` and `\"day\"`, the values can be the month or day names (case insensitive) or their 3-letter initials (e.g., `\"Mon\"`, `\"Tue\"`).\n- `null` indicating no sort.\n\n__Default value:__ `\"ascending\"`\n\n__Note:__ `null` is not supported for `row` and `column`."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "TextFieldDefWithCondition": {
+      "additionalProperties": false,
+      "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "One or more value definition(s) with a selection predicate.\n\n__Note:__ A field definition's `condition` property can only contain [value definitions](https://vega.github.io/vega-lite/docs/encoding.html#value-def)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "format": {
+          "description": "The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a text field. If not defined, this will be determined automatically.",
+          "type": "string"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "FieldDef": {
+      "additionalProperties": false,
+      "description": "Field Def without scale (and without bin: \"binned\" support).",
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "FieldEqualPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "equal": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/DateTime"
+            }
+          ],
+          "description": "The value that the field should be equal to."
+        },
+        "field": {
+          "description": "Field to be filtered.",
+          "type": "string"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for the field to be filtered."
+        }
+      },
+      "required": [
+        "equal",
+        "field"
+      ],
+      "type": "object"
+    },
+    "FieldGTEPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "description": "Field to be filtered.",
+          "type": "string"
+        },
+        "gte": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/DateTime"
+            }
+          ],
+          "description": "The value that the field should be greater than or equals to."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for the field to be filtered."
+        }
+      },
+      "required": [
+        "field",
+        "gte"
+      ],
+      "type": "object"
+    },
+    "FieldGTPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "description": "Field to be filtered.",
+          "type": "string"
+        },
+        "gt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/DateTime"
+            }
+          ],
+          "description": "The value that the field should be greater than."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for the field to be filtered."
+        }
+      },
+      "required": [
+        "field",
+        "gt"
+      ],
+      "type": "object"
+    },
+    "FieldLTEPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "description": "Field to be filtered.",
+          "type": "string"
+        },
+        "lte": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/DateTime"
+            }
+          ],
+          "description": "The value that the field should be less than or equals to."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for the field to be filtered."
+        }
+      },
+      "required": [
+        "field",
+        "lte"
+      ],
+      "type": "object"
+    },
+    "FieldLTPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "description": "Field to be filtered.",
+          "type": "string"
+        },
+        "lt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/DateTime"
+            }
+          ],
+          "description": "The value that the field should be less than."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for the field to be filtered."
+        }
+      },
+      "required": [
+        "field",
+        "lt"
+      ],
+      "type": "object"
+    },
+    "FieldOneOfPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "description": "Field to be filtered.",
+          "type": "string"
+        },
+        "oneOf": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "type": "boolean"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/DateTime"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "A set of values that the `field`'s value should be a member of,\nfor a data item included in the filtered data."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for the field to be filtered."
+        }
+      },
+      "required": [
+        "field",
+        "oneOf"
+      ],
+      "type": "object"
+    },
+    "FieldRangePredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "description": "Field to be filtered.",
+          "type": "string"
+        },
+        "range": {
+          "description": "An array of inclusive minimum and maximum values\nfor a field value of a data item to be included in the filtered data.",
+          "items": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "$ref": "#/definitions/DateTime"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for the field to be filtered."
+        }
+      },
+      "required": [
+        "field",
+        "range"
+      ],
+      "type": "object"
+    },
+    "FieldValidPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "description": "Field to be filtered.",
+          "type": "string"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for the field to be filtered."
+        },
+        "valid": {
+          "description": "If set to true the field's value has to be valid, meaning both not `null` and not [`NaN`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN).",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "field",
+        "valid"
+      ],
+      "type": "object"
+    },
+    "FilterTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "filter": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "The `filter` property must be one of the predicate definitions:\n\n1) an [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string,\nwhere `datum` can be used to refer to the current data object\n\n2) one of the field predicates: [`equal`](https://vega.github.io/vega-lite/docs/filter.html#equal-predicate),\n[`lt`](https://vega.github.io/vega-lite/docs/filter.html#lt-predicate),\n[`lte`](https://vega.github.io/vega-lite/docs/filter.html#lte-predicate),\n[`gt`](https://vega.github.io/vega-lite/docs/filter.html#gt-predicate),\n[`gte`](https://vega.github.io/vega-lite/docs/filter.html#gte-predicate),\n[`range`](https://vega.github.io/vega-lite/docs/filter.html#range-predicate),\nor [`oneOf`](https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate).\n\n3) a [selection predicate](https://vega.github.io/vega-lite/docs/filter.html#selection-predicate)\n\n4) a logical operand that combines (1), (2), or (3)."
+        }
+      },
+      "required": [
+        "filter"
+      ],
+      "type": "object"
+    },
+    "FlattenTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "description": "The output field names for extracted array values.\n\n__Default value:__ The field name of the corresponding array field",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "flatten": {
+          "description": "An array of one or more data fields containing arrays to flatten.\nIf multiple fields are specified, their array values should have a parallel structure, ideally with the same length.\nIf the lengths of parallel arrays do not match,\nthe longest array will be used with `null` values added for missing entries.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "flatten"
+      ],
+      "type": "object"
+    },
+    "FoldTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "description": "The output field names for the key and value properties produced by the fold transform.\n__Default value:__ `[\"key\", \"value\"]`",
+          "items": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "fold": {
+          "description": "An array of data fields indicating the properties to fold.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "fold"
+      ],
+      "type": "object"
+    },
+    "FontStyle": {
+      "enum": [
+        "normal",
+        "italic"
+      ],
+      "type": "string"
+    },
+    "FontWeight": {
+      "enum": [
+        "normal",
+        "bold",
+        "lighter",
+        "bolder",
+        100,
+        200,
+        300,
+        400,
+        500,
+        600,
+        700,
+        800,
+        900
+      ],
+      "type": [
+        "string",
+        "number"
+      ]
+    },
+    "GenericBinMixins<(boolean|BinParams)>": {
+      "additionalProperties": false,
+      "properties": {
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        }
+      },
+      "type": "object"
+    },
+    "GenericBinMixins<(boolean|BinParams|\"binned\")>": {
+      "additionalProperties": false,
+      "properties": {
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        }
+      },
+      "type": "object"
+    },
+    "FacetSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VgLayoutAlign"
+            },
+            {
+              "$ref": "#/definitions/RowCol<VgLayoutAlign>"
+            }
+          ],
+          "description": "The alignment to apply to grid rows and columns.\nThe supported string values are `\"all\"`, `\"each\"`, and `\"none\"`.\n\n- For `\"none\"`, a flow layout will be used, in which adjacent subviews are simply placed one after the other.\n- For `\"each\"`, subviews will be aligned into a clean grid structure, but each row or column may be of variable size.\n- For `\"all\"`, subviews will be aligned and each row or column will be sized identically based on the maximum observed size. String values for this property will be applied to both grid rows and columns.\n\nAlternatively, an object value of the form `{\"row\": string, \"column\": string}` can be used to supply different alignments for rows and columns.\n\n__Default value:__ `\"all\"`."
+        },
+        "bounds": {
+          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used.\n- If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
+          "enum": [
+            "full",
+            "flush"
+          ],
+          "type": "string"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/RowCol<boolean>"
+            }
+          ],
+          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\nAn object value of the form `{\"row\": boolean, \"column\": boolean}` can be used to supply different centering values for rows and columns.\n\n__Default value:__ `false`"
+        },
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "facet": {
+          "$ref": "#/definitions/FacetMapping",
+          "description": "An object that describes mappings between `row` and `column` channels and their field definitions."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale, axis, and legend resolutions for facets."
+        },
+        "spacing": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/RowCol<number>"
+            }
+          ],
+          "description": "The spacing in pixels between sub-views of the composition operator.\nAn object of the form `{\"row\": number, \"column\": number}` can be used to set\ndifferent spacing values for rows and columns.\n\n__Default value__: `10`"
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LayerSpec"
+            },
+            {
+              "$ref": "#/definitions/FacetedUnitSpec"
+            }
+          ],
+          "description": "A specification of the view that gets faceted."
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "facet",
+        "spec"
+      ],
+      "type": "object"
+    },
+    "HConcatSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "bounds": {
+          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used.\n- If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
+          "enum": [
+            "full",
+            "flush"
+          ],
+          "type": "string"
+        },
+        "center": {
+          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\n__Default value:__ `false`",
+          "type": "boolean"
+        },
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "hconcat": {
+          "description": "A list of views that should be concatenated and put into a row.",
+          "items": {
+            "$ref": "#/definitions/Spec"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale, axis, and legend resolutions for horizontally concatenated charts."
+        },
+        "spacing": {
+          "description": "The spacing in pixels between sub-views of the concat operator.\n\n__Default value__: `10`",
+          "type": "number"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "hconcat"
+      ],
+      "type": "object"
+    },
+    "RepeatSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VgLayoutAlign"
+            },
+            {
+              "$ref": "#/definitions/RowCol<VgLayoutAlign>"
+            }
+          ],
+          "description": "The alignment to apply to grid rows and columns.\nThe supported string values are `\"all\"`, `\"each\"`, and `\"none\"`.\n\n- For `\"none\"`, a flow layout will be used, in which adjacent subviews are simply placed one after the other.\n- For `\"each\"`, subviews will be aligned into a clean grid structure, but each row or column may be of variable size.\n- For `\"all\"`, subviews will be aligned and each row or column will be sized identically based on the maximum observed size. String values for this property will be applied to both grid rows and columns.\n\nAlternatively, an object value of the form `{\"row\": string, \"column\": string}` can be used to supply different alignments for rows and columns.\n\n__Default value:__ `\"all\"`."
+        },
+        "bounds": {
+          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used.\n- If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
+          "enum": [
+            "full",
+            "flush"
+          ],
+          "type": "string"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/RowCol<boolean>"
+            }
+          ],
+          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\nAn object value of the form `{\"row\": boolean, \"column\": boolean}` can be used to supply different centering values for rows and columns.\n\n__Default value:__ `false`"
+        },
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "repeat": {
+          "$ref": "#/definitions/Repeat",
+          "description": "An object that describes what fields should be repeated into views that are laid out as a `row` or `column`."
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale and legend resolutions for repeated charts."
+        },
+        "spacing": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/RowCol<number>"
+            }
+          ],
+          "description": "The spacing in pixels between sub-views of the composition operator.\nAn object of the form `{\"row\": number, \"column\": number}` can be used to set\ndifferent spacing values for rows and columns.\n\n__Default value__: `10`"
+        },
+        "spec": {
+          "$ref": "#/definitions/Spec"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "repeat",
+        "spec"
+      ],
+      "type": "object"
+    },
+    "Spec": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FacetedUnitSpec"
+        },
+        {
+          "$ref": "#/definitions/LayerSpec"
+        },
+        {
+          "$ref": "#/definitions/FacetSpec"
+        },
+        {
+          "$ref": "#/definitions/RepeatSpec"
+        },
+        {
+          "$ref": "#/definitions/VConcatSpec"
+        },
+        {
+          "$ref": "#/definitions/HConcatSpec"
+        }
+      ]
+    },
+    "CompositeUnitSpecAlias": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "$ref": "#/definitions/Encoding",
+          "description": "A key-value mapping between encoding channels and definition of fields."
+        },
+        "height": {
+          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        },
+        "mark": {
+          "$ref": "#/definitions/AnyMark",
+          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+        },
+        "selection": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectionDef"
+          },
+          "description": "A key-value mapping between selection names and definitions.",
+          "type": "object"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "width": {
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mark"
+      ],
+      "type": "object"
+    },
+    "FacetedCompositeUnitSpecAlias": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "$ref": "#/definitions/EncodingWithFacet",
+          "description": "A key-value mapping between encoding channels and definition of fields."
+        },
+        "height": {
+          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        },
+        "mark": {
+          "$ref": "#/definitions/AnyMark",
+          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+        },
+        "selection": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectionDef"
+          },
+          "description": "A key-value mapping between selection names and definitions.",
+          "type": "object"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "width": {
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mark"
+      ],
+      "type": "object"
+    },
+    "VConcatSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "bounds": {
+          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used.\n- If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
+          "enum": [
+            "full",
+            "flush"
+          ],
+          "type": "string"
+        },
+        "center": {
+          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\n__Default value:__ `false`",
+          "type": "boolean"
+        },
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale, axis, and legend resolutions for vertically concatenated charts."
+        },
+        "spacing": {
+          "description": "The spacing in pixels between sub-views of the concat operator.\n\n__Default value__: `10`",
+          "type": "number"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "vconcat": {
+          "description": "A list of views that should be concatenated and put into a column.",
+          "items": {
+            "$ref": "#/definitions/Spec"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "vconcat"
+      ],
+      "type": "object"
+    },
+    "Header": {
+      "additionalProperties": false,
+      "description": "Headers of row / column channels for faceted plots.",
+      "properties": {
+        "format": {
+          "description": "The formatting pattern for labels. This is D3's [number format pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for time field.\n\nSee the [format documentation](https://vega.github.io/vega-lite/docs/format.html) for more information.\n\n__Default value:__  derived from [numberFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for quantitative fields and from [timeFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for temporal fields.",
+          "type": "string"
+        },
+        "labelAngle": {
+          "description": "The rotation angle of the header labels.\n\n__Default value:__ `0` for column header, `-90` for row header.",
+          "maximum": 360,
+          "minimum": -360,
+          "type": "number"
+        },
+        "labelColor": {
+          "description": "The color of the header label, can be in hex color code or regular color name.",
+          "type": "string"
+        },
+        "labelFont": {
+          "description": "The font of the header label.",
+          "type": "string"
+        },
+        "labelFontSize": {
+          "description": "The font size of the header label, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "labelLimit": {
+          "description": "The maximum length of the header label in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "labelPadding": {
+          "description": "The orthogonal distance in pixels by which to displace the title from its position along the edge of the chart.\n\n__Default value:__ `10`",
+          "type": "number"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "titleAnchor": {
+          "description": "The anchor position for placing the title. One of `\"start\"`, `\"middle\"`, or `\"end\"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title.\n\n__Default value:__ `\"middle\"` for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.\n`\"start\"` for other composite views.\n\n__Note:__ [For now](https://github.com/vega/vega-lite/issues/2875), `anchor` is only customizable only for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.  For other composite views, `anchor` is always `\"start\"`.",
+          "type": "string"
+        },
+        "titleAngle": {
+          "description": "The rotation angle of the header title.\n\n__Default value:__ `0`.",
+          "maximum": 360,
+          "minimum": -360,
+          "type": "number"
+        },
+        "titleBaseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "Vertical text baseline for the header title. One of `\"top\"`, `\"bottom\"`, `\"middle\"`.\n\n__Default value:__ `\"middle\"`"
+        },
+        "titleColor": {
+          "description": "Color of the header title, can be in hex color code or regular color name.",
+          "type": "string"
+        },
+        "titleFont": {
+          "description": "Font of the header title. (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "titleFontSize": {
+          "description": "Font size of the header title.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "titleFontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "Font weight of the header title.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "titleLimit": {
+          "description": "The maximum length of the header title in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "titlePadding": {
+          "description": "The orthogonal distance in pixels by which to displace the title from its position along the edge of the chart.\n\n__Default value:__ `10`",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "HeaderConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "labelAngle": {
+          "description": "The rotation angle of the header labels.\n\n__Default value:__ `0` for column header, `-90` for row header.",
+          "maximum": 360,
+          "minimum": -360,
+          "type": "number"
+        },
+        "labelColor": {
+          "description": "The color of the header label, can be in hex color code or regular color name.",
+          "type": "string"
+        },
+        "labelFont": {
+          "description": "The font of the header label.",
+          "type": "string"
+        },
+        "labelFontSize": {
+          "description": "The font size of the header label, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "labelLimit": {
+          "description": "The maximum length of the header label in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "labelPadding": {
+          "description": "The orthogonal distance in pixels by which to displace the title from its position along the edge of the chart.\n\n__Default value:__ `10`",
+          "type": "number"
+        },
+        "titleAnchor": {
+          "description": "The anchor position for placing the title. One of `\"start\"`, `\"middle\"`, or `\"end\"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title.\n\n__Default value:__ `\"middle\"` for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.\n`\"start\"` for other composite views.\n\n__Note:__ [For now](https://github.com/vega/vega-lite/issues/2875), `anchor` is only customizable only for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.  For other composite views, `anchor` is always `\"start\"`.",
+          "type": "string"
+        },
+        "titleAngle": {
+          "description": "The rotation angle of the header title.\n\n__Default value:__ `0`.",
+          "maximum": 360,
+          "minimum": -360,
+          "type": "number"
+        },
+        "titleBaseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "Vertical text baseline for the header title. One of `\"top\"`, `\"bottom\"`, `\"middle\"`.\n\n__Default value:__ `\"middle\"`"
+        },
+        "titleColor": {
+          "description": "Color of the header title, can be in hex color code or regular color name.",
+          "type": "string"
+        },
+        "titleFont": {
+          "description": "Font of the header title. (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "titleFontSize": {
+          "description": "Font size of the header title.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "titleFontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "Font weight of the header title.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "titleLimit": {
+          "description": "The maximum length of the header title in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "titlePadding": {
+          "description": "The orthogonal distance in pixels by which to displace the title from its position along the edge of the chart.\n\n__Default value:__ `10`",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "ImputeMethod": {
+      "enum": [
+        "value",
+        "median",
+        "max",
+        "min",
+        "mean"
+      ],
+      "type": "string"
+    },
+    "ImputeParams": {
+      "additionalProperties": false,
+      "properties": {
+        "frame": {
+          "description": "A frame specification as a two-element array used to control the window over which the specified method is applied. The array entries should either be a number indicating the offset from the current data object, or null to indicate unbounded rows preceding or following the current data object.  For example, the value `[-5, 5]` indicates that the window should include five objects preceding and five objects following the current object.\n\n__Default value:__:  `[null, null]` indicating that the window includes all objects.",
+          "items": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "type": "array"
+        },
+        "keyvals": {
+          "anyOf": [
+            {
+              "items": {
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/ImputeSequence"
+            }
+          ],
+          "description": "Defines the key values that should be considered for imputation.\nAn array of key values or an object defining a [number sequence](https://vega.github.io/vega-lite/docs/impute.html#sequence-def).\n\nIf provided, this will be used in addition to the key values observed within the input data.  If not provided, the values will be derived from all unique values of the `key` field. For `impute` in `encoding`, the key field is the x-field if the y-field is imputed, or vice versa.\n\nIf there is no impute grouping, this property _must_ be specified."
+        },
+        "method": {
+          "$ref": "#/definitions/ImputeMethod",
+          "description": "The imputation method to use for the field value of imputed data objects.\nOne of `value`, `mean`, `median`, `max` or `min`.\n\n__Default value:__  `\"value\"`"
+        },
+        "value": {
+          "description": "The field value to use when the imputation `method` is `\"value\"`."
+        }
+      },
+      "type": "object"
+    },
+    "ImputeSequence": {
+      "additionalProperties": false,
+      "properties": {
+        "start": {
+          "description": "The starting value of the sequence.\n__Default value:__ `0`",
+          "type": "number"
+        },
+        "step": {
+          "description": "The step value between sequence entries.\n__Default value:__ `1` or `-1` if `stop < start`",
+          "type": "number"
+        },
+        "stop": {
+          "description": "The ending value(exclusive) of the sequence.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "stop"
+      ],
+      "type": "object"
+    },
+    "ImputeTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "frame": {
+          "description": "A frame specification as a two-element array used to control the window over which the specified method is applied. The array entries should either be a number indicating the offset from the current data object, or null to indicate unbounded rows preceding or following the current data object.  For example, the value `[-5, 5]` indicates that the window should include five objects preceding and five objects following the current object.\n\n__Default value:__:  `[null, null]` indicating that the window includes all objects.",
+          "items": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "type": "array"
+        },
+        "groupby": {
+          "description": "An optional array of fields by which to group the values.\nImputation will then be performed on a per-group basis.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "impute": {
+          "description": "The data field for which the missing values should be imputed.",
+          "type": "string"
+        },
+        "key": {
+          "description": "A key field that uniquely identifies data objects within a group.\nMissing key values (those occurring in the data but not in the current group) will be imputed.",
+          "type": "string"
+        },
+        "keyvals": {
+          "anyOf": [
+            {
+              "items": {
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/ImputeSequence"
+            }
+          ],
+          "description": "Defines the key values that should be considered for imputation.\nAn array of key values or an object defining a [number sequence](https://vega.github.io/vega-lite/docs/impute.html#sequence-def).\n\nIf provided, this will be used in addition to the key values observed within the input data.  If not provided, the values will be derived from all unique values of the `key` field. For `impute` in `encoding`, the key field is the x-field if the y-field is imputed, or vice versa.\n\nIf there is no impute grouping, this property _must_ be specified."
+        },
+        "method": {
+          "$ref": "#/definitions/ImputeMethod",
+          "description": "The imputation method to use for the field value of imputed data objects.\nOne of `value`, `mean`, `median`, `max` or `min`.\n\n__Default value:__  `\"value\"`"
+        },
+        "value": {
+          "description": "The field value to use when the imputation `method` is `\"value\"`."
+        }
+      },
+      "required": [
+        "impute",
+        "key"
+      ],
+      "type": "object"
+    },
+    "InlineData": {
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "$ref": "#/definitions/DataFormat",
+          "description": "An object that specifies the format for parsing the data."
+        },
+        "name": {
+          "description": "Provide a placeholder name and bind data at runtime.",
+          "type": "string"
+        },
+        "values": {
+          "$ref": "#/definitions/InlineDataset",
+          "description": "The full data set, included inline. This can be an array of objects or primitive values, an object, or a string.\nArrays of primitive values are ingested as objects with a `data` property. Strings are parsed according to the specified format type."
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "type": "object"
+    },
+    "InlineDataset": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "boolean"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "Interpolate": {
+      "enum": [
+        "linear",
+        "linear-closed",
+        "step",
+        "step-before",
+        "step-after",
+        "basis",
+        "basis-open",
+        "basis-closed",
+        "cardinal",
+        "cardinal-open",
+        "cardinal-closed",
+        "bundle",
+        "monotone"
+      ],
+      "type": "string"
+    },
+    "IntervalSelection": {
+      "additionalProperties": false,
+      "properties": {
+        "bind": {
+          "description": "Establishes a two-way binding between the interval selection and the scales\nused within the same view. This allows a user to interactively pan and\nzoom the view.",
+          "enum": [
+            "scales"
+          ],
+          "type": "string"
+        },
+        "empty": {
+          "description": "By default, all data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",
+          "enum": [
+            "all",
+            "none"
+          ],
+          "type": "string"
+        },
+        "encodings": {
+          "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mark": {
+          "$ref": "#/definitions/BrushConfig",
+          "description": "An interval selection also adds a rectangle mark to depict the\nextents of the interval. The `mark` property can be used to customize the\nappearance of the mark."
+        },
+        "on": {
+          "$ref": "#/definitions/VgEventStream",
+          "description": "A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)."
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolution",
+          "description": "With layered and multi-view displays, a strategy that determines how\nselections' data queries are resolved when applied in a filter transform,\nconditional encoding rule, or scale domain."
+        },
+        "translate": {
+          "description": "When truthy, allows a user to interactively move an interval selection\nback-and-forth. Can be `true`, `false` (to disable panning), or a\n[Vega event stream definition](https://vega.github.io/vega/docs/event-streams/)\nwhich must include a start and end event to trigger continuous panning.\n\n__Default value:__ `true`, which corresponds to\n`[mousedown, window:mouseup] > window:mousemove!` which corresponds to\nclicks and dragging within an interval selection to reposition it.",
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "type": {
+          "enum": [
+            "interval"
+          ],
+          "type": "string"
+        },
+        "zoom": {
+          "description": "When truthy, allows a user to interactively resize an interval selection.\nCan be `true`, `false` (to disable zooming), or a [Vega event stream\ndefinition](https://vega.github.io/vega/docs/event-streams/). Currently,\nonly `wheel` events are supported.\n\n\n__Default value:__ `true`, which corresponds to `wheel!`.",
+          "type": [
+            "string",
+            "boolean"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "IntervalSelectionConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "bind": {
+          "description": "Establishes a two-way binding between the interval selection and the scales\nused within the same view. This allows a user to interactively pan and\nzoom the view.",
+          "enum": [
+            "scales"
+          ],
+          "type": "string"
+        },
+        "empty": {
+          "description": "By default, all data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",
+          "enum": [
+            "all",
+            "none"
+          ],
+          "type": "string"
+        },
+        "encodings": {
+          "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mark": {
+          "$ref": "#/definitions/BrushConfig",
+          "description": "An interval selection also adds a rectangle mark to depict the\nextents of the interval. The `mark` property can be used to customize the\nappearance of the mark."
+        },
+        "on": {
+          "$ref": "#/definitions/VgEventStream",
+          "description": "A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)."
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolution",
+          "description": "With layered and multi-view displays, a strategy that determines how\nselections' data queries are resolved when applied in a filter transform,\nconditional encoding rule, or scale domain."
+        },
+        "translate": {
+          "description": "When truthy, allows a user to interactively move an interval selection\nback-and-forth. Can be `true`, `false` (to disable panning), or a\n[Vega event stream definition](https://vega.github.io/vega/docs/event-streams/)\nwhich must include a start and end event to trigger continuous panning.\n\n__Default value:__ `true`, which corresponds to\n`[mousedown, window:mouseup] > window:mousemove!` which corresponds to\nclicks and dragging within an interval selection to reposition it.",
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "zoom": {
+          "description": "When truthy, allows a user to interactively resize an interval selection.\nCan be `true`, `false` (to disable zooming), or a [Vega event stream\ndefinition](https://vega.github.io/vega/docs/event-streams/). Currently,\nonly `wheel` events are supported.\n\n\n__Default value:__ `true`, which corresponds to `wheel!`.",
+          "type": [
+            "string",
+            "boolean"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "JsonDataFormat": {
+      "additionalProperties": false,
+      "properties": {
+        "parse": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Parse"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "If set to `null`, disable type inference based on the spec and only use type inference based on the data.\nAlternatively, a parsing directive object can be provided for explicit data types. Each property of the object corresponds to a field name, and the value to the desired data type (one of `\"number\"`, `\"boolean\"`, `\"date\"`, or null (do not parse the field)).\nFor example, `\"parse\": {\"modified_on\": \"date\"}` parses the `modified_on` field in each input record a Date value.\n\nFor `\"date\"`, we parse data based using Javascript's [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).\nFor Specific date formats can be provided (e.g., `{foo: 'date:\"%m%d%Y\"'}`), using the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC date format parsing is supported similarly (e.g., `{foo: 'utc:\"%m%d%Y\"'}`). See more about [UTC time](https://vega.github.io/vega-lite/docs/timeunit.html#utc)"
+        },
+        "property": {
+          "description": "The JSON property containing the desired data.\nThis parameter can be used when the loaded JSON file may have surrounding structure or meta-data.\nFor example `\"property\": \"values.features\"` is equivalent to retrieving `json.values.features`\nfrom the loaded JSON object.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\nThe default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
+          "enum": [
+            "json"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "LabelOverlap": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "enum": [
+            "parity"
+          ],
+          "type": "string"
+        },
+        {
+          "enum": [
+            "greedy"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "Legend": {
+      "additionalProperties": false,
+      "description": "Properties of a legend or boolean flag for determining whether to show it.",
+      "properties": {
+        "clipHeight": {
+          "description": "The height in pixels to clip symbol legend entries and limit their size.",
+          "type": "number"
+        },
+        "columnPadding": {
+          "description": "The horizontal padding in pixels between symbol legend entries.\n\n__Default value:__ `10`.",
+          "type": "number"
+        },
+        "columns": {
+          "description": "The number of columns in which to arrange symbol legend entries. A value of `0` or lower indicates a single row with one column per entry.",
+          "type": "number"
+        },
+        "cornerRadius": {
+          "description": "Corner radius for the full legend.",
+          "type": "number"
+        },
+        "direction": {
+          "$ref": "#/definitions/Orientation",
+          "description": "The direction of the legend, one of `\"vertical\"` (default) or `\"horizontal\"`."
+        },
+        "fillColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Background fill color for the full legend."
+        },
+        "format": {
+          "description": "The formatting pattern for labels. This is D3's [number format pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and D3's [time format pattern](https://github.com/d3/d3-time-format#locale_format) for time field.\n\nSee the [format documentation](https://vega.github.io/vega-lite/docs/format.html) for more information.\n\n__Default value:__  derived from [numberFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for quantitative fields and from [timeFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for temporal fields.",
+          "type": "string"
+        },
+        "gradientLength": {
+          "description": "The length in pixels of the primary axis of a color gradient. This value corresponds to the height of a vertical gradient or the width of a horizontal gradient.\n\n__Default value:__ `200`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "gradientOpacity": {
+          "description": "Opacity of the color gradient.",
+          "type": "number"
+        },
+        "gradientStrokeColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the gradient stroke, can be in hex color code or regular color name.\n\n__Default value:__ `\"lightGray\"`."
+        },
+        "gradientStrokeWidth": {
+          "description": "The width of the gradient stroke, in pixels.\n\n__Default value:__ `0`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "gradientThickness": {
+          "description": "The thickness in pixels of the color gradient. This value corresponds to the width of a vertical gradient or the height of a horizontal gradient.\n\n__Default value:__ `16`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "gridAlign": {
+          "$ref": "#/definitions/VgLayoutAlign",
+          "description": "The alignment to apply to symbol legends rows and columns. The supported string values are `\"all\"`, `\"each\"` (the default), and `none`. For more information, see the [grid layout documentation](https://vega.github.io/vega/docs/layout).\n\n__Default value:__ `\"each\"`."
+        },
+        "labelAlign": {
+          "$ref": "#/definitions/Align",
+          "description": "The alignment of the legend label, can be left, center, or right."
+        },
+        "labelBaseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "The position of the baseline of legend label, can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`.\n\n__Default value:__ `\"middle\"`."
+        },
+        "labelColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the legend label, can be in hex color code or regular color name."
+        },
+        "labelFont": {
+          "description": "The font of the legend label.",
+          "type": "string"
+        },
+        "labelFontSize": {
+          "description": "The font size of legend label.\n\n__Default value:__ `10`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "labelFontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight of legend label."
+        },
+        "labelLimit": {
+          "description": "Maximum allowed pixel width of axis tick labels.\n\n__Default value:__ `160`.",
+          "type": "number"
+        },
+        "labelOffset": {
+          "description": "The offset of the legend label.",
+          "type": "number"
+        },
+        "labelOpacity": {
+          "description": "Opacity of labels.",
+          "type": "number"
+        },
+        "labelOverlap": {
+          "$ref": "#/definitions/LabelOverlap",
+          "description": "The strategy to use for resolving overlap of labels in gradient legends. If `false`, no overlap reduction is attempted. If set to `true` (default) or `\"parity\"`, a strategy of removing every other label is used. If set to `\"greedy\"`, a linear scan of the labels is performed, removing any label that overlaps with the last visible label (this often works better for log-scaled axes).\n\n__Default value:__ `true`."
+        },
+        "labelPadding": {
+          "description": "Padding in pixels between the legend and legend labels.",
+          "type": "number"
+        },
+        "offset": {
+          "description": "The offset in pixels by which to displace the legend from the data rectangle and axes.\n\n__Default value:__ `18`.",
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/LegendOrient",
+          "description": "The orientation of the legend, which determines how the legend is positioned within the scene. One of \"left\", \"right\", \"top-left\", \"top-right\", \"bottom-left\", \"bottom-right\", \"none\".\n\n__Default value:__ `\"right\"`"
+        },
+        "padding": {
+          "description": "The padding between the border and content of the legend group.\n\n__Default value:__ `0`.",
+          "type": "number"
+        },
+        "rowPadding": {
+          "description": "The vertical padding in pixels between symbol legend entries.\n\n__Default value:__ `2`.",
+          "type": "number"
+        },
+        "strokeColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Border stroke color for the full legend."
+        },
+        "strokeWidth": {
+          "description": "Border stroke width for the full legend.",
+          "type": "number"
+        },
+        "symbolFillColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the legend symbol,"
+        },
+        "symbolOffset": {
+          "description": "Horizontal pixel offset for legend symbols.\n\n__Default value:__ `0`.",
+          "type": "number"
+        },
+        "symbolOpacity": {
+          "description": "Opacity of the legend symbols.",
+          "type": "number"
+        },
+        "symbolSize": {
+          "description": "The size of the legend symbol, in pixels.\n\n__Default value:__ `100`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "symbolStrokeColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Stroke color for legend symbols."
+        },
+        "symbolStrokeWidth": {
+          "description": "The width of the symbol's stroke.\n\n__Default value:__ `1.5`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "symbolType": {
+          "$ref": "#/definitions/SymbolShape",
+          "description": "Default shape type (such as \"circle\") for legend symbols.\nCan be one of ``\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, or `\"triangle-left\"`.\n   * In addition to a set of built-in shapes, custom shapes can be defined using [SVG path strings](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths).\n   *\n   * __Default value:__ `\"circle\"`.\n   *"
+        },
+        "tickCount": {
+          "description": "The desired number of tick values for quantitative legends.",
+          "type": "number"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "titleAlign": {
+          "$ref": "#/definitions/Align",
+          "description": "Horizontal text alignment for legend titles.\n\n__Default value:__ `\"left\"`."
+        },
+        "titleBaseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "Vertical text baseline for legend titles.\n\n__Default value:__ `\"top\"`."
+        },
+        "titleColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the legend title, can be in hex color code or regular color name."
+        },
+        "titleFont": {
+          "description": "The font of the legend title.",
+          "type": "string"
+        },
+        "titleFontSize": {
+          "description": "The font size of the legend title.",
+          "type": "number"
+        },
+        "titleFontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight of the legend title.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "titleLimit": {
+          "description": "Maximum allowed pixel width of axis titles.\n\n__Default value:__ `180`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "titleOpacity": {
+          "description": "Opacity of the legend title.",
+          "type": "number"
+        },
+        "titlePadding": {
+          "description": "The padding, in pixels, between title and legend.\n\n__Default value:__ `5`.",
+          "type": "number"
+        },
+        "type": {
+          "description": "The type of the legend. Use `\"symbol\"` to create a discrete legend and `\"gradient\"` for a continuous color gradient.\n\n__Default value:__ `\"gradient\"` for non-binned quantitative fields and temporal fields; `\"symbol\"` otherwise.",
+          "enum": [
+            "symbol",
+            "gradient"
+          ],
+          "type": "string"
+        },
+        "values": {
+          "description": "Explicitly set the visible legend values.",
+          "items": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "$ref": "#/definitions/DateTime"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "zindex": {
+          "description": "A non-positive integer indicating z-index of the legend.\nIf zindex is 0, legend should be drawn behind all chart elements.\nTo put them in front, use zindex = 1.",
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "LegendConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "clipHeight": {
+          "description": "The height in pixels to clip symbol legend entries and limit their size.",
+          "type": "number"
+        },
+        "columnPadding": {
+          "description": "The horizontal padding in pixels between symbol legend entries.\n\n__Default value:__ `10`.",
+          "type": "number"
+        },
+        "columns": {
+          "description": "The number of columns in which to arrange symbol legend entries. A value of `0` or lower indicates a single row with one column per entry.",
+          "type": "number"
+        },
+        "cornerRadius": {
+          "description": "Corner radius for the full legend.",
+          "type": "number"
+        },
+        "fillColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Background fill color for the full legend."
+        },
+        "gradientDirection": {
+          "$ref": "#/definitions/Orientation",
+          "description": "The default direction (`\"horizontal\"` or `\"vertical\"`) for gradient legends.\n\n__Default value:__ `\"vertical\"`."
+        },
+        "gradientLabelLimit": {
+          "description": "The maximum allowed length in pixels of color ramp gradient labels.",
+          "type": "number"
+        },
+        "gradientLabelOffset": {
+          "description": "Vertical offset in pixels for color ramp gradient labels.\n\n__Default value:__ `2`.",
+          "type": "number"
+        },
+        "gradientLength": {
+          "description": "The length in pixels of the primary axis of a color gradient. This value corresponds to the height of a vertical gradient or the width of a horizontal gradient.\n\n__Default value:__ `200`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "gradientOpacity": {
+          "description": "Opacity of the color gradient.",
+          "type": "number"
+        },
+        "gradientStrokeColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the gradient stroke, can be in hex color code or regular color name.\n\n__Default value:__ `\"lightGray\"`."
+        },
+        "gradientStrokeWidth": {
+          "description": "The width of the gradient stroke, in pixels.\n\n__Default value:__ `0`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "gradientThickness": {
+          "description": "The thickness in pixels of the color gradient. This value corresponds to the width of a vertical gradient or the height of a horizontal gradient.\n\n__Default value:__ `16`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "gridAlign": {
+          "$ref": "#/definitions/VgLayoutAlign",
+          "description": "The alignment to apply to symbol legends rows and columns. The supported string values are `\"all\"`, `\"each\"` (the default), and `none`. For more information, see the [grid layout documentation](https://vega.github.io/vega/docs/layout).\n\n__Default value:__ `\"each\"`."
+        },
+        "labelAlign": {
+          "$ref": "#/definitions/Align",
+          "description": "The alignment of the legend label, can be left, center, or right."
+        },
+        "labelBaseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "The position of the baseline of legend label, can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`.\n\n__Default value:__ `\"middle\"`."
+        },
+        "labelColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the legend label, can be in hex color code or regular color name."
+        },
+        "labelFont": {
+          "description": "The font of the legend label.",
+          "type": "string"
+        },
+        "labelFontSize": {
+          "description": "The font size of legend label.\n\n__Default value:__ `10`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "labelFontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight of legend label."
+        },
+        "labelLimit": {
+          "description": "Maximum allowed pixel width of axis tick labels.\n\n__Default value:__ `160`.",
+          "type": "number"
+        },
+        "labelOffset": {
+          "description": "The offset of the legend label.",
+          "type": "number"
+        },
+        "labelOpacity": {
+          "description": "Opacity of labels.",
+          "type": "number"
+        },
+        "labelOverlap": {
+          "$ref": "#/definitions/LabelOverlap",
+          "description": "The strategy to use for resolving overlap of labels in gradient legends. If `false`, no overlap reduction is attempted. If set to `true` (default) or `\"parity\"`, a strategy of removing every other label is used. If set to `\"greedy\"`, a linear scan of the labels is performed, removing any label that overlaps with the last visible label (this often works better for log-scaled axes).\n\n__Default value:__ `\"greedy\"` for `log scales otherwise `true`.\n   *"
+        },
+        "labelPadding": {
+          "description": "Padding in pixels between the legend and legend labels.",
+          "type": "number"
+        },
+        "offset": {
+          "description": "The offset in pixels by which to displace the legend from the data rectangle and axes.\n\n__Default value:__ `18`.",
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/LegendOrient",
+          "description": "The orientation of the legend, which determines how the legend is positioned within the scene. One of \"left\", \"right\", \"top-left\", \"top-right\", \"bottom-left\", \"bottom-right\", \"none\".\n\n__Default value:__ `\"right\"`"
+        },
+        "padding": {
+          "description": "The padding between the border and content of the legend group.\n\n__Default value:__ `0`.",
+          "type": "number"
+        },
+        "rowPadding": {
+          "description": "The vertical padding in pixels between symbol legend entries.\n\n__Default value:__ `2`.",
+          "type": "number"
+        },
+        "shortTimeLabels": {
+          "description": "Whether month names and weekday names should be abbreviated.\n\n__Default value:__  `false`",
+          "type": "boolean"
+        },
+        "strokeColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Border stroke color for the full legend."
+        },
+        "strokeDash": {
+          "description": "Border stroke dash pattern for the full legend.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeWidth": {
+          "description": "Border stroke width for the full legend.",
+          "type": "number"
+        },
+        "symbolBaseFillColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Default fill color for legend symbols. Only applied if there is no `\"fill\"` scale color encoding for the legend.\n\n__Default value:__ `\"transparent\"`."
+        },
+        "symbolBaseStrokeColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Default stroke color for legend symbols. Only applied if there is no `\"fill\"` scale color encoding for the legend.\n\n__Default value:__ `\"gray\"`."
+        },
+        "symbolDirection": {
+          "$ref": "#/definitions/Orientation",
+          "description": "The default direction (`\"horizontal\"` or `\"vertical\"`) for symbol legends.\n\n__Default value:__ `\"vertical\"`."
+        },
+        "symbolFillColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the legend symbol,"
+        },
+        "symbolOffset": {
+          "description": "Horizontal pixel offset for legend symbols.\n\n__Default value:__ `0`.",
+          "type": "number"
+        },
+        "symbolOpacity": {
+          "description": "Opacity of the legend symbols.",
+          "type": "number"
+        },
+        "symbolSize": {
+          "description": "The size of the legend symbol, in pixels.\n\n__Default value:__ `100`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "symbolStrokeColor": {
+          "$ref": "#/definitions/Color",
+          "description": "Stroke color for legend symbols."
+        },
+        "symbolStrokeWidth": {
+          "description": "The width of the symbol's stroke.\n\n__Default value:__ `1.5`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "symbolType": {
+          "$ref": "#/definitions/SymbolShape",
+          "description": "Default shape type (such as \"circle\") for legend symbols.\nCan be one of ``\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, or `\"triangle-left\"`.\n   * In addition to a set of built-in shapes, custom shapes can be defined using [SVG path strings](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths).\n   *\n   * __Default value:__ `\"circle\"`.\n   *"
+        },
+        "titleAlign": {
+          "$ref": "#/definitions/Align",
+          "description": "Horizontal text alignment for legend titles.\n\n__Default value:__ `\"left\"`."
+        },
+        "titleBaseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "Vertical text baseline for legend titles.\n\n__Default value:__ `\"top\"`."
+        },
+        "titleColor": {
+          "$ref": "#/definitions/Color",
+          "description": "The color of the legend title, can be in hex color code or regular color name."
+        },
+        "titleFont": {
+          "description": "The font of the legend title.",
+          "type": "string"
+        },
+        "titleFontSize": {
+          "description": "The font size of the legend title.",
+          "type": "number"
+        },
+        "titleFontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight of the legend title.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "titleLimit": {
+          "description": "Maximum allowed pixel width of axis titles.\n\n__Default value:__ `180`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "titleOpacity": {
+          "description": "Opacity of the legend title.",
+          "type": "number"
+        },
+        "titlePadding": {
+          "description": "The padding, in pixels, between title and legend.\n\n__Default value:__ `5`.",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "LegendOrient": {
+      "enum": [
+        "none",
+        "left",
+        "right",
+        "top",
+        "bottom",
+        "top-left",
+        "top-right",
+        "bottom-left",
+        "bottom-right"
+      ],
+      "type": "string"
+    },
+    "LegendResolveMap": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "fill": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "opacity": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "shape": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "size": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "stroke": {
+          "$ref": "#/definitions/ResolveMode"
+        }
+      },
+      "type": "object"
+    },
+    "LineConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/Align",
+          "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
+        },
+        "angle": {
+          "description": "The rotation angle of the text, in degrees.",
+          "maximum": 360,
+          "minimum": 0,
+          "type": "number"
+        },
+        "baseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
+        },
+        "color": {
+          "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "string"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners.\n\n__Default value:__ `0`",
+          "type": "number"
+        },
+        "cursor": {
+          "$ref": "#/definitions/Cursor",
+          "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
+        },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of `\"ltr\"` (left-to-right) or `\"rtl\"` (right-to-left). This property determines on which side is truncated in response to the limit parameter.\n\n__Default value:__ `\"ltr\"`"
+        },
+        "dx": {
+          "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "dy": {
+          "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter.\n\n__Default value:__ `\"…\"`",
+          "type": "string"
+        },
+        "fill": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "filled": {
+          "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "boolean"
+        },
+        "font": {
+          "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "fontSize": {
+          "description": "The font size, in pixels.",
+          "type": "number"
+        },
+        "fontStyle": {
+          "$ref": "#/definitions/FontStyle",
+          "description": "The font style (e.g., `\"italic\"`)."
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "href": {
+          "description": "A URL to load upon mouse click. If defined, the mark acts as a hyperlink.",
+          "format": "uri",
+          "type": "string"
+        },
+        "interpolate": {
+          "$ref": "#/definitions/Interpolate",
+          "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "opacity": {
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
+        },
+        "point": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/OverlayMarkDef"
+            },
+            {
+              "enum": [
+                "transparent"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for overlaying points on top of line or area marks, or an object defining the properties of the overlayed points.\n\n- If this property is `\"transparent\"`, transparent points will be used (for enhancing tooltips and selections).\n\n- If this property is an empty object (`{}`) or `true`, filled points with default properties will be used.\n\n- If this property is `false`, no points would be automatically added to line or area marks.\n\n__Default value:__ `false`."
+        },
+        "radius": {
+          "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "shape": {
+          "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
+          "type": "string"
+        },
+        "size": {
+          "description": "Default size for marks.\n- For `point`/`circle`/`square`, this represents the pixel area of the marks. For example: in the case of circles, the radius is determined in part by the square root of the size value.\n- For `bar`, this represents the band size of the bar, in pixels.\n- For `text`, this represents the font size, in pixels.\n\n__Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text marks.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "stroke": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Stroke Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "strokeCap": {
+          "$ref": "#/definitions/StrokeCap",
+          "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"square\"`"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tension": {
+          "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "text": {
+          "description": "Placeholder text if the `text` channel is not specified",
+          "type": "string"
+        },
+        "theta": {
+          "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
+          "type": "number"
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TooltipContent"
+            }
+          ],
+          "description": "The tooltip text string to show upon mouse hover or an object defining which fields should the tooltip be derived from.\n\n- If `tooltip` is `{\"content\": \"encoding\"}`, then all fields from `encoding` will be used.\n- If `tooltip` is `{\"content\": \"data\"}`, then all fields that appear in the highlighted data point will be used."
+        }
+      },
+      "type": "object"
+    },
+    "LocalMultiTimeUnit": {
+      "enum": [
+        "yearquarter",
+        "yearquartermonth",
+        "yearmonth",
+        "yearmonthdate",
+        "yearmonthdatehours",
+        "yearmonthdatehoursminutes",
+        "yearmonthdatehoursminutesseconds",
+        "quartermonth",
+        "monthdate",
+        "hoursminutes",
+        "hoursminutesseconds",
+        "minutesseconds",
+        "secondsmilliseconds"
+      ],
+      "type": "string"
+    },
+    "LocalSingleTimeUnit": {
+      "enum": [
+        "year",
+        "quarter",
+        "month",
+        "day",
+        "date",
+        "hours",
+        "minutes",
+        "seconds",
+        "milliseconds"
+      ],
+      "type": "string"
+    },
+    "LogicalAnd<Predicate>": {
+      "additionalProperties": false,
+      "properties": {
+        "and": {
+          "items": {
+            "$ref": "#/definitions/LogicalOperand<Predicate>"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "and"
+      ],
+      "type": "object"
+    },
+    "SelectionAnd": {
+      "additionalProperties": false,
+      "properties": {
+        "and": {
+          "items": {
+            "$ref": "#/definitions/SelectionOperand"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "and"
+      ],
+      "type": "object"
+    },
+    "LogicalNot<Predicate>": {
+      "additionalProperties": false,
+      "properties": {
+        "not": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>"
+        }
+      },
+      "required": [
+        "not"
+      ],
+      "type": "object"
+    },
+    "SelectionNot": {
+      "additionalProperties": false,
+      "properties": {
+        "not": {
+          "$ref": "#/definitions/SelectionOperand"
+        }
+      },
+      "required": [
+        "not"
+      ],
+      "type": "object"
+    },
+    "LogicalOperand<Predicate>": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LogicalNot<Predicate>"
+        },
+        {
+          "$ref": "#/definitions/LogicalAnd<Predicate>"
+        },
+        {
+          "$ref": "#/definitions/LogicalOr<Predicate>"
+        },
+        {
+          "$ref": "#/definitions/Predicate"
+        }
+      ]
+    },
+    "SelectionOperand": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SelectionNot"
+        },
+        {
+          "$ref": "#/definitions/SelectionAnd"
+        },
+        {
+          "$ref": "#/definitions/SelectionOr"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "LogicalOr<Predicate>": {
+      "additionalProperties": false,
+      "properties": {
+        "or": {
+          "items": {
+            "$ref": "#/definitions/LogicalOperand<Predicate>"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "or"
+      ],
+      "type": "object"
+    },
+    "SelectionOr": {
+      "additionalProperties": false,
+      "properties": {
+        "or": {
+          "items": {
+            "$ref": "#/definitions/SelectionOperand"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "or"
+      ],
+      "type": "object"
+    },
+    "LookupData": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "Secondary data source to lookup in."
+        },
+        "fields": {
+          "description": "Fields in foreign data to lookup.\nIf not specified, the entire object is queried.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "key": {
+          "description": "Key in data to lookup.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "key"
+      ],
+      "type": "object"
+    },
+    "LookupTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "The field or fields for storing the computed formula value.\nIf `from.fields` is specified, the transform will use the same names for `as`.\nIf `from.fields` is not specified, `as` has to be a string and we put the whole object into the data under the specified name."
+        },
+        "default": {
+          "description": "The default value to use if lookup fails.\n\n__Default value:__ `null`",
+          "type": "string"
+        },
+        "from": {
+          "$ref": "#/definitions/LookupData",
+          "description": "Secondary data reference."
+        },
+        "lookup": {
+          "description": "Key in primary data source.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "lookup",
+        "from"
+      ],
+      "type": "object"
+    },
+    "Mark": {
+      "description": "All types of primitive marks.",
+      "enum": [
+        "area",
+        "bar",
+        "line",
+        "trail",
+        "point",
+        "text",
+        "tick",
+        "rect",
+        "rule",
+        "circle",
+        "square",
+        "geoshape"
+      ],
+      "type": "string"
+    },
+    "MarkConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/Align",
+          "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
+        },
+        "angle": {
+          "description": "The rotation angle of the text, in degrees.",
+          "maximum": 360,
+          "minimum": 0,
+          "type": "number"
+        },
+        "baseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
+        },
+        "color": {
+          "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "string"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners.\n\n__Default value:__ `0`",
+          "type": "number"
+        },
+        "cursor": {
+          "$ref": "#/definitions/Cursor",
+          "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
+        },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of `\"ltr\"` (left-to-right) or `\"rtl\"` (right-to-left). This property determines on which side is truncated in response to the limit parameter.\n\n__Default value:__ `\"ltr\"`"
+        },
+        "dx": {
+          "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "dy": {
+          "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter.\n\n__Default value:__ `\"…\"`",
+          "type": "string"
+        },
+        "fill": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "filled": {
+          "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "boolean"
+        },
+        "font": {
+          "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "fontSize": {
+          "description": "The font size, in pixels.",
+          "type": "number"
+        },
+        "fontStyle": {
+          "$ref": "#/definitions/FontStyle",
+          "description": "The font style (e.g., `\"italic\"`)."
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "href": {
+          "description": "A URL to load upon mouse click. If defined, the mark acts as a hyperlink.",
+          "format": "uri",
+          "type": "string"
+        },
+        "interpolate": {
+          "$ref": "#/definitions/Interpolate",
+          "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "opacity": {
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
+        },
+        "radius": {
+          "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "shape": {
+          "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
+          "type": "string"
+        },
+        "size": {
+          "description": "Default size for marks.\n- For `point`/`circle`/`square`, this represents the pixel area of the marks. For example: in the case of circles, the radius is determined in part by the square root of the size value.\n- For `bar`, this represents the band size of the bar, in pixels.\n- For `text`, this represents the font size, in pixels.\n\n__Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text marks.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "stroke": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Stroke Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "strokeCap": {
+          "$ref": "#/definitions/StrokeCap",
+          "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"square\"`"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tension": {
+          "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "text": {
+          "description": "Placeholder text if the `text` channel is not specified",
+          "type": "string"
+        },
+        "theta": {
+          "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
+          "type": "number"
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TooltipContent"
+            }
+          ],
+          "description": "The tooltip text string to show upon mouse hover or an object defining which fields should the tooltip be derived from.\n\n- If `tooltip` is `{\"content\": \"encoding\"}`, then all fields from `encoding` will be used.\n- If `tooltip` is `{\"content\": \"data\"}`, then all fields that appear in the highlighted data point will be used."
+        }
+      },
+      "type": "object"
+    },
+    "MarkDef": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/Align",
+          "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
+        },
+        "angle": {
+          "description": "The rotation angle of the text, in degrees.",
+          "maximum": 360,
+          "minimum": 0,
+          "type": "number"
+        },
+        "baseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
+        },
+        "binSpacing": {
+          "description": "Offset between bars for binned field.  Ideal value for this is either 0 (Preferred by statisticians) or 1 (Vega-Lite Default, D3 example style).\n\n__Default value:__ `1`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "clip": {
+          "description": "Whether a mark be clipped to the enclosing group’s width and height.",
+          "type": "boolean"
+        },
+        "color": {
+          "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "string"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners.\n\n__Default value:__ `0`",
+          "type": "number"
+        },
+        "cursor": {
+          "$ref": "#/definitions/Cursor",
+          "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
+        },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of `\"ltr\"` (left-to-right) or `\"rtl\"` (right-to-left). This property determines on which side is truncated in response to the limit parameter.\n\n__Default value:__ `\"ltr\"`"
+        },
+        "dx": {
+          "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "dy": {
+          "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter.\n\n__Default value:__ `\"…\"`",
+          "type": "string"
+        },
+        "fill": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "filled": {
+          "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "boolean"
+        },
+        "font": {
+          "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "fontSize": {
+          "description": "The font size, in pixels.",
+          "type": "number"
+        },
+        "fontStyle": {
+          "$ref": "#/definitions/FontStyle",
+          "description": "The font style (e.g., `\"italic\"`)."
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "href": {
+          "description": "A URL to load upon mouse click. If defined, the mark acts as a hyperlink.",
+          "format": "uri",
+          "type": "string"
+        },
+        "interpolate": {
+          "$ref": "#/definitions/Interpolate",
+          "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "line": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/OverlayMarkDef"
+            }
+          ],
+          "description": "A flag for overlaying line on top of area marks, or an object defining the properties of the overlayed lines.\n\n- If this value is an empty object (`{}`) or `true`, lines with default properties will be used.\n\n- If this value is `false`, no lines would be automatically added to area marks.\n\n__Default value:__ `false`."
+        },
+        "opacity": {
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
+        },
+        "point": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/OverlayMarkDef"
+            },
+            {
+              "enum": [
+                "transparent"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for overlaying points on top of line or area marks, or an object defining the properties of the overlayed points.\n\n- If this property is `\"transparent\"`, transparent points will be used (for enhancing tooltips and selections).\n\n- If this property is an empty object (`{}`) or `true`, filled points with default properties will be used.\n\n- If this property is `false`, no points would be automatically added to line or area marks.\n\n__Default value:__ `false`."
+        },
+        "radius": {
+          "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "shape": {
+          "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
+          "type": "string"
+        },
+        "size": {
+          "description": "Default size for marks.\n- For `point`/`circle`/`square`, this represents the pixel area of the marks. For example: in the case of circles, the radius is determined in part by the square root of the size value.\n- For `bar`, this represents the band size of the bar, in pixels.\n- For `text`, this represents the font size, in pixels.\n\n__Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text marks.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "stroke": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Stroke Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "strokeCap": {
+          "$ref": "#/definitions/StrokeCap",
+          "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"square\"`"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "style": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "A string or array of strings indicating the name of custom styles to apply to the mark. A style is a named collection of mark property defaults defined within the [style configuration](https://vega.github.io/vega-lite/docs/mark.html#style-config). If style is an array, later styles will override earlier styles. Any [mark properties](https://vega.github.io/vega-lite/docs/encoding.html#mark-prop) explicitly defined within the `encoding` will override a style default.\n\n__Default value:__ The mark's name.  For example, a bar mark will have style `\"bar\"` by default.\n__Note:__ Any specified style will augment the default style. For example, a bar mark with `\"style\": \"foo\"` will receive from `config.style.bar` and `config.style.foo` (the specified style `\"foo\"` has higher precedence)."
+        },
+        "tension": {
+          "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "text": {
+          "description": "Placeholder text if the `text` channel is not specified",
+          "type": "string"
+        },
+        "theta": {
+          "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
+          "type": "number"
+        },
+        "thickness": {
+          "description": "Thickness of the tick mark.\n\n__Default value:__  `1`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TooltipContent"
+            }
+          ],
+          "description": "The tooltip text string to show upon mouse hover or an object defining which fields should the tooltip be derived from.\n\n- If `tooltip` is `{\"content\": \"encoding\"}`, then all fields from `encoding` will be used.\n- If `tooltip` is `{\"content\": \"data\"}`, then all fields that appear in the highlighted data point will be used."
+        },
+        "type": {
+          "$ref": "#/definitions/Mark",
+          "description": "The mark type.\nOne of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"geoshape\"`, `\"rule\"`, and `\"text\"`."
+        },
+        "x2Offset": {
+          "description": "Offset for x2-position.",
+          "type": "number"
+        },
+        "xOffset": {
+          "description": "Offset for x-position.",
+          "type": "number"
+        },
+        "y2Offset": {
+          "description": "Offset for y2-position.",
+          "type": "number"
+        },
+        "yOffset": {
+          "description": "Offset for y-position.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Month": {
+      "maximum": 12,
+      "minimum": 1,
+      "type": "number"
+    },
+    "MultiSelection": {
+      "additionalProperties": false,
+      "properties": {
+        "empty": {
+          "description": "By default, all data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",
+          "enum": [
+            "all",
+            "none"
+          ],
+          "type": "string"
+        },
+        "encodings": {
+          "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nearest": {
+          "description": "When true, an invisible voronoi diagram is computed to accelerate discrete\nselection. The data value _nearest_ the mouse cursor is added to the selection.\n\nSee the [nearest transform](https://vega.github.io/vega-lite/docs/nearest.html) documentation for more information.",
+          "type": "boolean"
+        },
+        "on": {
+          "$ref": "#/definitions/VgEventStream",
+          "description": "A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)."
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolution",
+          "description": "With layered and multi-view displays, a strategy that determines how\nselections' data queries are resolved when applied in a filter transform,\nconditional encoding rule, or scale domain."
+        },
+        "toggle": {
+          "description": "Controls whether data values should be toggled or only ever inserted into\nmulti selections. Can be `true`, `false` (for insertion only), or a\n[Vega expression](https://vega.github.io/vega/docs/expressions/).\n\n__Default value:__ `true`, which corresponds to `event.shiftKey` (i.e.,\ndata values are toggled when a user interacts with the shift-key pressed).\n\nSee the [toggle transform](https://vega.github.io/vega-lite/docs/toggle.html) documentation for more information.",
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "type": {
+          "enum": [
+            "multi"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "MultiSelectionConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "empty": {
+          "description": "By default, all data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",
+          "enum": [
+            "all",
+            "none"
+          ],
+          "type": "string"
+        },
+        "encodings": {
+          "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nearest": {
+          "description": "When true, an invisible voronoi diagram is computed to accelerate discrete\nselection. The data value _nearest_ the mouse cursor is added to the selection.\n\nSee the [nearest transform](https://vega.github.io/vega-lite/docs/nearest.html) documentation for more information.",
+          "type": "boolean"
+        },
+        "on": {
+          "$ref": "#/definitions/VgEventStream",
+          "description": "A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)."
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolution",
+          "description": "With layered and multi-view displays, a strategy that determines how\nselections' data queries are resolved when applied in a filter transform,\nconditional encoding rule, or scale domain."
+        },
+        "toggle": {
+          "description": "Controls whether data values should be toggled or only ever inserted into\nmulti selections. Can be `true`, `false` (for insertion only), or a\n[Vega expression](https://vega.github.io/vega/docs/expressions/).\n\n__Default value:__ `true`, which corresponds to `event.shiftKey` (i.e.,\ndata values are toggled when a user interacts with the shift-key pressed).\n\nSee the [toggle transform](https://vega.github.io/vega-lite/docs/toggle.html) documentation for more information.",
+          "type": [
+            "string",
+            "boolean"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "MultiTimeUnit": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LocalMultiTimeUnit"
+        },
+        {
+          "$ref": "#/definitions/UtcMultiTimeUnit"
+        }
+      ]
+    },
+    "NamedData": {
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "$ref": "#/definitions/DataFormat",
+          "description": "An object that specifies the format for parsing the data."
+        },
+        "name": {
+          "description": "Provide a placeholder name and bind data at runtime.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "NiceTime": {
+      "enum": [
+        "second",
+        "minute",
+        "hour",
+        "day",
+        "week",
+        "month",
+        "year"
+      ],
+      "type": "string"
+    },
+    "OrderFieldDef": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "sort": {
+          "$ref": "#/definitions/SortOrder",
+          "description": "The sort order. One of `\"ascending\"` (default) or `\"descending\"`."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Orient": {
+      "enum": [
+        "horizontal",
+        "vertical"
+      ],
+      "type": "string"
+    },
+    "Orientation": {
+      "enum": [
+        "horizontal",
+        "vertical"
+      ],
+      "type": "string"
+    },
+    "OverlayMarkDef": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/Align",
+          "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
+        },
+        "angle": {
+          "description": "The rotation angle of the text, in degrees.",
+          "maximum": 360,
+          "minimum": 0,
+          "type": "number"
+        },
+        "baseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
+        },
+        "clip": {
+          "description": "Whether a mark be clipped to the enclosing group’s width and height.",
+          "type": "boolean"
+        },
+        "color": {
+          "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "string"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners.\n\n__Default value:__ `0`",
+          "type": "number"
+        },
+        "cursor": {
+          "$ref": "#/definitions/Cursor",
+          "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
+        },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of `\"ltr\"` (left-to-right) or `\"rtl\"` (right-to-left). This property determines on which side is truncated in response to the limit parameter.\n\n__Default value:__ `\"ltr\"`"
+        },
+        "dx": {
+          "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "dy": {
+          "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter.\n\n__Default value:__ `\"…\"`",
+          "type": "string"
+        },
+        "fill": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "filled": {
+          "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "boolean"
+        },
+        "font": {
+          "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "fontSize": {
+          "description": "The font size, in pixels.",
+          "type": "number"
+        },
+        "fontStyle": {
+          "$ref": "#/definitions/FontStyle",
+          "description": "The font style (e.g., `\"italic\"`)."
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "href": {
+          "description": "A URL to load upon mouse click. If defined, the mark acts as a hyperlink.",
+          "format": "uri",
+          "type": "string"
+        },
+        "interpolate": {
+          "$ref": "#/definitions/Interpolate",
+          "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "opacity": {
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
+        },
+        "radius": {
+          "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "shape": {
+          "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
+          "type": "string"
+        },
+        "size": {
+          "description": "Default size for marks.\n- For `point`/`circle`/`square`, this represents the pixel area of the marks. For example: in the case of circles, the radius is determined in part by the square root of the size value.\n- For `bar`, this represents the band size of the bar, in pixels.\n- For `text`, this represents the font size, in pixels.\n\n__Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text marks.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "stroke": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Stroke Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "strokeCap": {
+          "$ref": "#/definitions/StrokeCap",
+          "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"square\"`"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "style": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "A string or array of strings indicating the name of custom styles to apply to the mark. A style is a named collection of mark property defaults defined within the [style configuration](https://vega.github.io/vega-lite/docs/mark.html#style-config). If style is an array, later styles will override earlier styles. Any [mark properties](https://vega.github.io/vega-lite/docs/encoding.html#mark-prop) explicitly defined within the `encoding` will override a style default.\n\n__Default value:__ The mark's name.  For example, a bar mark will have style `\"bar\"` by default.\n__Note:__ Any specified style will augment the default style. For example, a bar mark with `\"style\": \"foo\"` will receive from `config.style.bar` and `config.style.foo` (the specified style `\"foo\"` has higher precedence)."
+        },
+        "tension": {
+          "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "text": {
+          "description": "Placeholder text if the `text` channel is not specified",
+          "type": "string"
+        },
+        "theta": {
+          "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
+          "type": "number"
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TooltipContent"
+            }
+          ],
+          "description": "The tooltip text string to show upon mouse hover or an object defining which fields should the tooltip be derived from.\n\n- If `tooltip` is `{\"content\": \"encoding\"}`, then all fields from `encoding` will be used.\n- If `tooltip` is `{\"content\": \"data\"}`, then all fields that appear in the highlighted data point will be used."
+        },
+        "x2Offset": {
+          "description": "Offset for x2-position.",
+          "type": "number"
+        },
+        "xOffset": {
+          "description": "Offset for x-position.",
+          "type": "number"
+        },
+        "y2Offset": {
+          "description": "Offset for y2-position.",
+          "type": "number"
+        },
+        "yOffset": {
+          "description": "Offset for y-position.",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "Padding": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "bottom": {
+              "type": "number"
+            },
+            "left": {
+              "type": "number"
+            },
+            "right": {
+              "type": "number"
+            },
+            "top": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        }
+      ],
+      "minimum": 0
+    },
+    "Parse": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ParseValue"
+      },
+      "type": "object"
+    },
+    "ParseValue": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "enum": [
+            "string"
+          ],
+          "type": "string"
+        },
+        {
+          "enum": [
+            "boolean"
+          ],
+          "type": "string"
+        },
+        {
+          "enum": [
+            "date"
+          ],
+          "type": "string"
+        },
+        {
+          "enum": [
+            "number"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "PartsMixins<BoxPlotPart>": {
+      "additionalProperties": false,
+      "description": "Make all properties in T optional",
+      "properties": {
+        "box": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "median": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "outliers": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "rule": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "ticks": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "PartsMixins<ErrorBandPart>": {
+      "additionalProperties": false,
+      "description": "Make all properties in T optional",
+      "properties": {
+        "band": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "borders": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "PartsMixins<ErrorBarPart>": {
+      "additionalProperties": false,
+      "description": "Make all properties in T optional",
+      "properties": {
+        "rule": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        },
+        "ticks": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/MarkConfig"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "PositionFieldDef": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "axis": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Axis"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object defining properties of axis's gridlines, ticks and labels.\nIf `null`, the axis for the encoding channel will be removed.\n\n__Default value:__ If undefined, default [axis properties](https://vega.github.io/vega-lite/docs/axis.html) are applied."
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "impute": {
+          "$ref": "#/definitions/ImputeParams",
+          "description": "An object defining the properties of the Impute Operation to be applied.\nThe field value of the other positional channel is taken as `key` of the `Impute` Operation.\nThe field of the `color` channel if specified is used as `groupby` of the `Impute` Operation."
+        },
+        "scale": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Scale"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object defining properties of the channel's scale, which is the function that transforms values in the data domain (numbers, dates, strings, etc) to visual values (pixels, colors, sizes) of the encoding channels.\n\nIf `null`, the scale will be [disabled and the data value will be directly encoded](https://vega.github.io/vega-lite/docs/scale.html#disable).\n\n__Default value:__ If undefined, default [scale properties](https://vega.github.io/vega-lite/docs/scale.html) are applied."
+        },
+        "sort": {
+          "$ref": "#/definitions/Sort",
+          "description": "Sort order for the encoded field.\n\nFor continuous fields (quantitative or temporal), `sort` can be either `\"ascending\"` or `\"descending\"`.\n\nFor discrete fields, `sort` can be one of the following:\n- `\"ascending\"` or `\"descending\"` -- for sorting by the values' natural order in Javascript.\n- [A sort field definition](https://vega.github.io/vega-lite/docs/sort.html#sort-field) for sorting by another field.\n- [An array specifying the field values in preferred order](https://vega.github.io/vega-lite/docs/sort.html#sort-array). In this case, the sort order will obey the values in the array, followed by any unspecified values in their original order.  For discrete time field, values in the sort array can be [date-time definition objects](types#datetime). In addition, for time units `\"month\"` and `\"day\"`, the values can be the month or day names (case insensitive) or their 3-letter initials (e.g., `\"Mon\"`, `\"Tue\"`).\n- `null` indicating no sort.\n\n__Default value:__ `\"ascending\"`\n\n__Note:__ `null` is not supported for `row` and `column`."
+        },
+        "stack": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StackOffset"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Type of stacking offset if the field should be stacked.\n`stack` is only applicable for `x` and `y` channels with continuous domains.\nFor example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true:\n(1) the mark is `bar` or `area`;\n(2) the stacked measure channel (x or y) has a linear scale;\n(3) At least one of non-position channels mapped to an unaggregated field that is different from x and y.  Otherwise, `null` by default."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "Predicate": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FieldEqualPredicate"
+        },
+        {
+          "$ref": "#/definitions/FieldRangePredicate"
+        },
+        {
+          "$ref": "#/definitions/FieldOneOfPredicate"
+        },
+        {
+          "$ref": "#/definitions/FieldLTPredicate"
+        },
+        {
+          "$ref": "#/definitions/FieldGTPredicate"
+        },
+        {
+          "$ref": "#/definitions/FieldLTEPredicate"
+        },
+        {
+          "$ref": "#/definitions/FieldGTEPredicate"
+        },
+        {
+          "$ref": "#/definitions/FieldValidPredicate"
+        },
+        {
+          "$ref": "#/definitions/SelectionPredicate"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "Projection": {
+      "additionalProperties": false,
+      "properties": {
+        "center": {
+          "description": "Sets the projection’s center to the specified center, a two-element array of longitude and latitude in degrees.\n\n__Default value:__ `[0, 0]`",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "clipAngle": {
+          "description": "Sets the projection’s clipping circle radius to the specified angle in degrees. If `null`, switches to [antimeridian](http://bl.ocks.org/mbostock/3788999) cutting rather than small-circle clipping.",
+          "type": "number"
+        },
+        "clipExtent": {
+          "description": "Sets the projection’s viewport clip extent to the specified bounds in pixels. The extent bounds are specified as an array `[[x0, y0], [x1, y1]]`, where `x0` is the left-side of the viewport, `y0` is the top, `x1` is the right and `y1` is the bottom. If `null`, no viewport clipping is performed.",
+          "items": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "coefficient": {
+          "type": "number"
+        },
+        "distance": {
+          "type": "number"
+        },
+        "fraction": {
+          "type": "number"
+        },
+        "lobes": {
+          "type": "number"
+        },
+        "parallel": {
+          "type": "number"
+        },
+        "precision": {
+          "description": "Sets the threshold for the projection’s [adaptive resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels. This value corresponds to the [Douglas–Peucker distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm). If precision is not specified, returns the projection’s current resampling precision which defaults to `√0.5 ≅ 0.70710…`.",
+          "type": "string"
+        },
+        "radius": {
+          "type": "number"
+        },
+        "ratio": {
+          "type": "number"
+        },
+        "rotate": {
+          "description": "Sets the projection’s three-axis rotation to the specified angles, which must be a two- or three-element array of numbers [`lambda`, `phi`, `gamma`] specifying the rotation angles in degrees about each spherical axis. (These correspond to yaw, pitch and roll.)\n\n__Default value:__ `[0, 0, 0]`",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "spacing": {
+          "type": "number"
+        },
+        "tilt": {
+          "type": "number"
+        },
+        "type": {
+          "$ref": "#/definitions/ProjectionType",
+          "description": "The cartographic projection to use. This value is case-insensitive, for example `\"albers\"` and `\"Albers\"` indicate the same projection type. You can find all valid projection types [in the documentation](https://vega.github.io/vega-lite/docs/projection.html#projection-types).\n\n__Default value:__ `mercator`"
+        }
+      },
+      "type": "object"
+    },
+    "ProjectionConfig": {
+      "$ref": "#/definitions/Projection",
+      "description": "Any property of Projection can be in config"
+    },
+    "ProjectionType": {
+      "$ref": "#/definitions/VgProjectionType"
+    },
+    "RangeConfig": {
+      "additionalProperties": {
+        "$ref": "#/definitions/RangeConfigValue"
+      },
+      "properties": {
+        "category": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/VgScheme"
+            }
+          ],
+          "description": "Default range for _nominal_ (categorical) fields."
+        },
+        "diverging": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/VgScheme"
+            }
+          ],
+          "description": "Default range for diverging _quantitative_ fields."
+        },
+        "heatmap": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/VgScheme"
+            }
+          ],
+          "description": "Default range for _quantitative_ heatmaps."
+        },
+        "ordinal": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/VgScheme"
+            }
+          ],
+          "description": "Default range for _ordinal_ fields."
+        },
+        "ramp": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/VgScheme"
+            }
+          ],
+          "description": "Default range for _quantitative_ and _temporal_ fields."
+        },
+        "symbol": {
+          "description": "Default range palette for the `shape` channel.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "RangeConfigValue": {
+      "anyOf": [
+        {
+          "items": {
+            "type": [
+              "number",
+              "string"
+            ]
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/definitions/VgScheme"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "step": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "step"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Repeat": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "description": "Horizontal repeated views.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "row": {
+          "description": "Vertical repeated views.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "RepeatRef": {
+      "additionalProperties": false,
+      "description": "Reference to a repeated value.",
+      "properties": {
+        "repeat": {
+          "enum": [
+            "row",
+            "column"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "repeat"
+      ],
+      "type": "object"
+    },
+    "Resolve": {
+      "additionalProperties": false,
+      "description": "Defines how scales, axes, and legends from different specs should be combined. Resolve is a mapping from `scale`, `axis`, and `legend` to a mapping from channels to resolutions.",
+      "properties": {
+        "axis": {
+          "$ref": "#/definitions/AxisResolveMap"
+        },
+        "legend": {
+          "$ref": "#/definitions/LegendResolveMap"
+        },
+        "scale": {
+          "$ref": "#/definitions/ScaleResolveMap"
+        }
+      },
+      "type": "object"
+    },
+    "ResolveMode": {
+      "enum": [
+        "independent",
+        "shared"
+      ],
+      "type": "string"
+    },
+    "RowCol<VgLayoutAlign>": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "$ref": "#/definitions/VgLayoutAlign"
+        },
+        "row": {
+          "$ref": "#/definitions/VgLayoutAlign"
+        }
+      },
+      "type": "object"
+    },
+    "RowCol<boolean>": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "type": "boolean"
+        },
+        "row": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "RowCol<number>": {
+      "additionalProperties": false,
+      "properties": {
+        "column": {
+          "type": "number"
+        },
+        "row": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "SampleTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "sample": {
+          "description": "The maximum number of data objects to include in the sample.\n\n__Default value:__ `1000`",
+          "type": "number"
+        }
+      },
+      "required": [
+        "sample"
+      ],
+      "type": "object"
+    },
+    "Scale": {
+      "additionalProperties": false,
+      "properties": {
+        "base": {
+          "description": "The logarithm base of the `log` scale (default `10`).",
+          "type": "number"
+        },
+        "clamp": {
+          "description": "If `true`, values that exceed the data domain are clamped to either the minimum or maximum range value\n\n__Default value:__ derived from the [scale config](https://vega.github.io/vega-lite/docs/config.html#scale-config)'s `clamp` (`true` by default).",
+          "type": "boolean"
+        },
+        "domain": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "type": "boolean"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/DateTime"
+              },
+              "type": "array"
+            },
+            {
+              "enum": [
+                "unaggregated"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/SelectionDomain"
+            }
+          ],
+          "description": "Customized domain values.\n\nFor _quantitative_ fields, `domain` can take the form of a two-element array with minimum and maximum values.  [Piecewise scales](https://vega.github.io/vega-lite/docs/scale.html#piecewise) can be created by providing a `domain` with more than two entries.\nIf the input field is aggregated, `domain` can also be a string value `\"unaggregated\"`, indicating that the domain should include the raw data values prior to the aggregation.\n\nFor _temporal_ fields, `domain` can be a two-element array minimum and maximum values, in the form of either timestamps or the [DateTime definition objects](https://vega.github.io/vega-lite/docs/types.html#datetime).\n\nFor _ordinal_ and _nominal_ fields, `domain` can be an array that lists valid input values.\n\nThe `selection` property can be used to [interactively determine](https://vega.github.io/vega-lite/docs/selection.html#scale-domains) the scale domain."
+        },
+        "exponent": {
+          "description": "The exponent of the `pow` scale.",
+          "type": "number"
+        },
+        "interpolate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScaleInterpolate"
+            },
+            {
+              "$ref": "#/definitions/ScaleInterpolateParams"
+            }
+          ],
+          "description": "The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include `rgb`, `hsl`, `hsl-long`, `lab`, `hcl`, `hcl-long`, `cubehelix` and `cubehelix-long` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued _type_ property and an optional numeric _gamma_ property applicable to rgb and cubehelix interpolators. For more, see the [d3-interpolate documentation](https://github.com/d3/d3-interpolate).\n\n* __Default value:__ `hcl`\n\n__Note:__ Sequential scales do not support `interpolate` as they have a fixed interpolator.  Since Vega-Lite uses sequential scales for quantitative fields by default, you have to set the scale `type` to other quantitative scale type such as `\"linear\"` to customize `interpolate`."
+        },
+        "nice": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/NiceTime"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "interval": {
+                  "type": "string"
+                },
+                "step": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "interval",
+                "step"
+              ],
+              "type": "object"
+            }
+          ],
+          "description": "Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain might be _[0.2, 1.0]_.\n\nFor quantitative scales such as linear, `nice` can be either a boolean flag or a number. If `nice` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain.\n\nFor temporal fields with time and utc scales, the `nice` value can be a string indicating the desired time interval. Legal values are `\"millisecond\"`, `\"second\"`, `\"minute\"`, `\"hour\"`, `\"day\"`, `\"week\"`, `\"month\"`, and `\"year\"`. Alternatively, `time` and `utc` scales can accept an object-valued interval specifier of the form `{\"interval\": \"month\", \"step\": 3}`, which includes a desired number of interval steps. Here, the domain would snap to quarter (Jan, Apr, Jul, Oct) boundaries.\n\n__Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise."
+        },
+        "padding": {
+          "description": "For _[continuous](https://vega.github.io/vega-lite/docs/scale.html#continuous)_ scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the zero, nice, domainMin, and domainMax properties.\n\nFor _[band](https://vega.github.io/vega-lite/docs/scale.html#band)_ scales, shortcut for setting `paddingInner` and `paddingOuter` to the same value.\n\nFor _[point](https://vega.github.io/vega-lite/docs/scale.html#point)_ scales, alias for `paddingOuter`.\n\n__Default value:__ For _continuous_ scales, derived from the [scale config](https://vega.github.io/vega-lite/docs/scale.html#config)'s `continuousPadding`.\nFor _band and point_ scales, see `paddingInner` and `paddingOuter`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "paddingInner": {
+          "description": "The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1].\n\nFor point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands).\n\n__Default value:__ derived from the [scale config](https://vega.github.io/vega-lite/docs/scale.html#config)'s `bandPaddingInner`.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "paddingOuter": {
+          "description": "The outer padding (spacing) at the ends of the range of band and point scales,\nas a fraction of the step size. This value must lie in the range [0,1].\n\n__Default value:__ derived from the [scale config](https://vega.github.io/vega-lite/docs/scale.html#config)'s `bandPaddingOuter` for band scales and `pointPadding` for point scales.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "range": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "The range of the scale. One of:\n\n- A string indicating a [pre-defined named scale range](https://vega.github.io/vega-lite/docs/scale.html#range-config) (e.g., example, `\"symbol\"`, or `\"diverging\"`).\n\n- For [continuous scales](https://vega.github.io/vega-lite/docs/scale.html#continuous), two-element array indicating  minimum and maximum values, or an array with more than two entries for specifying a [piecewise scale](https://vega.github.io/vega-lite/docs/scale.html#piecewise).\n\n- For [discrete](https://vega.github.io/vega-lite/docs/scale.html#discrete) and [discretizing](https://vega.github.io/vega-lite/docs/scale.html#discretizing) scales, an array of desired output values.\n\n__Notes:__\n\n1) For [sequential](https://vega.github.io/vega-lite/docs/scale.html#sequential), [ordinal](https://vega.github.io/vega-lite/docs/scale.html#ordinal), and discretizing color scales, you can also specify a color [`scheme`](https://vega.github.io/vega-lite/docs/scale.html#scheme) instead of `range`.\n\n2) Any directly specified `range` for `x` and `y` channels will be ignored. Range can be customized via the view's corresponding [size](https://vega.github.io/vega-lite/docs/size.html) (`width` and `height`) or via [range steps and paddings properties](#range-step) for [band](#band) and [point](#point) scales."
+        },
+        "rangeStep": {
+          "description": "The distance between the starts of adjacent bands or points in [band](https://vega.github.io/vega-lite/docs/scale.html#band) and [point](https://vega.github.io/vega-lite/docs/scale.html#point) scales.\n\nIf `rangeStep` is `null` or if the view contains the scale's corresponding [size](https://vega.github.io/vega-lite/docs/size.html) (`width` for `x` scales and `height` for `y` scales), `rangeStep` will be automatically determined to fit the size of the view.\n\n__Default value:__  derived the [scale config](https://vega.github.io/vega-lite/docs/config.html#scale-config)'s `textXRangeStep` (`90` by default) for x-scales of `text` marks and `rangeStep` (`21` by default) for x-scales of other marks and y-scales.\n\n__Warning__: If `rangeStep` is `null` and the cardinality of the scale's domain is higher than `width` or `height`, the rangeStep might become less than one pixel and the mark might not appear correctly.",
+          "minimum": 0,
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "round": {
+          "description": "If `true`, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid.\n\n__Default value:__ `false`.",
+          "type": "boolean"
+        },
+        "scheme": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/SchemeParams"
+            }
+          ],
+          "description": "A string indicating a color [scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme) name (e.g., `\"category10\"` or `\"viridis\"`) or a [scheme parameter object](https://vega.github.io/vega-lite/docs/scale.html#scheme-params).\n\nDiscrete color schemes may be used with [discrete](https://vega.github.io/vega-lite/docs/scale.html#discrete) or [discretizing](https://vega.github.io/vega-lite/docs/scale.html#discretizing) scales. Continuous color schemes are intended for use with [sequential](https://vega.github.io/vega-lite/docs/scales.html#sequential) scales.\n\nFor the full list of supported schemes, please refer to the [Vega Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference."
+        },
+        "type": {
+          "$ref": "#/definitions/ScaleType",
+          "description": "The type of scale.  Vega-Lite supports the following categories of scale types:\n\n1) [**Continuous Scales**](https://vega.github.io/vega-lite/docs/scale.html#continuous) -- mapping continuous domains to continuous output ranges ([`\"linear\"`](https://vega.github.io/vega-lite/docs/scale.html#linear), [`\"pow\"`](https://vega.github.io/vega-lite/docs/scale.html#pow), [`\"sqrt\"`](https://vega.github.io/vega-lite/docs/scale.html#sqrt), [`\"log\"`](https://vega.github.io/vega-lite/docs/scale.html#log), [`\"time\"`](https://vega.github.io/vega-lite/docs/scale.html#time), [`\"utc\"`](https://vega.github.io/vega-lite/docs/scale.html#utc), [`\"sequential\"`](https://vega.github.io/vega-lite/docs/scale.html#sequential)).\n\n2) [**Discrete Scales**](https://vega.github.io/vega-lite/docs/scale.html#discrete) -- mapping discrete domains to discrete ([`\"ordinal\"`](https://vega.github.io/vega-lite/docs/scale.html#ordinal)) or continuous ([`\"band\"`](https://vega.github.io/vega-lite/docs/scale.html#band) and [`\"point\"`](https://vega.github.io/vega-lite/docs/scale.html#point)) output ranges.\n\n3) [**Discretizing Scales**](https://vega.github.io/vega-lite/docs/scale.html#discretizing) -- mapping continuous domains to discrete output ranges ([`\"bin-linear\"`](https://vega.github.io/vega-lite/docs/scale.html#bin-linear), [`\"bin-ordinal\"`](https://vega.github.io/vega-lite/docs/scale.html#bin-ordinal), [`\"quantile\"`](https://vega.github.io/vega-lite/docs/scale.html#quantile), [`\"quantize\"`](https://vega.github.io/vega-lite/docs/scale.html#quantize) and [`\"threshold\"`](https://vega.github.io/vega-lite/docs/scale.html#threshold).\n\n__Default value:__ please see the [scale type table](https://vega.github.io/vega-lite/docs/scale.html#type)."
+        },
+        "zero": {
+          "description": "If `true`, ensures that a zero baseline value is included in the scale domain.\n\n__Default value:__ `true` for x and y channels if the quantitative field is not binned and no custom `domain` is provided; `false` otherwise.\n\n__Note:__ Log, time, and utc scales do not support `zero`.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "ScaleConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "bandPaddingInner": {
+          "description": "Default inner padding for `x` and `y` band-ordinal scales.\n\n__Default value:__ `0.1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "bandPaddingOuter": {
+          "description": "Default outer padding for `x` and `y` band-ordinal scales.\nIf not specified, by default, band scale's paddingOuter is paddingInner/2.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "clamp": {
+          "description": "If true, values that exceed the data domain are clamped to either the minimum or maximum range value",
+          "type": "boolean"
+        },
+        "continuousPadding": {
+          "description": "Default padding for continuous scales.\n\n__Default:__ `5` for continuous x-scale of a vertical bar and continuous y-scale of a horizontal bar.; `0` otherwise.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "maxBandSize": {
+          "description": "The default max value for mapping quantitative fields to bar's size/bandSize.\n\nIf undefined (default), we will use the scale's `rangeStep` - 1.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "maxFontSize": {
+          "description": "The default max value for mapping quantitative fields to text's size/fontSize.\n\n__Default value:__ `40`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "maxOpacity": {
+          "description": "Default max opacity for mapping a field to opacity.\n\n__Default value:__ `0.8`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "maxSize": {
+          "description": "Default max value for point size scale.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "maxStrokeWidth": {
+          "description": "Default max strokeWidth for the scale of strokeWidth for rule and line marks and of size for trail marks.\n\n__Default value:__ `4`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "minBandSize": {
+          "description": "The default min value for mapping quantitative fields to bar and tick's size/bandSize scale with zero=false.\n\n__Default value:__ `2`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "minFontSize": {
+          "description": "The default min value for mapping quantitative fields to tick's size/fontSize scale with zero=false\n\n__Default value:__ `8`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "minOpacity": {
+          "description": "Default minimum opacity for mapping a field to opacity.\n\n__Default value:__ `0.3`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "minSize": {
+          "description": "Default minimum value for point size scale with zero=false.\n\n__Default value:__ `9`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "minStrokeWidth": {
+          "description": "Default minimum strokeWidth for the scale of strokeWidth for rule and line marks and of size for trail marks with zero=false.\n\n__Default value:__ `1`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "pointPadding": {
+          "description": "Default outer padding for `x` and `y` point-ordinal scales.\n\n__Default value:__ `0.5`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "quantileCount": {
+          "description": "Default range cardinality for [`quantile`](https://vega.github.io/vega-lite/docs/scale.html#quantile) scale.\n\n__Default value:__ `4`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "quantizeCount": {
+          "description": "Default range cardinality for [`quantize`](https://vega.github.io/vega-lite/docs/scale.html#quantize) scale.\n\n__Default value:__ `4`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "rangeStep": {
+          "description": "Default range step for band and point scales of (1) the `y` channel\nand (2) the `x` channel when the mark is not `text`.\n\n__Default value:__ `21`",
+          "minimum": 0,
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "round": {
+          "description": "If true, rounds numeric output values to integers.\nThis can be helpful for snapping to the pixel grid.\n(Only available for `x`, `y`, and `size` scales.)",
+          "type": "boolean"
+        },
+        "textXRangeStep": {
+          "description": "Default range step for `x` band and point scales of text marks.\n\n__Default value:__ `90`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "useUnaggregatedDomain": {
+          "description": "Use the source data range before aggregation as scale domain instead of aggregated data for aggregate axis.\n\nThis is equivalent to setting `domain` to `\"unaggregate\"` for aggregated _quantitative_ fields by default.\n\nThis property only works with aggregate functions that produce values within the raw data domain (`\"mean\"`, `\"average\"`, `\"median\"`, `\"q1\"`, `\"q3\"`, `\"min\"`, `\"max\"`). For other aggregations that produce values outside of the raw data domain (e.g. `\"count\"`, `\"sum\"`), this property is ignored.\n\n__Default value:__ `false`",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "ScaleInterpolate": {
+      "enum": [
+        "rgb",
+        "lab",
+        "hcl",
+        "hsl",
+        "hsl-long",
+        "hcl-long",
+        "cubehelix",
+        "cubehelix-long"
+      ],
+      "type": "string"
+    },
+    "ScaleInterpolateParams": {
+      "additionalProperties": false,
+      "properties": {
+        "gamma": {
+          "type": "number"
+        },
+        "type": {
+          "enum": [
+            "rgb",
+            "cubehelix",
+            "cubehelix-long"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "ScaleResolveMap": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "fill": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "opacity": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "shape": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "size": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "stroke": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "x": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "y": {
+          "$ref": "#/definitions/ResolveMode"
+        }
+      },
+      "type": "object"
+    },
+    "ScaleType": {
+      "enum": [
+        "linear",
+        "bin-linear",
+        "log",
+        "pow",
+        "sqrt",
+        "time",
+        "utc",
+        "sequential",
+        "quantile",
+        "quantize",
+        "threshold",
+        "ordinal",
+        "bin-ordinal",
+        "point",
+        "band"
+      ],
+      "type": "string"
+    },
+    "SchemeParams": {
+      "additionalProperties": false,
+      "properties": {
+        "count": {
+          "description": "The number of colors to use in the scheme. This can be useful for scale types such as `\"quantize\"`, which use the length of the scale range to determine the number of discrete bins for the scale domain.",
+          "type": "number"
+        },
+        "extent": {
+          "description": "For sequential and diverging schemes only, determines the extent of the color range to use. For example `[0.2, 1]` will rescale the color scheme such that color values in the range _[0, 0.2)_ are excluded from the scheme.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "A color scheme name for sequential/ordinal scales (e.g., `\"category10\"` or `\"viridis\"`).\n\nFor the full list of supported schemes, please refer to the [Vega Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "SelectionConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "interval": {
+          "$ref": "#/definitions/IntervalSelectionConfig",
+          "description": "The default definition for an [`interval`](https://vega.github.io/vega-lite/docs/selection.html#type) selection. All properties and transformations\nfor an interval selection definition (except `type`) may be specified here.\n\nFor instance, setting `interval` to `{\"translate\": false}` disables the ability to move\ninterval selections by default."
+        },
+        "multi": {
+          "$ref": "#/definitions/MultiSelectionConfig",
+          "description": "The default definition for a [`multi`](https://vega.github.io/vega-lite/docs/selection.html#type) selection. All properties and transformations\nfor a multi selection definition (except `type`) may be specified here.\n\nFor instance, setting `multi` to `{\"toggle\": \"event.altKey\"}` adds additional values to\nmulti selections when clicking with the alt-key pressed by default."
+        },
+        "single": {
+          "$ref": "#/definitions/SingleSelectionConfig",
+          "description": "The default definition for a [`single`](https://vega.github.io/vega-lite/docs/selection.html#type) selection. All properties and transformations\n  for a single selection definition (except `type`) may be specified here.\n\nFor instance, setting `single` to `{\"on\": \"dblclick\"}` populates single selections on double-click by default."
+        }
+      },
+      "type": "object"
+    },
+    "SelectionDef": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SingleSelection"
+        },
+        {
+          "$ref": "#/definitions/MultiSelection"
+        },
+        {
+          "$ref": "#/definitions/IntervalSelection"
+        }
+      ]
+    },
+    "SelectionDomain": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "field": {
+              "description": "The field name to extract selected values for, when a selection is [projected](https://vega.github.io/vega-lite/docs/project.html)\nover multiple fields or encodings.",
+              "type": "string"
+            },
+            "selection": {
+              "description": "The name of a selection.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "selection"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "encoding": {
+              "description": "The encoding channel to extract selected values for, when a selection is [projected](https://vega.github.io/vega-lite/docs/project.html)\nover multiple fields or encodings.",
+              "type": "string"
+            },
+            "selection": {
+              "description": "The name of a selection.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "selection"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "SelectionPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "selection": {
+          "$ref": "#/definitions/SelectionOperand",
+          "description": "Filter using a selection name."
+        }
+      },
+      "required": [
+        "selection"
+      ],
+      "type": "object"
+    },
+    "SelectionResolution": {
+      "enum": [
+        "global",
+        "union",
+        "intersect"
+      ],
+      "type": "string"
+    },
+    "SingleDefChannel": {
+      "enum": [
+        "x",
+        "y",
+        "x2",
+        "y2",
+        "longitude",
+        "latitude",
+        "longitude2",
+        "latitude2",
+        "row",
+        "column",
+        "color",
+        "fill",
+        "stroke",
+        "size",
+        "shape",
+        "opacity",
+        "text",
+        "tooltip",
+        "href",
+        "key"
+      ],
+      "type": "string"
+    },
+    "SingleSelection": {
+      "additionalProperties": false,
+      "properties": {
+        "bind": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VgBinding"
+            },
+            {
+              "additionalProperties": {
+                "$ref": "#/definitions/VgBinding"
+              },
+              "type": "object"
+            }
+          ],
+          "description": "Establish a two-way binding between a single selection and input elements\n(also known as dynamic query widgets). A binding takes the form of\nVega's [input element binding definition](https://vega.github.io/vega/docs/signals/#bind)\nor can be a mapping between projected field/encodings and binding definitions.\n\nSee the [bind transform](https://vega.github.io/vega-lite/docs/bind.html) documentation for more information."
+        },
+        "empty": {
+          "description": "By default, all data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",
+          "enum": [
+            "all",
+            "none"
+          ],
+          "type": "string"
+        },
+        "encodings": {
+          "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nearest": {
+          "description": "When true, an invisible voronoi diagram is computed to accelerate discrete\nselection. The data value _nearest_ the mouse cursor is added to the selection.\n\nSee the [nearest transform](https://vega.github.io/vega-lite/docs/nearest.html) documentation for more information.",
+          "type": "boolean"
+        },
+        "on": {
+          "$ref": "#/definitions/VgEventStream",
+          "description": "A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)."
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolution",
+          "description": "With layered and multi-view displays, a strategy that determines how\nselections' data queries are resolved when applied in a filter transform,\nconditional encoding rule, or scale domain."
+        },
+        "type": {
+          "enum": [
+            "single"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "SingleSelectionConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "bind": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VgBinding"
+            },
+            {
+              "additionalProperties": {
+                "$ref": "#/definitions/VgBinding"
+              },
+              "type": "object"
+            }
+          ],
+          "description": "Establish a two-way binding between a single selection and input elements\n(also known as dynamic query widgets). A binding takes the form of\nVega's [input element binding definition](https://vega.github.io/vega/docs/signals/#bind)\nor can be a mapping between projected field/encodings and binding definitions.\n\nSee the [bind transform](https://vega.github.io/vega-lite/docs/bind.html) documentation for more information."
+        },
+        "empty": {
+          "description": "By default, all data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",
+          "enum": [
+            "all",
+            "none"
+          ],
+          "type": "string"
+        },
+        "encodings": {
+          "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nearest": {
+          "description": "When true, an invisible voronoi diagram is computed to accelerate discrete\nselection. The data value _nearest_ the mouse cursor is added to the selection.\n\nSee the [nearest transform](https://vega.github.io/vega-lite/docs/nearest.html) documentation for more information.",
+          "type": "boolean"
+        },
+        "on": {
+          "$ref": "#/definitions/VgEventStream",
+          "description": "A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)."
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolution",
+          "description": "With layered and multi-view displays, a strategy that determines how\nselections' data queries are resolved when applied in a filter transform,\nconditional encoding rule, or scale domain."
+        }
+      },
+      "type": "object"
+    },
+    "SingleTimeUnit": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LocalSingleTimeUnit"
+        },
+        {
+          "$ref": "#/definitions/UtcSingleTimeUnit"
+        }
+      ]
+    },
+    "Sort": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "boolean"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "$ref": "#/definitions/DateTime"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/definitions/SortOrder"
+        },
+        {
+          "$ref": "#/definitions/EncodingSortField"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "SortField": {
+      "additionalProperties": false,
+      "description": "A sort definition for transform",
+      "properties": {
+        "field": {
+          "description": "The name of the field to sort.",
+          "type": "string"
+        },
+        "order": {
+          "$ref": "#/definitions/VgComparatorOrder",
+          "description": "Whether to sort the field in ascending or descending order."
+        }
+      },
+      "required": [
+        "field"
+      ],
+      "type": "object"
+    },
+    "SortOrder": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/VgComparatorOrder"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "StackOffset": {
+      "enum": [
+        "zero",
+        "center",
+        "normalize"
+      ],
+      "type": "string"
+    },
+    "StackTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Output field names. This can be either a string or an array of strings with\ntwo elements denoting the name for the fields for stack start and stack end\nrespectively.\nIf a single string(eg.\"val\") is provided, the end field will be \"val_end\"."
+        },
+        "groupby": {
+          "description": "The data fields to group by.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "offset": {
+          "description": "Mode for stacking marks.\n__Default value:__ `\"zero\"`",
+          "enum": [
+            "zero",
+            "center",
+            "normalize"
+          ],
+          "type": "string"
+        },
+        "sort": {
+          "description": "Field that determines the order of leaves in the stacked charts.",
+          "items": {
+            "$ref": "#/definitions/SortField"
+          },
+          "type": "array"
+        },
+        "stack": {
+          "description": "The field which is stacked.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "stack",
+        "groupby",
+        "as"
+      ],
+      "type": "object"
+    },
+    "StrokeCap": {
+      "enum": [
+        "butt",
+        "round",
+        "square"
+      ],
+      "type": "string"
+    },
+    "StrokeJoin": {
+      "enum": [
+        "miter",
+        "round",
+        "bevel"
+      ],
+      "type": "string"
+    },
+    "StyleConfigIndex": {
+      "additionalProperties": {
+        "$ref": "#/definitions/VgMarkConfig"
+      },
+      "type": "object"
+    },
+    "SymbolShape": {
+      "type": "string"
+    },
+    "TextBaseline": {
+      "anyOf": [
+        {
+          "enum": [
+            "alphabetic"
+          ],
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/Baseline"
+        }
+      ]
+    },
+    "TextConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/Align",
+          "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
+        },
+        "angle": {
+          "description": "The rotation angle of the text, in degrees.",
+          "maximum": 360,
+          "minimum": 0,
+          "type": "number"
+        },
+        "baseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
+        },
+        "color": {
+          "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "string"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners.\n\n__Default value:__ `0`",
+          "type": "number"
+        },
+        "cursor": {
+          "$ref": "#/definitions/Cursor",
+          "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
+        },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of `\"ltr\"` (left-to-right) or `\"rtl\"` (right-to-left). This property determines on which side is truncated in response to the limit parameter.\n\n__Default value:__ `\"ltr\"`"
+        },
+        "dx": {
+          "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "dy": {
+          "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter.\n\n__Default value:__ `\"…\"`",
+          "type": "string"
+        },
+        "fill": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "filled": {
+          "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "boolean"
+        },
+        "font": {
+          "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "fontSize": {
+          "description": "The font size, in pixels.",
+          "type": "number"
+        },
+        "fontStyle": {
+          "$ref": "#/definitions/FontStyle",
+          "description": "The font style (e.g., `\"italic\"`)."
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "href": {
+          "description": "A URL to load upon mouse click. If defined, the mark acts as a hyperlink.",
+          "format": "uri",
+          "type": "string"
+        },
+        "interpolate": {
+          "$ref": "#/definitions/Interpolate",
+          "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "opacity": {
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
+        },
+        "radius": {
+          "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "shape": {
+          "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
+          "type": "string"
+        },
+        "shortTimeLabels": {
+          "description": "Whether month names and weekday names should be abbreviated.",
+          "type": "boolean"
+        },
+        "size": {
+          "description": "Default size for marks.\n- For `point`/`circle`/`square`, this represents the pixel area of the marks. For example: in the case of circles, the radius is determined in part by the square root of the size value.\n- For `bar`, this represents the band size of the bar, in pixels.\n- For `text`, this represents the font size, in pixels.\n\n__Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text marks.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "stroke": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Stroke Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "strokeCap": {
+          "$ref": "#/definitions/StrokeCap",
+          "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"square\"`"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tension": {
+          "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "text": {
+          "description": "Placeholder text if the `text` channel is not specified",
+          "type": "string"
+        },
+        "theta": {
+          "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
+          "type": "number"
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TooltipContent"
+            }
+          ],
+          "description": "The tooltip text string to show upon mouse hover or an object defining which fields should the tooltip be derived from.\n\n- If `tooltip` is `{\"content\": \"encoding\"}`, then all fields from `encoding` will be used.\n- If `tooltip` is `{\"content\": \"data\"}`, then all fields that appear in the highlighted data point will be used."
+        }
+      },
+      "type": "object"
+    },
+    "TextFieldDef": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- To indicate that the data for the `x` (or `y`) channel are already binned, you can set the `bin` property of the `x` (or `y`) channel to `\"binned\"` and map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "format": {
+          "description": "The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a text field. If not defined, this will be determined automatically.",
+          "type": "string"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        },
+        "title": {
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle` property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html)."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "TickConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/Align",
+          "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
+        },
+        "angle": {
+          "description": "The rotation angle of the text, in degrees.",
+          "maximum": 360,
+          "minimum": 0,
+          "type": "number"
+        },
+        "bandSize": {
+          "description": "The width of the ticks.\n\n__Default value:__  2/3 of rangeStep.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "baseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
+        },
+        "color": {
+          "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "string"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners.\n\n__Default value:__ `0`",
+          "type": "number"
+        },
+        "cursor": {
+          "$ref": "#/definitions/Cursor",
+          "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
+        },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of `\"ltr\"` (left-to-right) or `\"rtl\"` (right-to-left). This property determines on which side is truncated in response to the limit parameter.\n\n__Default value:__ `\"ltr\"`"
+        },
+        "dx": {
+          "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "dy": {
+          "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter.\n\n__Default value:__ `\"…\"`",
+          "type": "string"
+        },
+        "fill": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "filled": {
+          "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
+          "type": "boolean"
+        },
+        "font": {
+          "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "fontSize": {
+          "description": "The font size, in pixels.",
+          "type": "number"
+        },
+        "fontStyle": {
+          "$ref": "#/definitions/FontStyle",
+          "description": "The font style (e.g., `\"italic\"`)."
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "href": {
+          "description": "A URL to load upon mouse click. If defined, the mark acts as a hyperlink.",
+          "format": "uri",
+          "type": "string"
+        },
+        "interpolate": {
+          "$ref": "#/definitions/Interpolate",
+          "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "opacity": {
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
+        },
+        "radius": {
+          "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "shape": {
+          "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
+          "type": "string"
+        },
+        "size": {
+          "description": "Default size for marks.\n- For `point`/`circle`/`square`, this represents the pixel area of the marks. For example: in the case of circles, the radius is determined in part by the square root of the size value.\n- For `bar`, this represents the band size of the bar, in pixels.\n- For `text`, this represents the font size, in pixels.\n\n__Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text marks.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "stroke": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Stroke Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "strokeCap": {
+          "$ref": "#/definitions/StrokeCap",
+          "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"square\"`"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tension": {
+          "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "text": {
+          "description": "Placeholder text if the `text` channel is not specified",
+          "type": "string"
+        },
+        "theta": {
+          "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
+          "type": "number"
+        },
+        "thickness": {
+          "description": "Thickness of the tick mark.\n\n__Default value:__  `1`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TooltipContent"
+            }
+          ],
+          "description": "The tooltip text string to show upon mouse hover or an object defining which fields should the tooltip be derived from.\n\n- If `tooltip` is `{\"content\": \"encoding\"}`, then all fields from `encoding` will be used.\n- If `tooltip` is `{\"content\": \"data\"}`, then all fields that appear in the highlighted data point will be used."
+        }
+      },
+      "type": "object"
+    },
+    "TimeUnit": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SingleTimeUnit"
+        },
+        {
+          "$ref": "#/definitions/MultiTimeUnit"
+        }
+      ]
+    },
+    "TimeUnitTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "description": "The output field to write the timeUnit value.",
+          "type": "string"
+        },
+        "field": {
+          "description": "The data field to apply time unit.",
+          "type": "string"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "The timeUnit."
+        }
+      },
+      "required": [
+        "timeUnit",
+        "field",
+        "as"
+      ],
+      "type": "object"
+    },
+    "TitleAnchor": {
+      "enum": [
+        "start",
+        "middle",
+        "end"
+      ],
+      "type": "string"
+    },
+    "TitleConfig": {
+      "$ref": "#/definitions/VgTitleConfig"
+    },
+    "TitleFrame": {
+      "enum": [
+        "bounds",
+        "group"
+      ],
+      "type": "string"
+    },
+    "TitleOrient": {
+      "enum": [
+        "none",
+        "left",
+        "right",
+        "top",
+        "bottom"
+      ],
+      "type": "string"
+    },
+    "TitleParams": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/Align"
+        },
+        "anchor": {
+          "$ref": "#/definitions/TitleAnchor",
+          "description": "The anchor position for placing the title. One of `\"start\"`, `\"middle\"`, or `\"end\"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title.\n\n__Default value:__ `\"middle\"` for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.\n`\"start\"` for other composite views.\n\n__Note:__ [For now](https://github.com/vega/vega-lite/issues/2875), `anchor` is only customizable only for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.  For other composite views, `anchor` is always `\"start\"`."
+        },
+        "angle": {
+          "description": "Angle in degrees of title text.",
+          "type": "number"
+        },
+        "baseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "Vertical text baseline for title text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
+        },
+        "color": {
+          "$ref": "#/definitions/Color",
+          "description": "Text color for title text."
+        },
+        "font": {
+          "description": "Font name for title text.",
+          "type": "string"
+        },
+        "fontSize": {
+          "description": "Font size in pixels for title text.\n\n__Default value:__ `10`.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "Font weight for title text.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "frame": {
+          "$ref": "#/definitions/TitleFrame",
+          "description": "The reference frame for the anchor position, one of `\"bounds\"` (to anchor relative to the full bounding box) or `\"group\"` (to anchor relative to the group width or height)."
+        },
+        "limit": {
+          "description": "The maximum allowed length in pixels of legend labels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "offset": {
+          "description": "The orthogonal offset in pixels by which to displace the title from its position along the edge of the chart.",
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/TitleOrient",
+          "description": "Default title orientation (`\"top\"`, `\"bottom\"`, `\"left\"`, or `\"right\"`)"
+        },
+        "style": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "A [mark style property](https://vega.github.io/vega-lite/docs/config.html#style) to apply to the title text mark.\n\n__Default value:__ `\"group-title\"`."
+        },
+        "text": {
+          "description": "The title text.",
+          "type": "string"
+        },
+        "zindex": {
+          "description": "The integer z-index indicating the layering of the title group relative to other axis, mark and legend groups.\n\n__Default value:__ `0`.",
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "type": "object"
+    },
+    "TooltipContent": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "enum": [
+            "encoding",
+            "data"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "type": "object"
+    },
+    "TopLevelLayerSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
+          "format": "uri",
+          "type": "string"
+        },
+        "autosize": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AutosizeType"
+            },
+            {
+              "$ref": "#/definitions/AutoSizeParams"
+            }
+          ],
+          "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
+        },
+        "background": {
+          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "type": "string"
+        },
+        "config": {
+          "$ref": "#/definitions/Config",
+          "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
+        },
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "datasets": {
+          "$ref": "#/definitions/Datasets",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "$ref": "#/definitions/Encoding",
+          "description": "A shared key-value mapping between encoding channels and definition of fields in the underlying layers."
+        },
+        "height": {
+          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        },
+        "layer": {
+          "description": "Layer or single view specifications to be layered.\n\n__Note__: Specifications inside `layer` cannot use `row` and `column` channels as layering facet specifications is not allowed. Instead, use the [facet operator](https://vega.github.io/vega-lite/docs/facet.html) and place a layer inside a facet.",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LayerSpec"
+              },
+              {
+                "$ref": "#/definitions/CompositeUnitSpec"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "padding": {
+          "$ref": "#/definitions/Padding",
+          "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of the geographic projection shared by underlying layers."
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale, axis, and legend resolutions for layers."
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "usermeta": {
+          "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
+          "type": "object"
+        },
+        "width": {
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "layer"
+      ],
+      "type": "object"
+    },
+    "TopLevelHConcatSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
+          "format": "uri",
+          "type": "string"
+        },
+        "autosize": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AutosizeType"
+            },
+            {
+              "$ref": "#/definitions/AutoSizeParams"
+            }
+          ],
+          "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
+        },
+        "background": {
+          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "type": "string"
+        },
+        "bounds": {
+          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used.\n- If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
+          "enum": [
+            "full",
+            "flush"
+          ],
+          "type": "string"
+        },
+        "center": {
+          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\n__Default value:__ `false`",
+          "type": "boolean"
+        },
+        "config": {
+          "$ref": "#/definitions/Config",
+          "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
+        },
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "datasets": {
+          "$ref": "#/definitions/Datasets",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "hconcat": {
+          "description": "A list of views that should be concatenated and put into a row.",
+          "items": {
+            "$ref": "#/definitions/Spec"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "padding": {
+          "$ref": "#/definitions/Padding",
+          "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale, axis, and legend resolutions for horizontally concatenated charts."
+        },
+        "spacing": {
+          "description": "The spacing in pixels between sub-views of the concat operator.\n\n__Default value__: `10`",
+          "type": "number"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "usermeta": {
+          "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "hconcat"
+      ],
+      "type": "object"
+    },
+    "TopLevelRepeatSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
+          "format": "uri",
+          "type": "string"
+        },
+        "align": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VgLayoutAlign"
+            },
+            {
+              "$ref": "#/definitions/RowCol<VgLayoutAlign>"
+            }
+          ],
+          "description": "The alignment to apply to grid rows and columns.\nThe supported string values are `\"all\"`, `\"each\"`, and `\"none\"`.\n\n- For `\"none\"`, a flow layout will be used, in which adjacent subviews are simply placed one after the other.\n- For `\"each\"`, subviews will be aligned into a clean grid structure, but each row or column may be of variable size.\n- For `\"all\"`, subviews will be aligned and each row or column will be sized identically based on the maximum observed size. String values for this property will be applied to both grid rows and columns.\n\nAlternatively, an object value of the form `{\"row\": string, \"column\": string}` can be used to supply different alignments for rows and columns.\n\n__Default value:__ `\"all\"`."
+        },
+        "autosize": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AutosizeType"
+            },
+            {
+              "$ref": "#/definitions/AutoSizeParams"
+            }
+          ],
+          "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
+        },
+        "background": {
+          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "type": "string"
+        },
+        "bounds": {
+          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used.\n- If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
+          "enum": [
+            "full",
+            "flush"
+          ],
+          "type": "string"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/RowCol<boolean>"
+            }
+          ],
+          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\nAn object value of the form `{\"row\": boolean, \"column\": boolean}` can be used to supply different centering values for rows and columns.\n\n__Default value:__ `false`"
+        },
+        "config": {
+          "$ref": "#/definitions/Config",
+          "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
+        },
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "datasets": {
+          "$ref": "#/definitions/Datasets",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "padding": {
+          "$ref": "#/definitions/Padding",
+          "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
+        },
+        "repeat": {
+          "$ref": "#/definitions/Repeat",
+          "description": "An object that describes what fields should be repeated into views that are laid out as a `row` or `column`."
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale and legend resolutions for repeated charts."
+        },
+        "spacing": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/RowCol<number>"
+            }
+          ],
+          "description": "The spacing in pixels between sub-views of the composition operator.\nAn object of the form `{\"row\": number, \"column\": number}` can be used to set\ndifferent spacing values for rows and columns.\n\n__Default value__: `10`"
+        },
+        "spec": {
+          "$ref": "#/definitions/Spec"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "usermeta": {
+          "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "repeat",
+        "spec"
+      ],
+      "type": "object"
+    },
+    "TopLevelVConcatSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
+          "format": "uri",
+          "type": "string"
+        },
+        "autosize": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AutosizeType"
+            },
+            {
+              "$ref": "#/definitions/AutoSizeParams"
+            }
+          ],
+          "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
+        },
+        "background": {
+          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "type": "string"
+        },
+        "bounds": {
+          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used.\n- If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
+          "enum": [
+            "full",
+            "flush"
+          ],
+          "type": "string"
+        },
+        "center": {
+          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\n__Default value:__ `false`",
+          "type": "boolean"
+        },
+        "config": {
+          "$ref": "#/definitions/Config",
+          "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
+        },
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "datasets": {
+          "$ref": "#/definitions/Datasets",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "padding": {
+          "$ref": "#/definitions/Padding",
+          "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale, axis, and legend resolutions for vertically concatenated charts."
+        },
+        "spacing": {
+          "description": "The spacing in pixels between sub-views of the concat operator.\n\n__Default value__: `10`",
+          "type": "number"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "usermeta": {
+          "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
+          "type": "object"
+        },
+        "vconcat": {
+          "description": "A list of views that should be concatenated and put into a column.",
+          "items": {
+            "$ref": "#/definitions/Spec"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "vconcat"
+      ],
+      "type": "object"
+    },
+    "TopLevelFacetSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
+          "format": "uri",
+          "type": "string"
+        },
+        "align": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VgLayoutAlign"
+            },
+            {
+              "$ref": "#/definitions/RowCol<VgLayoutAlign>"
+            }
+          ],
+          "description": "The alignment to apply to grid rows and columns.\nThe supported string values are `\"all\"`, `\"each\"`, and `\"none\"`.\n\n- For `\"none\"`, a flow layout will be used, in which adjacent subviews are simply placed one after the other.\n- For `\"each\"`, subviews will be aligned into a clean grid structure, but each row or column may be of variable size.\n- For `\"all\"`, subviews will be aligned and each row or column will be sized identically based on the maximum observed size. String values for this property will be applied to both grid rows and columns.\n\nAlternatively, an object value of the form `{\"row\": string, \"column\": string}` can be used to supply different alignments for rows and columns.\n\n__Default value:__ `\"all\"`."
+        },
+        "autosize": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AutosizeType"
+            },
+            {
+              "$ref": "#/definitions/AutoSizeParams"
+            }
+          ],
+          "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
+        },
+        "background": {
+          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "type": "string"
+        },
+        "bounds": {
+          "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used.\n- If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
+          "enum": [
+            "full",
+            "flush"
+          ],
+          "type": "string"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/RowCol<boolean>"
+            }
+          ],
+          "description": "Boolean flag indicating if subviews should be centered relative to their respective rows or columns.\n\nAn object value of the form `{\"row\": boolean, \"column\": boolean}` can be used to supply different centering values for rows and columns.\n\n__Default value:__ `false`"
+        },
+        "config": {
+          "$ref": "#/definitions/Config",
+          "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
+        },
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "datasets": {
+          "$ref": "#/definitions/Datasets",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "facet": {
+          "$ref": "#/definitions/FacetMapping",
+          "description": "An object that describes mappings between `row` and `column` channels and their field definitions."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "padding": {
+          "$ref": "#/definitions/Padding",
+          "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
+        },
+        "resolve": {
+          "$ref": "#/definitions/Resolve",
+          "description": "Scale, axis, and legend resolutions for facets."
+        },
+        "spacing": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/RowCol<number>"
+            }
+          ],
+          "description": "The spacing in pixels between sub-views of the composition operator.\nAn object of the form `{\"row\": number, \"column\": number}` can be used to set\ndifferent spacing values for rows and columns.\n\n__Default value__: `10`"
+        },
+        "spec": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LayerSpec"
+            },
+            {
+              "$ref": "#/definitions/FacetedUnitSpec"
+            }
+          ],
+          "description": "A specification of the view that gets faceted."
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "usermeta": {
+          "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "data",
+        "facet",
+        "spec"
+      ],
+      "type": "object"
+    },
+    "TopLevelFacetedUnitSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
+          "format": "uri",
+          "type": "string"
+        },
+        "autosize": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AutosizeType"
+            },
+            {
+              "$ref": "#/definitions/AutoSizeParams"
+            }
+          ],
+          "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
+        },
+        "background": {
+          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "type": "string"
+        },
+        "config": {
+          "$ref": "#/definitions/Config",
+          "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
+        },
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "datasets": {
+          "$ref": "#/definitions/Datasets",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "$ref": "#/definitions/EncodingWithFacet",
+          "description": "A key-value mapping between encoding channels and definition of fields."
+        },
+        "height": {
+          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        },
+        "mark": {
+          "$ref": "#/definitions/AnyMark",
+          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "padding": {
+          "$ref": "#/definitions/Padding",
+          "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+        },
+        "selection": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectionDef"
+          },
+          "description": "A key-value mapping between selection names and definitions.",
+          "type": "object"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "usermeta": {
+          "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
+          "type": "object"
+        },
+        "width": {
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "data",
+        "mark"
+      ],
+      "type": "object"
+    },
+    "TopLevelSpec": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TopLevelFacetedUnitSpec"
+        },
+        {
+          "$ref": "#/definitions/TopLevelFacetSpec"
+        },
+        {
+          "$ref": "#/definitions/TopLevelLayerSpec"
+        },
+        {
+          "$ref": "#/definitions/TopLevelRepeatSpec"
+        },
+        {
+          "$ref": "#/definitions/TopLevelVConcatSpec"
+        },
+        {
+          "$ref": "#/definitions/TopLevelHConcatSpec"
+        }
+      ]
+    },
+    "TopoDataFormat": {
+      "additionalProperties": false,
+      "properties": {
+        "feature": {
+          "description": "The name of the TopoJSON object set to convert to a GeoJSON feature collection.\nFor example, in a map of the world, there may be an object set named `\"countries\"`.\nUsing the feature property, we can extract this set and generate a GeoJSON feature object for each country.",
+          "type": "string"
+        },
+        "mesh": {
+          "description": "The name of the TopoJSON object set to convert to mesh.\nSimilar to the `feature` option, `mesh` extracts a named TopoJSON object set.\n  Unlike the `feature` option, the corresponding geo data is returned as a single, unified mesh instance, not as individual GeoJSON features.\nExtracting a mesh is useful for more efficiently drawing borders or other geographic elements that you do not need to associate with specific regions such as individual countries, states or counties.",
+          "type": "string"
+        },
+        "parse": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Parse"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "If set to `null`, disable type inference based on the spec and only use type inference based on the data.\nAlternatively, a parsing directive object can be provided for explicit data types. Each property of the object corresponds to a field name, and the value to the desired data type (one of `\"number\"`, `\"boolean\"`, `\"date\"`, or null (do not parse the field)).\nFor example, `\"parse\": {\"modified_on\": \"date\"}` parses the `modified_on` field in each input record a Date value.\n\nFor `\"date\"`, we parse data based using Javascript's [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).\nFor Specific date formats can be provided (e.g., `{foo: 'date:\"%m%d%Y\"'}`), using the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC date format parsing is supported similarly (e.g., `{foo: 'utc:\"%m%d%Y\"'}`). See more about [UTC time](https://vega.github.io/vega-lite/docs/timeunit.html#utc)"
+        },
+        "type": {
+          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\nThe default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
+          "enum": [
+            "topojson"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Transform": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FilterTransform"
+        },
+        {
+          "$ref": "#/definitions/CalculateTransform"
+        },
+        {
+          "$ref": "#/definitions/LookupTransform"
+        },
+        {
+          "$ref": "#/definitions/BinTransform"
+        },
+        {
+          "$ref": "#/definitions/TimeUnitTransform"
+        },
+        {
+          "$ref": "#/definitions/ImputeTransform"
+        },
+        {
+          "$ref": "#/definitions/AggregateTransform"
+        },
+        {
+          "$ref": "#/definitions/WindowTransform"
+        },
+        {
+          "$ref": "#/definitions/StackTransform"
+        },
+        {
+          "$ref": "#/definitions/FlattenTransform"
+        },
+        {
+          "$ref": "#/definitions/FoldTransform"
+        },
+        {
+          "$ref": "#/definitions/SampleTransform"
+        }
+      ]
+    },
+    "Type": {
+      "description": "Constants and utilities for data type \n Data type based on level of measurement",
+      "enum": [
+        "quantitative",
+        "ordinal",
+        "temporal",
+        "nominal",
+        "geojson"
+      ],
+      "type": "string"
+    },
+    "UrlData": {
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "$ref": "#/definitions/DataFormat",
+          "description": "An object that specifies the format for parsing the data."
+        },
+        "name": {
+          "description": "Provide a placeholder name and bind data at runtime.",
+          "type": "string"
+        },
+        "url": {
+          "description": "An URL from which to load the data set. Use the `format.type` property\nto ensure the loaded data is correctly parsed.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "type": "object"
+    },
+    "UtcMultiTimeUnit": {
+      "enum": [
+        "utcyearquarter",
+        "utcyearquartermonth",
+        "utcyearmonth",
+        "utcyearmonthdate",
+        "utcyearmonthdatehours",
+        "utcyearmonthdatehoursminutes",
+        "utcyearmonthdatehoursminutesseconds",
+        "utcquartermonth",
+        "utcmonthdate",
+        "utchoursminutes",
+        "utchoursminutesseconds",
+        "utcminutesseconds",
+        "utcsecondsmilliseconds"
+      ],
+      "type": "string"
+    },
+    "UtcSingleTimeUnit": {
+      "enum": [
+        "utcyear",
+        "utcquarter",
+        "utcmonth",
+        "utcday",
+        "utcdate",
+        "utchours",
+        "utcminutes",
+        "utcseconds",
+        "utcmilliseconds"
+      ],
+      "type": "string"
+    },
+    "ValueDef": {
+      "additionalProperties": false,
+      "description": "Definition object for a constant value of an encoding channel.",
+      "properties": {
+        "value": {
+          "description": "A constant value in visual domain (e.g., `\"red\"` / \"#0099ff\" for color, values between `0` to `1` for opacity).",
+          "type": [
+            "number",
+            "string",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "ValueDefWithCondition": {
+      "additionalProperties": false,
+      "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ConditionalValueDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "A field definition or one or more value definition(s) with a selection predicate."
+        },
+        "value": {
+          "description": "A constant value in visual domain.",
+          "type": [
+            "number",
+            "string",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "MarkPropValueDefWithCondition": {
+      "additionalProperties": false,
+      "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalMarkPropFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ConditionalValueDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "A field definition or one or more value definition(s) with a selection predicate."
+        },
+        "value": {
+          "description": "A constant value in visual domain.",
+          "type": [
+            "number",
+            "string",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "TextValueDefWithCondition": {
+      "additionalProperties": false,
+      "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalTextFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ConditionalValueDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "A field definition or one or more value definition(s) with a selection predicate."
+        },
+        "value": {
+          "description": "A constant value in visual domain.",
+          "type": [
+            "number",
+            "string",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "VgBinding": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/VgCheckboxBinding"
+        },
+        {
+          "$ref": "#/definitions/VgRadioBinding"
+        },
+        {
+          "$ref": "#/definitions/VgSelectBinding"
+        },
+        {
+          "$ref": "#/definitions/VgRangeBinding"
+        },
+        {
+          "$ref": "#/definitions/VgGenericBinding"
+        }
+      ]
+    },
+    "VgCheckboxBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "element": {
+          "type": "string"
+        },
+        "input": {
+          "enum": [
+            "checkbox"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "input"
+      ],
+      "type": "object"
+    },
+    "VgComparatorOrder": {
+      "enum": [
+        "ascending",
+        "descending"
+      ],
+      "type": "string"
+    },
+    "VgEventStream": {
+    },
+    "VgGenericBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "element": {
+          "type": "string"
+        },
+        "input": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "input"
+      ],
+      "type": "object"
+    },
+    "VgLayoutAlign": {
+      "enum": [
+        "none",
+        "each",
+        "all"
+      ],
+      "type": "string"
+    },
+    "VgMarkConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/Align",
+          "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
+        },
+        "angle": {
+          "description": "The rotation angle of the text, in degrees.",
+          "maximum": 360,
+          "minimum": 0,
+          "type": "number"
+        },
+        "baseline": {
+          "$ref": "#/definitions/TextBaseline",
+          "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners.\n\n__Default value:__ `0`",
+          "type": "number"
+        },
+        "cursor": {
+          "$ref": "#/definitions/Cursor",
+          "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
+        },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of `\"ltr\"` (left-to-right) or `\"rtl\"` (right-to-left). This property determines on which side is truncated in response to the limit parameter.\n\n__Default value:__ `\"ltr\"`"
+        },
+        "dx": {
+          "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "dy": {
+          "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
+          "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter.\n\n__Default value:__ `\"…\"`",
+          "type": "string"
+        },
+        "fill": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "font": {
+          "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
+          "type": "string"
+        },
+        "fontSize": {
+          "description": "The font size, in pixels.",
+          "type": "number"
+        },
+        "fontStyle": {
+          "$ref": "#/definitions/FontStyle",
+          "description": "The font style (e.g., `\"italic\"`)."
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/FontWeight",
+          "description": "The font weight.\nThis can be either a string (e.g `\"bold\"`, `\"normal\"`) or a number (`100`, `200`, `300`, ..., `900` where `\"normal\"` = `400` and `\"bold\"` = `700`)."
+        },
+        "href": {
+          "description": "A URL to load upon mouse click. If defined, the mark acts as a hyperlink.",
+          "format": "uri",
+          "type": "string"
+        },
+        "interpolate": {
+          "$ref": "#/definitions/Interpolate",
+          "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
+          "type": "number"
+        },
+        "opacity": {
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
+        },
+        "radius": {
+          "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "shape": {
+          "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
+          "type": "string"
+        },
+        "size": {
+          "description": "The pixel area each the point/circle/square.\nFor example: in the case of circles, the radius is determined in part by the square root of the size value.\n\n__Default value:__ `30`",
+          "minimum": 0,
+          "type": "number"
+        },
+        "stroke": {
+          "$ref": "#/definitions/Color",
+          "description": "Default Stroke Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)"
+        },
+        "strokeCap": {
+          "$ref": "#/definitions/StrokeCap",
+          "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"square\"`"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tension": {
+          "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "text": {
+          "description": "Placeholder text if the `text` channel is not specified",
+          "type": "string"
+        },
+        "theta": {
+          "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
+          "type": "number"
+        },
+        "tooltip": {
+          "description": "The tooltip text to show upon mouse hover."
+        }
+      },
+      "type": "object"
+    },
+    "VgProjectionType": {
+      "enum": [
+        "albers",
+        "albersUsa",
+        "azimuthalEqualArea",
+        "azimuthalEquidistant",
+        "conicConformal",
+        "conicEqualArea",
+        "conicEquidistant",
+        "equirectangular",
+        "gnomonic",
+        "mercator",
+        "orthographic",
+        "stereographic",
+        "transverseMercator"
+      ],
+      "type": "string"
+    },
+    "VgRadioBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "element": {
+          "type": "string"
+        },
+        "input": {
+          "enum": [
+            "radio"
+          ],
+          "type": "string"
+        },
+        "options": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "input",
+        "options"
+      ],
+      "type": "object"
+    },
+    "VgRangeBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "element": {
+          "type": "string"
+        },
+        "input": {
+          "enum": [
+            "range"
+          ],
+          "type": "string"
+        },
+        "max": {
+          "type": "number"
+        },
+        "min": {
+          "type": "number"
+        },
+        "step": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "input"
+      ],
+      "type": "object"
+    },
+    "VgScheme": {
+      "additionalProperties": false,
+      "properties": {
+        "count": {
+          "type": "number"
+        },
+        "extent": {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "scheme": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "scheme"
+      ],
+      "type": "object"
+    },
+    "VgSelectBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "element": {
+          "type": "string"
+        },
+        "input": {
+          "enum": [
+            "select"
+          ],
+          "type": "string"
+        },
+        "options": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "input",
+        "options"
+      ],
+      "type": "object"
+    },
+    "ViewConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "clip": {
+          "description": "Whether the view should be clipped.",
+          "type": "boolean"
+        },
+        "fill": {
+          "description": "The fill color.\n\n__Default value:__ (none)",
+          "type": "string"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ (none)",
+          "type": "number"
+        },
+        "height": {
+          "description": "The default height of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) y-scale with `rangeStep` = `null`.\n\n__Default value:__ `200`",
+          "type": "number"
+        },
+        "stroke": {
+          "description": "The stroke color.\n\n__Default value:__ (none)",
+          "type": "string"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.\n\n__Default value:__ (none)",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.\n\n__Default value:__ (none)",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of miter (default), round or bevel.\n\n__Default value:__ 'miter'"
+        },
+        "strokeMiterLimit": {
+          "description": "The stroke line join method. One of miter (default), round or bevel.\n\n__Default value:__ 'miter'",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ (none)",
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.\n\n__Default value:__ (none)",
+          "type": "number"
+        },
+        "width": {
+          "description": "The default width of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with `rangeStep` = `null`.\n\n__Default value:__ `200`",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "WindowFieldDef": {
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "description": "The output name for the window operation.",
+          "type": "string"
+        },
+        "field": {
+          "description": "The data field for which to compute the aggregate or window function. This can be omitted for window functions that do not operate over a field such as `count`, `rank`, `dense_rank`.",
+          "type": "string"
+        },
+        "op": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AggregateOp"
+            },
+            {
+              "$ref": "#/definitions/WindowOnlyOp"
+            }
+          ],
+          "description": "The window or aggregation operations to apply within a window, including `rank`, `lead`, `sum`, `average` or `count`. See the list of all supported operations [here](https://vega.github.io/vega-lite/docs/window.html#ops)."
+        },
+        "param": {
+          "description": "Parameter values for the window functions. Parameter values can be omitted for operations that do not accept a parameter.\n\nSee the list of all supported operations and their parameters [here](https://vega.github.io/vega-lite/docs/transforms/window.html).",
+          "type": "number"
+        }
+      },
+      "required": [
+        "op",
+        "as"
+      ],
+      "type": "object"
+    },
+    "WindowOnlyOp": {
+      "enum": [
+        "row_number",
+        "rank",
+        "dense_rank",
+        "percent_rank",
+        "cume_dist",
+        "ntile",
+        "lag",
+        "lead",
+        "first_value",
+        "last_value",
+        "nth_value"
+      ],
+      "type": "string"
+    },
+    "WindowTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "frame": {
+          "description": "A frame specification as a two-element array indicating how the sliding window should proceed. The array entries should either be a number indicating the offset from the current data object, or null to indicate unbounded rows preceding or following the current data object. The default value is `[null, 0]`, indicating that the sliding window includes the current object and all preceding objects. The value `[-5, 5]` indicates that the window should include five objects preceding and five objects following the current object. Finally, `[null, null]` indicates that the window frame should always include all data objects. The only operators affected are the aggregation operations and the `first_value`, `last_value`, and `nth_value` window operations. The other window operations are not affected by this.\n\n__Default value:__:  `[null, 0]` (includes the current object and all preceding objects)",
+          "items": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "type": "array"
+        },
+        "groupby": {
+          "description": "The data fields for partitioning the data objects into separate windows. If unspecified, all data points will be in a single group.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ignorePeers": {
+          "description": "Indicates if the sliding window frame should ignore peer values. (Peer values are those considered identical by the sort criteria). The default is false, causing the window frame to expand to include all peer values. If set to true, the window frame will be defined by offset values only. This setting only affects those operations that depend on the window frame, namely aggregation operations and the first_value, last_value, and nth_value window operations.\n\n__Default value:__ `false`",
+          "type": "boolean"
+        },
+        "sort": {
+          "description": "A sort field definition for sorting data objects within a window. If two data objects are considered equal by the comparator, they are considered “peer” values of equal rank. If sort is not specified, the order is undefined: data objects are processed in the order they are observed and none are considered peers (the ignorePeers parameter is ignored and treated as if set to `true`).",
+          "items": {
+            "$ref": "#/definitions/SortField"
+          },
+          "type": "array"
+        },
+        "window": {
+          "description": "The definition of the fields in the window, and what calculations to use.",
+          "items": {
+            "$ref": "#/definitions/WindowFieldDef"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "window"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/altair/vegalite/v3/theme.py
+++ b/altair/vegalite/v3/theme.py
@@ -1,0 +1,15 @@
+"""Tools for enabling and registering chart themes"""
+
+from ...utils.theme import ThemeRegistry
+
+# The entry point group that can be used by other packages to declare other
+# renderers that will be auto-detected. Explicit registration is also
+# allowed by the PluginRegistery API.
+ENTRY_POINT_GROUP = 'altair.vegalite.v2.theme'  # type: str
+themes = ThemeRegistry(entry_point_group=ENTRY_POINT_GROUP)
+
+themes.register('default', lambda: {"config": {"view": {"width": 400, "height": 300}}})
+themes.register('opaque', lambda: {"config": {"background": "white",
+                                              "view": {"width": 400, "height": 300}}})
+themes.register('none', lambda: {})
+themes.enable('default')

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -27,6 +27,7 @@ SCHEMA_VERSION = {
     'vega-lite': {
         'v1': 'v1.3.1',
         'v2': 'v2.6.0',
+        'v3': 'v3.0.0-rc8',
     }
 }
 


### PR DESCRIPTION
This PR generates the low-level API for Vega-Lite 3. Once we release Altair 2.3 (#1216), this can be merged, and then we can iterate on higher-level APIs for new transforms & other features.

Replaces #1095 

Note: this involves very little new hand-written code: everything under ``altair/vegalite/v3`` is generated by the following commands:
```
$ python tools/generate_schema_interface.py
$ cp altair/vegalite/v2/*.py altair/vegalite/v3
```