### PR TITLE
Add minimum version to pandas to account for dependency on RangeIndex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ entrypoints
 jinja2
 jsonschema
 numpy
-pandas
+pandas>=0.23.4
 six
 toolz
 typing>=3.6;python_version<"3.5"


### PR DESCRIPTION
This commit pins the minimum supported version of pandas to be 23.4.
Currently there is a hard dependency on pandas.RangeIndex in /altair/utils/core.py:179, and version 23.4 is the earliest pandas version that I was able to find online documented with that feature.
Note that I did not do an exhaustive search over pandas versions so this limit could be moved lower on a more thorough search. Alternatively, it might need to be moved higher as I did no testing beyond the features we use in our product.
Testing should probably be done for other unpinned libraries as well as it is doubtful that early versions of those libraries would be able to run Altair.