### PR TITLE
WIP: add method-based attribute setting to encoding classes

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -108,7 +108,6 @@ class SchemaValidationError(jsonschema.ValidationError):
             return six.text_type(self).encode("utf-8")
 
 
-
 class UndefinedType(object):
     """A singleton object for marking undefined attributes"""
     __instance = None
@@ -528,3 +527,28 @@ class _FromDict(object):
             return cls(dct)
         else:
             return cls(dct)
+
+
+class _PropertySetter(object):
+    def __init__(self, prop, schema):
+        self.prop = prop
+        self.schema = schema
+
+    def __get__(self, obj, cls):
+        self.obj = obj
+        self.cls = cls
+        return self
+
+    def __call__(self, *args, **kwargs):
+        obj = self.obj.copy()
+        # TODO: use schema to validate
+        obj[self.prop] = (args[0] if args else kwargs)
+        return obj
+
+
+def with_property_setters(cls):
+    """Decorator to add property setters to a Schema class."""
+    schema = cls.resolve_references()
+    for prop, propschema in schema.get('properties', {}).items():
+        setattr(cls, prop, _PropertySetter(prop, propschema))
+    return cls

--- a/altair/vegalite/v2/schema/channels.py
+++ b/altair/vegalite/v2/schema/channels.py
@@ -6,7 +6,7 @@
 import six
 from . import core
 import pandas as pd
-from altair.utils.schemapi import Undefined
+from altair.utils.schemapi import Undefined, with_property_setters
 from altair.utils import parse_shorthand
 
 
@@ -67,7 +67,7 @@ class FieldChannelMixin(object):
 class ValueChannelMixin(object):
     def to_dict(self, validate=True, ignore=(), context=None):
         context = context or {}
-        condition = getattr(self, 'condition', Undefined)
+        condition = self._get('condition')
         copy = self  # don't copy unless we need to
         if condition is not Undefined:
             if isinstance(condition, core.SchemaBase):
@@ -81,6 +81,7 @@ class ValueChannelMixin(object):
                                                       context=context)
 
 
