### PR TITLE
Set minimum pandas version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ entrypoints
 jinja2
 jsonschema
 numpy
-pandas
+pandas>=0.21.0
 six
 toolz
 typing>=3.6;python_version<"3.5"


### PR DESCRIPTION
If you have an old pandas installed, plots just fail with `infer_dtype() takes no keyword arguments`.

The `skipna` arg was added in pandas `0.21.0`. 

ref:  https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.api.types.infer_dtype.html