### PR TITLE
Specify vega==1.4.0 in notebook installation instructions

### DIFF
--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -87,7 +87,10 @@ To install the notebook and Altair with conda, run the following command::
 
 To install the notebook and Altair with pip, run the following command::
 
-    $ pip install -U altair vega_datasets notebook vega
+    $ pip install -U altair vega_datasets notebook vega==1.4.0
+    
+If you don't specify the version, pip will install vega version 2.x, which Altair
+does not currently support.
 
 Once the packages and extensions are installed, launch the notebook by running::
 


### PR DESCRIPTION
I found that altair looks for vega in the entrypoint 'altair.vegalite.v2.renderer' (implying it doesn't support vegalite v3), but the PyPI package vega now puts its entrypoint in 'altair.vegalite.v3.renderer' in all version starting at 2.0.0 (see [ipyvega commit](https://github.com/vega/ipyvega/commit/d01f00217f0166ef9b304d195bea17c4bd844d41#diff-2eeaed663bd0d25b7e608891384b7298R37)).
So to use altair in a Jupyter notebook, we must specify an older version of vega. Otherwise `alt.renderers.enable('notebook')` fails with a message saying that vega cannot be found.

(We should probably update the error message as well.)