### PR TITLE
DOC: Change detail encoding example

### DIFF
--- a/doc/user_guide/encoding.rst
+++ b/doc/user_guide/encoding.rst
@@ -98,7 +98,7 @@ Level of Detail Channel:
 =======  ================  ===============================  =========================================
 Channel  Altair Class      Description                      Example
 =======  ================  ===============================  =========================================
-detail   :class:`Detail`   Additional property to group by  :ref:`gallery_select_detail`
+detail   :class:`Detail`   Additional property to group by  :ref:`gallery_ranged_dot_plot`
 =======  ================  ===============================  =========================================
 
 Order Channel:


### PR DESCRIPTION
The [Selection Detail Example](https://altair-viz.github.io/gallery/select_detail.html#gallery-select-detail) does not actually use the detail encoding so I changed the example to [Ranged Dot Plot](https://altair-viz.github.io/gallery/ranged_dot_plot.html) which does. 