### PR TITLE
DOC: Added CO2 Concentration case study

### DIFF
--- a/altair/examples/co2_concentration.py
+++ b/altair/examples/co2_concentration.py
@@ -1,0 +1,65 @@
+"""
+Iowa's renewable energy boom
+----------------------------
+This example is a fully developed line chart that uses a window transformation. It was inspired by `Gregor Aisch's work at datawrapper <https://www.datawrapper.de/_/OHgEm/>_`.
+"""
+import altair as alt
+from vega_datasets import data
+
+source = data.co2_concentration()
+
+base = alt.Chart(
+    source,
+    title="Carbon Dioxide in the Atmosphere"
+).transform_calculate(
+    year="year(datum.Date)"
+).transform_calculate(
+    decade="floor(datum.year / 10)"
+).transform_calculate(
+    scaled_date="(datum.year % 10) + (month(datum.Date)/12)"
+).transform_window(
+    window=[
+        {'op': 'first_value', 'as': 'first_date', 'field': 'scaled_date'},
+        {'op': 'last_value', 'as': 'last_date', 'field': 'scaled_date'}
+    ],
+    sort=[
+        {"field": "scaled_date", "order": "ascending"},
+        {"field": "scaled_date", "order": "ascending"}
+    ],
+    groupby=["decade"],
+    frame=[None, None]
+).transform_calculate(
+  end="datum.first_date === datum.scaled_date ? 'first' : datum.last_date === datum.scaled_date ? 'last' : null"
+).encode(
+    x=alt.X(
+        "scaled_date:Q",
+        axis=alt.Axis(title="Year into Decade", tickCount=11)
+    ),
+    y=alt.Y(
+        "CO2:Q",
+        title="CO2 concentration in ppm",
+        scale=alt.Scale(zero=False)
+    )
+)
+
+line = base.mark_line().encode(
+    color=alt.Color(
+        "decade:O",
+        scale=alt.Scale(scheme="magma"),
+        legend=None
+    )
+)
+
+start_year = base.transform_filter(
+  {"field": "end", "equal": "first"}
+).mark_text(baseline="top").encode(text="year:N")
+
+end_year = base.transform_filter(
+  {"field": "end", "equal": "last"}
+).mark_text(baseline="bottom").encode(text="year:N")
+
+(line + start_year + end_year).configure_text(
+    align="left",
+    dx=1,
+    dy=3
+).properties(width=600, height=375)

--- a/altair/examples/co2_concentration.py
+++ b/altair/examples/co2_concentration.py
@@ -3,6 +3,7 @@ Iowa's renewable energy boom
 ----------------------------
 This example is a fully developed line chart that uses a window transformation. It was inspired by `Gregor Aisch's work at datawrapper <https://www.datawrapper.de/_/OHgEm/>_`.
 """
+# category: case studies
 import altair as alt
 from vega_datasets import data
 


### PR DESCRIPTION
Working backward from the [Vega-Lite docs](https://vega.github.io/vega-lite/examples/layer_line_co2_concentration.html), I recreated an example of Gregor Aisch's CO2 chart.

I suspect you might have thoughts about how to best format the window function. It was a first time writing one so I'm sure there is room for improvement.

![visualization](https://user-images.githubusercontent.com/9993/50750105-13027300-11f8-11e9-8875-054487e05290.png)

```python
import altair as alt
from vega_datasets import data

source = data.co2_concentration()

base = alt.Chart(
    source,
    title="Carbon Dioxide in the Atmosphere"
).transform_calculate(
    year="year(datum.Date)"
).transform_calculate(
    decade="floor(datum.year / 10)"
).transform_calculate(
    scaled_date="(datum.year % 10) + (month(datum.Date)/12)"
).transform_window(
    window=[
        {'op': 'first_value', 'as': 'first_date', 'field': 'scaled_date'},
        {'op': 'last_value', 'as': 'last_date', 'field': 'scaled_date'}
    ],
    sort=[
        {"field": "scaled_date", "order": "ascending"},
        {"field": "scaled_date", "order": "ascending"}
    ],
    groupby=["decade"],
    frame=[None, None]
).transform_calculate(
  end="datum.first_date === datum.scaled_date ? 'first' : datum.last_date === datum.scaled_date ? 'last' : null"
).encode(
    x=alt.X(
        "scaled_date:Q",
        axis=alt.Axis(title="Year into Decade", tickCount=11)
    ),
    y=alt.Y(
        "CO2:Q",
        title="CO2 concentration in ppm",
        scale=alt.Scale(zero=False)
    )
)

line = base.mark_line().encode(
    color=alt.Color(
        "decade:O",
        scale=alt.Scale(scheme="magma"),
        legend=None
    )
)

start_year = base.transform_filter(
  {"field": "end", "equal": "first"}
).mark_text(baseline="top").encode(text="year:N")

end_year = base.transform_filter(
  {"field": "end", "equal": "last"}
).mark_text(baseline="bottom").encode(text="year:N")

(line + start_year + end_year).configure_text(
    align="left",
    dx=1,
    dy=3
).properties(width=600, height=375)
```