### PR TITLE
ENH: support vega-themes

### DIFF
--- a/altair/vegalite/v3/tests/test_theme.py
+++ b/altair/vegalite/v3/tests/test_theme.py
@@ -1,0 +1,17 @@
+import pytest
+
+import altair.vegalite.v3 as alt
+from altair.vegalite.v3.theme import VEGA_THEMES
+
+
+@pytest.fixture
+def chart():
+    return alt.Chart('data.csv').mark_bar().encode(x='x:Q')
+
+def test_vega_themes(chart):
+    for theme in VEGA_THEMES:
+        with alt.themes.enable(theme):
+            dct = chart.to_dict()
+        assert dct['usermeta'] == {'embedOptions': {'theme': theme}}
+        assert dct['config'] == {"view": {"width": 400, "height": 300},
+                                 "mark": {"tooltip": None}}

--- a/altair/vegalite/v3/theme.py
+++ b/altair/vegalite/v3/theme.py
@@ -2,6 +2,23 @@
 
 from ...utils.theme import ThemeRegistry
 
+VEGA_THEMES = ['ggplot2', 'quartz', 'vox', 'fivethirtyeight', 'dark', 'latimes']
+
+
+class VegaTheme(object):
+    """Implementation of a builtin vega theme."""
+    def __init__(self, theme):
+        self.theme = theme
+        
+    def __call__(self):
+        return {"usermeta": {"embedOptions": {"theme": self.theme}},
+                "config": {"view": {"width": 400, "height": 300},
+                           "mark": {"tooltip": None}}}
+
+    def __repr__(self):
+        return "VegaTheme({!r})".format(self.theme)
+
+
 # The entry point group that can be used by other packages to declare other
 # renderers that will be auto-detected. Explicit registration is also
 # allowed by the PluginRegistery API.
@@ -14,4 +31,8 @@ themes.register('opaque', lambda: {"config": {"background": "white",
                                               "view": {"width": 400, "height": 300},
                                               "mark": {"tooltip": None}}})
 themes.register('none', lambda: {})
+  
+for theme in VEGA_THEMES:
+    themes.register(theme, VegaTheme(theme))
+
 themes.enable('default')


### PR DESCRIPTION
This PR adds support for vega themes. For example:
```python
import altair as alt
alt.themes.enable('dark')

from vega_datasets import data
cars = data.cars()

alt.Chart(cars).mark_point().encode(
    x='Horsepower',
    y='Miles_per_Gallon',
    color='Origin',
).interactive()
```
![visualization - 2019-05-29T205206 398](https://user-images.githubusercontent.com/781659/58607230-a003a280-8253-11e9-8723-76f0ff7930b2.png)

This requires your frontend to use the most recent release of vega-embed.

Fixes #781 
