### PR TITLE
DOC: Added new line chart examples with points over the series

### DIFF
--- a/altair/examples/line_chart_with_interpolation.py
+++ b/altair/examples/line_chart_with_interpolation.py
@@ -1,6 +1,6 @@
 """
-Line Chart with Points
-----------------------
+Line Chart with Interpolation
+-----------------------------
 This chart shows a line chart with the path interpolated. A full list of interpolation methods is available `in the documentation <https://altair-viz.github.io/user_guide/generated/core/altair.LineConfig.html?highlight=interpolate#altair-lineconfig>`_.
 """
 # category: line charts

--- a/altair/examples/line_chart_with_interpolation.py
+++ b/altair/examples/line_chart_with_interpolation.py
@@ -1,0 +1,15 @@
+"""
+Line Chart with Points
+----------------------
+This chart shows a line chart with the path interpolated. A full list of interpolation methods is available `in the documentation <https://altair-viz.github.io/user_guide/generated/core/altair.LineConfig.html?highlight=interpolate#altair-lineconfig>`_.
+"""
+# category: line charts
+import altair as alt
+from vega_datasets import data
+
+source = data.wheat()
+
+alt.Chart(source).mark_line(interpolate="monotone").encode(
+    x="year:O",
+    y="wheat:Q"
+).properties(width=600)

--- a/altair/examples/line_chart_with_points.py
+++ b/altair/examples/line_chart_with_points.py
@@ -7,10 +7,9 @@ This chart shows a line chart with points marking each value.
 import altair as alt
 from vega_datasets import data
 
-source = data.iowa_electricity()
+source = data.wheat()
 
 alt.Chart(source).mark_line(point=True).encode(
-    x="year",
-    y="net_generation",
-    color="source"
-)
+    x="year:O",
+    y="wheat:Q"
+).properties(width=600)

--- a/altair/examples/line_chart_with_points.py
+++ b/altair/examples/line_chart_with_points.py
@@ -1,20 +1,16 @@
 """
 Line Chart with Points
 ----------------------
-This chart shows a simple line chart with points marking each value.
+This chart shows a line chart with points marking each value.
 """
 # category: line charts
 import altair as alt
-import numpy as np
-import pandas as pd
+from vega_datasets import data
 
-x = np.arange(100)
-source = pd.DataFrame({
-  'x': x,
-  'f(x)': np.sin(x / 5)}
-)
+source = data.iowa_electricity()
 
 alt.Chart(source).mark_line(point=True).encode(
-    x='x',
-    y='f(x)'
+    x="year",
+    y="net_generation",
+    color="source"
 )

--- a/altair/examples/line_chart_with_stroked_points.py
+++ b/altair/examples/line_chart_with_stroked_points.py
@@ -7,16 +7,15 @@ This chart shows a line chart with stroked points marking each value.
 import altair as alt
 from vega_datasets import data
 
-source = data.iowa_electricity()
+source = data.wheat()
 
 base = alt.Chart(source).encode(
-    x="year",
-    y="net_generation",
-    color="source"
+    x="year:O",
+    y="wheat:Q"
 )
 
 line = base.mark_line()
 
-point = base.mark_point(fill="white")
+point = base.mark_point(fill="white", stroke="steelblue")
 
-line + point
+(line + point).properties(width=600)

--- a/altair/examples/line_chart_with_stroked_points.py
+++ b/altair/examples/line_chart_with_stroked_points.py
@@ -1,0 +1,22 @@
+"""
+Line Chart with Stroked Points
+------------------------------
+This chart shows a line chart with stroked points marking each value.
+"""
+# category: line charts
+import altair as alt
+from vega_datasets import data
+
+source = data.iowa_electricity()
+
+base = alt.Chart(source).encode(
+    x="year",
+    y="net_generation",
+    color="source"
+)
+
+line = base.mark_line()
+
+point = base.mark_point(fill="white")
+
+line + point

--- a/altair/examples/multi_series_line.py
+++ b/altair/examples/multi_series_line.py
@@ -1,17 +1,17 @@
 """
-Multi Series Line Chart
+Multiple-Series Line Chart
 -----------------------
 
-This example shows how to make a multi series line chart of the daily closing stock prices for AAPL, AMZN, GOOG, IBM, and MSFT between 2000 and 2010.
+This example shows how to make a line chart with multiple series of data.
 """
 # category: line charts
 import altair as alt
 from vega_datasets import data
 
-source = data.stocks()
+source = data.iowa_electricity()
 
 alt.Chart(source).mark_line().encode(
-    x='date',
-    y='price',
-    color='symbol'
+    x="year",
+    y="net_generation",
+    color="source"
 )

--- a/altair/examples/multi_series_line.py
+++ b/altair/examples/multi_series_line.py
@@ -1,6 +1,6 @@
 """
 Multiple-Series Line Chart
------------------------
+--------------------------
 
 This example shows how to make a line chart with multiple series of data.
 """


### PR DESCRIPTION
I've added three new line chart examples lifted from the ones upstream in the Vega Lite docs. In the interest of uniformity, I've also modified the multi-series example and ensured that the three new ones have a matching dataset.

If you like these, I'll make some more line charts change soon so we can give it the same attention we recently gave the bar charts.