### PR TITLE
accept __geo_interface__ attribute as data

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -114,14 +114,15 @@ def merge_props_geom(feat):
     Merge properties with geometry
     * Overwrites 'type' and 'geometry' entries if existing    
     """
-    
+
+    geom = {k: feat[k] for k in ('type', 'geometry')}
     try:
-        feat['properties'].update({k: feat[k] for k in ('type', 'geometry')})
+        feat['properties'].update(geom)
         props_geom = feat['properties']
     except (AttributeError, KeyError):
         # AttributeError when 'properties' equals None
         # KeyError when 'properties' is non-existing        
-        props_geom = {k: feat[k] for k in ('type', 'geometry')}    
+        props_geom = geom   
 
     return props_geom   
 

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -125,19 +125,21 @@ def sanitize_geo_interface(geo):
             geo[key] = geo[key].tolist()
     
     # parse (nested) tuples as lists
-    geo = deepcopy(json.loads(json.dumps(geo)))
+    geo = json.loads(json.dumps(geo))
+
+    reserved_keys = [
+        "type",
+        "bbox",
+        "coordinates",
+        "geometries",
+        "geometry",
+        "properties",
+        "features"
+    ]
 
     # Try to parse the object properties as foreign members, expect the reserved keys
     if geo['type'] == 'FeatureCollection':
-        reserved_keys = [
-            "type",
-            "bbox",
-            "coordinates",
-            "geometries",
-            "geometry",
-            "properties",
-            "features"
-        ]
+
         reserved_keys_used = bool(
             set(geo['features'][0]["properties"].keys()).intersection(reserved_keys)
         )

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -140,33 +140,37 @@ def sanitize_geo_interface(geo):
         
         geo = geo['features']
         if len(geo) > 0:
-            reserved_members_used = bool(
-                set(geo[0]["properties"].keys()).intersection(reserved_members)
-            )
+
             current_members = list(geo[0].keys())
             false_members = reserved_members + current_members
 
+            false_members_used = bool(
+                set(geo[0]["properties"].keys()).intersection(false_members)
+            )            
+
             for feat in geo:
                 for k, v in list(feat["properties"].items()):
-                    if not reserved_members_used or k not in false_members:
+                    if not false_members_used or k not in false_members:
                         feat[k] = v
                         feat["properties"].pop(k, None)
-                if not reserved_members_used:
+                if not false_members_used:
                     feat.pop("properties", None)
         
     
     elif geo['type'] == 'Feature':  
-        reserved_members_used = bool(
-            set(geo["properties"].keys()).intersection(reserved_members)
-        )
+
         current_members = list(geo.keys())
         false_members = reserved_members + current_members
 
+        false_members_used = bool(
+            set(geo["properties"].keys()).intersection(false_members)
+        )        
+
         for k, v in list(geo["properties"].items()):
-            if not reserved_members_used or k not in false_members:
+            if not false_members_used or k not in false_members:
                 geo[k] = v
                 geo["properties"].pop(k, None)
-        if not reserved_members_used:
+        if not false_members_used:
             geo.pop("properties", None)        
     
     else:

--- a/altair/vegalite/v3/api.py
+++ b/altair/vegalite/v3/api.py
@@ -79,8 +79,8 @@ def _prepare_data(data, context):
     if data is Undefined:
         return data
 
-    # convert dataframes to dict
-    if isinstance(data, pd.DataFrame):
+    # convert dataframes  or objects with __geo_interface__ to dict
+    if isinstance(data, pd.DataFrame) or hasattr(data, '__geo_interface__'):
         data = pipe(data, data_transformers.get())
 
     # convert string input to a URLData

--- a/altair/vegalite/v3/tests/test_geo_interface.py
+++ b/altair/vegalite/v3/tests/test_geo_interface.py
@@ -12,10 +12,10 @@ def not_raises(ExpectedException):
         yield
 
     except ExpectedException as error:
-        raise AssertionError(f"Raised exception {error} when it should not!")
+        raise AssertionError("Raised exception {}".format(error))
 
     except Exception as error:
-        raise AssertionError(f"An unexpected exception {error} raised.")
+        raise AssertionError("An unexpected exception {} raised.".format(error))
 
 def geom_obj(geom):
     class Geom(object):

--- a/altair/vegalite/v3/tests/test_geo_interface.py
+++ b/altair/vegalite/v3/tests/test_geo_interface.py
@@ -1,0 +1,217 @@
+import pytest
+import jsonschema
+
+import altair.vegalite.v3 as alt
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def not_raises(ExpectedException):
+    try:
+        yield
+
+    except ExpectedException as error:
+        raise AssertionError(f"Raised exception {error} when it should not!")
+
+    except Exception as error:
+        raise AssertionError(f"An unexpected exception {error} raised.")
+
+def geom_obj(geom):
+    class Geom(object):
+        pass
+    geom_obj = Geom()
+    setattr(geom_obj, '__geo_interface__', geom)
+    return geom_obj
+
+# correct translation of Polygon geometry to Feature type
+def test_geo_interface_polygon_feature():
+    geom = {
+        "coordinates": [[
+            (0, 0), 
+            (0, 2), 
+            (2, 2), 
+            (2, 0), 
+            (0, 0)
+        ]],
+        "type": "Polygon"
+    }
+    feat = geom_obj(geom)
+    
+    with not_raises(jsonschema.ValidationError):
+        chart = alt.Chart(feat).mark_geoshape().to_dict()
+    
+    ds_key = list(chart['datasets'].keys())[0]
+    assert chart['datasets'][ds_key]['type'] == 'Feature'
+
+# removal of empty `properties` key
+def test_geo_interface_removal_empty_properties():
+    geom = {
+        "geometry": {
+            "coordinates": [[
+                [6.90, 53.48],
+                [5.98, 51.85],
+                [6.07, 53.51],
+                [6.90, 53.48]
+            ]], 
+            "type": "Polygon"
+        }, 
+        "id": None, 
+        "properties": {}, 
+        "type": "Feature"
+    }
+    feat = geom_obj(geom)
+
+    with not_raises(jsonschema.ValidationError):
+        chart = alt.Chart(feat).mark_geoshape().to_dict()
+    
+    ds_key = list(chart['datasets'].keys())[0]
+    with pytest.raises(KeyError):
+        chart['datasets'][ds_key]['properties']
+
+# correct registration of foreign member (unnest items in `properties`)
+def test_geo_interface_register_foreign_member():
+    geom = {
+        "geometry": {
+            "coordinates": [[
+                [6.90, 53.48],
+                [5.98, 51.85],
+                [6.07, 53.51],
+                [6.90, 53.48]
+            ]], 
+            "type": "Polygon"
+        }, 
+        "id": None, 
+        "properties": {"foo": "bah"}, 
+        "type": "Feature"
+    }
+    feat = geom_obj(geom)
+
+    with not_raises(jsonschema.ValidationError):
+        chart = alt.Chart(feat).mark_geoshape().to_dict()
+
+    ds_key = list(chart['datasets'].keys())[0]
+    assert chart['datasets'][ds_key]['foo'] == 'bah'
+
+# correct serializing of arrays and nested tuples
+def test_geo_interface_serializing_arrays_tuples():
+    import array as arr
+    geom = {
+        "bbox": arr.array('d', [1, 2, 3, 4]),    
+        "geometry": {
+            "coordinates": [tuple((
+                tuple((6.90, 53.48)),
+                tuple((5.98, 51.85)),
+                tuple((6.07, 53.51)),
+                tuple((6.90, 53.48))
+            ))], 
+            "type": "Polygon"
+        }, 
+        "id": 27, 
+        "properties": {}, 
+        "type": "Feature"
+    }
+    feat = geom_obj(geom)
+
+    with not_raises(jsonschema.ValidationError):
+        chart = alt.Chart(feat).mark_geoshape().to_dict()
+
+    ds_key = list(chart['datasets'].keys())[0]
+    assert chart['datasets'][ds_key]['bbox'] == [1.0, 2.0, 3.0, 4.0]
+    assert chart['datasets'][ds_key]['geometry']['coordinates'][0][0] == [6.9, 53.48]
+
+# keep reserved or existing members within properties
+def test_geo_interface_reserved_members():
+    geom = {
+        "geometry": {
+            "coordinates": [[
+                [6.90, 53.48],
+                [5.98, 51.85],
+                [6.07, 53.51],
+                [6.90, 53.48]
+            ]], 
+            "type": "Polygon"
+        }, 
+        "id": 27, 
+        "properties": {"type": "foo"}, 
+        "type": "Feature"
+    }
+    feat = geom_obj(geom)
+
+    with not_raises(jsonschema.ValidationError):
+        chart = alt.Chart(feat).mark_geoshape().to_dict()
+
+    ds_key = list(chart['datasets'].keys())[0]
+    assert chart['datasets'][ds_key]['type'] == 'Feature'
+    assert chart['datasets'][ds_key]['properties']['type'] == 'foo'
+
+# an empty FeatureCollection is valid
+def test_geo_interface_empty_feature_collection():
+    geom = {
+        "type": "FeatureCollection",
+        "features": []
+    }
+    feat = geom_obj(geom)
+
+    with not_raises(jsonschema.ValidationError):
+        chart = alt.Chart(feat).mark_geoshape().to_dict()
+
+    ds_key = list(chart['datasets'].keys())[0]
+    assert chart['datasets'][ds_key] == []
+
+# Features in a FeatureCollection shall not overwrite existing or reserved members
+def test_geo_interface_feature_collection():
+    geom = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "geometry": {
+                    "coordinates": [[
+                        [6.90, 53.48],
+                        [5.98, 51.85],
+                        [6.07, 53.51],
+                        [6.90, 53.48]
+                    ]], 
+                    "type": "Polygon"
+                }, 
+                "id": 27, 
+                "properties": {
+                    "type": "foo", 
+                    "id": 1, 
+                    "geometry": 1
+                }, 
+                "type": "Feature"
+            },    
+            {
+                "geometry": {
+                    "coordinates": [[
+                        [8.90, 53.48],
+                        [7.98, 51.85],
+                        [8.07, 53.51],
+                        [8.90, 53.48]
+                    ]],
+                    "type": "Polygon"
+                }, 
+                "id": 28, 
+                "properties": {
+                    "type": "foo", 
+                    "id": 2, 
+                    "geometry": 1
+                }, 
+                "type": "Feature"
+            },
+              
+        ]
+    }
+    feat = geom_obj(geom)
+
+    with not_raises(jsonschema.ValidationError):
+        chart = alt.Chart(feat).mark_geoshape().to_dict()
+
+    ds_key = list(chart['datasets'].keys())[0]
+    assert chart['datasets'][ds_key][0]['id'] == 27
+    assert chart['datasets'][ds_key][1]['id'] == 28
+    assert 'coordinates' in chart['datasets'][ds_key][0]['geometry']
+    assert 'coordinates' in chart['datasets'][ds_key][1]['geometry'] 
+    assert chart['datasets'][ds_key][0]['type'] == 'Feature'
+    assert chart['datasets'][ds_key][1]['type'] == 'Feature' 

--- a/altair/vegalite/v3/tests/test_geo_interface.py
+++ b/altair/vegalite/v3/tests/test_geo_interface.py
@@ -21,10 +21,10 @@ def test_geo_interface_polygon_feature():
         "type": "Polygon"
     }
     feat = geom_obj(geom)
-    chart = alt.Chart(feat).mark_geoshape().to_dict()
-    
-    ds_key = list(chart['datasets'].keys())[0]
-    assert chart['datasets'][ds_key]['type'] == 'Feature'
+
+    with alt.data_transformers.enable(consolidate_datasets=False):
+        spec = alt.Chart(feat).mark_geoshape().to_dict()
+    assert spec['data']['values']['type'] == 'Feature'
 
 # merge geometry with empty properties dictionary
 def test_geo_interface_removal_empty_properties():
@@ -43,10 +43,10 @@ def test_geo_interface_removal_empty_properties():
         "type": "Feature"
     }
     feat = geom_obj(geom)
-    chart = alt.Chart(feat).mark_geoshape().to_dict()
-    
-    ds_key = list(chart['datasets'].keys())[0]
-    assert chart['datasets'][ds_key]['type'] == 'Feature'
+
+    with alt.data_transformers.enable(consolidate_datasets=False):
+        spec = alt.Chart(feat).mark_geoshape().to_dict()
+    assert spec['data']['values']['type'] == 'Feature'
 
 # only register metadata in the properties member
 def test_geo_interface_register_foreign_member():
@@ -65,12 +65,12 @@ def test_geo_interface_register_foreign_member():
         "type": "Feature"
     }
     feat = geom_obj(geom)
-    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
-    ds_key = list(chart['datasets'].keys())[0]
+    with alt.data_transformers.enable(consolidate_datasets=False):
+        spec = alt.Chart(feat).mark_geoshape().to_dict()
     with pytest.raises(KeyError):
-        chart['datasets'][ds_key]['id']    
-    assert chart['datasets'][ds_key]['foo'] == 'bah'
+        spec['data']['values']['id']    
+    assert spec['data']['values']['foo'] == 'bah'
 
 
 # correct serializing of arrays and nested tuples
@@ -92,10 +92,10 @@ def test_geo_interface_serializing_arrays_tuples():
         "type": "Feature"
     }
     feat = geom_obj(geom)
-    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
-    ds_key = list(chart['datasets'].keys())[0]
-    assert chart['datasets'][ds_key]['geometry']['coordinates'][0][0] == [6.90, 53.48]
+    with alt.data_transformers.enable(consolidate_datasets=False):
+        spec = alt.Chart(feat).mark_geoshape().to_dict()
+    assert spec['data']['values']['geometry']['coordinates'][0][0] == [6.9, 53.48]
 
 # overwrite existing 'type' value in properties with `Feature`
 def test_geo_interface_reserved_members():
@@ -114,10 +114,10 @@ def test_geo_interface_reserved_members():
         "type": "Feature"
     }
     feat = geom_obj(geom)
-    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
-    ds_key = list(chart['datasets'].keys())[0]
-    assert chart['datasets'][ds_key]['type'] == 'Feature'
+    with alt.data_transformers.enable(consolidate_datasets=False):
+        spec = alt.Chart(feat).mark_geoshape().to_dict()
+    assert spec['data']['values']['type'] == 'Feature'
 
 # an empty FeatureCollection is valid
 def test_geo_interface_empty_feature_collection():
@@ -126,10 +126,10 @@ def test_geo_interface_empty_feature_collection():
         "features": []
     }
     feat = geom_obj(geom)
-    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
-    ds_key = list(chart['datasets'].keys())[0]
-    assert chart['datasets'][ds_key] == []
+    with alt.data_transformers.enable(consolidate_datasets=False):
+        spec = alt.Chart(feat).mark_geoshape().to_dict()
+    assert spec['data']['values'] == []
 
 # Features in a FeatureCollection only keep properties and geometry
 def test_geo_interface_feature_collection():
@@ -176,15 +176,15 @@ def test_geo_interface_feature_collection():
         ]
     }
     feat = geom_obj(geom)
-    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
-    ds_key = list(chart['datasets'].keys())[0]
-    assert chart['datasets'][ds_key][0]['id'] == 1
-    assert chart['datasets'][ds_key][1]['id'] == 2
-    assert 'coordinates' in chart['datasets'][ds_key][0]['geometry']
-    assert 'coordinates' in chart['datasets'][ds_key][1]['geometry'] 
-    assert chart['datasets'][ds_key][0]['type'] == 'Feature'
-    assert chart['datasets'][ds_key][1]['type'] == 'Feature' 
+    with alt.data_transformers.enable(consolidate_datasets=False):
+        spec = alt.Chart(feat).mark_geoshape().to_dict()
+    assert spec['data']['values'][0]['id'] == 1
+    assert spec['data']['values'][1]['id'] == 2
+    assert 'coordinates' in spec['data']['values'][0]['geometry']
+    assert 'coordinates' in spec['data']['values'][1]['geometry'] 
+    assert spec['data']['values'][0]['type'] == 'Feature'
+    assert spec['data']['values'][1]['type'] == 'Feature' 
 
 # typical output of a __geo_interface__ from geopandas GeoDataFrame
 # notic that the index value is registerd as a commonly used identifier
@@ -215,7 +215,7 @@ def test_geo_interface_feature_collection_gdf():
         'type': 'FeatureCollection'
     }
     feat = geom_obj(geom)
-    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
-    ds_key = list(chart['datasets'].keys())[0]
-    assert chart['datasets'][ds_key][0]['id'] == 'BWA'
+    with alt.data_transformers.enable(consolidate_datasets=False):
+        spec = alt.Chart(feat).mark_geoshape().to_dict()
+    assert spec['data']['values'][0]['id'] == 'BWA'

--- a/altair/vegalite/v3/tests/test_geo_interface.py
+++ b/altair/vegalite/v3/tests/test_geo_interface.py
@@ -1,21 +1,5 @@
 import pytest
-import jsonschema
-
 import altair.vegalite.v3 as alt
-
-from contextlib import contextmanager
-
-
-@contextmanager
-def not_raises(ExpectedException):
-    try:
-        yield
-
-    except ExpectedException as error:
-        raise AssertionError("Raised exception {}".format(error))
-
-    except Exception as error:
-        raise AssertionError("An unexpected exception {} raised.".format(error))
 
 def geom_obj(geom):
     class Geom(object):
@@ -37,9 +21,7 @@ def test_geo_interface_polygon_feature():
         "type": "Polygon"
     }
     feat = geom_obj(geom)
-    
-    with not_raises(jsonschema.ValidationError):
-        chart = alt.Chart(feat).mark_geoshape().to_dict()
+    chart = alt.Chart(feat).mark_geoshape().to_dict()
     
     ds_key = list(chart['datasets'].keys())[0]
     assert chart['datasets'][ds_key]['type'] == 'Feature'
@@ -61,9 +43,7 @@ def test_geo_interface_removal_empty_properties():
         "type": "Feature"
     }
     feat = geom_obj(geom)
-
-    with not_raises(jsonschema.ValidationError):
-        chart = alt.Chart(feat).mark_geoshape().to_dict()
+    chart = alt.Chart(feat).mark_geoshape().to_dict()
     
     ds_key = list(chart['datasets'].keys())[0]
     assert chart['datasets'][ds_key]['type'] == 'Feature'
@@ -85,9 +65,7 @@ def test_geo_interface_register_foreign_member():
         "type": "Feature"
     }
     feat = geom_obj(geom)
-
-    with not_raises(jsonschema.ValidationError):
-        chart = alt.Chart(feat).mark_geoshape().to_dict()
+    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
     ds_key = list(chart['datasets'].keys())[0]
     with pytest.raises(KeyError):
@@ -114,9 +92,7 @@ def test_geo_interface_serializing_arrays_tuples():
         "type": "Feature"
     }
     feat = geom_obj(geom)
-
-    with not_raises(jsonschema.ValidationError):
-        chart = alt.Chart(feat).mark_geoshape().to_dict()
+    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
     ds_key = list(chart['datasets'].keys())[0]
     assert chart['datasets'][ds_key]['geometry']['coordinates'][0][0] == [6.90, 53.48]
@@ -138,9 +114,7 @@ def test_geo_interface_reserved_members():
         "type": "Feature"
     }
     feat = geom_obj(geom)
-
-    with not_raises(jsonschema.ValidationError):
-        chart = alt.Chart(feat).mark_geoshape().to_dict()
+    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
     ds_key = list(chart['datasets'].keys())[0]
     assert chart['datasets'][ds_key]['type'] == 'Feature'
@@ -152,9 +126,7 @@ def test_geo_interface_empty_feature_collection():
         "features": []
     }
     feat = geom_obj(geom)
-
-    with not_raises(jsonschema.ValidationError):
-        chart = alt.Chart(feat).mark_geoshape().to_dict()
+    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
     ds_key = list(chart['datasets'].keys())[0]
     assert chart['datasets'][ds_key] == []
@@ -204,9 +176,7 @@ def test_geo_interface_feature_collection():
         ]
     }
     feat = geom_obj(geom)
-
-    with not_raises(jsonschema.ValidationError):
-        chart = alt.Chart(feat).mark_geoshape().to_dict()
+    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
     ds_key = list(chart['datasets'].keys())[0]
     assert chart['datasets'][ds_key][0]['id'] == 1
@@ -245,9 +215,7 @@ def test_geo_interface_feature_collection_gdf():
         'type': 'FeatureCollection'
     }
     feat = geom_obj(geom)
-
-    with not_raises(jsonschema.ValidationError):
-        chart = alt.Chart(feat).mark_geoshape().to_dict()
+    chart = alt.Chart(feat).mark_geoshape().to_dict()
 
     ds_key = list(chart['datasets'].keys())[0]
     assert chart['datasets'][ds_key][0]['id'] == 'BWA'

--- a/altair/vegalite/v3/tests/test_geo_interface.py
+++ b/altair/vegalite/v3/tests/test_geo_interface.py
@@ -215,3 +215,41 @@ def test_geo_interface_feature_collection():
     assert 'coordinates' in chart['datasets'][ds_key][1]['geometry'] 
     assert chart['datasets'][ds_key][0]['type'] == 'Feature'
     assert chart['datasets'][ds_key][1]['type'] == 'Feature' 
+
+# typical output of a __geo_interface__ from geopandas GeoDataFrame
+# notic that the index value is registerd as a commonly used identifier
+# with the name "id" (in this case 49).
+# if there also is a column name used with "id", it should stay within
+# the properties group.
+def test_geo_interface_feature_collection_gdf():
+    geom = {
+        'bbox': (19.89, -26.82, 29.43, -17.66),
+        'features': [
+            {'bbox': (19.89, -26.82, 29.43, -17.66),
+            'geometry': {
+                'coordinates': [[
+                    [6.90, 53.48],
+                    [5.98, 51.85],
+                    [6.07, 53.51],
+                    [6.90, 53.48]
+                ]], 
+                'type': 'Polygon'},
+            'id': '49',
+            'properties': {
+                'continent': 'Africa','gdp_md_est': 35900.0,
+                'id': 'BWA',
+                'iso_a3': 'BWA',
+                'name': 'Botswana',
+                'pop_est': 2214858},
+            'type': 'Feature'}
+        ],
+        'type': 'FeatureCollection'
+    }
+    feat = geom_obj(geom)
+
+    with not_raises(jsonschema.ValidationError):
+        chart = alt.Chart(feat).mark_geoshape().to_dict()
+
+    ds_key = list(chart['datasets'].keys())[0]
+    assert chart['datasets'][ds_key][0]['id'] == '49'
+    assert chart['datasets'][ds_key][0]['properties']['id'] == 'BWA'  

--- a/doc/user_guide/data.rst
+++ b/doc/user_guide/data.rst
@@ -13,7 +13,7 @@ The dataset can be specified in one of the following ways:
 - as a `Pandas DataFrame <http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html>`_
 - as a :class:`Data` or related object (i.e. :class:`UrlData`, :class:`InlineData`, :class:`NamedData`)
 - as a url string pointing to a ``json`` or ``csv`` formatted text file
-- as an object that supports the `__geo_interface__`
+- as an object that supports the `__geo_interface__` (eg. `Geopandas GeoDataFrame <http://geopandas.org/data_structures.html#geodataframe>`_, `Shapely Geometries <https://shapely.readthedocs.io/en/latest/manual.html#geometric-objects>`_, `GeoJSON Objects <https://github.com/jazzband/geojson#geojson-objects>`_)
 
 For example, here we specify data via a DataFrame:
 
@@ -251,14 +251,13 @@ the geo_interface is serialized in order to:
 
 Altair can interpret a spatial bounded entity (a Feature) or a list of Features 
 (FeatureCollection). In order for correct interpretation it is made sure that all records 
-contains a single geometry (one of Point, LineString, Polygon, MultiPoint, 
+contain a single geometry (one of Point, LineString, Polygon, MultiPoint, 
 MultiLineString, MultiPolygon, and GeometryCollection) and is stored as a Feature entity.
 
 The most basic Feature is an entity that only contains a Geometry object. For example
 a Polygon:
 
-.. altair-plot::
-    :output: repr
+.. code:: python
 
     {
         "type": "Feature",
@@ -279,16 +278,15 @@ The `__geo_interface__` provides two approaches to store metadata.
 - Metadata stored as a dictionary within the key `properties` (so called properties 
 member). This properties member must exist in a valid Feature entity.
 - Metada may be stored directly as foreign members on the top-level of the Feature. 
-But there is no normative processing model for usage of this declaration.
+There is no normative processing model for usage of this declaration.
 
 Altair serializes the metadata from the properties in combination with the declared
-geometry as Feature entities. This result of this approach is that the keys `type` 
+geometry as Feature entities. The result of this approach is that the keys `type` 
 and `geometry` in the properties member will be overwriten if used.
 
-So an `__geo_interface__` that is registered as such
+So a `__geo_interface__` that is registered as such
 
-.. altair-plot::
-    :output: repr
+.. code:: python
 
     {
         "type": "Feature",
@@ -305,8 +303,7 @@ So an `__geo_interface__` that is registered as such
 
 Is serialized as such:
 
-.. altair-plot::
-    :output: repr
+.. code:: python
 
     {
         "type": "Feature",
@@ -340,9 +337,9 @@ Try to avoid putting projected data into Altair, but reproject your spatial data
 EPSG:4326 first.
 
 If your data comes in a different projection (eg. with units in meters) and you don't 
-have the option to reproject the data, than try using the project configuration 
+have the option to reproject the data, try using the project configuration 
 `(type: 'identity', reflectY': True)`. It draws the geometries in a cartesian grid 
-without applying a projection configuration.
+without applying a projection.
 
 .. _data-winding-order:
 
@@ -353,17 +350,16 @@ go in a certain direction, and polygon rings do too. The GeoJSON-like structure 
 __geo_interface__ recommends the right-hand rule winding order for Polygon and 
 MultiPolygons. Meaning that the exterior rings should be counterclockwise and interior 
 rings are clockwise. While it recommends the right-hand rule winding order, it does not 
-reject geometries do not use the right-hand rule.
+reject geometries that do not use the right-hand rule.
 
 Altair does NOT follow the right-hand rule for geometries, but uses the left-hand rule. 
 Meaning that exterior rings should be clockwise and interior rings should be 
 counterclockwise. 
 
 If you face a problem regarding winding order, try to force the left-hand rule on your
-data before usage in Altair:
+data before usage in Altair using GeoPandas for example as such:
 
-.. altair-plot::
-    :output: repr
+.. code:: python
 
     from shapely.ops import orient # version >=1.7a2
     gdf = gdf.geometry.apply(orient, args=(-1,))

--- a/doc/user_guide/data.rst
+++ b/doc/user_guide/data.rst
@@ -245,16 +245,17 @@ Python protocol for Geospatial Data. The protocol follows a GeoJSON-like structu
 store geo-spatial vector data.
 
 To make working with Geospatial Data as similar as working with long-form structured data 
-the geo_interface is serialized in order to be interpreted by Altair and to provide 
-users a similar experience as when working with tabular data such as Pandas.
+the geo_interface is serialized in order to:
+- make it be correctly interpreted by Altair
+- provide users a similar experience as when working with tabular data such as Pandas.
 
 Altair can interpret a spatial bounded entity (a Feature) or a list of Features 
-(FeatureCollection). In order for correct interpreation it is made sure that all records 
-containing a single geometry, such as Point, LineString, Polygon, MultiPoint, 
-MultiLineString, MultiPolygon, and GeometryCollection are stored as a Feature entity.
+(FeatureCollection). In order for correct interpretation it is made sure that all records 
+contains a single geometry (one of Point, LineString, Polygon, MultiPoint, 
+MultiLineString, MultiPolygon, and GeometryCollection) and is stored as a Feature entity.
 
-So the most basic Feature is an entity that only contains a Geometry object. For example
-a simple Polygon:
+The most basic Feature is an entity that only contains a Geometry object. For example
+a Polygon:
 
 .. altair-plot::
     :output: repr
@@ -275,8 +276,9 @@ a simple Polygon:
 
 Often, the Feature contains also additional metadata next to the Geometry object.
 The `__geo_interface__` provides two approaches to store metadata.
-- Stored as a dictionary within the key `properties` (so called properties member)
-- Stored directly on the top-level of the Feature (so called foreign members).
+- Metadata stored as a dictionary within the key `properties` (so called properties 
+member)
+- Metada stored directly on the top-level of the Feature (so called foreign members).
 
 Altair aims to serialize the metadata directly on the top-level of the Feature to 
 avoid the need of nested dictionaries. In some situations this is not possible 
@@ -338,7 +340,7 @@ GeoPandas vs Pandas
 A `GeoDataFrame` is a `DataFrame` including a special column with spatial geometries.
 Where Altair only accesses dataframe columns and not dataframe indices for a 
 `DataFrame` this is not the case for a `GeoDataFrame`. The `__geo_interface__` of a
-`GeoDataFrame` registers the draframe indices as a commonly used identifier on the 
+`GeoDataFrame` registers the dataframe indices as a commonly used identifier on the 
 top-level of each Feature with the key-name "id". If there is a column name in your 
 `GeoDataFrame` with the name "id", it is accesible as "properties.id" in Altair.
 
@@ -353,26 +355,27 @@ Try to avoid putting projected data into Altair, but reproject your spatial data
 EPSG:4326 first.
 
 If your data comes in a different projection with units in meters than the projection
-type `(type: 'identity', reflectY': True)` might be an option. It draws the geomtries 
-in a cartesian grid without applying a projection configuration.
+and you don't have the option to reproject try the projection type 
+`(type: 'identity', reflectY': True)`. It draws the geometries in a cartesian grid 
+without applying a projection configuration.
 
 .. _data-winding-order:
 
 Winding order
 ~~~~~~~~~~~~~
-LineString and Polygon geometries contain coordinates in an order: lines go in a 
-certain direction, and polygon rings do too. The GeoJSON-like structure of the 
-__geo_interface__ recommends the right-hand rule winding order. Meaning that the
-exterior rings should be counterclockwise and interior rings are clockwise. While it
-recommends the right-hand rule winding order, it does not reject geometries do not use
-the right-hand rule.
+LineString, Polygon and MultiPolygon geometries contain coordinates in an order: lines 
+go in a certain direction, and polygon rings do too. The GeoJSON-like structure of the 
+__geo_interface__ recommends the right-hand rule winding order for Polygon and 
+MultiPolygons. Meaning that the exterior rings should be counterclockwise and interior 
+rings are clockwise. While it recommends the right-hand rule winding order, it does not 
+reject geometries do not use the right-hand rule.
 
-Altair does NOT follow the right-hand rule for geometires, but uses the left-hand rule. 
+Altair does NOT follow the right-hand rule for geometries, but uses the left-hand rule. 
 Meaning that exterior rings should be clockwise and interior rings should be 
 counterclockwise. 
 
-If you face a problem regarding winding orders, try to force the left-hand rule on your
-data before usage in Altair. 
+If you face a problem regarding winding order, try to force the left-hand rule on your
+data before usage in Altair:
 
 .. altair-plot::
     :output: repr


### PR DESCRIPTION
I'm not sure if I've understood you correctly here: https://github.com/altair-viz/altair/issues/588#issuecomment-522193822

But in this PR I tried to integrate serialising data objects with a `__geo_interface__` attribute.
And it worked OK for Python packages that deal with geographical data types that support the `__geo_interface__`. I tried the packages `shapely`, `pyshp`, `geojson`, `geopandas`.

It works for:
* `InlineData`
* `json` data transformer and
*  `data_server` data transformer.

See animated gif:
![ezgif com-optimize-2](https://user-images.githubusercontent.com/5186265/63229978-e6d7b780-c206-11e9-906f-a38a8813b489.gif)

After I got this working, I compared it to https://github.com/altair-viz/altair/pull/818/files, but the idea is very much the same. Maybe @iliatimofeev can shed a light on this proof of concept as well.