### PR TITLE
MAINT: fix travis issue with jsonschema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 
 before_install:
   - pip install pip --upgrade;
+  - pip install -U pytest;
 
 install:
   - pip install -e .[dev];


### PR DESCRIPTION
jsonschema's 3.0 release introduces an incompatibility with the pytest version installed by default on travis. This should fix the issue.