### PR TITLE
DOC: Add window transform example

### DIFF
--- a/doc/user_guide/transform.rst
+++ b/doc/user_guide/transform.rst
@@ -723,7 +723,6 @@ If we plot the `z-scores`_ of the stock prices, rather than the stock prices the
 .. altair-plot::
 
     import altair as alt
-    from altair import expr
     from vega_datasets import data
 
     alt.Chart(data.stocks.url).transform_window(

--- a/doc/user_guide/transform.rst
+++ b/doc/user_guide/transform.rst
@@ -671,7 +671,10 @@ For example, consider the following cumulative frequency distribution:
         sort=[{'field': 'IMDB_Rating'}],
         frame=[None, 0],
         cumulative_count='count(*)',
-    ).mark_area().encode(x='IMDB_Rating:Q', y='cumulative_count:Q')
+    ).mark_area().encode(
+        x='IMDB_Rating:Q',
+        y='cumulative_count:Q',
+    )
 
 First, we pass a sort field definition, which indicates how data objects should be sorted within the window.
 Here, movies should be sorted by their IMDB rating.
@@ -709,7 +712,11 @@ For example, consider the following time series of stock prices:
     import altair as alt
     from vega_datasets import data
 
-    alt.Chart(data.stocks.url).mark_line().encode(x='date:T', y='price:Q', color='symbol:N')
+    alt.Chart(data.stocks.url).mark_line().encode(
+        x='date:T',
+        y='price:Q',
+        color='symbol:N',
+    )
 
 It's hard to see the overall pattern in the above example, because Google's stock price is much higher than the other stock prices.
 If we plot the z-scores of the stock prices, rather than the stock prices themselves, then the overall pattern becomes clearer:
@@ -726,7 +733,11 @@ If we plot the z-scores of the stock prices, rather than the stock prices themse
         frame=[None, None], groupby=['symbol'],
     ).transform_calculate(
         z_score=(expr.datum.price - expr.datum.mean_price) / expr.datum.stdev_price,
-    ).mark_line().encode(x='date:T', y='z_score:Q', color='symbol:N')
+    ).mark_line().encode(
+        x='date:T',
+        y='z_score:Q',
+        color='symbol:N',
+    )
 
 By using two aggregation functions (``mean`` and ``stdev``) within the window transform, we are able to compute the z-scores within the calculate transform.
 

--- a/doc/user_guide/transform.rst
+++ b/doc/user_guide/transform.rst
@@ -732,7 +732,7 @@ If we plot the z-scores of the stock prices, rather than the stock prices themse
         stdev_price='stdev(price)',
         frame=[None, None], groupby=['symbol'],
     ).transform_calculate(
-        z_score=(expr.datum.price - expr.datum.mean_price) / expr.datum.stdev_price,
+        z_score=(alt.datum.price - alt.datum.mean_price) / alt.datum.stdev_price,
     ).mark_line().encode(
         x='date:T',
         y='z_score:Q',

--- a/doc/user_guide/transform.rst
+++ b/doc/user_guide/transform.rst
@@ -730,7 +730,8 @@ If we plot the z-scores of the stock prices, rather than the stock prices themse
     alt.Chart(data.stocks.url).transform_window(
         mean_price='mean(price)',
         stdev_price='stdev(price)',
-        frame=[None, None], groupby=['symbol'],
+        frame=[None, None],
+        groupby=['symbol'],
     ).transform_calculate(
         z_score=(alt.datum.price - alt.datum.mean_price) / alt.datum.stdev_price,
     ).mark_line().encode(

--- a/doc/user_guide/transform.rst
+++ b/doc/user_guide/transform.rst
@@ -702,10 +702,8 @@ last_value    None       Assigns a value from the last data object in the curren
 nth_value     Number     Assigns a value from the nth data object in the current sliding window frame. If no such object exists, assigns ``null``. Requires a non-negative integer parameter that indicates the offset from the start of the window frame. This operation must have a corresponding entry in the `fields` parameter array.
 ============  =========  =========================================================================================================================================================================================================================================================================================================================
 
-Notice that using an aggregate transform is like using an SQL ``GROUP BY``:
-the input data objects are replaced by the output data objects, which contain the results of applying the aggregation function.
-However, using a window transform is like broadcasting the results to the input data objects.
-By using a window transform, and preserving the input data objects, we can compute statistics, such as `z-scores`_.
+While an aggregate transform computes a single value that summarises all data objects, a window transform adds a new property to each data object.
+This new property is computed from the neighbouring data objects: that is, from the data objects delimited by the window field definition.
 For example, consider the following time series of stock prices:
 
 .. altair-plot::
@@ -720,7 +718,7 @@ For example, consider the following time series of stock prices:
     )
 
 It's hard to see the overall pattern in the above example, because Google's stock price is much higher than the other stock prices.
-If we plot the z-scores of the stock prices, rather than the stock prices themselves, then the overall pattern becomes clearer:
+If we plot the `z-scores`_ of the stock prices, rather than the stock prices themselves, then the overall pattern becomes clearer:
 
 .. altair-plot::
 

--- a/doc/user_guide/transform.rst
+++ b/doc/user_guide/transform.rst
@@ -702,9 +702,10 @@ last_value    None       Assigns a value from the last data object in the curren
 nth_value     Number     Assigns a value from the nth data object in the current sliding window frame. If no such object exists, assigns ``null``. Requires a non-negative integer parameter that indicates the offset from the start of the window frame. This operation must have a corresponding entry in the `fields` parameter array.
 ============  =========  =========================================================================================================================================================================================================================================================================================================================
 
-Notice that when we use an aggregation function within an aggregate transform, the data objects are collapsed.
-However, when we use an aggregation function within a window transform, the data objects are augmented.
-It's by augmenting, rather than collapsing, that we can compute statistics, such as `z-scores`_.
+Notice that using an aggregate transform is like using an SQL ``GROUP BY``:
+the input data objects are replaced by the output data objects, which contain the results of applying the aggregation function.
+However, using a window transform is like broadcasting the results to the input data objects.
+By using a window transform, and preserving the input data objects, we can compute statistics, such as `z-scores`_.
 For example, consider the following time series of stock prices:
 
 .. altair-plot::


### PR DESCRIPTION
This example shows that aggregation functions aren't only for aggregate transforms. By using two aggregation functions within a window transform we are able to compute z-scores within a calculate transform.

See also: https://vega-js.slack.com/archives/C0NG6SXFX/p1548451285140300