### PR TITLE
MAINT: unpin docutils in dev requirements

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,12 +1,10 @@
+docutils
 flake8
 pytest
 sphinx
 m2r
 vega_datasets
 recommonmark
-
-docutils==0.14; python_version < '3'  # docutils 0.15 breaks in python 2
-docutils; python_version >= '3'
 
 ipython<6; python_version < '3'  # ipython 6 not compatible with python 2
 ipython; python_version >= '3'


### PR DESCRIPTION
0.15.1 was released, so it should work properly now.