### PR TITLE
Support Altair in Apache Zeppelin

### DIFF
--- a/altair/utils/html.py
+++ b/altair/utils/html.py
@@ -58,7 +58,7 @@ requirejs.config({
     });
     {%- endif %}
     require(['vega-embed'], function(vegaEmbed){
-    {%- endif %}
+    {%- endif %} (function(root) {
       var spec = {{ spec }};
       var embedOpt = {{ embed_options }};
 
@@ -73,6 +73,7 @@ requirejs.config({
       const el = document.getElementById('{{ output_div }}');
       vegaEmbed("#{{ output_div }}", spec, embedOpt)
         .catch(error => showError(el, error));
+    })(window);
     {%- if requirejs %}
     });
     {%- endif %}

--- a/altair/utils/html.py
+++ b/altair/utils/html.py
@@ -58,7 +58,7 @@ requirejs.config({
     });
     {%- endif %}
     require(['vega-embed'], function(vegaEmbed){
-    {%- endif %} (function(root) {
+    {%- endif %} (function(vegaEmbed) {
       var spec = {{ spec }};
       var embedOpt = {{ embed_options }};
 
@@ -73,7 +73,7 @@ requirejs.config({
       const el = document.getElementById('{{ output_div }}');
       vegaEmbed("#{{ output_div }}", spec, embedOpt)
         .catch(error => showError(el, error));
-    })(window);
+    })(vegaEmbed);
     {%- if requirejs %}
     });
     {%- endif %}

--- a/altair/vegalite/v3/display.py
+++ b/altair/vegalite/v3/display.py
@@ -74,10 +74,10 @@ colab_renderer = HTMLRenderer(mode='vega-lite',
                               vegalite_version=VEGALITE_VERSION)
 
 zeppelin_renderer = HTMLRenderer(mode='vega-lite',
-                              fullhtml=True, requirejs=False,
-                              vega_version=VEGA_VERSION,
-                              vegaembed_version=VEGAEMBED_VERSION,
-                              vegalite_version=VEGALITE_VERSION)
+                                fullhtml=True, requirejs=False,
+                                vega_version=VEGA_VERSION,
+                                vegaembed_version=VEGAEMBED_VERSION,
+                                vegalite_version=VEGALITE_VERSION)
 
 kaggle_renderer = HTMLRenderer(mode='vega-lite',
                                fullhtml=False, requirejs=True,

--- a/altair/vegalite/v3/display.py
+++ b/altair/vegalite/v3/display.py
@@ -73,6 +73,12 @@ colab_renderer = HTMLRenderer(mode='vega-lite',
                               vegaembed_version=VEGAEMBED_VERSION,
                               vegalite_version=VEGALITE_VERSION)
 
+zeppelin_renderer = HTMLRenderer(mode='vega-lite',
+                              fullhtml=True, requirejs=False,
+                              vega_version=VEGA_VERSION,
+                              vegaembed_version=VEGAEMBED_VERSION,
+                              vegalite_version=VEGALITE_VERSION)
+
 kaggle_renderer = HTMLRenderer(mode='vega-lite',
                                fullhtml=False, requirejs=True,
                                vega_version=VEGA_VERSION,
@@ -87,6 +93,7 @@ renderers.register('kaggle', kaggle_renderer)
 renderers.register('json', json_renderer)
 renderers.register('png', png_renderer)
 renderers.register('svg', svg_renderer)
+renderers.register('zeppelin', zeppelin_renderer)
 renderers.enable('default')
 
 


### PR DESCRIPTION
This PR is to support Altair in Apache Zeppelin. I create a new render for Zeppelin. The changes I made in HTMLTemplate is especially for Zeppelin. Without this change. The rendering only works for the time, afterwards, I will get js error of `el is already defined`.

Here's the screenshot in Zeppelin.

![image](https://user-images.githubusercontent.com/164491/61719422-74a2bd00-ad97-11e9-846e-e7781b6ee494.png)
