### PR TITLE
MAINT: fix flake8 errors in type comments

### DIFF
--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -101,7 +101,7 @@ class Displayable(object):
     schema_path = ('altair', '')
 
     def __init__(self, spec, validate=False):
-        # type: (dict, bool) ->: None
+        # type: (dict, bool) -> None
         self.spec = spec
         self.validate = validate
         self._validate()

--- a/altair/utils/plugin_registry.py
+++ b/altair/utils/plugin_registry.py
@@ -1,4 +1,4 @@
-from typing import Generic, TypeVar, cast
+from typing import Any, Union, List, Generic, TypeVar, cast
 
 import entrypoints
 from toolz import curry
@@ -72,7 +72,7 @@ class PluginRegistry(Generic[PluginType]):
         """
         self.entry_point_group = entry_point_group
         self.plugin_type = plugin_type
-        self._active = None     # type: None
+        self._active = None     # type: str
         self._active_name = ''  # type: str
         self._plugins = {}      # type: dict
         self._options = {}      # type: dict


### PR DESCRIPTION
In the most recent version of flake8, typing comments are flake-checked, so we need to update this here.