### PR TITLE
DOC: Really move Seattle weather heatmap example into case studies

### DIFF
--- a/altair/examples/weather_heatmap.py
+++ b/altair/examples/weather_heatmap.py
@@ -3,7 +3,7 @@ Seattle Weather Heatmap
 -----------------------
 This example shows the 2010 daily high temperature (F) in Seattle, WA.
 """
-# category: line charts
+# category: case studies
 import altair as alt
 from vega_datasets import data
 


### PR DESCRIPTION
I think a mistake was made in #1286 where the weather heat map was moved to the line chart section instead of the case studies. 