### PR TITLE
BUG: make infer_dtype utility work with pandas 0.20

### DIFF
--- a/altair/utils/tests/test_core.py
+++ b/altair/utils/tests/test_core.py
@@ -1,10 +1,12 @@
 import types
 
+import numpy as np
 import pandas as pd
 import pytest
 
 import altair as alt
 from .. import parse_shorthand, update_nested, infer_encoding_types
+from ..core import infer_dtype
 
 FAKE_CHANNELS_MODULE = '''
 """Fake channels module for utility tests."""
@@ -53,6 +55,16 @@ class StrokeWidthValue(ValueChannel, schemapi.SchemaBase):
     _schema = {}
     _encoding_name = "strokeWidth"
 '''
+
+@pytest.mark.parametrize('value,expected_type', [
+    ([1, 2, 3], 'integer'),
+    ([1.0, 2.0, 3.0], 'floating'),
+    ([1, 2.0, 3], 'mixed-integer-float'),
+    (['a', 'b', 'c'], 'string'),
+    (['a', 'b', np.nan], 'mixed'),
+])
+def test_infer_dtype(value, expected_type):
+    assert infer_dtype(value) == expected_type
 
 
 def test_parse_shorthand():


### PR DESCRIPTION
Currently Altair's type inference fails with pandas version 0.20.X (it works with older or newer versions)

Confirmed that this fix works with all pandas versions back to at least 0.14.X (and probably further, but I didn't check): https://colab.research.google.com/drive/1SaigNiN-W8DY54zzKoou0cPc5XvjxMSt#scrollTo=UyS-QGDzIQCL

Replaces #1610