### PR TITLE
ENH: add universal HTML renderer

### DIFF
--- a/altair/utils/html.py
+++ b/altair/utils/html.py
@@ -90,10 +90,12 @@ HTML_TEMPLATE_UNIVERSAL = jinja2.Template("""
     const outputDiv = "{{ output_div }}";
     const baseUrl = "{{ base_url }}"
     const element = document.getElementById(outputDiv);
+    const vegaVersion = "{{ vega_version }}";
+    const vegaLiteVersion = "{{ vegalite_version }}";
+    const vegaEmbedVersion = "{{ vegaembed_version }}";
 
     function loadScript(url) {
-      var fullUrl = `${baseUrl}/${url}`
-      console.log(`loadScript("${fullUrl}")`);
+      var fullUrl = `${baseUrl}/${url}`;
       return new Promise(function(resolve, reject) {
         var s = document.createElement('script');
         s.src = fullUrl;
@@ -105,7 +107,7 @@ HTML_TEMPLATE_UNIVERSAL = jinja2.Template("""
     }
 
     function showError(e) {
-      element.innerHTML = `<div class="error" style="color:red;">${e}</div>`
+      element.innerHTML = `<div class="error" style="color:red;">${e}</div>`;
     }
 
     function displayChart(vegaEmbed) {
@@ -117,23 +119,21 @@ HTML_TEMPLATE_UNIVERSAL = jinja2.Template("""
     }
 
     if(typeof define === "function" && define.amd) {
-      console.log("loading vega libraries viaw requirejs");
       requirejs.config({
         paths: {
-          "vega": "{{ base_url }}/vega@{{ vega_version }}?noext",
-          "vega-lib": "{{ base_url }}/vega-lib?noext",
-          "vega-lite": "{{ base_url }}/vega-lite@{{ vegalite_version }}?noext",
-          "vega-embed": "{{ base_url }}/vega-embed@{{ vegaembed_version }}?noext",
+          "vega": `${baseUrl}/vega@${vegaVersion}?noext`,
+          "vega-lib": `${baseUrl}/vega-lib?noext`,
+          "vega-lite": `${baseUrl}/vega-lite@${vegaLiteVersion}?noext`,
+          "vega-embed": `${baseUrl}/vega-embed@${vegaEmbedVersion}?noext`,
         }
       });
       require(["vega-embed"], displayChart);
     } else if (typeof vegaEmbed === "function") {
-      console.log("vegaEmbed already loaded");
       displayChart(vegaEmbed);
     } else {
-      loadScript('vega@{{ vega_version }}?noext')
-        .then(() => loadScript('vega-lite@{{ vegalite_version }}?noext'))
-        .then(() => loadScript('vega-embed@{{ vegaembed_version }}?noext'))
+      loadScript(`vega@${vegaVersion}?noext`)
+        .then(() => loadScript(`vega-lite@${vegaLiteVersion}?noext`))
+        .then(() => loadScript(`vega-embed@${vegaEmbedVersion}?noext`))
         .catch(url => showError(`Error loading javascript from ${url}`))
         .then(() => displayChart(vegaEmbed));
     }

--- a/altair/vega/v4/display.py
+++ b/altair/vega/v4/display.py
@@ -61,8 +61,12 @@ kaggle_renderer = HTMLRenderer(mode='vega',
                                vega_version=VEGA_VERSION,
                                vegaembed_version=VEGAEMBED_VERSION)
 
+html_renderer = HTMLRenderer(mode='vega', template='universal',
+                             vega_version=VEGA_VERSION,
+                             vegaembed_version=VEGAEMBED_VERSION)
 
 renderers.register('default', default_renderer)
+renderers.register('html', html_renderer)
 renderers.register('jupyterlab', default_renderer)
 renderers.register('nteract', default_renderer)
 renderers.register('colab', colab_renderer)

--- a/altair/vega/v5/display.py
+++ b/altair/vega/v5/display.py
@@ -62,7 +62,13 @@ kaggle_renderer = HTMLRenderer(mode='vega',
                                vegaembed_version=VEGAEMBED_VERSION)
 
 
+html_renderer = HTMLRenderer(mode='vega', template='universal',
+                             vega_version=VEGA_VERSION,
+                             vegaembed_version=VEGAEMBED_VERSION)
+
+
 renderers.register('default', default_renderer)
+renderers.register('html', html_renderer)
 renderers.register('jupyterlab', default_renderer)
 renderers.register('nteract', default_renderer)
 renderers.register('colab', colab_renderer)

--- a/altair/vegalite/v2/display.py
+++ b/altair/vegalite/v2/display.py
@@ -79,7 +79,13 @@ kaggle_renderer = HTMLRenderer(mode='vega-lite',
                                vegaembed_version=VEGAEMBED_VERSION,
                                vegalite_version=VEGALITE_VERSION)
 
+html_renderer = HTMLRenderer(mode='vega-lite', template='universal',
+                             vega_version=VEGA_VERSION,
+                             vegaembed_version=VEGAEMBED_VERSION,
+                             vegalite_version=VEGALITE_VERSION)
+
 renderers.register('default', default_renderer)
+renderers.register('html', html_renderer)
 renderers.register('jupyterlab', default_renderer)
 renderers.register('nteract', default_renderer)
 renderers.register('colab', colab_renderer)

--- a/altair/vegalite/v3/display.py
+++ b/altair/vegalite/v3/display.py
@@ -85,7 +85,13 @@ kaggle_renderer = HTMLRenderer(mode='vega-lite',
                                vegaembed_version=VEGAEMBED_VERSION,
                                vegalite_version=VEGALITE_VERSION)
 
+html_renderer = HTMLRenderer(mode='vega-lite', template='universal',
+                             vega_version=VEGA_VERSION,
+                             vegaembed_version=VEGAEMBED_VERSION,
+                             vegalite_version=VEGALITE_VERSION)
+
 renderers.register('default', default_renderer)
+renderers.register('html', html_renderer)
 renderers.register('jupyterlab', default_renderer)
 renderers.register('nteract', default_renderer)
 renderers.register('colab', colab_renderer)


### PR DESCRIPTION
This adds the ``html`` renderer to Altair. If you use
```python
alt.renderers.enable('html')
```
The chart will render correctly, with the correct versions of Vega/Vega-Lite/Vega-Embed, in a variety of frontends.

I have tested that this renderer displays charts correctly in Jupyter Notebook, JupyterLab, Colab, Kaggle, nbviewer, and nbconvert HTML, without the need for any separately installed frontend extensions.

The downside is that unlike the vega labextension and nbextension the HTML renderer loads JS resources from the web, and so it cannot be used offline.