### PR TITLE
Update install instructions to include Vega

### DIFF
--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -31,11 +31,11 @@ Altair version 3 works best with JupyterLab version 1.0 or later.
 
 To install JupyterLab and Altair with conda, run the following command::
 
-    $ conda install -c conda-forge altair vega_datasets jupyterlab
+    $ conda install -c conda-forge altair vega vega_datasets jupyterlab
 
 To install JupyterLab and Altair with pip, run the following command::
 
-    $ pip install -U altair vega_datasets jupyterlab
+    $ pip install -U altair vega vega_datasets jupyterlab
 
 Once this is finished, run::
 


### PR DESCRIPTION
A few of my students had trouble installing altair and getting plots to show up because `vega` wasn't included as a required package. This was the case in jupyterlab. Folks on jupyter seemed to be fine. 

Request adding this to the documentation