### PR TITLE
Missing character in util-core doc

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -282,7 +282,7 @@ def parse_shorthand(shorthand, data=None, parse_aggregates=True,
     >>> parse_shorthand('name') == {'field': 'name'}
     True
 
-    >> parse_shorthand('name:Q') == {'field': 'name', 'type': 'quantitative'}
+    >>> parse_shorthand('name:Q') == {'field': 'name', 'type': 'quantitative'}
     True
 
     >>> parse_shorthand('average(col)') == {'aggregate': 'average', 'field': 'col'}


### PR DESCRIPTION
Hi,

I'm not sure if this really counts as a typo. While reading through the source code I noticed this tiny missing ">" in a function docstring. Turns out it's the only occurrence of its kind in the whole codebase.

Hope this helps!