### PR TITLE
DOC: Simple Isotype grid example

### DIFF
--- a/altair/examples/isotype_grid.py
+++ b/altair/examples/isotype_grid.py
@@ -17,4 +17,7 @@ alt.Chart(data).transform_calculate(
     x=alt.X("col:O", axis=None),
     y=alt.Y("row:O", axis=None),
     shape=alt.ShapeValue("M1.7 -1.7h-0.8c0.3 -0.2 0.6 -0.5 0.6 -0.9c0 -0.6 -0.4 -1 -1 -1c-0.6 0 -1 0.4 -1 1c0 0.4 0.2 0.7 0.6 0.9h-0.8c-0.4 0 -0.7 0.3 -0.7 0.6v1.9c0 0.3 0.3 0.6 0.6 0.6h0.2c0 0 0 0.1 0 0.1v1.9c0 0.3 0.2 0.6 0.3 0.6h1.3c0.2 0 0.3 -0.3 0.3 -0.6v-1.8c0 0 0 -0.1 0 -0.1h0.2c0.3 0 0.6 -0.3 0.6 -0.6v-2c0.2 -0.3 -0.1 -0.6 -0.4 -0.6z")
-).properties(width=400, height=400)
+).properties(
+    width=400,
+    height=400
+).configure_view(strokeWidth=0)

--- a/altair/examples/isotype_grid.py
+++ b/altair/examples/isotype_grid.py
@@ -9,15 +9,30 @@ import pandas as pd
 
 data = pd.DataFrame([dict(id=i) for i in range(1, 101)])
 
+person = (
+    "M1.7 -1.7h-0.8c0.3 -0.2 0.6 -0.5 0.6 -0.9c0 -0.6 "
+    "-0.4 -1 -1 -1c-0.6 0 -1 0.4 -1 1c0 0.4 0.2 0.7 0.6 "
+    "0.9h-0.8c-0.4 0 -0.7 0.3 -0.7 0.6v1.9c0 0.3 0.3 0.6 "
+    "0.6 0.6h0.2c0 0 0 0.1 0 0.1v1.9c0 0.3 0.2 0.6 0.3 "
+    "0.6h1.3c0.2 0 0.3 -0.3 0.3 -0.6v-1.8c0 0 0 -0.1 0 "
+    "-0.1h0.2c0.3 0 0.6 -0.3 0.6 -0.6v-2c0.2 -0.3 -0.1 "
+    "-0.6 -0.4 -0.6z"
+)
+
 alt.Chart(data).transform_calculate(
-    col="ceil(datum.id/10)"
+    row="ceil(datum.id/10)"
 ).transform_calculate(
-    row="datum.id - datum.col*10"
-).mark_point(filled=True, size=50).encode(
+    col="datum.id - datum.row*10"
+).mark_point(
+    filled=True,
+    size=50
+).encode(
     x=alt.X("col:O", axis=None),
     y=alt.Y("row:O", axis=None),
-    shape=alt.ShapeValue("M1.7 -1.7h-0.8c0.3 -0.2 0.6 -0.5 0.6 -0.9c0 -0.6 -0.4 -1 -1 -1c-0.6 0 -1 0.4 -1 1c0 0.4 0.2 0.7 0.6 0.9h-0.8c-0.4 0 -0.7 0.3 -0.7 0.6v1.9c0 0.3 0.3 0.6 0.6 0.6h0.2c0 0 0 0.1 0 0.1v1.9c0 0.3 0.2 0.6 0.3 0.6h1.3c0.2 0 0.3 -0.3 0.3 -0.6v-1.8c0 0 0 -0.1 0 -0.1h0.2c0.3 0 0.6 -0.3 0.6 -0.6v-2c0.2 -0.3 -0.1 -0.6 -0.4 -0.6z")
+    shape=alt.ShapeValue(person)
 ).properties(
     width=400,
     height=400
-).configure_view(strokeWidth=0)
+).configure_view(
+    strokeWidth=0
+)

