### PR TITLE
Clean up alt.selection (fixes #1431)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 # Altair Change Log
 
-## Version 3.0.0rc1 (prerelease)
+## Version 3.0.0 (unreleased)
 
-Update to Vega-Lite 3.0 and Vega 5.0 & support all new features. See
+Update to Vega-Lite 3.2 and Vega 5.0 & support all new features. See
 https://github.com/vega/vega-lite/releases/tag/v3.0.0 for Vega-Lite
 feature lists.
 
@@ -13,6 +13,26 @@ feature lists.
   ``transform_fold()``, ``transform_sample()``, ``transform_stack()``
 - tooltips enabled by default. Pass encoding ``tooltip=None`` to disable.
 - new ``columns`` keyword that allows wrapped faceting and concatenation.
+
+### Backward-incompatible changes:
+
+- selections can be bound to scales directly; i.e. you can use
+  ```
+  alt.Scale(domain=selection)
+  ```
+  instead of
+  ```
+  alt.Scale(domain=selection.ref())
+  ```
+
+- selections can no longer be passed directly as chart properties; i.e. you should use
+  ```
+  chart.add_selection(selection1, selection2)
+  ```
+  instead of
+  ```
+  chart.properties(selection=selection1 + selection2)
+  ```
 
 ## Version 2.4.1 (Released February 21, 2019)
 

--- a/altair/examples/interactive_cross_highlight.py
+++ b/altair/examples/interactive_cross_highlight.py
@@ -36,10 +36,9 @@ bar = alt.Chart(source).mark_bar().encode(
     y='count()',
     color=alt.condition(pts, alt.ColorValue("steelblue"), alt.ColorValue("grey"))
 ).properties(
-    selection=pts,
     width=550,
     height=200
-)
+).add_selection(pts)
 
 alt.vconcat(
     rect + circ,

--- a/altair/examples/interactive_layered_crossfilter.py
+++ b/altair/examples/interactive_layered_crossfilter.py
@@ -27,7 +27,7 @@ base = alt.Chart().mark_bar().encode(
 )
 
 # blue background with selection
-background = base.properties(selection=brush)
+background = base.add_selection(brush)
 
 # yellow highlights on the transformed data
 highlight = base.encode(

--- a/altair/examples/interval_selection.py
+++ b/altair/examples/interval_selection.py
@@ -15,7 +15,7 @@ source = data.sp500.url
 brush = alt.selection(type='interval', encodings=['x'])
 
 upper = alt.Chart().mark_area().encode(
-    alt.X('date:T', scale={'domain': brush.ref()}),
+    alt.X('date:T', scale=alt.Scale(domain=brush)),
     y='price:Q'
 ).properties(
     width=600,

--- a/altair/examples/scatter_with_histogram.py
+++ b/altair/examples/scatter_with_histogram.py
@@ -32,7 +32,7 @@ points = alt.Chart().mark_point(filled=True, color="black").encode(
     x='x',
     y='y'
 ).transform_filter(
-    pts.ref()
+    pts
 ).properties(
     width=300,
     height=300
@@ -44,10 +44,9 @@ mag = alt.Chart().mark_bar().encode(
     y="count()",
     color=alt.condition(pts, alt.value("black"), alt.value("lightgray"))
 ).properties(
-    selection=pts,
     width=300,
     height=300
-)
+).add_selection(pts)
 
 # build the chart:
 alt.hconcat(

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -243,6 +243,8 @@ class SchemaBase(object):
             elif isinstance(val, dict):
                 return {k: _todict(v) for k, v in val.items()
                         if v is not Undefined}
+            elif hasattr(val, 'to_dict'):
+                return val.to_dict()
             else:
                 return val
 

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -197,7 +197,7 @@ class NamedSelection(SelectionMapping):
 
         Examples
         --------
-        >>> import altair as alt
+        >>> import altair.vegalite.v2 as alt
         >>> sel = alt.selection_interval(name='interval')
         >>> sel.ref()
         {'selection': 'interval'}
@@ -685,7 +685,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         The aggregate transform allows you to specify transforms directly using
         the same shorthand syntax as used in encodings:
 
-        >>> import altair as alt
+        >>> import altair.vegalite.v2 as alt
         >>> chart1 = alt.Chart().transform_aggregate(
         ...     mean_acc='mean(Acceleration)',
         ...     groupby=['Origin']
@@ -752,7 +752,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
         Examples
         --------
-        >>> import altair as alt
+        >>> import altair.vegalite.v2 as alt
         >>> chart = alt.Chart().transform_bin("x_binned", "x")
         >>> chart.transform[0]
         BinTransform({
@@ -807,7 +807,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
         Examples
         --------
-        >>> import altair as alt
+        >>> import altair.vegalite.v2 as alt
         >>> from altair import datum, expr
 
         >>> chart = alt.Chart().transform_calculate(y = 2 * expr.sin(datum.x))
@@ -941,7 +941,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
         Examples
         --------
-        >>> import altair as alt
+        >>> import altair.vegalite.v2 as alt
         >>> from altair import datum, expr
 
         >>> chart = alt.Chart().transform_timeunit(month='month(date)')
@@ -1041,7 +1041,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         --------
         A cumulative line chart
 
-        >>> import altair as alt
+        >>> import altair.vegalite.v2 as alt
         >>> import numpy as np
         >>> import pandas as pd
         >>> data = pd.DataFrame({'x': np.arange(100),

--- a/altair/vegalite/v3/api.py
+++ b/altair/vegalite/v3/api.py
@@ -162,7 +162,7 @@ class Selection(object):
         self.selection = selection
 
     def ref(self):
-        return 
+        return {'selection': self.name}
 
     def to_dict(self):
         return {'selection': self.name}

--- a/altair/vegalite/v3/tests/test_api.py
+++ b/altair/vegalite/v3/tests/test_api.py
@@ -254,35 +254,29 @@ def test_facet_parse_data():
                             'row': {'field': 'row', 'type': 'nominal'}}
 
 
-def test_SelectionMapping():
+def test_selection():
     # test instantiation of selections
     interval = alt.selection_interval(name='selec_1')
-    assert interval['selec_1'].type == 'interval'
-    assert interval._get_name() == 'selec_1'
+    assert interval.selection.type == 'interval'
+    assert interval.name == 'selec_1'
 
     single = alt.selection_single(name='selec_2')
-    assert single['selec_2'].type == 'single'
-    assert single._get_name() == 'selec_2'
+    assert single.selection.type == 'single'
+    assert single.name == 'selec_2'
 
     multi = alt.selection_multi(name='selec_3')
-    assert multi['selec_3'].type == 'multi'
-    assert multi._get_name() == 'selec_3'
+    assert multi.selection.type == 'multi'
+    assert multi.name == 'selec_3'
 
-    # test addition
-    x = single + multi + interval
-    assert set(x.to_dict().keys()) == {'selec_1', 'selec_2', 'selec_3'}
-
-    y = single.copy()
-    y += multi
-    y += interval
-    assert x.to_dict() == y.to_dict()
+    # test adding to chart
+    chart = alt.Chart().add_selection(single)
+    chart = chart.add_selection(multi, interval)
+    assert set(chart.selection.keys()) == {'selec_1', 'selec_2', 'selec_3'}
 
     # test logical operations
-    x = single & multi
-    assert isinstance(x, alt.SelectionAnd)
-
-    y = single | multi
-    assert isinstance(y, alt.SelectionOr)
+    assert isinstance(single & multi, alt.SelectionAnd)
+    assert isinstance(single | multi, alt.SelectionOr)
+    assert isinstance(~single, alt.SelectionNot)
 
 
 def test_transforms():
@@ -416,8 +410,8 @@ def test_add_selection():
         selections[1],
         selections[2]
     )
-    expected = selections[0] + selections[1] + selections[2]
-    assert chart.selection.to_dict() == expected.to_dict()
+    expected = {s.name: s.selection for s in selections}
+    assert chart.selection == expected
 
 
 def test_LookupData():

--- a/doc/user_guide/compound_charts.rst
+++ b/doc/user_guide/compound_charts.rst
@@ -181,7 +181,7 @@ with a ``brush`` selection to add interaction:
     brush = alt.selection(type='interval', encodings=['x'])
 
     upper = alt.Chart(sp500).mark_area().encode(
-        x=alt.X('date:T', scale={'domain': brush.ref()}),
+        x=alt.X('date:T', scale=alt.Scale(domain=brush),
         y='price:Q'
     ).properties(
         width=600,

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -239,6 +239,8 @@ class SchemaBase(object):
             elif isinstance(val, dict):
                 return {k: _todict(v) for k, v in val.items()
                         if v is not Undefined}
+            elif hasattr(val, 'to_dict'):
+                return val.to_dict()
             else:
                 return val
 


### PR DESCRIPTION
This cleans up the syntax of ``alt.selection_*()``. The main effects are

- you no longer need to use ``selection.ref()`` when referencing the selection (e.g. as a scale domain). Concretely, if ``selection=alt.selection_interval()`` then ``alt.Scale(domain=selection.ref())`` can now be written ``alt.Scale(domain=selection)``.
- it's no longer possible to pass a selection directly as a property; it must be passed via the ``add_selection`` function
- it's no longer possible to use the addition operator to combine two selections; so, rather than ``chart.properties(selection=sel1+sel2)``, we instead do ``chart.add_selection(sel1, sel2)``.