### PR TITLE
MAINT: make tooltips opt-in

### DIFF
--- a/altair/examples/errorbars_with_ci.py
+++ b/altair/examples/errorbars_with_ci.py
@@ -19,7 +19,6 @@ error_bars = alt.Chart(source).mark_errorbar(extent='ci').encode(
 points = alt.Chart(source).mark_point(filled=True, color='black').encode(
   x=alt.X('yield:Q', aggregate='mean'),
   y=alt.Y('variety:N'),
-  tooltip=None
 )
 
 error_bars + points

--- a/altair/examples/errorbars_with_std.py
+++ b/altair/examples/errorbars_with_std.py
@@ -18,7 +18,6 @@ error_bars = alt.Chart(source).mark_errorbar(extent='stdev').encode(
 points = alt.Chart(source).mark_point(filled=True, color='black').encode(
   x=alt.X('yield:Q', aggregate='mean'),
   y=alt.Y('variety:N'),
-  tooltip=None,
 )
 
 error_bars + points

--- a/altair/examples/interactive_brush.py
+++ b/altair/examples/interactive_brush.py
@@ -16,5 +16,4 @@ alt.Chart(source).mark_point().encode(
     x='Horsepower:Q',
     y='Miles_per_Gallon:Q',
     color=alt.condition(brush, 'Cylinders:O', alt.value('grey')),
-    tooltip=None
 ).add_selection(brush)

--- a/altair/examples/interactive_scatter_plot.py
+++ b/altair/examples/interactive_scatter_plot.py
@@ -13,5 +13,4 @@ alt.Chart(source).mark_circle().encode(
     x='Horsepower',
     y='Miles_per_Gallon',
     color='Origin',
-    tooltip=None,
 ).interactive()

--- a/altair/examples/multiline_tooltip.py
+++ b/altair/examples/multiline_tooltip.py
@@ -64,6 +64,4 @@ alt.layer(
     line, selectors, points, rules, text
 ).properties(
     width=600, height=300
-).configure_mark(
-    tooltip=None
 )

--- a/altair/examples/scatter_linked_brush.py
+++ b/altair/examples/scatter_linked_brush.py
@@ -15,7 +15,6 @@ brush = alt.selection(type='interval', resolve='global')
 base = alt.Chart(source).mark_point().encode(
     y='Miles_per_Gallon',
     color=alt.condition(brush, 'Origin', alt.ColorValue('gray')),
-    tooltip=None
 ).add_selection(
     brush
 ).properties(

--- a/altair/examples/select_mark_area.py
+++ b/altair/examples/select_mark_area.py
@@ -21,7 +21,6 @@ base = alt.Chart(source).mark_area(
 ).encode(
     x='yearmonth(date):T',
     y='sum(count):Q',
-    tooltip=None
 )
 
 brush = alt.selection_interval(encodings=['x'],empty='all')

--- a/altair/examples/selection_layer_bar_month.py
+++ b/altair/examples/selection_layer_bar_month.py
@@ -16,7 +16,6 @@ bars = alt.Chart().mark_bar().encode(
     x='month(date):O',
     y='mean(precipitation):Q',
     opacity=alt.condition(brush, alt.OpacityValue(1), alt.OpacityValue(0.7)),
-    tooltip=None
 ).add_selection(
     brush
 )

--- a/altair/examples/stem_and_leaf.py
+++ b/altair/examples/stem_and_leaf.py
@@ -32,7 +32,6 @@ alt.Chart(source).mark_text(
     ),
     alt.Y('stem:N', title='', axis=alt.Axis(tickSize=0)),
     text='leaf:N',
-    tooltip=None
 ).configure_axis(
     labelFontSize=20
 ).configure_text(

--- a/altair/examples/us_state_capitals.py
+++ b/altair/examples/us_state_capitals.py
@@ -28,7 +28,6 @@ hover = alt.selection(type='single', on='mouseover', nearest=True,
 base = alt.Chart(capitals).encode(
     longitude='lon:Q',
     latitude='lat:Q',
-    tooltip=None
 )
 
 text = base.mark_text(dy=-5, align='right').encode( 

--- a/altair/vegalite/tests/test_common.py
+++ b/altair/vegalite/tests/test_common.py
@@ -19,16 +19,10 @@ def basic_spec():
         }
     }
 
-@pytest.fixture
-def final_spec(basic_spec):
-    spec = {
-        'config': {
-            'view': {
-                'height': 300,
-                'width': 400
-            }
-        }
-    }
+
+def make_final_spec(alt, basic_spec):
+    theme = alt.themes.get()
+    spec = theme()
     spec.update(basic_spec)
     return spec
 
@@ -46,7 +40,7 @@ def make_basic_chart(alt):
 
 
 @pytest.mark.parametrize('alt', [v2, v3])
-def test_basic_chart_to_dict(alt, final_spec):
+def test_basic_chart_to_dict(alt, basic_spec):
     chart = alt.Chart('data.csv').mark_line().encode(
         alt.X('xval:Q'),
         y=alt.Y('yval:O'),
@@ -58,11 +52,11 @@ def test_basic_chart_to_dict(alt, final_spec):
     assert dct.pop('$schema').startswith('http')
 
     # remainder of spec should match the basic spec
-    assert dct == final_spec
+    assert dct == make_final_spec(alt, basic_spec)
 
 
 @pytest.mark.parametrize('alt', [v2, v3])
-def test_basic_chart_from_dict(alt, basic_spec, final_spec):
+def test_basic_chart_from_dict(alt, basic_spec):
     chart = alt.Chart.from_dict(basic_spec)
     dct = chart.to_dict()
 
@@ -70,7 +64,7 @@ def test_basic_chart_from_dict(alt, basic_spec, final_spec):
     assert dct.pop('$schema').startswith('http')
 
     # remainder of spec should match the basic spec
-    assert dct == final_spec
+    assert dct == make_final_spec(alt, basic_spec)
 
 
 @pytest.mark.parametrize('alt', [v2, v3])

--- a/altair/vegalite/v3/tests/test_api.py
+++ b/altair/vegalite/v3/tests/test_api.py
@@ -448,10 +448,12 @@ def test_themes():
 
     try:
         alt.themes.enable('default')
-        assert chart.to_dict()['config'] == {"view": {"width": 400, "height": 300}}
+        assert chart.to_dict()['config'] == {"mark": {"tooltip": None},
+                                             "view": {"width": 400, "height": 300}}
 
         alt.themes.enable('opaque')
         assert chart.to_dict()['config'] == {"background": "white",
+                                             "mark": {"tooltip": None},
                                              "view": {"width": 400, "height": 300}}
 
         alt.themes.enable('none')

--- a/altair/vegalite/v3/theme.py
+++ b/altair/vegalite/v3/theme.py
@@ -8,8 +8,10 @@ from ...utils.theme import ThemeRegistry
 ENTRY_POINT_GROUP = 'altair.vegalite.v3.theme'  # type: str
 themes = ThemeRegistry(entry_point_group=ENTRY_POINT_GROUP)
 
-themes.register('default', lambda: {"config": {"view": {"width": 400, "height": 300}}})
+themes.register('default', lambda: {"config": {"view": {"width": 400, "height": 300},
+                                               "mark": {"tooltip": None}}})
 themes.register('opaque', lambda: {"config": {"background": "white",
-                                              "view": {"width": 400, "height": 300}}})
+                                              "view": {"width": 400, "height": 300},
+                                              "mark": {"tooltip": None}}})
 themes.register('none', lambda: {})
 themes.enable('default')


### PR DESCRIPTION
In Vega-Lite 2, tooltips would only be added to a chart if they were specifically listed in encodings.
Vega-Lite 3 changed this so that tooltips are shown unless explicitly disabled.

This uses a new theme argument (equivalent to ``chart.configure_mark(tooltip=None)``) to restore the previous behavior, in which tooltips are opt-in rather than opt-out.