### PR TITLE
Truncate top-level chart repr

### DIFF
--- a/altair/vegalite/v3/api.py
+++ b/altair/vegalite/v3/api.py
@@ -476,6 +476,11 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             result = save(**kwds)
         return result
 
+    # Fallback for when rendering fails; the full repr is too long to be
+    # useful in nearly all cases.
+    def __repr__(self):
+        return "alt.{}(...)".format(self.__class__.__name__)
+
     # Layering and stacking
     def __add__(self, other):
         if not isinstance(other, TopLevelMixin):


### PR DESCRIPTION
Any time there is a rendering error Jupyter defaults to printing the chart repr. This can sometimes be _very_ long, and obscure the actual error. This change suppresses the full chart repr.