--- a/altair/examples/isotype_grid.py
+++ b/altair/examples/isotype_grid.py
@@ -1,0 +1,20 @@
+"""
+Isotype grid
+------------
+This example is a grid of isotype figures.
+"""
+# category: other charts
+import altair as alt
+import pandas as pd
+
+data = pd.DataFrame([dict(id=i) for i in range(1, 101)])
+
+alt.Chart(data).transform_calculate(
+    col="ceil (datum.id/10)"
+).transform_calculate(
+    row="datum.id - datum.col*10"
+).mark_point(filled=True, size=50).encode(
+    x=alt.X("col:O", axis=None),
+    y=alt.Y("row:O", axis=None),
+    shape=alt.ShapeValue("M1.7 -1.7h-0.8c0.3 -0.2 0.6 -0.5 0.6 -0.9c0 -0.6 -0.4 -1 -1 -1c-0.6 0 -1 0.4 -1 1c0 0.4 0.2 0.7 0.6 0.9h-0.8c-0.4 0 -0.7 0.3 -0.7 0.6v1.9c0 0.3 0.3 0.6 0.6 0.6h0.2c0 0 0 0.1 0 0.1v1.9c0 0.3 0.2 0.6 0.3 0.6h1.3c0.2 0 0.3 -0.3 0.3 -0.6v-1.8c0 0 0 -0.1 0 -0.1h0.2c0.3 0 0.6 -0.3 0.6 -0.6v-2c0.2 -0.3 -0.1 -0.6 -0.4 -0.6z")
+).properties(width=400, height=400)

--- a/altair/examples/isotype_grid.py
+++ b/altair/examples/isotype_grid.py
@@ -1,5 +1,5 @@
 """
-Isotype grid
+Isotype Grid
 ------------
 This example is a grid of isotype figures.
 """

--- a/altair/examples/isotype_grid.py
+++ b/altair/examples/isotype_grid.py
@@ -10,7 +10,7 @@ import pandas as pd
 data = pd.DataFrame([dict(id=i) for i in range(1, 101)])
 
 alt.Chart(data).transform_calculate(
-    col="ceil (datum.id/10)"
+    col="ceil(datum.id/10)"
 ).transform_calculate(
     row="datum.id - datum.col*10"
 ).mark_point(filled=True, size=50).encode(


### PR DESCRIPTION
Mirrors a [Vega-Lite example](https://vega.github.io/vega-lite/examples/isotype_grid.html) upstream.

![visualization 2](https://user-images.githubusercontent.com/9993/50815775-351cf380-12d3-11e9-9a69-86d11e30feab.png)

```python
import altair as alt
import pandas as pd

data = pd.DataFrame([dict(id=i) for i in range(1, 101)])

alt.Chart(data).transform_calculate(
    col="ceil (datum.id/10)"
).transform_calculate(
    row="datum.id - datum.col*10"
).mark_point(filled=True, size=50).encode(
    x=alt.X("col:O", axis=None),
    y=alt.Y("row:O", axis=None),
    shape=alt.ShapeValue("M1.7 -1.7h-0.8c0.3 -0.2 0.6 -0.5 0.6 -0.9c0 -0.6 -0.4 -1 -1 -1c-0.6 0 -1 0.4 -1 1c0 0.4 0.2 0.7 0.6 0.9h-0.8c-0.4 0 -0.7 0.3 -0.7 0.6v1.9c0 0.3 0.3 0.6 0.6 0.6h0.2c0 0 0 0.1 0 0.1v1.9c0 0.3 0.2 0.6 0.3 0.6h1.3c0.2 0 0.3 -0.3 0.3 -0.6v-1.8c0 0 0 -0.1 0 -0.1h0.2c0.3 0 0.6 -0.3 0.6 -0.6v-2c0.2 -0.3 -0.1 -0.6 -0.4 -0.6z")
).properties(width=400, height=400).configure_view(strokeWidth=0)
```