+@with_property_setters
 class Color(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
     """Color schema wrapper
 
@@ -209,6 +210,7 @@ class Color(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
                                     sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class ColorValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
     """ColorValue schema wrapper
 
@@ -231,6 +233,7 @@ class ColorValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
         super(ColorValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Column(FieldChannelMixin, core.FacetFieldDef):
     """Column schema wrapper
 
@@ -338,6 +341,7 @@ class Column(FieldChannelMixin, core.FacetFieldDef):
                                      type=type, **kwds)
 
 
+@with_property_setters
 class Detail(FieldChannelMixin, core.FieldDef):
     """Detail schema wrapper
 
@@ -416,6 +420,7 @@ class Detail(FieldChannelMixin, core.FieldDef):
                                      timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class Fill(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
     """Fill schema wrapper
 
@@ -544,6 +549,7 @@ class Fill(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
                                    sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class FillValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
     """FillValue schema wrapper
 
@@ -566,6 +572,7 @@ class FillValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
         super(FillValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Href(FieldChannelMixin, core.FieldDefWithCondition):
     """Href schema wrapper
 
@@ -651,6 +658,7 @@ class Href(FieldChannelMixin, core.FieldDefWithCondition):
                                    type=type, **kwds)
 
 
+@with_property_setters
 class HrefValue(ValueChannelMixin, core.ValueDefWithCondition):
     """HrefValue schema wrapper
 
@@ -673,6 +681,7 @@ class HrefValue(ValueChannelMixin, core.ValueDefWithCondition):
         super(HrefValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Key(FieldChannelMixin, core.FieldDef):
     """Key schema wrapper
 
@@ -751,6 +760,7 @@ class Key(FieldChannelMixin, core.FieldDef):
                                   timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class Latitude(FieldChannelMixin, core.FieldDef):
     """Latitude schema wrapper
 
@@ -829,6 +839,7 @@ class Latitude(FieldChannelMixin, core.FieldDef):
                                        timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class Latitude2(FieldChannelMixin, core.FieldDef):
     """Latitude2 schema wrapper
 
@@ -907,6 +918,7 @@ class Latitude2(FieldChannelMixin, core.FieldDef):
                                         timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class Longitude(FieldChannelMixin, core.FieldDef):
     """Longitude schema wrapper
 
@@ -985,6 +997,7 @@ class Longitude(FieldChannelMixin, core.FieldDef):
                                         timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class Longitude2(FieldChannelMixin, core.FieldDef):
     """Longitude2 schema wrapper
 
@@ -1063,6 +1076,7 @@ class Longitude2(FieldChannelMixin, core.FieldDef):
                                          timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class Opacity(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
     """Opacity schema wrapper
 
@@ -1191,6 +1205,7 @@ class Opacity(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
                                       sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class OpacityValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
     """OpacityValue schema wrapper
 
@@ -1213,6 +1228,7 @@ class OpacityValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
         super(OpacityValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Order(FieldChannelMixin, core.OrderFieldDef):
     """Order schema wrapper
 
@@ -1292,6 +1308,7 @@ class Order(FieldChannelMixin, core.OrderFieldDef):
                                     sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class OrderValue(ValueChannelMixin, core.ValueDef):
     """OrderValue schema wrapper
 
@@ -1312,6 +1329,7 @@ class OrderValue(ValueChannelMixin, core.ValueDef):
         super(OrderValue, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class Row(FieldChannelMixin, core.FacetFieldDef):
     """Row schema wrapper
 
@@ -1419,6 +1437,7 @@ class Row(FieldChannelMixin, core.FacetFieldDef):
                                   **kwds)
 
 
+@with_property_setters
 class Shape(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
     """Shape schema wrapper
 
@@ -1547,6 +1566,7 @@ class Shape(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
                                     sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class ShapeValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
     """ShapeValue schema wrapper
 
@@ -1569,6 +1589,7 @@ class ShapeValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
         super(ShapeValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Size(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
     """Size schema wrapper
 
@@ -1697,6 +1718,7 @@ class Size(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
                                    sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class SizeValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
     """SizeValue schema wrapper
 
@@ -1719,6 +1741,7 @@ class SizeValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
         super(SizeValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Stroke(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
     """Stroke schema wrapper
 
@@ -1847,6 +1870,7 @@ class Stroke(FieldChannelMixin, core.MarkPropFieldDefWithCondition):
                                      sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class StrokeValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
     """StrokeValue schema wrapper
 
@@ -1869,6 +1893,7 @@ class StrokeValue(ValueChannelMixin, core.MarkPropValueDefWithCondition):
         super(StrokeValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Text(FieldChannelMixin, core.TextFieldDefWithCondition):
     """Text schema wrapper
 
@@ -1958,6 +1983,7 @@ class Text(FieldChannelMixin, core.TextFieldDefWithCondition):
                                    title=title, type=type, **kwds)
 
 
+@with_property_setters
 class TextValue(ValueChannelMixin, core.TextValueDefWithCondition):
     """TextValue schema wrapper
 
@@ -1980,6 +2006,7 @@ class TextValue(ValueChannelMixin, core.TextValueDefWithCondition):
         super(TextValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Tooltip(FieldChannelMixin, core.TextFieldDefWithCondition):
     """Tooltip schema wrapper
 
@@ -2069,6 +2096,7 @@ class Tooltip(FieldChannelMixin, core.TextFieldDefWithCondition):
                                       timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class TooltipValue(ValueChannelMixin, core.TextValueDefWithCondition):
     """TooltipValue schema wrapper
 
@@ -2091,6 +2119,7 @@ class TooltipValue(ValueChannelMixin, core.TextValueDefWithCondition):
         super(TooltipValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class X(FieldChannelMixin, core.PositionFieldDef):
     """X schema wrapper
 
@@ -2239,6 +2268,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
                                 title=title, type=type, **kwds)
 
 
+@with_property_setters
 class XValue(ValueChannelMixin, core.ValueDef):
     """XValue schema wrapper
 
@@ -2259,6 +2289,7 @@ class XValue(ValueChannelMixin, core.ValueDef):
         super(XValue, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class X2(FieldChannelMixin, core.FieldDef):
     """X2 schema wrapper
 
@@ -2337,6 +2368,7 @@ class X2(FieldChannelMixin, core.FieldDef):
                                  timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class X2Value(ValueChannelMixin, core.ValueDef):
     """X2Value schema wrapper
 
@@ -2357,6 +2389,7 @@ class X2Value(ValueChannelMixin, core.ValueDef):
         super(X2Value, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class Y(FieldChannelMixin, core.PositionFieldDef):
     """Y schema wrapper
 
@@ -2505,6 +2538,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
                                 title=title, type=type, **kwds)
 
 
+@with_property_setters
 class YValue(ValueChannelMixin, core.ValueDef):
     """YValue schema wrapper
 
@@ -2525,6 +2559,7 @@ class YValue(ValueChannelMixin, core.ValueDef):
         super(YValue, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class Y2(FieldChannelMixin, core.FieldDef):
     """Y2 schema wrapper
 
@@ -2603,6 +2638,7 @@ class Y2(FieldChannelMixin, core.FieldDef):
                                  timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class Y2Value(ValueChannelMixin, core.ValueDef):
     """Y2Value schema wrapper
 

--- a/altair/vegalite/v3/schema/channels.py
+++ b/altair/vegalite/v3/schema/channels.py
@@ -6,7 +6,7 @@
 import six
 from . import core
 import pandas as pd
-from altair.utils.schemapi import Undefined
+from altair.utils.schemapi import Undefined, with_property_setters
 from altair.utils import parse_shorthand
 
 
@@ -67,7 +67,7 @@ class FieldChannelMixin(object):
 class ValueChannelMixin(object):
     def to_dict(self, validate=True, ignore=(), context=None):
         context = context or {}
-        condition = getattr(self, 'condition', Undefined)
+        condition = self._get('condition')
         copy = self  # don't copy unless we need to
         if condition is not Undefined:
             if isinstance(condition, core.SchemaBase):
@@ -81,6 +81,7 @@ class ValueChannelMixin(object):
                                                       context=context)
 
 
+@with_property_setters
 class Color(FieldChannelMixin, core.StringFieldDefWithCondition):
     """Color schema wrapper
 
@@ -279,6 +280,7 @@ class Color(FieldChannelMixin, core.StringFieldDefWithCondition):
                                     sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class ColorValue(ValueChannelMixin, core.StringValueDefWithCondition):
     """ColorValue schema wrapper
 
@@ -303,6 +305,7 @@ class ColorValue(ValueChannelMixin, core.StringValueDefWithCondition):
         super(ColorValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Column(FieldChannelMixin, core.FacetFieldDef):
     """Column schema wrapper
 
@@ -465,6 +468,7 @@ class Column(FieldChannelMixin, core.FacetFieldDef):
                                      type=type, **kwds)
 
 
+@with_property_setters
 class Detail(FieldChannelMixin, core.FieldDefWithoutScale):
     """Detail schema wrapper
 
@@ -598,6 +602,7 @@ class Detail(FieldChannelMixin, core.FieldDefWithoutScale):
                                      timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class Facet(FieldChannelMixin, core.FacetFieldDef):
     """Facet schema wrapper
 
@@ -760,6 +765,7 @@ class Facet(FieldChannelMixin, core.FacetFieldDef):
                                     **kwds)
 
 
+@with_property_setters
 class Fill(FieldChannelMixin, core.StringFieldDefWithCondition):
     """Fill schema wrapper
 
@@ -958,6 +964,7 @@ class Fill(FieldChannelMixin, core.StringFieldDefWithCondition):
                                    sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class FillValue(ValueChannelMixin, core.StringValueDefWithCondition):
     """FillValue schema wrapper
 
@@ -982,6 +989,7 @@ class FillValue(ValueChannelMixin, core.StringValueDefWithCondition):
         super(FillValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class FillOpacity(FieldChannelMixin, core.NumericFieldDefWithCondition):
     """FillOpacity schema wrapper
 
@@ -1180,6 +1188,7 @@ class FillOpacity(FieldChannelMixin, core.NumericFieldDefWithCondition):
                                           sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class FillOpacityValue(ValueChannelMixin, core.NumericValueDefWithCondition):
     """FillOpacityValue schema wrapper
 
@@ -1204,6 +1213,7 @@ class FillOpacityValue(ValueChannelMixin, core.NumericValueDefWithCondition):
         super(FillOpacityValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Href(FieldChannelMixin, core.TextFieldDefWithCondition):
     """Href schema wrapper
 
@@ -1374,6 +1384,7 @@ class Href(FieldChannelMixin, core.TextFieldDefWithCondition):
                                    **kwds)
 
 
+@with_property_setters
 class HrefValue(ValueChannelMixin, core.TextValueDefWithCondition):
     """HrefValue schema wrapper
 
@@ -1398,6 +1409,7 @@ class HrefValue(ValueChannelMixin, core.TextValueDefWithCondition):
         super(HrefValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Key(FieldChannelMixin, core.FieldDefWithoutScale):
     """Key schema wrapper
 
@@ -1531,6 +1543,7 @@ class Key(FieldChannelMixin, core.FieldDefWithoutScale):
                                   timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class Latitude(FieldChannelMixin, core.LatLongFieldDef):
     """Latitude schema wrapper
 
@@ -1663,6 +1676,7 @@ class Latitude(FieldChannelMixin, core.LatLongFieldDef):
                                        timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class LatitudeValue(ValueChannelMixin, core.NumberValueDef):
     """LatitudeValue schema wrapper
 
@@ -1683,6 +1697,7 @@ class LatitudeValue(ValueChannelMixin, core.NumberValueDef):
         super(LatitudeValue, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class Latitude2(FieldChannelMixin, core.SecondaryFieldDef):
     """Latitude2 schema wrapper
 
@@ -1781,6 +1796,7 @@ class Latitude2(FieldChannelMixin, core.SecondaryFieldDef):
                                         timeUnit=timeUnit, title=title, **kwds)
 
 
+@with_property_setters
 class Latitude2Value(ValueChannelMixin, core.NumberValueDef):
     """Latitude2Value schema wrapper
 
@@ -1801,6 +1817,7 @@ class Latitude2Value(ValueChannelMixin, core.NumberValueDef):
         super(Latitude2Value, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class Longitude(FieldChannelMixin, core.LatLongFieldDef):
     """Longitude schema wrapper
 
@@ -1933,6 +1950,7 @@ class Longitude(FieldChannelMixin, core.LatLongFieldDef):
                                         timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class LongitudeValue(ValueChannelMixin, core.NumberValueDef):
     """LongitudeValue schema wrapper
 
@@ -1953,6 +1971,7 @@ class LongitudeValue(ValueChannelMixin, core.NumberValueDef):
         super(LongitudeValue, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class Longitude2(FieldChannelMixin, core.SecondaryFieldDef):
     """Longitude2 schema wrapper
 
@@ -2051,6 +2070,7 @@ class Longitude2(FieldChannelMixin, core.SecondaryFieldDef):
                                          timeUnit=timeUnit, title=title, **kwds)
 
 
+@with_property_setters
 class Longitude2Value(ValueChannelMixin, core.NumberValueDef):
     """Longitude2Value schema wrapper
 
@@ -2071,6 +2091,7 @@ class Longitude2Value(ValueChannelMixin, core.NumberValueDef):
         super(Longitude2Value, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class Opacity(FieldChannelMixin, core.NumericFieldDefWithCondition):
     """Opacity schema wrapper
 
@@ -2269,6 +2290,7 @@ class Opacity(FieldChannelMixin, core.NumericFieldDefWithCondition):
                                       sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class OpacityValue(ValueChannelMixin, core.NumericValueDefWithCondition):
     """OpacityValue schema wrapper
 
@@ -2293,6 +2315,7 @@ class OpacityValue(ValueChannelMixin, core.NumericValueDefWithCondition):
         super(OpacityValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Order(FieldChannelMixin, core.OrderFieldDef):
     """Order schema wrapper
 
@@ -2427,6 +2450,7 @@ class Order(FieldChannelMixin, core.OrderFieldDef):
                                     sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class OrderValue(ValueChannelMixin, core.NumberValueDef):
     """OrderValue schema wrapper
 
@@ -2447,6 +2471,7 @@ class OrderValue(ValueChannelMixin, core.NumberValueDef):
         super(OrderValue, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class Row(FieldChannelMixin, core.FacetFieldDef):
     """Row schema wrapper
 
@@ -2609,6 +2634,7 @@ class Row(FieldChannelMixin, core.FacetFieldDef):
                                   **kwds)
 
 
+@with_property_setters
 class Shape(FieldChannelMixin, core.ShapeFieldDefWithCondition):
     """Shape schema wrapper
 
@@ -2807,6 +2833,7 @@ class Shape(FieldChannelMixin, core.ShapeFieldDefWithCondition):
                                     sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class ShapeValue(ValueChannelMixin, core.ShapeValueDefWithCondition):
     """ShapeValue schema wrapper
 
@@ -2831,6 +2858,7 @@ class ShapeValue(ValueChannelMixin, core.ShapeValueDefWithCondition):
         super(ShapeValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Size(FieldChannelMixin, core.NumericFieldDefWithCondition):
     """Size schema wrapper
 
@@ -3029,6 +3057,7 @@ class Size(FieldChannelMixin, core.NumericFieldDefWithCondition):
                                    sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class SizeValue(ValueChannelMixin, core.NumericValueDefWithCondition):
     """SizeValue schema wrapper
 
@@ -3053,6 +3082,7 @@ class SizeValue(ValueChannelMixin, core.NumericValueDefWithCondition):
         super(SizeValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Stroke(FieldChannelMixin, core.StringFieldDefWithCondition):
     """Stroke schema wrapper
 
@@ -3251,6 +3281,7 @@ class Stroke(FieldChannelMixin, core.StringFieldDefWithCondition):
                                      sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class StrokeValue(ValueChannelMixin, core.StringValueDefWithCondition):
     """StrokeValue schema wrapper
 
@@ -3275,6 +3306,7 @@ class StrokeValue(ValueChannelMixin, core.StringValueDefWithCondition):
         super(StrokeValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class StrokeOpacity(FieldChannelMixin, core.NumericFieldDefWithCondition):
     """StrokeOpacity schema wrapper
 
@@ -3474,6 +3506,7 @@ class StrokeOpacity(FieldChannelMixin, core.NumericFieldDefWithCondition):
                                             type=type, **kwds)
 
 
+@with_property_setters
 class StrokeOpacityValue(ValueChannelMixin, core.NumericValueDefWithCondition):
     """StrokeOpacityValue schema wrapper
 
@@ -3498,6 +3531,7 @@ class StrokeOpacityValue(ValueChannelMixin, core.NumericValueDefWithCondition):
         super(StrokeOpacityValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class StrokeWidth(FieldChannelMixin, core.NumericFieldDefWithCondition):
     """StrokeWidth schema wrapper
 
@@ -3696,6 +3730,7 @@ class StrokeWidth(FieldChannelMixin, core.NumericFieldDefWithCondition):
                                           sort=sort, timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class StrokeWidthValue(ValueChannelMixin, core.NumericValueDefWithCondition):
     """StrokeWidthValue schema wrapper
 
@@ -3720,6 +3755,7 @@ class StrokeWidthValue(ValueChannelMixin, core.NumericValueDefWithCondition):
         super(StrokeWidthValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Text(FieldChannelMixin, core.TextFieldDefWithCondition):
     """Text schema wrapper
 
@@ -3890,6 +3926,7 @@ class Text(FieldChannelMixin, core.TextFieldDefWithCondition):
                                    **kwds)
 
 
+@with_property_setters
 class TextValue(ValueChannelMixin, core.TextValueDefWithCondition):
     """TextValue schema wrapper
 
@@ -3914,6 +3951,7 @@ class TextValue(ValueChannelMixin, core.TextValueDefWithCondition):
         super(TextValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class Tooltip(FieldChannelMixin, core.TextFieldDefWithCondition):
     """Tooltip schema wrapper
 
@@ -4084,6 +4122,7 @@ class Tooltip(FieldChannelMixin, core.TextFieldDefWithCondition):
                                       **kwds)
 
 
+@with_property_setters
 class TooltipValue(ValueChannelMixin, core.TextValueDefWithCondition):
     """TooltipValue schema wrapper
 
@@ -4108,6 +4147,7 @@ class TooltipValue(ValueChannelMixin, core.TextValueDefWithCondition):
         super(TooltipValue, self).__init__(value=value, condition=condition, **kwds)
 
 
+@with_property_setters
 class X(FieldChannelMixin, core.PositionFieldDef):
     """X schema wrapper
 
@@ -4337,6 +4377,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
                                 timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class XValue(ValueChannelMixin, core.XValueDef):
     """XValue schema wrapper
 
@@ -4357,6 +4398,7 @@ class XValue(ValueChannelMixin, core.XValueDef):
         super(XValue, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class X2(FieldChannelMixin, core.SecondaryFieldDef):
     """X2 schema wrapper
 
@@ -4455,6 +4497,7 @@ class X2(FieldChannelMixin, core.SecondaryFieldDef):
                                  timeUnit=timeUnit, title=title, **kwds)
 
 
+@with_property_setters
 class X2Value(ValueChannelMixin, core.XValueDef):
     """X2Value schema wrapper
 
@@ -4475,6 +4518,7 @@ class X2Value(ValueChannelMixin, core.XValueDef):
         super(X2Value, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class XError(FieldChannelMixin, core.SecondaryFieldDef):
     """XError schema wrapper
 
@@ -4573,6 +4617,7 @@ class XError(FieldChannelMixin, core.SecondaryFieldDef):
                                      timeUnit=timeUnit, title=title, **kwds)
 
 
+@with_property_setters
 class XErrorValue(ValueChannelMixin, core.NumberValueDef):
     """XErrorValue schema wrapper
 
@@ -4593,6 +4638,7 @@ class XErrorValue(ValueChannelMixin, core.NumberValueDef):
         super(XErrorValue, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class XError2(FieldChannelMixin, core.SecondaryFieldDef):
     """XError2 schema wrapper
 
@@ -4691,6 +4737,7 @@ class XError2(FieldChannelMixin, core.SecondaryFieldDef):
                                       timeUnit=timeUnit, title=title, **kwds)
 
 
+@with_property_setters
 class XError2Value(ValueChannelMixin, core.NumberValueDef):
     """XError2Value schema wrapper
 
@@ -4711,6 +4758,7 @@ class XError2Value(ValueChannelMixin, core.NumberValueDef):
         super(XError2Value, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class Y(FieldChannelMixin, core.PositionFieldDef):
     """Y schema wrapper
 
@@ -4940,6 +4988,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
                                 timeUnit=timeUnit, title=title, type=type, **kwds)
 
 
+@with_property_setters
 class YValue(ValueChannelMixin, core.YValueDef):
     """YValue schema wrapper
 
@@ -4960,6 +5009,7 @@ class YValue(ValueChannelMixin, core.YValueDef):
         super(YValue, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class Y2(FieldChannelMixin, core.SecondaryFieldDef):
     """Y2 schema wrapper
 
@@ -5058,6 +5108,7 @@ class Y2(FieldChannelMixin, core.SecondaryFieldDef):
                                  timeUnit=timeUnit, title=title, **kwds)
 
 
+@with_property_setters
 class Y2Value(ValueChannelMixin, core.YValueDef):
     """Y2Value schema wrapper
 
@@ -5078,6 +5129,7 @@ class Y2Value(ValueChannelMixin, core.YValueDef):
         super(Y2Value, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class YError(FieldChannelMixin, core.SecondaryFieldDef):
     """YError schema wrapper
 
@@ -5176,6 +5228,7 @@ class YError(FieldChannelMixin, core.SecondaryFieldDef):
                                      timeUnit=timeUnit, title=title, **kwds)
 
 
+@with_property_setters
 class YErrorValue(ValueChannelMixin, core.NumberValueDef):
     """YErrorValue schema wrapper
 
@@ -5196,6 +5249,7 @@ class YErrorValue(ValueChannelMixin, core.NumberValueDef):
         super(YErrorValue, self).__init__(value=value, **kwds)
 
 
+@with_property_setters
 class YError2(FieldChannelMixin, core.SecondaryFieldDef):
     """YError2 schema wrapper
 
@@ -5294,6 +5348,7 @@ class YError2(FieldChannelMixin, core.SecondaryFieldDef):
                                       timeUnit=timeUnit, title=title, **kwds)
 
 
+@with_property_setters
 class YError2Value(ValueChannelMixin, core.NumberValueDef):
     """YError2Value schema wrapper
 

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -132,7 +132,7 @@ class FieldChannelMixin(object):
 class ValueChannelMixin(object):
     def to_dict(self, validate=True, ignore=(), context=None):
         context = context or {}
-        condition = getattr(self, 'condition', Undefined)
+        condition = self._get('condition')
         copy = self  # don't copy unless we need to
         if condition is not Undefined:
             if isinstance(condition, core.SchemaBase):
@@ -149,6 +149,7 @@ class ValueChannelMixin(object):
 
 class FieldSchemaGenerator(SchemaGenerator):
     schema_class_template = textwrap.dedent('''
+    @with_property_setters
     class {classname}(FieldChannelMixin, core.{basename}):
         """{docstring}"""
         _class_is_valid_at_instantiation = False
@@ -160,6 +161,7 @@ class FieldSchemaGenerator(SchemaGenerator):
 
 class ValueSchemaGenerator(SchemaGenerator):
     schema_class_template = textwrap.dedent('''
+    @with_property_setters
     class {classname}(ValueChannelMixin, core.{basename}):
         """{docstring}"""
         _class_is_valid_at_instantiation = False
@@ -281,7 +283,7 @@ def generate_vegalite_channel_wrappers(schemafile, version, imports=None):
         imports = ["import six",
                    "from . import core",
                    "import pandas as pd",
-                   "from altair.utils.schemapi import Undefined",
+                   "from altair.utils.schemapi import Undefined, with_property_setters",
                    "from altair.utils import parse_shorthand"]
     contents = [HEADER]
     contents.extend(imports)


### PR DESCRIPTION
Do not merge until Altair 4.0.

This is a new prototype of how to set encoding attributes via methods rather than arguments. So rather than
```python
alt.Chart(data).mark_point().encode(
    alt.X('column:Q', axis=alt.Axis(None), scale=alt.Scale(zero=False), title='my title'),
    alt.Color('color:N', legend=alt.Legend(orient='bottom'), scale=alt.Scale(scheme='viridis'))
)
```
you could instead do
```python
alt.Chart(data).mark_point().encode(
    alt.X('column:Q').axis(None).scale(zero=False).title('my title'),
    alt.Color('color:N').legend(orient='bottom').scale(scheme='viridis')
)
```
note that the old way still works as well.

The tradeoff is that attributes of encoding classes can no longer be accessed directly via ``getattr``, but this was not a very common pattern anyway.

Still TODO:
- [ ] add useful documentation and keyword argument completion for these functions.
- [ ] tests ensuring equivalence of old and new syntax.

If you'd like to try this in its current state, you can run
```
pip install git+https://github.com/jakevdp/altair.git@attr-access
```