### PR TITLE
Internal: add inheritance structure to core classes

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -41,7 +41,7 @@ def debug_mode(arg):
 
 
 def _subclasses(cls):
-    """Breadth-first sequence of classes which inherit from cls."""
+    """Breadth-first sequence of all classes which inherit from cls."""
     seen = set()
     current_set = {cls}
     while current_set:
@@ -498,7 +498,9 @@ class _FromDict(object):
             return args[0] if args else kwds
 
         if cls is None:
-            # TODO: do something more than simply selecting the last match?
+            # If there are multiple matches, we use the last one in the dict.
+            # Our class dict is constructed breadth-first from top to bottom,
+            # so the last class that matches is the most specific.
             matches = self.class_dict[self.hash_schema(schema)]
             cls = matches[-1] if matches else _passthrough
         schema = _resolve_references(schema, rootschema)

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -40,6 +40,17 @@ def debug_mode(arg):
         DEBUG_MODE = original
 
 
+def _subclasses(cls):
+    """Breadth-first sequence of classes which inherit from cls."""
+    seen = set()
+    current_set = {cls}
+    while current_set:
+        seen |= current_set
+        current_set = set.union(*(set(cls.__subclasses__()) for cls in current_set))
+        for cls in current_set - seen:
+            yield cls
+
+
 def _todict(obj, validate, context):
     """Convert an object to a dict representation."""
     if isinstance(obj, SchemaBase):
@@ -337,7 +348,7 @@ class SchemaBase(object):
     @classmethod
     def _default_wrapper_classes(cls):
         """Return the set of classes used within cls.from_dict()"""
-        return SchemaBase.__subclasses__()
+        return _subclasses(SchemaBase)
 
     @classmethod
     def from_dict(cls, dct, validate=True, _wrapper_classes=None):

--- a/altair/vega/v4/schema/core.py
+++ b/altair/vega/v4/schema/core.py
@@ -16,7 +16,7 @@ def load_schema():
 class VegaSchema(SchemaBase):
     @classmethod
     def _default_wrapper_classes(cls):
-        return VegaSchema.__subclasses__()
+        return _subclasses(VegaSchema)
 
 
 class Root(VegaSchema):

--- a/altair/vega/v4/schema/core.py
+++ b/altair/vega/v4/schema/core.py
@@ -3,7 +3,7 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
 
-from altair.utils.schemapi import SchemaBase, Undefined
+from altair.utils.schemapi import SchemaBase, Undefined, _subclasses
 
 import pkgutil
 import json

--- a/altair/vega/v5/schema/core.py
+++ b/altair/vega/v5/schema/core.py
@@ -16,7 +16,7 @@ def load_schema():
 class VegaSchema(SchemaBase):
     @classmethod
     def _default_wrapper_classes(cls):
-        return VegaSchema.__subclasses__()
+        return _subclasses(VegaSchema)
 
 
 class Root(VegaSchema):

--- a/altair/vega/v5/schema/core.py
+++ b/altair/vega/v5/schema/core.py
@@ -3,7 +3,7 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
 
-from altair.utils.schemapi import SchemaBase, Undefined
+from altair.utils.schemapi import SchemaBase, Undefined, _subclasses
 
 import pkgutil
 import json

--- a/altair/vegalite/v2/api.py
+++ b/altair/vegalite/v2/api.py
@@ -92,8 +92,7 @@ def _prepare_data(data, context):
         data = _consolidate_data(data, context)
 
     # if data is still not a recognized type, then return
-    if not isinstance(data, (dict, core.Data, core.UrlData,
-                             core.InlineData, core.NamedData)):
+    if not isinstance(data, (dict, core.Data)):
         warnings.warn("data of type {} not recognized".format(type(data)))
 
     return data
@@ -329,19 +328,12 @@ def condition(predicate, if_true, if_false, **kwargs):
     spec: dict or VegaLiteSchema
         the spec that describes the condition
     """
-    selection_predicates = (core.SelectionNot, core.SelectionOr,
-                            core.SelectionAnd, core.SelectionOperand)
-    test_predicates = (six.string_types, expr.Expression, core.Predicate,
-                       core.LogicalOperandPredicate, core.LogicalNotPredicate,
-                       core.LogicalOrPredicate, core.LogicalAndPredicate,
-                       core.FieldEqualPredicate, core.FieldOneOfPredicate,
-                       core.FieldRangePredicate, core.FieldLTPredicate,
-                       core.FieldGTPredicate, core.FieldLTEPredicate,
-                       core.FieldGTEPredicate, core.SelectionPredicate)
+    test_predicates = (six.string_types, expr.Expression, 
+                       core.LogicalOperandPredicate)
 
     if isinstance(predicate, NamedSelection):
         condition = {'selection': predicate._get_name()}
-    elif isinstance(predicate, selection_predicates):
+    elif isinstance(predicate, core.SelectionOperand):
         condition = {'selection': predicate}
     elif isinstance(predicate, test_predicates):
         condition = {'test': predicate}
@@ -872,11 +864,9 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         alt.FilterTransform : underlying transform object
 
         """
-        selection_predicates = (core.SelectionNot, core.SelectionOr,
-                                core.SelectionAnd, core.SelectionOperand)
         if isinstance(filter, NamedSelection):
             filter = {'selection': filter._get_name()}
-        elif isinstance(filter, selection_predicates):
+        elif isinstance(filter, core.SelectionOperand):
             filter = {'selection': filter}
         return self._add_transform(core.FilterTransform(filter=filter, **kwargs))
 

--- a/altair/vegalite/v2/schema/core.py
+++ b/altair/vegalite/v2/schema/core.py
@@ -3,7 +3,7 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
 
-from altair.utils.schemapi import SchemaBase, Undefined
+from altair.utils.schemapi import SchemaBase, Undefined, _subclasses
 
 import pkgutil
 import json
@@ -16,7 +16,7 @@ def load_schema():
 class VegaLiteSchema(SchemaBase):
     @classmethod
     def _default_wrapper_classes(cls):
-        return VegaLiteSchema.__subclasses__()
+        return _subclasses(VegaLiteSchema)
 
 
 class Root(VegaLiteSchema):
@@ -59,27 +59,6 @@ class AggregateOp(VegaLiteSchema):
 
     def __init__(self, *args):
         super(AggregateOp, self).__init__(*args)
-
-
-class AggregateTransform(VegaLiteSchema):
-    """AggregateTransform schema wrapper
-
-    Mapping(required=[aggregate])
-
-    Attributes
-    ----------
-
-    aggregate : List(:class:`AggregatedFieldDef`)
-        Array of objects that define fields to aggregate.
-    groupby : List(string)
-        The data fields to group by. If not specified, a single group containing all data
-        objects will be used.
-    """
-    _schema = {'$ref': '#/definitions/AggregateTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, aggregate=Undefined, groupby=Undefined, **kwds):
-        super(AggregateTransform, self).__init__(aggregate=aggregate, groupby=groupby, **kwds)
 
 
 class AggregatedFieldDef(VegaLiteSchema):
@@ -1001,30 +980,6 @@ class BarConfig(VegaLiteSchema):
                                         theta=theta, tooltip=tooltip, **kwds)
 
 
-class Baseline(VegaLiteSchema):
-    """Baseline schema wrapper
-
-    enum('top', 'middle', 'bottom')
-    """
-    _schema = {'$ref': '#/definitions/Baseline'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args):
-        super(Baseline, self).__init__(*args)
-
-
-class BasicType(VegaLiteSchema):
-    """BasicType schema wrapper
-
-    enum('quantitative', 'ordinal', 'temporal', 'nominal')
-    """
-    _schema = {'$ref': '#/definitions/BasicType'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args):
-        super(BasicType, self).__init__(*args)
-
-
 class BinParams(VegaLiteSchema):
     """BinParams schema wrapper
 
@@ -1081,29 +1036,6 @@ class BinParams(VegaLiteSchema):
                                         steps=steps, **kwds)
 
 
-class BinTransform(VegaLiteSchema):
-    """BinTransform schema wrapper
-
-    Mapping(required=[bin, field, as])
-
-    Attributes
-    ----------
-
-    bin : anyOf(boolean, :class:`BinParams`)
-        An object indicating bin properties, or simply ``true`` for using default bin
-        parameters.
-    field : string
-        The data field to bin.
-    as : anyOf(string, List(string))
-        The output fields at which to write the start and end bin values.
-    """
-    _schema = {'$ref': '#/definitions/BinTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, bin=Undefined, field=Undefined, **kwds):
-        super(BinTransform, self).__init__(bin=bin, field=field, **kwds)
-
-
 class BrushConfig(VegaLiteSchema):
     """BrushConfig schema wrapper
 
@@ -1144,29 +1076,8 @@ class BrushConfig(VegaLiteSchema):
                                           strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, **kwds)
 
 
-class CalculateTransform(VegaLiteSchema):
-    """CalculateTransform schema wrapper
-
-    Mapping(required=[calculate, as])
-
-    Attributes
-    ----------
-
-    calculate : string
-        A `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`__
-        string. Use the variable ``datum`` to refer to the current data object.
-    as : string
-        The field for storing the computed formula value.
-    """
-    _schema = {'$ref': '#/definitions/CalculateTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, calculate=Undefined, **kwds):
-        super(CalculateTransform, self).__init__(calculate=calculate, **kwds)
-
-
-class CompositeUnitSpec(VegaLiteSchema):
-    """CompositeUnitSpec schema wrapper
+class CompositeUnitSpecAlias(VegaLiteSchema):
+    """CompositeUnitSpecAlias schema wrapper
 
     Mapping(required=[mark])
 
@@ -1255,16 +1166,17 @@ class CompositeUnitSpec(VegaLiteSchema):
         **See also:** The documentation for `width and height
         <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
     """
-    _schema = {'$ref': '#/definitions/CompositeUnitSpec'}
+    _schema = {'$ref': '#/definitions/CompositeUnitSpecAlias'}
     _rootschema = Root._schema
 
     def __init__(self, mark=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
                  height=Undefined, name=Undefined, projection=Undefined, selection=Undefined,
                  title=Undefined, transform=Undefined, width=Undefined, **kwds):
-        super(CompositeUnitSpec, self).__init__(mark=mark, data=data, description=description,
-                                                encoding=encoding, height=height, name=name,
-                                                projection=projection, selection=selection, title=title,
-                                                transform=transform, width=width, **kwds)
+        super(CompositeUnitSpecAlias, self).__init__(mark=mark, data=data, description=description,
+                                                     encoding=encoding, height=height, name=name,
+                                                     projection=projection, selection=selection,
+                                                     title=title, transform=transform, width=width,
+                                                     **kwds)
 
 
 class ConditionalFieldDef(VegaLiteSchema):
@@ -1292,31 +1204,7 @@ class ConditionalMarkPropFieldDef(VegaLiteSchema):
         super(ConditionalMarkPropFieldDef, self).__init__(*args, **kwds)
 
 
-class ConditionalTextFieldDef(VegaLiteSchema):
-    """ConditionalTextFieldDef schema wrapper
-
-    anyOf(:class:`ConditionalPredicateTextFieldDef`, :class:`ConditionalSelectionTextFieldDef`)
-    """
-    _schema = {'$ref': '#/definitions/ConditionalTextFieldDef'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(ConditionalTextFieldDef, self).__init__(*args, **kwds)
-
-
-class ConditionalValueDef(VegaLiteSchema):
-    """ConditionalValueDef schema wrapper
-
-    anyOf(:class:`ConditionalPredicateValueDef`, :class:`ConditionalSelectionValueDef`)
-    """
-    _schema = {'$ref': '#/definitions/ConditionalValueDef'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(ConditionalValueDef, self).__init__(*args, **kwds)
-
-
-class ConditionalPredicateFieldDef(VegaLiteSchema):
+class ConditionalPredicateFieldDef(ConditionalFieldDef):
     """ConditionalPredicateFieldDef schema wrapper
 
     Mapping(required=[test, type])
@@ -1394,7 +1282,7 @@ class ConditionalPredicateFieldDef(VegaLiteSchema):
                                                            title=title, **kwds)
 
 
-class ConditionalPredicateMarkPropFieldDef(VegaLiteSchema):
+class ConditionalPredicateMarkPropFieldDef(ConditionalMarkPropFieldDef):
     """ConditionalPredicateMarkPropFieldDef schema wrapper
 
     Mapping(required=[test, type])
@@ -1518,110 +1406,7 @@ class ConditionalPredicateMarkPropFieldDef(VegaLiteSchema):
                                                                    **kwds)
 
 
-class ConditionalPredicateTextFieldDef(VegaLiteSchema):
-    """ConditionalPredicateTextFieldDef schema wrapper
-
-    Mapping(required=[test, type])
-
-    Attributes
-    ----------
-
-    test : :class:`LogicalOperandPredicate`
-
-    type : :class:`Type`
-        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
-        ``"ordinal"``, or ``"nominal"`` ).
-        It can also be a ``"geojson"`` type for encoding `'geoshape'
-        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
-    aggregate : :class:`Aggregate`
-        Aggregation function for the field
-        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
-
-        **Default value:** ``undefined`` (None)
-    bin : anyOf(boolean, :class:`BinParams`)
-        A flag for binning a ``quantitative`` field, or `an object defining binning
-        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`__.
-        If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
-
-        **Default value:** ``false``
-    field : anyOf(string, :class:`RepeatRef`)
-        **Required.** A string defining the name of the field from which to pull a data
-        value
-        or an object defining iterated values from the `repeat
-        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
-
-        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
-        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
-        If field names contain dots or brackets but are not nested, you can use ``\\`` to
-        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
-        See more details about escaping in the `field documentation
-        <https://vega.github.io/vega-lite/docs/field.html>`__.
-
-        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
-    format : string
-        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`__ for a
-        text field. If not defined, this will be determined automatically.
-    timeUnit : :class:`TimeUnit`
-        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
-        field.
-        or `a temporal field that gets casted as ordinal
-        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
-
-        **Default value:** ``undefined`` (None)
-    title : anyOf(string, None)
-        A title for the field. If ``null``, the title will be removed.
-
-        **Default value:**  derived from the field's name and transformation function (
-        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
-        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
-        field is binned or has a time unit applied, the applied function is shown in
-        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
-        Otherwise, the title is simply the field name.
-
-        **Notes** :
-
-        1) You can customize the default field title format by providing the [fieldTitle
-        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
-        `fieldTitle function via the compile function's options
-        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
-
-        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
-        defined, axis/header/legend title will be used.
-    """
-    _schema = {'$ref': '#/definitions/ConditionalPredicate<TextFieldDef>'}
-    _rootschema = Root._schema
-
-    def __init__(self, test=Undefined, type=Undefined, aggregate=Undefined, bin=Undefined,
-                 field=Undefined, format=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
-        super(ConditionalPredicateTextFieldDef, self).__init__(test=test, type=type,
-                                                               aggregate=aggregate, bin=bin,
-                                                               field=field, format=format,
-                                                               timeUnit=timeUnit, title=title, **kwds)
-
-
-class ConditionalPredicateValueDef(VegaLiteSchema):
-    """ConditionalPredicateValueDef schema wrapper
-
-    Mapping(required=[test, value])
-
-    Attributes
-    ----------
-
-    test : :class:`LogicalOperandPredicate`
-
-    value : anyOf(float, string, boolean)
-        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
-        between ``0`` to ``1`` for opacity).
-    """
-    _schema = {'$ref': '#/definitions/ConditionalPredicate<ValueDef>'}
-    _rootschema = Root._schema
-
-    def __init__(self, test=Undefined, value=Undefined, **kwds):
-        super(ConditionalPredicateValueDef, self).__init__(test=test, value=value, **kwds)
-
-
-class ConditionalSelectionFieldDef(VegaLiteSchema):
+class ConditionalSelectionFieldDef(ConditionalFieldDef):
     """ConditionalSelectionFieldDef schema wrapper
 
     Mapping(required=[selection, type])
@@ -1701,7 +1486,7 @@ class ConditionalSelectionFieldDef(VegaLiteSchema):
                                                            timeUnit=timeUnit, title=title, **kwds)
 
 
-class ConditionalSelectionMarkPropFieldDef(VegaLiteSchema):
+class ConditionalSelectionMarkPropFieldDef(ConditionalMarkPropFieldDef):
     """ConditionalSelectionMarkPropFieldDef schema wrapper
 
     Mapping(required=[selection, type])
@@ -1827,7 +1612,101 @@ class ConditionalSelectionMarkPropFieldDef(VegaLiteSchema):
                                                                    **kwds)
 
 
-class ConditionalSelectionTextFieldDef(VegaLiteSchema):
+class ConditionalTextFieldDef(VegaLiteSchema):
+    """ConditionalTextFieldDef schema wrapper
+
+    anyOf(:class:`ConditionalPredicateTextFieldDef`, :class:`ConditionalSelectionTextFieldDef`)
+    """
+    _schema = {'$ref': '#/definitions/ConditionalTextFieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(ConditionalTextFieldDef, self).__init__(*args, **kwds)
+
+
+class ConditionalPredicateTextFieldDef(ConditionalTextFieldDef):
+    """ConditionalPredicateTextFieldDef schema wrapper
+
+    Mapping(required=[test, type])
+
+    Attributes
+    ----------
+
+    test : :class:`LogicalOperandPredicate`
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`)
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`__.
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        **Default value:** ``false``
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    format : string
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`__ for a
+        text field. If not defined, this will be determined automatically.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/ConditionalPredicate<TextFieldDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, test=Undefined, type=Undefined, aggregate=Undefined, bin=Undefined,
+                 field=Undefined, format=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
+        super(ConditionalPredicateTextFieldDef, self).__init__(test=test, type=type,
+                                                               aggregate=aggregate, bin=bin,
+                                                               field=field, format=format,
+                                                               timeUnit=timeUnit, title=title, **kwds)
+
+
+class ConditionalSelectionTextFieldDef(ConditionalTextFieldDef):
     """ConditionalSelectionTextFieldDef schema wrapper
 
     Mapping(required=[selection, type])
@@ -1911,7 +1790,40 @@ class ConditionalSelectionTextFieldDef(VegaLiteSchema):
                                                                timeUnit=timeUnit, title=title, **kwds)
 
 
-class ConditionalSelectionValueDef(VegaLiteSchema):
+class ConditionalValueDef(VegaLiteSchema):
+    """ConditionalValueDef schema wrapper
+
+    anyOf(:class:`ConditionalPredicateValueDef`, :class:`ConditionalSelectionValueDef`)
+    """
+    _schema = {'$ref': '#/definitions/ConditionalValueDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(ConditionalValueDef, self).__init__(*args, **kwds)
+
+
+class ConditionalPredicateValueDef(ConditionalValueDef):
+    """ConditionalPredicateValueDef schema wrapper
+
+    Mapping(required=[test, value])
+
+    Attributes
+    ----------
+
+    test : :class:`LogicalOperandPredicate`
+
+    value : anyOf(float, string, boolean)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _schema = {'$ref': '#/definitions/ConditionalPredicate<ValueDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, test=Undefined, value=Undefined, **kwds):
+        super(ConditionalPredicateValueDef, self).__init__(test=test, value=value, **kwds)
+
+
+class ConditionalSelectionValueDef(ConditionalValueDef):
     """ConditionalSelectionValueDef schema wrapper
 
     Mapping(required=[selection, value])
@@ -2114,45 +2026,6 @@ class Config(VegaLiteSchema):
                                      title=title, trail=trail, view=view, **kwds)
 
 
-class CsvDataFormat(VegaLiteSchema):
-    """CsvDataFormat schema wrapper
-
-    Mapping(required=[])
-
-    Attributes
-    ----------
-
-    parse : anyOf(enum('auto'), :class:`Parse`, None)
-        If set to ``"auto"`` (the default), perform automatic type inference to determine
-        the desired data types.
-        If set to ``null``, disable type inference based on the spec and only use type
-        inference based on the data.
-        Alternatively, a parsing directive object can be provided for explicit data types.
-        Each property of the object corresponds to a field name, and the value to the
-        desired data type (one of ``"number"``, ``"boolean"``, ``"date"``, or null (do not
-        parse the field)).
-        For example, ``"parse": {"modified_on": "date"}`` parses the ``modified_on`` field
-        in each input record a Date value.
-
-        For ``"date"``, we parse data based using Javascript's `Date.parse()
-        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse>`__.
-        For Specific date formats can be provided (e.g., ``{foo: 'date:"%m%d%Y"'}`` ), using
-        the `d3-time-format syntax <https://github.com/d3/d3-time-format#locale_format>`__.
-        UTC date format parsing is supported similarly (e.g., ``{foo: 'utc:"%m%d%Y"'}`` ).
-        See more about `UTC time
-        <https://vega.github.io/vega-lite/docs/timeunit.html#utc>`__
-    type : enum('csv', 'tsv')
-        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``, ``"dsv"``.
-        The default format type is determined by the extension of the file URL.
-        If no extension is detected, ``"json"`` will be used by default.
-    """
-    _schema = {'$ref': '#/definitions/CsvDataFormat'}
-    _rootschema = Root._schema
-
-    def __init__(self, parse=Undefined, type=Undefined, **kwds):
-        super(CsvDataFormat, self).__init__(parse=parse, type=type, **kwds)
-
-
 class Cursor(VegaLiteSchema):
     """Cursor schema wrapper
 
@@ -2192,6 +2065,45 @@ class DataFormat(VegaLiteSchema):
 
     def __init__(self, *args, **kwds):
         super(DataFormat, self).__init__(*args, **kwds)
+
+
+class CsvDataFormat(DataFormat):
+    """CsvDataFormat schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    parse : anyOf(enum('auto'), :class:`Parse`, None)
+        If set to ``"auto"`` (the default), perform automatic type inference to determine
+        the desired data types.
+        If set to ``null``, disable type inference based on the spec and only use type
+        inference based on the data.
+        Alternatively, a parsing directive object can be provided for explicit data types.
+        Each property of the object corresponds to a field name, and the value to the
+        desired data type (one of ``"number"``, ``"boolean"``, ``"date"``, or null (do not
+        parse the field)).
+        For example, ``"parse": {"modified_on": "date"}`` parses the ``modified_on`` field
+        in each input record a Date value.
+
+        For ``"date"``, we parse data based using Javascript's `Date.parse()
+        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse>`__.
+        For Specific date formats can be provided (e.g., ``{foo: 'date:"%m%d%Y"'}`` ), using
+        the `d3-time-format syntax <https://github.com/d3/d3-time-format#locale_format>`__.
+        UTC date format parsing is supported similarly (e.g., ``{foo: 'utc:"%m%d%Y"'}`` ).
+        See more about `UTC time
+        <https://vega.github.io/vega-lite/docs/timeunit.html#utc>`__
+    type : enum('csv', 'tsv')
+        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``, ``"dsv"``.
+        The default format type is determined by the extension of the file URL.
+        If no extension is detected, ``"json"`` will be used by default.
+    """
+    _schema = {'$ref': '#/definitions/CsvDataFormat'}
+    _rootschema = Root._schema
+
+    def __init__(self, parse=Undefined, type=Undefined, **kwds):
+        super(CsvDataFormat, self).__init__(parse=parse, type=type, **kwds)
 
 
 class Datasets(VegaLiteSchema):
@@ -2293,7 +2205,7 @@ class Dir(VegaLiteSchema):
         super(Dir, self).__init__(*args)
 
 
-class DsvDataFormat(VegaLiteSchema):
+class DsvDataFormat(DataFormat):
     """DsvDataFormat schema wrapper
 
     Mapping(required=[delimiter])
@@ -2468,41 +2380,6 @@ class Encoding(VegaLiteSchema):
                                        y=y, y2=y2, **kwds)
 
 
-class EncodingSortField(VegaLiteSchema):
-    """EncodingSortField schema wrapper
-
-    Mapping(required=[op])
-    A sort definition for sorting a discrete scale in an encoding field definition.
-
-    Attributes
-    ----------
-
-    op : :class:`AggregateOp`
-        An `aggregate operation
-        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__ to perform on the
-        field prior to sorting (e.g., ``"count"``, ``"mean"`` and ``"median"`` ).
-        This property is required in cases where the sort field and the data reference field
-        do not match.
-        The input data objects will be aggregated, grouped by the encoded data field.
-
-        For a full list of operations, please see the documentation for `aggregate
-        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__.
-    field : anyOf(string, :class:`RepeatRef`)
-        The data `field <https://vega.github.io/vega-lite/docs/field.html>`__ to sort by.
-
-        **Default value:** If unspecified, defaults to the field specified in the outer data
-        reference.
-    order : :class:`SortOrder`
-        The sort order. One of ``"ascending"`` (default), ``"descending"``, or ``null`` (no
-        not sort).
-    """
-    _schema = {'$ref': '#/definitions/EncodingSortField'}
-    _rootschema = Root._schema
-
-    def __init__(self, op=Undefined, field=Undefined, order=Undefined, **kwds):
-        super(EncodingSortField, self).__init__(op=op, field=field, order=order, **kwds)
-
-
 class EncodingWithFacet(VegaLiteSchema):
     """EncodingWithFacet schema wrapper
 
@@ -2641,109 +2518,6 @@ class EncodingWithFacet(VegaLiteSchema):
                                                 **kwds)
 
 
-class LayerSpec(VegaLiteSchema):
-    """LayerSpec schema wrapper
-
-    Mapping(required=[layer])
-    Layer Spec with encoding and projection
-
-    Attributes
-    ----------
-
-    layer : List(anyOf(:class:`LayerSpec`, :class:`CompositeUnitSpec`))
-        Layer or single view specifications to be layered.
-
-        **Note** : Specifications inside ``layer`` cannot use ``row`` and ``column``
-        channels as layering facet specifications is not allowed.
-    data : :class:`Data`
-        An object describing the data source
-    description : string
-        Description of this mark for commenting purpose.
-    encoding : :class:`Encoding`
-        A shared key-value mapping between encoding channels and definition of fields in the
-        underlying layers.
-    height : float
-        The height of a visualization.
-
-        **Default value:**
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its y-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
-          be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For y-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the height is `determined by the range step, paddings, and the
-          cardinality of the field mapped to y-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
-          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
-          ``rangeStep``.
-
-        **Note** : For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        height of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    name : string
-        Name of the visualization for later reference.
-    projection : :class:`Projection`
-        An object defining properties of the geographic projection shared by underlying
-        layers.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for layers.
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    width : float
-        The width of a visualization.
-
-        **Default value:** This will be determined by the following rules:
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its x-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
-          be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For x-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the width is `determined by the range step, paddings, and the
-          cardinality of the field mapped to x-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
-          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
-          `config.scale.textXRangeStep
-          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
-          ``text`` mark and the value of ``rangeStep`` for other marks.
-
-        **Note:** For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        width of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    """
-    _schema = {'$ref': '#/definitions/LayerSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, layer=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
-                 height=Undefined, name=Undefined, projection=Undefined, resolve=Undefined,
-                 title=Undefined, transform=Undefined, width=Undefined, **kwds):
-        super(LayerSpec, self).__init__(layer=layer, data=data, description=description,
-                                        encoding=encoding, height=height, name=name,
-                                        projection=projection, resolve=resolve, title=title,
-                                        transform=transform, width=width, **kwds)
-
-
 class FacetFieldDef(VegaLiteSchema):
     """FacetFieldDef schema wrapper
 
@@ -2866,6 +2640,110 @@ class FacetMapping(VegaLiteSchema):
 
     def __init__(self, column=Undefined, row=Undefined, **kwds):
         super(FacetMapping, self).__init__(column=column, row=row, **kwds)
+
+
+class FacetedCompositeUnitSpecAlias(VegaLiteSchema):
+    """FacetedCompositeUnitSpecAlias schema wrapper
+
+    Mapping(required=[mark])
+
+    Attributes
+    ----------
+
+    mark : :class:`AnyMark`
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and ``"text"`` ) or a `mark
+        definition object <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`EncodingWithFacet`
+        A key-value mapping between encoding channels and definition of fields.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    projection : :class:`Projection`
+        An object defining properties of geographic projection, which will be applied to
+        ``shape`` path for ``"geoshape"`` marks
+        and to ``latitude`` and ``"longitude"`` channels for other marks.
+    selection : Mapping(required=[])
+        A key-value mapping between selection names and definitions.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    """
+    _schema = {'$ref': '#/definitions/FacetedCompositeUnitSpecAlias'}
+    _rootschema = Root._schema
+
+    def __init__(self, mark=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, projection=Undefined, selection=Undefined,
+                 title=Undefined, transform=Undefined, width=Undefined, **kwds):
+        super(FacetedCompositeUnitSpecAlias, self).__init__(mark=mark, data=data,
+                                                            description=description, encoding=encoding,
+                                                            height=height, name=name,
+                                                            projection=projection, selection=selection,
+                                                            title=title, transform=transform,
+                                                            width=width, **kwds)
 
 
 class FieldDef(VegaLiteSchema):
@@ -3027,411 +2905,6 @@ class FieldDefWithCondition(VegaLiteSchema):
                                                     title=title, **kwds)
 
 
-class MarkPropFieldDefWithCondition(VegaLiteSchema):
-    """MarkPropFieldDefWithCondition schema wrapper
-
-    Mapping(required=[type])
-    A FieldDef with Condition :raw-html:`<ValueDef>`
-
-    Attributes
-    ----------
-
-    type : :class:`Type`
-        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
-        ``"ordinal"``, or ``"nominal"`` ).
-        It can also be a ``"geojson"`` type for encoding `'geoshape'
-        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
-    aggregate : :class:`Aggregate`
-        Aggregation function for the field
-        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
-
-        **Default value:** ``undefined`` (None)
-    bin : anyOf(boolean, :class:`BinParams`)
-        A flag for binning a ``quantitative`` field, or `an object defining binning
-        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`__.
-        If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
-
-        **Default value:** ``false``
-    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
-        One or more value definition(s) with a selection predicate.
-
-        **Note:** A field definition's ``condition`` property can only contain `value
-        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
-        since Vega-Lite only allows at most one encoded field per encoding channel.
-    field : anyOf(string, :class:`RepeatRef`)
-        **Required.** A string defining the name of the field from which to pull a data
-        value
-        or an object defining iterated values from the `repeat
-        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
-
-        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
-        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
-        If field names contain dots or brackets but are not nested, you can use ``\\`` to
-        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
-        See more details about escaping in the `field documentation
-        <https://vega.github.io/vega-lite/docs/field.html>`__.
-
-        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
-    legend : anyOf(:class:`Legend`, None)
-        An object defining properties of the legend.
-        If ``null``, the legend for the encoding channel will be removed.
-
-        **Default value:** If undefined, default `legend properties
-        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
-    scale : anyOf(:class:`Scale`, None)
-        An object defining properties of the channel's scale, which is the function that
-        transforms values in the data domain (numbers, dates, strings, etc) to visual values
-        (pixels, colors, sizes) of the encoding channels.
-
-        If ``null``, the scale will be `disabled and the data value will be directly encoded
-        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
-
-        **Default value:** If undefined, default `scale properties
-        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
-    sort : :class:`Sort`
-        Sort order for the encoded field.
-
-        For continuous fields (quantitative or temporal), ``sort`` can be either
-        ``"ascending"`` or ``"descending"``.
-
-        For discrete fields, ``sort`` can be one of the following:
-
-
-        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
-          Javascript.
-        * `A sort field definition
-          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
-          another field.
-        * `An array specifying the field values in preferred order
-          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
-          sort order will obey the values in the array, followed by any unspecified values
-          in their original order.  For discrete time field, values in the sort array can be
-          `date-time definition objects <types#datetime>`__. In addition, for time units
-          ``"month"`` and ``"day"``, the values can be the month or day names (case
-          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
-        * ``null`` indicating no sort.
-
-        **Default value:** ``"ascending"``
-
-        **Note:** ``null`` is not supported for ``row`` and ``column``.
-    timeUnit : :class:`TimeUnit`
-        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
-        field.
-        or `a temporal field that gets casted as ordinal
-        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
-
-        **Default value:** ``undefined`` (None)
-    title : anyOf(string, None)
-        A title for the field. If ``null``, the title will be removed.
-
-        **Default value:**  derived from the field's name and transformation function (
-        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
-        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
-        field is binned or has a time unit applied, the applied function is shown in
-        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
-        Otherwise, the title is simply the field name.
-
-        **Notes** :
-
-        1) You can customize the default field title format by providing the [fieldTitle
-        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
-        `fieldTitle function via the compile function's options
-        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
-
-        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
-        defined, axis/header/legend title will be used.
-    """
-    _schema = {'$ref': '#/definitions/MarkPropFieldDefWithCondition'}
-    _rootschema = Root._schema
-
-    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
-                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
-                 title=Undefined, **kwds):
-        super(MarkPropFieldDefWithCondition, self).__init__(type=type, aggregate=aggregate, bin=bin,
-                                                            condition=condition, field=field,
-                                                            legend=legend, scale=scale, sort=sort,
-                                                            timeUnit=timeUnit, title=title, **kwds)
-
-
-class TextFieldDefWithCondition(VegaLiteSchema):
-    """TextFieldDefWithCondition schema wrapper
-
-    Mapping(required=[type])
-    A FieldDef with Condition :raw-html:`<ValueDef>`
-
-    Attributes
-    ----------
-
-    type : :class:`Type`
-        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
-        ``"ordinal"``, or ``"nominal"`` ).
-        It can also be a ``"geojson"`` type for encoding `'geoshape'
-        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
-    aggregate : :class:`Aggregate`
-        Aggregation function for the field
-        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
-
-        **Default value:** ``undefined`` (None)
-    bin : anyOf(boolean, :class:`BinParams`)
-        A flag for binning a ``quantitative`` field, or `an object defining binning
-        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`__.
-        If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
-
-        **Default value:** ``false``
-    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
-        One or more value definition(s) with a selection predicate.
-
-        **Note:** A field definition's ``condition`` property can only contain `value
-        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
-        since Vega-Lite only allows at most one encoded field per encoding channel.
-    field : anyOf(string, :class:`RepeatRef`)
-        **Required.** A string defining the name of the field from which to pull a data
-        value
-        or an object defining iterated values from the `repeat
-        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
-
-        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
-        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
-        If field names contain dots or brackets but are not nested, you can use ``\\`` to
-        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
-        See more details about escaping in the `field documentation
-        <https://vega.github.io/vega-lite/docs/field.html>`__.
-
-        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
-    format : string
-        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`__ for a
-        text field. If not defined, this will be determined automatically.
-    timeUnit : :class:`TimeUnit`
-        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
-        field.
-        or `a temporal field that gets casted as ordinal
-        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
-
-        **Default value:** ``undefined`` (None)
-    title : anyOf(string, None)
-        A title for the field. If ``null``, the title will be removed.
-
-        **Default value:**  derived from the field's name and transformation function (
-        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
-        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
-        field is binned or has a time unit applied, the applied function is shown in
-        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
-        Otherwise, the title is simply the field name.
-
-        **Notes** :
-
-        1) You can customize the default field title format by providing the [fieldTitle
-        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
-        `fieldTitle function via the compile function's options
-        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
-
-        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
-        defined, axis/header/legend title will be used.
-    """
-    _schema = {'$ref': '#/definitions/TextFieldDefWithCondition'}
-    _rootschema = Root._schema
-
-    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
-                 field=Undefined, format=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
-        super(TextFieldDefWithCondition, self).__init__(type=type, aggregate=aggregate, bin=bin,
-                                                        condition=condition, field=field, format=format,
-                                                        timeUnit=timeUnit, title=title, **kwds)
-
-
-class FieldEqualPredicate(VegaLiteSchema):
-    """FieldEqualPredicate schema wrapper
-
-    Mapping(required=[equal, field])
-
-    Attributes
-    ----------
-
-    equal : anyOf(string, float, boolean, :class:`DateTime`)
-        The value that the field should be equal to.
-    field : string
-        Field to be filtered.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldEqualPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, equal=Undefined, field=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldEqualPredicate, self).__init__(equal=equal, field=field, timeUnit=timeUnit, **kwds)
-
-
-class FieldGTEPredicate(VegaLiteSchema):
-    """FieldGTEPredicate schema wrapper
-
-    Mapping(required=[field, gte])
-
-    Attributes
-    ----------
-
-    field : string
-        Field to be filtered.
-    gte : anyOf(string, float, :class:`DateTime`)
-        The value that the field should be greater than or equals to.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldGTEPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, gte=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldGTEPredicate, self).__init__(field=field, gte=gte, timeUnit=timeUnit, **kwds)
-
-
-class FieldGTPredicate(VegaLiteSchema):
-    """FieldGTPredicate schema wrapper
-
-    Mapping(required=[field, gt])
-
-    Attributes
-    ----------
-
-    field : string
-        Field to be filtered.
-    gt : anyOf(string, float, :class:`DateTime`)
-        The value that the field should be greater than.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldGTPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, gt=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldGTPredicate, self).__init__(field=field, gt=gt, timeUnit=timeUnit, **kwds)
-
-
-class FieldLTEPredicate(VegaLiteSchema):
-    """FieldLTEPredicate schema wrapper
-
-    Mapping(required=[field, lte])
-
-    Attributes
-    ----------
-
-    field : string
-        Field to be filtered.
-    lte : anyOf(string, float, :class:`DateTime`)
-        The value that the field should be less than or equals to.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldLTEPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, lte=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldLTEPredicate, self).__init__(field=field, lte=lte, timeUnit=timeUnit, **kwds)
-
-
-class FieldLTPredicate(VegaLiteSchema):
-    """FieldLTPredicate schema wrapper
-
-    Mapping(required=[field, lt])
-
-    Attributes
-    ----------
-
-    field : string
-        Field to be filtered.
-    lt : anyOf(string, float, :class:`DateTime`)
-        The value that the field should be less than.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldLTPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, lt=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldLTPredicate, self).__init__(field=field, lt=lt, timeUnit=timeUnit, **kwds)
-
-
-class FieldOneOfPredicate(VegaLiteSchema):
-    """FieldOneOfPredicate schema wrapper
-
-    Mapping(required=[field, oneOf])
-
-    Attributes
-    ----------
-
-    field : string
-        Field to be filtered.
-    oneOf : anyOf(List(string), List(float), List(boolean), List(:class:`DateTime`))
-        A set of values that the ``field`` 's value should be a member of,
-        for a data item included in the filtered data.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldOneOfPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, oneOf=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldOneOfPredicate, self).__init__(field=field, oneOf=oneOf, timeUnit=timeUnit, **kwds)
-
-
-class FieldRangePredicate(VegaLiteSchema):
-    """FieldRangePredicate schema wrapper
-
-    Mapping(required=[field, range])
-
-    Attributes
-    ----------
-
-    field : string
-        Field to be filtered.
-    range : List(anyOf(float, :class:`DateTime`, None))
-        An array of inclusive minimum and maximum values
-        for a field value of a data item to be included in the filtered data.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldRangePredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, range=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldRangePredicate, self).__init__(field=field, range=range, timeUnit=timeUnit, **kwds)
-
-
-class FilterTransform(VegaLiteSchema):
-    """FilterTransform schema wrapper
-
-    Mapping(required=[filter])
-
-    Attributes
-    ----------
-
-    filter : :class:`LogicalOperandPredicate`
-        The ``filter`` property must be one of the predicate definitions:
-
-        1) an `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`__
-        string,
-        where ``datum`` can be used to refer to the current data object
-
-        2) one of the field predicates: `equal
-        <https://vega.github.io/vega-lite/docs/filter.html#equal-predicate>`__,
-        `lt <https://vega.github.io/vega-lite/docs/filter.html#lt-predicate>`__,
-        `lte <https://vega.github.io/vega-lite/docs/filter.html#lte-predicate>`__,
-        `gt <https://vega.github.io/vega-lite/docs/filter.html#gt-predicate>`__,
-        `gte <https://vega.github.io/vega-lite/docs/filter.html#gte-predicate>`__,
-        `range <https://vega.github.io/vega-lite/docs/filter.html#range-predicate>`__,
-        or `oneOf <https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate>`__.
-
-        3) a `selection predicate
-        <https://vega.github.io/vega-lite/docs/filter.html#selection-predicate>`__
-
-        4) a logical operand that combines (1), (2), or (3).
-    """
-    _schema = {'$ref': '#/definitions/FilterTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, filter=Undefined, **kwds):
-        super(FilterTransform, self).__init__(filter=filter, **kwds)
-
-
 class FontStyle(VegaLiteSchema):
     """FontStyle schema wrapper
 
@@ -3456,7 +2929,7 @@ class FontWeight(VegaLiteSchema):
         super(FontWeight, self).__init__(*args, **kwds)
 
 
-class FontWeightNumber(VegaLiteSchema):
+class FontWeightNumber(FontWeight):
     """FontWeightNumber schema wrapper
 
     float
@@ -3468,7 +2941,7 @@ class FontWeightNumber(VegaLiteSchema):
         super(FontWeightNumber, self).__init__(*args)
 
 
-class FontWeightString(VegaLiteSchema):
+class FontWeightString(FontWeight):
     """FontWeightString schema wrapper
 
     enum('normal', 'bold')
@@ -3478,510 +2951,6 @@ class FontWeightString(VegaLiteSchema):
 
     def __init__(self, *args):
         super(FontWeightString, self).__init__(*args)
-
-
-class FacetSpec(VegaLiteSchema):
-    """FacetSpec schema wrapper
-
-    Mapping(required=[facet, spec])
-
-    Attributes
-    ----------
-
-    facet : :class:`FacetMapping`
-        An object that describes mappings between ``row`` and ``column`` channels and their
-        field definitions.
-    spec : anyOf(:class:`LayerSpec`, :class:`CompositeUnitSpec`)
-        A specification of the view that gets faceted.
-    align : anyOf(:class:`VgLayoutAlign`, :class:`RowColVgLayoutAlign`)
-        The alignment to apply to grid rows and columns.
-        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
-
-
-        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
-          placed one after the other.
-        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
-          or column may be of variable size.
-        * For ``"all"``, subviews will be aligned and each row or column will be sized
-          identically based on the maximum observed size. String values for this property
-          will be applied to both grid rows and columns.
-
-        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
-        be used to supply different alignments for rows and columns.
-
-        **Default value:** ``"all"``.
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : anyOf(boolean, :class:`RowColboolean`)
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
-        supply different centering values for rows and columns.
-
-        **Default value:** ``false``
-    data : :class:`Data`
-        An object describing the data source
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for facets.
-    spacing : anyOf(float, :class:`RowColnumber`)
-        The spacing in pixels between sub-views of the composition operator.
-        An object of the form ``{"row": number, "column": number}`` can be used to set
-        different spacing values for rows and columns.
-
-        **Default value** : ``10``
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    """
-    _schema = {'$ref': '#/definitions/FacetSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, facet=Undefined, spec=Undefined, align=Undefined, bounds=Undefined,
-                 center=Undefined, data=Undefined, description=Undefined, name=Undefined,
-                 resolve=Undefined, spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
-        super(FacetSpec, self).__init__(facet=facet, spec=spec, align=align, bounds=bounds,
-                                        center=center, data=data, description=description, name=name,
-                                        resolve=resolve, spacing=spacing, title=title,
-                                        transform=transform, **kwds)
-
-
-class HConcatSpec(VegaLiteSchema):
-    """HConcatSpec schema wrapper
-
-    Mapping(required=[hconcat])
-
-    Attributes
-    ----------
-
-    hconcat : List(:class:`Spec`)
-        A list of views that should be concatenated and put into a row.
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : boolean
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        **Default value:** ``false``
-    data : :class:`Data`
-        An object describing the data source
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for horizontally concatenated charts.
-    spacing : float
-        The spacing in pixels between sub-views of the concat operator.
-
-        **Default value** : ``10``
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    """
-    _schema = {'$ref': '#/definitions/HConcatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, hconcat=Undefined, bounds=Undefined, center=Undefined, data=Undefined,
-                 description=Undefined, name=Undefined, resolve=Undefined, spacing=Undefined,
-                 title=Undefined, transform=Undefined, **kwds):
-        super(HConcatSpec, self).__init__(hconcat=hconcat, bounds=bounds, center=center, data=data,
-                                          description=description, name=name, resolve=resolve,
-                                          spacing=spacing, title=title, transform=transform, **kwds)
-
-
-class RepeatSpec(VegaLiteSchema):
-    """RepeatSpec schema wrapper
-
-    Mapping(required=[repeat, spec])
-
-    Attributes
-    ----------
-
-    repeat : :class:`Repeat`
-        An object that describes what fields should be repeated into views that are laid out
-        as a ``row`` or ``column``.
-    spec : :class:`Spec`
-
-    align : anyOf(:class:`VgLayoutAlign`, :class:`RowColVgLayoutAlign`)
-        The alignment to apply to grid rows and columns.
-        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
-
-
-        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
-          placed one after the other.
-        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
-          or column may be of variable size.
-        * For ``"all"``, subviews will be aligned and each row or column will be sized
-          identically based on the maximum observed size. String values for this property
-          will be applied to both grid rows and columns.
-
-        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
-        be used to supply different alignments for rows and columns.
-
-        **Default value:** ``"all"``.
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : anyOf(boolean, :class:`RowColboolean`)
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
-        supply different centering values for rows and columns.
-
-        **Default value:** ``false``
-    data : :class:`Data`
-        An object describing the data source
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    resolve : :class:`Resolve`
-        Scale and legend resolutions for repeated charts.
-    spacing : anyOf(float, :class:`RowColnumber`)
-        The spacing in pixels between sub-views of the composition operator.
-        An object of the form ``{"row": number, "column": number}`` can be used to set
-        different spacing values for rows and columns.
-
-        **Default value** : ``10``
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    """
-    _schema = {'$ref': '#/definitions/RepeatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, repeat=Undefined, spec=Undefined, align=Undefined, bounds=Undefined,
-                 center=Undefined, data=Undefined, description=Undefined, name=Undefined,
-                 resolve=Undefined, spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
-        super(RepeatSpec, self).__init__(repeat=repeat, spec=spec, align=align, bounds=bounds,
-                                         center=center, data=data, description=description, name=name,
-                                         resolve=resolve, spacing=spacing, title=title,
-                                         transform=transform, **kwds)
-
-
-class Spec(VegaLiteSchema):
-    """Spec schema wrapper
-
-    anyOf(:class:`CompositeUnitSpec`, :class:`LayerSpec`, :class:`FacetSpec`,
-    :class:`RepeatSpec`, :class:`VConcatSpec`, :class:`HConcatSpec`)
-    """
-    _schema = {'$ref': '#/definitions/Spec'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(Spec, self).__init__(*args, **kwds)
-
-
-class CompositeUnitSpecAlias(VegaLiteSchema):
-    """CompositeUnitSpecAlias schema wrapper
-
-    Mapping(required=[mark])
-
-    Attributes
-    ----------
-
-    mark : :class:`AnyMark`
-        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
-        ``"tick"``, ``"line"``,
-        ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and ``"text"`` ) or a `mark
-        definition object <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
-    data : :class:`Data`
-        An object describing the data source
-    description : string
-        Description of this mark for commenting purpose.
-    encoding : :class:`Encoding`
-        A key-value mapping between encoding channels and definition of fields.
-    height : float
-        The height of a visualization.
-
-        **Default value:**
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its y-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
-          be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For y-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the height is `determined by the range step, paddings, and the
-          cardinality of the field mapped to y-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
-          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
-          ``rangeStep``.
-
-        **Note** : For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        height of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    name : string
-        Name of the visualization for later reference.
-    projection : :class:`Projection`
-        An object defining properties of geographic projection, which will be applied to
-        ``shape`` path for ``"geoshape"`` marks
-        and to ``latitude`` and ``"longitude"`` channels for other marks.
-    selection : Mapping(required=[])
-        A key-value mapping between selection names and definitions.
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    width : float
-        The width of a visualization.
-
-        **Default value:** This will be determined by the following rules:
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its x-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
-          be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For x-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the width is `determined by the range step, paddings, and the
-          cardinality of the field mapped to x-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
-          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
-          `config.scale.textXRangeStep
-          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
-          ``text`` mark and the value of ``rangeStep`` for other marks.
-
-        **Note:** For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        width of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    """
-    _schema = {'$ref': '#/definitions/CompositeUnitSpecAlias'}
-    _rootschema = Root._schema
-
-    def __init__(self, mark=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
-                 height=Undefined, name=Undefined, projection=Undefined, selection=Undefined,
-                 title=Undefined, transform=Undefined, width=Undefined, **kwds):
-        super(CompositeUnitSpecAlias, self).__init__(mark=mark, data=data, description=description,
-                                                     encoding=encoding, height=height, name=name,
-                                                     projection=projection, selection=selection,
-                                                     title=title, transform=transform, width=width,
-                                                     **kwds)
-
-
-class FacetedCompositeUnitSpecAlias(VegaLiteSchema):
-    """FacetedCompositeUnitSpecAlias schema wrapper
-
-    Mapping(required=[mark])
-
-    Attributes
-    ----------
-
-    mark : :class:`AnyMark`
-        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
-        ``"tick"``, ``"line"``,
-        ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and ``"text"`` ) or a `mark
-        definition object <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
-    data : :class:`Data`
-        An object describing the data source
-    description : string
-        Description of this mark for commenting purpose.
-    encoding : :class:`EncodingWithFacet`
-        A key-value mapping between encoding channels and definition of fields.
-    height : float
-        The height of a visualization.
-
-        **Default value:**
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its y-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
-          be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For y-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the height is `determined by the range step, paddings, and the
-          cardinality of the field mapped to y-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
-          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
-          ``rangeStep``.
-
-        **Note** : For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        height of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    name : string
-        Name of the visualization for later reference.
-    projection : :class:`Projection`
-        An object defining properties of geographic projection, which will be applied to
-        ``shape`` path for ``"geoshape"`` marks
-        and to ``latitude`` and ``"longitude"`` channels for other marks.
-    selection : Mapping(required=[])
-        A key-value mapping between selection names and definitions.
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    width : float
-        The width of a visualization.
-
-        **Default value:** This will be determined by the following rules:
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its x-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
-          be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For x-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the width is `determined by the range step, paddings, and the
-          cardinality of the field mapped to x-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
-          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
-          `config.scale.textXRangeStep
-          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
-          ``text`` mark and the value of ``rangeStep`` for other marks.
-
-        **Note:** For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        width of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    """
-    _schema = {'$ref': '#/definitions/FacetedCompositeUnitSpecAlias'}
-    _rootschema = Root._schema
-
-    def __init__(self, mark=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
-                 height=Undefined, name=Undefined, projection=Undefined, selection=Undefined,
-                 title=Undefined, transform=Undefined, width=Undefined, **kwds):
-        super(FacetedCompositeUnitSpecAlias, self).__init__(mark=mark, data=data,
-                                                            description=description, encoding=encoding,
-                                                            height=height, name=name,
-                                                            projection=projection, selection=selection,
-                                                            title=title, transform=transform,
-                                                            width=width, **kwds)
-
-
-class VConcatSpec(VegaLiteSchema):
-    """VConcatSpec schema wrapper
-
-    Mapping(required=[vconcat])
-
-    Attributes
-    ----------
-
-    vconcat : List(:class:`Spec`)
-        A list of views that should be concatenated and put into a column.
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : boolean
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        **Default value:** ``false``
-    data : :class:`Data`
-        An object describing the data source
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for vertically concatenated charts.
-    spacing : float
-        The spacing in pixels between sub-views of the concat operator.
-
-        **Default value** : ``10``
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    """
-    _schema = {'$ref': '#/definitions/VConcatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, vconcat=Undefined, bounds=Undefined, center=Undefined, data=Undefined,
-                 description=Undefined, name=Undefined, resolve=Undefined, spacing=Undefined,
-                 title=Undefined, transform=Undefined, **kwds):
-        super(VConcatSpec, self).__init__(vconcat=vconcat, bounds=bounds, center=center, data=data,
-                                          description=description, name=name, resolve=resolve,
-                                          spacing=spacing, title=title, transform=transform, **kwds)
-
-
-class GeoType(VegaLiteSchema):
-    """GeoType schema wrapper
-
-    enum('latitude', 'longitude', 'geojson')
-    """
-    _schema = {'$ref': '#/definitions/GeoType'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args):
-        super(GeoType, self).__init__(*args)
 
 
 class Header(VegaLiteSchema):
@@ -4192,7 +3161,7 @@ class HorizontalAlign(VegaLiteSchema):
         super(HorizontalAlign, self).__init__(*args)
 
 
-class InlineData(VegaLiteSchema):
+class InlineData(Data):
     """InlineData schema wrapper
 
     Mapping(required=[values])
@@ -4241,70 +3210,6 @@ class Interpolate(VegaLiteSchema):
 
     def __init__(self, *args):
         super(Interpolate, self).__init__(*args)
-
-
-class IntervalSelection(VegaLiteSchema):
-    """IntervalSelection schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('interval')
-
-    bind : enum('scales')
-        Establishes a two-way binding between the interval selection and the scales
-        used within the same view. This allows a user to interactively pan and
-        zoom the view.
-    empty : enum('all', 'none')
-        By default, all data values are considered to lie within an empty selection.
-        When set to ``none``, empty selections contain no data values.
-    encodings : List(:class:`SingleDefChannel`)
-        An array of encoding channels. The corresponding data field values
-        must match for a data tuple to fall within the selection.
-    fields : List(string)
-        An array of field names whose values must match for a data tuple to
-        fall within the selection.
-    mark : :class:`BrushConfig`
-        An interval selection also adds a rectangle mark to depict the
-        extents of the interval. The ``mark`` property can be used to customize the
-        appearance of the mark.
-    on : :class:`VgEventStream`
-        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
-        selector) that triggers the selection.
-        For interval selections, the event stream must specify a `start and end
-        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
-    resolve : :class:`SelectionResolution`
-        With layered and multi-view displays, a strategy that determines how
-        selections' data queries are resolved when applied in a filter transform,
-        conditional encoding rule, or scale domain.
-    translate : anyOf(string, boolean)
-        When truthy, allows a user to interactively move an interval selection
-        back-and-forth. Can be ``true``, ``false`` (to disable panning), or a
-        `Vega event stream definition <https://vega.github.io/vega/docs/event-streams/>`__
-        which must include a start and end event to trigger continuous panning.
-
-        **Default value:** ``true``, which corresponds to
-        ``[mousedown, window:mouseup] > window:mousemove!`` which corresponds to
-        clicks and dragging within an interval selection to reposition it.
-    zoom : anyOf(string, boolean)
-        When truthy, allows a user to interactively resize an interval selection.
-        Can be ``true``, ``false`` (to disable zooming), or a `Vega event stream
-        definition <https://vega.github.io/vega/docs/event-streams/>`__. Currently,
-        only ``wheel`` events are supported.
-
-        **Default value:** ``true``, which corresponds to ``wheel!``.
-    """
-    _schema = {'$ref': '#/definitions/IntervalSelection'}
-    _rootschema = Root._schema
-
-    def __init__(self, type=Undefined, bind=Undefined, empty=Undefined, encodings=Undefined,
-                 fields=Undefined, mark=Undefined, on=Undefined, resolve=Undefined, translate=Undefined,
-                 zoom=Undefined, **kwds):
-        super(IntervalSelection, self).__init__(type=type, bind=bind, empty=empty, encodings=encodings,
-                                                fields=fields, mark=mark, on=on, resolve=resolve,
-                                                translate=translate, zoom=zoom, **kwds)
 
 
 class IntervalSelectionConfig(VegaLiteSchema):
@@ -4369,7 +3274,7 @@ class IntervalSelectionConfig(VegaLiteSchema):
                                                       translate=translate, zoom=zoom, **kwds)
 
 
-class JsonDataFormat(VegaLiteSchema):
+class JsonDataFormat(DataFormat):
     """JsonDataFormat schema wrapper
 
     Mapping(required=[])
@@ -4893,34 +3798,20 @@ class LineConfig(VegaLiteSchema):
                                          **kwds)
 
 
-class LocalMultiTimeUnit(VegaLiteSchema):
-    """LocalMultiTimeUnit schema wrapper
+class LogicalOperandPredicate(VegaLiteSchema):
+    """LogicalOperandPredicate schema wrapper
 
-    enum('yearquarter', 'yearquartermonth', 'yearmonth', 'yearmonthdate', 'yearmonthdatehours',
-    'yearmonthdatehoursminutes', 'yearmonthdatehoursminutesseconds', 'quartermonth',
-    'monthdate', 'hoursminutes', 'hoursminutesseconds', 'minutesseconds', 'secondsmilliseconds')
+    anyOf(:class:`LogicalNotPredicate`, :class:`LogicalAndPredicate`,
+    :class:`LogicalOrPredicate`, :class:`Predicate`)
     """
-    _schema = {'$ref': '#/definitions/LocalMultiTimeUnit'}
+    _schema = {'$ref': '#/definitions/LogicalOperand<Predicate>'}
     _rootschema = Root._schema
 
-    def __init__(self, *args):
-        super(LocalMultiTimeUnit, self).__init__(*args)
+    def __init__(self, *args, **kwds):
+        super(LogicalOperandPredicate, self).__init__(*args, **kwds)
 
 
-class LocalSingleTimeUnit(VegaLiteSchema):
-    """LocalSingleTimeUnit schema wrapper
-
-    enum('year', 'quarter', 'month', 'day', 'date', 'hours', 'minutes', 'seconds',
-    'milliseconds')
-    """
-    _schema = {'$ref': '#/definitions/LocalSingleTimeUnit'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args):
-        super(LocalSingleTimeUnit, self).__init__(*args)
-
-
-class LogicalAndPredicate(VegaLiteSchema):
+class LogicalAndPredicate(LogicalOperandPredicate):
     """LogicalAndPredicate schema wrapper
 
     Mapping(required=[and])
@@ -4938,25 +3829,7 @@ class LogicalAndPredicate(VegaLiteSchema):
         super(LogicalAndPredicate, self).__init__(**kwds)
 
 
-class SelectionAnd(VegaLiteSchema):
-    """SelectionAnd schema wrapper
-
-    Mapping(required=[and])
-
-    Attributes
-    ----------
-
-    and : List(:class:`SelectionOperand`)
-
-    """
-    _schema = {'$ref': '#/definitions/SelectionAnd'}
-    _rootschema = Root._schema
-
-    def __init__(self, **kwds):
-        super(SelectionAnd, self).__init__(**kwds)
-
-
-class LogicalNotPredicate(VegaLiteSchema):
+class LogicalNotPredicate(LogicalOperandPredicate):
     """LogicalNotPredicate schema wrapper
 
     Mapping(required=[not])
@@ -4974,50 +3847,7 @@ class LogicalNotPredicate(VegaLiteSchema):
         super(LogicalNotPredicate, self).__init__(**kwds)
 
 
-class SelectionNot(VegaLiteSchema):
-    """SelectionNot schema wrapper
-
-    Mapping(required=[not])
-
-    Attributes
-    ----------
-
-    not : :class:`SelectionOperand`
-
-    """
-    _schema = {'$ref': '#/definitions/SelectionNot'}
-    _rootschema = Root._schema
-
-    def __init__(self, **kwds):
-        super(SelectionNot, self).__init__(**kwds)
-
-
-class LogicalOperandPredicate(VegaLiteSchema):
-    """LogicalOperandPredicate schema wrapper
-
-    anyOf(:class:`LogicalNotPredicate`, :class:`LogicalAndPredicate`,
-    :class:`LogicalOrPredicate`, :class:`Predicate`)
-    """
-    _schema = {'$ref': '#/definitions/LogicalOperand<Predicate>'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(LogicalOperandPredicate, self).__init__(*args, **kwds)
-
-
-class SelectionOperand(VegaLiteSchema):
-    """SelectionOperand schema wrapper
-
-    anyOf(:class:`SelectionNot`, :class:`SelectionAnd`, :class:`SelectionOr`, string)
-    """
-    _schema = {'$ref': '#/definitions/SelectionOperand'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(SelectionOperand, self).__init__(*args, **kwds)
-
-
-class LogicalOrPredicate(VegaLiteSchema):
+class LogicalOrPredicate(LogicalOperandPredicate):
     """LogicalOrPredicate schema wrapper
 
     Mapping(required=[or])
@@ -5033,24 +3863,6 @@ class LogicalOrPredicate(VegaLiteSchema):
 
     def __init__(self, **kwds):
         super(LogicalOrPredicate, self).__init__(**kwds)
-
-
-class SelectionOr(VegaLiteSchema):
-    """SelectionOr schema wrapper
-
-    Mapping(required=[or])
-
-    Attributes
-    ----------
-
-    or : List(:class:`SelectionOperand`)
-
-    """
-    _schema = {'$ref': '#/definitions/SelectionOr'}
-    _rootschema = Root._schema
-
-    def __init__(self, **kwds):
-        super(SelectionOr, self).__init__(**kwds)
 
 
 class LookupData(VegaLiteSchema):
@@ -5076,36 +3888,7 @@ class LookupData(VegaLiteSchema):
         super(LookupData, self).__init__(data=data, key=key, fields=fields, **kwds)
 
 
-class LookupTransform(VegaLiteSchema):
-    """LookupTransform schema wrapper
-
-    Mapping(required=[lookup, from])
-
-    Attributes
-    ----------
-
-    lookup : string
-        Key in primary data source.
-    default : string
-        The default value to use if lookup fails.
-
-        **Default value:** ``null``
-    as : anyOf(string, List(string))
-        The field or fields for storing the computed formula value.
-        If ``from.fields`` is specified, the transform will use the same names for ``as``.
-        If ``from.fields`` is not specified, ``as`` has to be a string and we put the whole
-        object into the data under the specified name.
-    from : :class:`LookupData`
-        Secondary data reference.
-    """
-    _schema = {'$ref': '#/definitions/LookupTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, lookup=Undefined, default=Undefined, **kwds):
-        super(LookupTransform, self).__init__(lookup=lookup, default=default, **kwds)
-
-
-class Mark(VegaLiteSchema):
+class Mark(AnyMark):
     """Mark schema wrapper
 
     enum('area', 'bar', 'line', 'trail', 'point', 'text', 'tick', 'rect', 'rule', 'circle',
@@ -5323,7 +4106,7 @@ class MarkConfig(VegaLiteSchema):
                                          theta=theta, tooltip=tooltip, **kwds)
 
 
-class MarkDef(VegaLiteSchema):
+class MarkDef(AnyMark):
     """MarkDef schema wrapper
 
     Mapping(required=[type])
@@ -5595,6 +4378,155 @@ class MarkDef(VegaLiteSchema):
                                       yOffset=yOffset, **kwds)
 
 
+class MarkPropFieldDefWithCondition(VegaLiteSchema):
+    """MarkPropFieldDefWithCondition schema wrapper
+
+    Mapping(required=[type])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`)
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`__.
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/MarkPropFieldDefWithCondition'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, **kwds):
+        super(MarkPropFieldDefWithCondition, self).__init__(type=type, aggregate=aggregate, bin=bin,
+                                                            condition=condition, field=field,
+                                                            legend=legend, scale=scale, sort=sort,
+                                                            timeUnit=timeUnit, title=title, **kwds)
+
+
+class MarkPropValueDefWithCondition(VegaLiteSchema):
+    """MarkPropValueDefWithCondition schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean)
+        A constant value in visual domain.
+    """
+    _schema = {'$ref': '#/definitions/MarkPropValueDefWithCondition'}
+    _rootschema = Root._schema
+
+    def __init__(self, condition=Undefined, value=Undefined, **kwds):
+        super(MarkPropValueDefWithCondition, self).__init__(condition=condition, value=value, **kwds)
+
+
 class Month(VegaLiteSchema):
     """Month schema wrapper
 
@@ -5605,61 +4537,6 @@ class Month(VegaLiteSchema):
 
     def __init__(self, *args):
         super(Month, self).__init__(*args)
-
-
-class MultiSelection(VegaLiteSchema):
-    """MultiSelection schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('multi')
-
-    empty : enum('all', 'none')
-        By default, all data values are considered to lie within an empty selection.
-        When set to ``none``, empty selections contain no data values.
-    encodings : List(:class:`SingleDefChannel`)
-        An array of encoding channels. The corresponding data field values
-        must match for a data tuple to fall within the selection.
-    fields : List(string)
-        An array of field names whose values must match for a data tuple to
-        fall within the selection.
-    nearest : boolean
-        When true, an invisible voronoi diagram is computed to accelerate discrete
-        selection. The data value *nearest* the mouse cursor is added to the selection.
-
-        See the `nearest transform <https://vega.github.io/vega-lite/docs/nearest.html>`__
-        documentation for more information.
-    on : :class:`VgEventStream`
-        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
-        selector) that triggers the selection.
-        For interval selections, the event stream must specify a `start and end
-        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
-    resolve : :class:`SelectionResolution`
-        With layered and multi-view displays, a strategy that determines how
-        selections' data queries are resolved when applied in a filter transform,
-        conditional encoding rule, or scale domain.
-    toggle : anyOf(string, boolean)
-        Controls whether data values should be toggled or only ever inserted into
-        multi selections. Can be ``true``, ``false`` (for insertion only), or a
-        `Vega expression <https://vega.github.io/vega/docs/expressions/>`__.
-
-        **Default value:** ``true``, which corresponds to ``event.shiftKey`` (i.e.,
-        data values are toggled when a user interacts with the shift-key pressed).
-
-        See the `toggle transform <https://vega.github.io/vega-lite/docs/toggle.html>`__
-        documentation for more information.
-    """
-    _schema = {'$ref': '#/definitions/MultiSelection'}
-    _rootschema = Root._schema
-
-    def __init__(self, type=Undefined, empty=Undefined, encodings=Undefined, fields=Undefined,
-                 nearest=Undefined, on=Undefined, resolve=Undefined, toggle=Undefined, **kwds):
-        super(MultiSelection, self).__init__(type=type, empty=empty, encodings=encodings, fields=fields,
-                                             nearest=nearest, on=on, resolve=resolve, toggle=toggle,
-                                             **kwds)
 
 
 class MultiSelectionConfig(VegaLiteSchema):
@@ -5715,19 +4592,7 @@ class MultiSelectionConfig(VegaLiteSchema):
                                                    toggle=toggle, **kwds)
 
 
-class MultiTimeUnit(VegaLiteSchema):
-    """MultiTimeUnit schema wrapper
-
-    anyOf(:class:`LocalMultiTimeUnit`, :class:`UtcMultiTimeUnit`)
-    """
-    _schema = {'$ref': '#/definitions/MultiTimeUnit'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(MultiTimeUnit, self).__init__(*args, **kwds)
-
-
-class NamedData(VegaLiteSchema):
+class NamedData(Data):
     """NamedData schema wrapper
 
     Mapping(required=[name])
@@ -6249,7 +5114,7 @@ class PositionFieldDef(VegaLiteSchema):
                                                timeUnit=timeUnit, title=title, **kwds)
 
 
-class Predicate(VegaLiteSchema):
+class Predicate(LogicalOperandPredicate):
     """Predicate schema wrapper
 
     anyOf(:class:`FieldEqualPredicate`, :class:`FieldRangePredicate`,
@@ -6261,6 +5126,162 @@ class Predicate(VegaLiteSchema):
 
     def __init__(self, *args, **kwds):
         super(Predicate, self).__init__(*args, **kwds)
+
+
+class FieldEqualPredicate(Predicate):
+    """FieldEqualPredicate schema wrapper
+
+    Mapping(required=[equal, field])
+
+    Attributes
+    ----------
+
+    equal : anyOf(string, float, boolean, :class:`DateTime`)
+        The value that the field should be equal to.
+    field : string
+        Field to be filtered.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldEqualPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, equal=Undefined, field=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldEqualPredicate, self).__init__(equal=equal, field=field, timeUnit=timeUnit, **kwds)
+
+
+class FieldGTEPredicate(Predicate):
+    """FieldGTEPredicate schema wrapper
+
+    Mapping(required=[field, gte])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    gte : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be greater than or equals to.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldGTEPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, gte=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldGTEPredicate, self).__init__(field=field, gte=gte, timeUnit=timeUnit, **kwds)
+
+
+class FieldGTPredicate(Predicate):
+    """FieldGTPredicate schema wrapper
+
+    Mapping(required=[field, gt])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    gt : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be greater than.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldGTPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, gt=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldGTPredicate, self).__init__(field=field, gt=gt, timeUnit=timeUnit, **kwds)
+
+
+class FieldLTEPredicate(Predicate):
+    """FieldLTEPredicate schema wrapper
+
+    Mapping(required=[field, lte])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    lte : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be less than or equals to.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldLTEPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, lte=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldLTEPredicate, self).__init__(field=field, lte=lte, timeUnit=timeUnit, **kwds)
+
+
+class FieldLTPredicate(Predicate):
+    """FieldLTPredicate schema wrapper
+
+    Mapping(required=[field, lt])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    lt : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be less than.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldLTPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, lt=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldLTPredicate, self).__init__(field=field, lt=lt, timeUnit=timeUnit, **kwds)
+
+
+class FieldOneOfPredicate(Predicate):
+    """FieldOneOfPredicate schema wrapper
+
+    Mapping(required=[field, oneOf])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    oneOf : anyOf(List(string), List(float), List(boolean), List(:class:`DateTime`))
+        A set of values that the ``field`` 's value should be a member of,
+        for a data item included in the filtered data.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldOneOfPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, oneOf=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldOneOfPredicate, self).__init__(field=field, oneOf=oneOf, timeUnit=timeUnit, **kwds)
+
+
+class FieldRangePredicate(Predicate):
+    """FieldRangePredicate schema wrapper
+
+    Mapping(required=[field, range])
+
+    Attributes
+    ----------
+
+    field : string
+        Field to be filtered.
+    range : List(anyOf(float, :class:`DateTime`, None))
+        An array of inclusive minimum and maximum values
+        for a field value of a data item to be included in the filtered data.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldRangePredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, range=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldRangePredicate, self).__init__(field=field, range=range, timeUnit=timeUnit, **kwds)
 
 
 class Projection(VegaLiteSchema):
@@ -7114,6 +6135,125 @@ class SelectionDef(VegaLiteSchema):
         super(SelectionDef, self).__init__(*args, **kwds)
 
 
+class IntervalSelection(SelectionDef):
+    """IntervalSelection schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('interval')
+
+    bind : enum('scales')
+        Establishes a two-way binding between the interval selection and the scales
+        used within the same view. This allows a user to interactively pan and
+        zoom the view.
+    empty : enum('all', 'none')
+        By default, all data values are considered to lie within an empty selection.
+        When set to ``none``, empty selections contain no data values.
+    encodings : List(:class:`SingleDefChannel`)
+        An array of encoding channels. The corresponding data field values
+        must match for a data tuple to fall within the selection.
+    fields : List(string)
+        An array of field names whose values must match for a data tuple to
+        fall within the selection.
+    mark : :class:`BrushConfig`
+        An interval selection also adds a rectangle mark to depict the
+        extents of the interval. The ``mark`` property can be used to customize the
+        appearance of the mark.
+    on : :class:`VgEventStream`
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
+        selector) that triggers the selection.
+        For interval selections, the event stream must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
+    resolve : :class:`SelectionResolution`
+        With layered and multi-view displays, a strategy that determines how
+        selections' data queries are resolved when applied in a filter transform,
+        conditional encoding rule, or scale domain.
+    translate : anyOf(string, boolean)
+        When truthy, allows a user to interactively move an interval selection
+        back-and-forth. Can be ``true``, ``false`` (to disable panning), or a
+        `Vega event stream definition <https://vega.github.io/vega/docs/event-streams/>`__
+        which must include a start and end event to trigger continuous panning.
+
+        **Default value:** ``true``, which corresponds to
+        ``[mousedown, window:mouseup] > window:mousemove!`` which corresponds to
+        clicks and dragging within an interval selection to reposition it.
+    zoom : anyOf(string, boolean)
+        When truthy, allows a user to interactively resize an interval selection.
+        Can be ``true``, ``false`` (to disable zooming), or a `Vega event stream
+        definition <https://vega.github.io/vega/docs/event-streams/>`__. Currently,
+        only ``wheel`` events are supported.
+
+        **Default value:** ``true``, which corresponds to ``wheel!``.
+    """
+    _schema = {'$ref': '#/definitions/IntervalSelection'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, bind=Undefined, empty=Undefined, encodings=Undefined,
+                 fields=Undefined, mark=Undefined, on=Undefined, resolve=Undefined, translate=Undefined,
+                 zoom=Undefined, **kwds):
+        super(IntervalSelection, self).__init__(type=type, bind=bind, empty=empty, encodings=encodings,
+                                                fields=fields, mark=mark, on=on, resolve=resolve,
+                                                translate=translate, zoom=zoom, **kwds)
+
+
+class MultiSelection(SelectionDef):
+    """MultiSelection schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('multi')
+
+    empty : enum('all', 'none')
+        By default, all data values are considered to lie within an empty selection.
+        When set to ``none``, empty selections contain no data values.
+    encodings : List(:class:`SingleDefChannel`)
+        An array of encoding channels. The corresponding data field values
+        must match for a data tuple to fall within the selection.
+    fields : List(string)
+        An array of field names whose values must match for a data tuple to
+        fall within the selection.
+    nearest : boolean
+        When true, an invisible voronoi diagram is computed to accelerate discrete
+        selection. The data value *nearest* the mouse cursor is added to the selection.
+
+        See the `nearest transform <https://vega.github.io/vega-lite/docs/nearest.html>`__
+        documentation for more information.
+    on : :class:`VgEventStream`
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
+        selector) that triggers the selection.
+        For interval selections, the event stream must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
+    resolve : :class:`SelectionResolution`
+        With layered and multi-view displays, a strategy that determines how
+        selections' data queries are resolved when applied in a filter transform,
+        conditional encoding rule, or scale domain.
+    toggle : anyOf(string, boolean)
+        Controls whether data values should be toggled or only ever inserted into
+        multi selections. Can be ``true``, ``false`` (for insertion only), or a
+        `Vega expression <https://vega.github.io/vega/docs/expressions/>`__.
+
+        **Default value:** ``true``, which corresponds to ``event.shiftKey`` (i.e.,
+        data values are toggled when a user interacts with the shift-key pressed).
+
+        See the `toggle transform <https://vega.github.io/vega-lite/docs/toggle.html>`__
+        documentation for more information.
+    """
+    _schema = {'$ref': '#/definitions/MultiSelection'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, empty=Undefined, encodings=Undefined, fields=Undefined,
+                 nearest=Undefined, on=Undefined, resolve=Undefined, toggle=Undefined, **kwds):
+        super(MultiSelection, self).__init__(type=type, empty=empty, encodings=encodings, fields=fields,
+                                             nearest=nearest, on=on, resolve=resolve, toggle=toggle,
+                                             **kwds)
+
+
 class SelectionDomain(VegaLiteSchema):
     """SelectionDomain schema wrapper
 
@@ -7126,7 +6266,73 @@ class SelectionDomain(VegaLiteSchema):
         super(SelectionDomain, self).__init__(*args, **kwds)
 
 
-class SelectionPredicate(VegaLiteSchema):
+class SelectionOperand(VegaLiteSchema):
+    """SelectionOperand schema wrapper
+
+    anyOf(:class:`SelectionNot`, :class:`SelectionAnd`, :class:`SelectionOr`, string)
+    """
+    _schema = {'$ref': '#/definitions/SelectionOperand'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(SelectionOperand, self).__init__(*args, **kwds)
+
+
+class SelectionAnd(SelectionOperand):
+    """SelectionAnd schema wrapper
+
+    Mapping(required=[and])
+
+    Attributes
+    ----------
+
+    and : List(:class:`SelectionOperand`)
+
+    """
+    _schema = {'$ref': '#/definitions/SelectionAnd'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(SelectionAnd, self).__init__(**kwds)
+
+
+class SelectionNot(SelectionOperand):
+    """SelectionNot schema wrapper
+
+    Mapping(required=[not])
+
+    Attributes
+    ----------
+
+    not : :class:`SelectionOperand`
+
+    """
+    _schema = {'$ref': '#/definitions/SelectionNot'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(SelectionNot, self).__init__(**kwds)
+
+
+class SelectionOr(SelectionOperand):
+    """SelectionOr schema wrapper
+
+    Mapping(required=[or])
+
+    Attributes
+    ----------
+
+    or : List(:class:`SelectionOperand`)
+
+    """
+    _schema = {'$ref': '#/definitions/SelectionOr'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(SelectionOr, self).__init__(**kwds)
+
+
+class SelectionPredicate(Predicate):
     """SelectionPredicate schema wrapper
 
     Mapping(required=[selection])
@@ -7170,7 +6376,7 @@ class SingleDefChannel(VegaLiteSchema):
         super(SingleDefChannel, self).__init__(*args)
 
 
-class SingleSelection(VegaLiteSchema):
+class SingleSelection(SelectionDef):
     """SingleSelection schema wrapper
 
     Mapping(required=[type])
@@ -7276,18 +6482,6 @@ class SingleSelectionConfig(VegaLiteSchema):
                                                     resolve=resolve, **kwds)
 
 
-class SingleTimeUnit(VegaLiteSchema):
-    """SingleTimeUnit schema wrapper
-
-    anyOf(:class:`LocalSingleTimeUnit`, :class:`UtcSingleTimeUnit`)
-    """
-    _schema = {'$ref': '#/definitions/SingleTimeUnit'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(SingleTimeUnit, self).__init__(*args, **kwds)
-
-
 class Sort(VegaLiteSchema):
     """Sort schema wrapper
 
@@ -7299,6 +6493,41 @@ class Sort(VegaLiteSchema):
 
     def __init__(self, *args, **kwds):
         super(Sort, self).__init__(*args, **kwds)
+
+
+class EncodingSortField(Sort):
+    """EncodingSortField schema wrapper
+
+    Mapping(required=[op])
+    A sort definition for sorting a discrete scale in an encoding field definition.
+
+    Attributes
+    ----------
+
+    op : :class:`AggregateOp`
+        An `aggregate operation
+        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__ to perform on the
+        field prior to sorting (e.g., ``"count"``, ``"mean"`` and ``"median"`` ).
+        This property is required in cases where the sort field and the data reference field
+        do not match.
+        The input data objects will be aggregated, grouped by the encoded data field.
+
+        For a full list of operations, please see the documentation for `aggregate
+        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__.
+    field : anyOf(string, :class:`RepeatRef`)
+        The data `field <https://vega.github.io/vega-lite/docs/field.html>`__ to sort by.
+
+        **Default value:** If unspecified, defaults to the field specified in the outer data
+        reference.
+    order : :class:`SortOrder`
+        The sort order. One of ``"ascending"`` (default), ``"descending"``, or ``null`` (no
+        not sort).
+    """
+    _schema = {'$ref': '#/definitions/EncodingSortField'}
+    _rootschema = Root._schema
+
+    def __init__(self, op=Undefined, field=Undefined, order=Undefined, **kwds):
+        super(EncodingSortField, self).__init__(op=op, field=field, order=order, **kwds)
 
 
 class SortField(VegaLiteSchema):
@@ -7322,7 +6551,7 @@ class SortField(VegaLiteSchema):
         super(SortField, self).__init__(field=field, order=order, **kwds)
 
 
-class SortOrder(VegaLiteSchema):
+class SortOrder(Sort):
     """SortOrder schema wrapper
 
     anyOf(:class:`VgComparatorOrder`, None)
@@ -7332,6 +6561,441 @@ class SortOrder(VegaLiteSchema):
 
     def __init__(self, *args, **kwds):
         super(SortOrder, self).__init__(*args, **kwds)
+
+
+class Spec(VegaLiteSchema):
+    """Spec schema wrapper
+
+    anyOf(:class:`CompositeUnitSpec`, :class:`LayerSpec`, :class:`FacetSpec`,
+    :class:`RepeatSpec`, :class:`VConcatSpec`, :class:`HConcatSpec`)
+    """
+    _schema = {'$ref': '#/definitions/Spec'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(Spec, self).__init__(*args, **kwds)
+
+
+class CompositeUnitSpec(Spec):
+    """CompositeUnitSpec schema wrapper
+
+    Mapping(required=[mark])
+
+    Attributes
+    ----------
+
+    mark : :class:`AnyMark`
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and ``"text"`` ) or a `mark
+        definition object <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`Encoding`
+        A key-value mapping between encoding channels and definition of fields.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    projection : :class:`Projection`
+        An object defining properties of geographic projection, which will be applied to
+        ``shape`` path for ``"geoshape"`` marks
+        and to ``latitude`` and ``"longitude"`` channels for other marks.
+    selection : Mapping(required=[])
+        A key-value mapping between selection names and definitions.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    """
+    _schema = {'$ref': '#/definitions/CompositeUnitSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, mark=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, projection=Undefined, selection=Undefined,
+                 title=Undefined, transform=Undefined, width=Undefined, **kwds):
+        super(CompositeUnitSpec, self).__init__(mark=mark, data=data, description=description,
+                                                encoding=encoding, height=height, name=name,
+                                                projection=projection, selection=selection, title=title,
+                                                transform=transform, width=width, **kwds)
+
+
+class FacetSpec(Spec):
+    """FacetSpec schema wrapper
+
+    Mapping(required=[facet, spec])
+
+    Attributes
+    ----------
+
+    facet : :class:`FacetMapping`
+        An object that describes mappings between ``row`` and ``column`` channels and their
+        field definitions.
+    spec : anyOf(:class:`LayerSpec`, :class:`CompositeUnitSpec`)
+        A specification of the view that gets faceted.
+    align : anyOf(:class:`VgLayoutAlign`, :class:`RowColVgLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for facets.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/FacetSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, facet=Undefined, spec=Undefined, align=Undefined, bounds=Undefined,
+                 center=Undefined, data=Undefined, description=Undefined, name=Undefined,
+                 resolve=Undefined, spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
+        super(FacetSpec, self).__init__(facet=facet, spec=spec, align=align, bounds=bounds,
+                                        center=center, data=data, description=description, name=name,
+                                        resolve=resolve, spacing=spacing, title=title,
+                                        transform=transform, **kwds)
+
+
+class HConcatSpec(Spec):
+    """HConcatSpec schema wrapper
+
+    Mapping(required=[hconcat])
+
+    Attributes
+    ----------
+
+    hconcat : List(:class:`Spec`)
+        A list of views that should be concatenated and put into a row.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : boolean
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        **Default value:** ``false``
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for horizontally concatenated charts.
+    spacing : float
+        The spacing in pixels between sub-views of the concat operator.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/HConcatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, hconcat=Undefined, bounds=Undefined, center=Undefined, data=Undefined,
+                 description=Undefined, name=Undefined, resolve=Undefined, spacing=Undefined,
+                 title=Undefined, transform=Undefined, **kwds):
+        super(HConcatSpec, self).__init__(hconcat=hconcat, bounds=bounds, center=center, data=data,
+                                          description=description, name=name, resolve=resolve,
+                                          spacing=spacing, title=title, transform=transform, **kwds)
+
+
+class LayerSpec(Spec):
+    """LayerSpec schema wrapper
+
+    Mapping(required=[layer])
+    Layer Spec with encoding and projection
+
+    Attributes
+    ----------
+
+    layer : List(anyOf(:class:`LayerSpec`, :class:`CompositeUnitSpec`))
+        Layer or single view specifications to be layered.
+
+        **Note** : Specifications inside ``layer`` cannot use ``row`` and ``column``
+        channels as layering facet specifications is not allowed.
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`Encoding`
+        A shared key-value mapping between encoding channels and definition of fields in the
+        underlying layers.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    projection : :class:`Projection`
+        An object defining properties of the geographic projection shared by underlying
+        layers.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for layers.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    """
+    _schema = {'$ref': '#/definitions/LayerSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, layer=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, projection=Undefined, resolve=Undefined,
+                 title=Undefined, transform=Undefined, width=Undefined, **kwds):
+        super(LayerSpec, self).__init__(layer=layer, data=data, description=description,
+                                        encoding=encoding, height=height, name=name,
+                                        projection=projection, resolve=resolve, title=title,
+                                        transform=transform, width=width, **kwds)
+
+
+class RepeatSpec(Spec):
+    """RepeatSpec schema wrapper
+
+    Mapping(required=[repeat, spec])
+
+    Attributes
+    ----------
+
+    repeat : :class:`Repeat`
+        An object that describes what fields should be repeated into views that are laid out
+        as a ``row`` or ``column``.
+    spec : :class:`Spec`
+
+    align : anyOf(:class:`VgLayoutAlign`, :class:`RowColVgLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale and legend resolutions for repeated charts.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/RepeatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, repeat=Undefined, spec=Undefined, align=Undefined, bounds=Undefined,
+                 center=Undefined, data=Undefined, description=Undefined, name=Undefined,
+                 resolve=Undefined, spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
+        super(RepeatSpec, self).__init__(repeat=repeat, spec=spec, align=align, bounds=bounds,
+                                         center=center, data=data, description=description, name=name,
+                                         resolve=resolve, spacing=spacing, title=title,
+                                         transform=transform, **kwds)
 
 
 class StackOffset(VegaLiteSchema):
@@ -7392,6 +7056,18 @@ class TextBaseline(VegaLiteSchema):
 
     def __init__(self, *args, **kwds):
         super(TextBaseline, self).__init__(*args, **kwds)
+
+
+class Baseline(TextBaseline):
+    """Baseline schema wrapper
+
+    enum('top', 'middle', 'bottom')
+    """
+    _schema = {'$ref': '#/definitions/Baseline'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Baseline, self).__init__(*args)
 
 
 class TextConfig(VegaLiteSchema):
@@ -7679,6 +7355,114 @@ class TextFieldDef(VegaLiteSchema):
                                            format=format, timeUnit=timeUnit, title=title, **kwds)
 
 
+class TextFieldDefWithCondition(VegaLiteSchema):
+    """TextFieldDefWithCondition schema wrapper
+
+    Mapping(required=[type])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    type : :class:`Type`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+    bin : anyOf(boolean, :class:`BinParams`)
+        A flag for binning a ``quantitative`` field, or `an object defining binning
+        parameters <https://vega.github.io/vega-lite/docs/bin.html#params>`__.
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        **Default value:** ``false``
+    condition : anyOf(:class:`ConditionalValueDef`, List(:class:`ConditionalValueDef`))
+        One or more value definition(s) with a selection predicate.
+
+        **Note:** A field definition's ``condition`` property can only contain `value
+        definitions <https://vega.github.io/vega-lite/docs/encoding.html#value-def>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : anyOf(string, :class:`RepeatRef`)
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **Note:** Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access
+        nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+
+        **Note:** ``field`` is not required if ``aggregate`` is ``count``.
+    format : string
+        The `formatting pattern <https://vega.github.io/vega-lite/docs/format.html>`__ for a
+        text field. If not defined, this will be determined automatically.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the [fieldTitle
+        property in the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or
+        `fieldTitle function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/TextFieldDefWithCondition'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, format=Undefined, timeUnit=Undefined, title=Undefined, **kwds):
+        super(TextFieldDefWithCondition, self).__init__(type=type, aggregate=aggregate, bin=bin,
+                                                        condition=condition, field=field, format=format,
+                                                        timeUnit=timeUnit, title=title, **kwds)
+
+
+class TextValueDefWithCondition(VegaLiteSchema):
+    """TextValueDefWithCondition schema wrapper
+
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef>
+
+    Attributes
+    ----------
+
+    condition : anyOf(:class:`ConditionalTextFieldDef`, :class:`ConditionalValueDef`,
+    List(:class:`ConditionalValueDef`))
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(float, string, boolean)
+        A constant value in visual domain.
+    """
+    _schema = {'$ref': '#/definitions/TextValueDefWithCondition'}
+    _rootschema = Root._schema
+
+    def __init__(self, condition=Undefined, value=Undefined, **kwds):
+        super(TextValueDefWithCondition, self).__init__(condition=condition, value=value, **kwds)
+
+
 class TickConfig(VegaLiteSchema):
     """TickConfig schema wrapper
 
@@ -7904,26 +7688,55 @@ class TimeUnit(VegaLiteSchema):
         super(TimeUnit, self).__init__(*args, **kwds)
 
 
-class TimeUnitTransform(VegaLiteSchema):
-    """TimeUnitTransform schema wrapper
+class MultiTimeUnit(TimeUnit):
+    """MultiTimeUnit schema wrapper
 
-    Mapping(required=[timeUnit, field, as])
-
-    Attributes
-    ----------
-
-    field : string
-        The data field to apply time unit.
-    timeUnit : :class:`TimeUnit`
-        The timeUnit.
-    as : string
-        The output field to write the timeUnit value.
+    anyOf(:class:`LocalMultiTimeUnit`, :class:`UtcMultiTimeUnit`)
     """
-    _schema = {'$ref': '#/definitions/TimeUnitTransform'}
+    _schema = {'$ref': '#/definitions/MultiTimeUnit'}
     _rootschema = Root._schema
 
-    def __init__(self, field=Undefined, timeUnit=Undefined, **kwds):
-        super(TimeUnitTransform, self).__init__(field=field, timeUnit=timeUnit, **kwds)
+    def __init__(self, *args, **kwds):
+        super(MultiTimeUnit, self).__init__(*args, **kwds)
+
+
+class LocalMultiTimeUnit(MultiTimeUnit):
+    """LocalMultiTimeUnit schema wrapper
+
+    enum('yearquarter', 'yearquartermonth', 'yearmonth', 'yearmonthdate', 'yearmonthdatehours',
+    'yearmonthdatehoursminutes', 'yearmonthdatehoursminutesseconds', 'quartermonth',
+    'monthdate', 'hoursminutes', 'hoursminutesseconds', 'minutesseconds', 'secondsmilliseconds')
+    """
+    _schema = {'$ref': '#/definitions/LocalMultiTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(LocalMultiTimeUnit, self).__init__(*args)
+
+
+class SingleTimeUnit(TimeUnit):
+    """SingleTimeUnit schema wrapper
+
+    anyOf(:class:`LocalSingleTimeUnit`, :class:`UtcSingleTimeUnit`)
+    """
+    _schema = {'$ref': '#/definitions/SingleTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(SingleTimeUnit, self).__init__(*args, **kwds)
+
+
+class LocalSingleTimeUnit(SingleTimeUnit):
+    """LocalSingleTimeUnit schema wrapper
+
+    enum('year', 'quarter', 'month', 'day', 'date', 'hours', 'minutes', 'seconds',
+    'milliseconds')
+    """
+    _schema = {'$ref': '#/definitions/LocalSingleTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(LocalSingleTimeUnit, self).__init__(*args)
 
 
 class TitleOrient(VegaLiteSchema):
@@ -7984,451 +7797,21 @@ class TitleParams(VegaLiteSchema):
                                           style=style, **kwds)
 
 
-class TopLevelLayerSpec(VegaLiteSchema):
-    """TopLevelLayerSpec schema wrapper
+class TopLevelSpec(VegaLiteSchema):
+    """TopLevelSpec schema wrapper
 
-    Mapping(required=[layer])
-
-    Attributes
-    ----------
-
-    layer : List(anyOf(:class:`LayerSpec`, :class:`CompositeUnitSpec`))
-        Layer or single view specifications to be layered.
-
-        **Note** : Specifications inside ``layer`` cannot use ``row`` and ``column``
-        channels as layering facet specifications is not allowed.
-    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
-        Sets how the visualization size should be determined. If a string, should be one of
-        ``"pad"``, ``"fit"`` or ``"none"``.
-        Object values can additionally specify parameters for content sizing and automatic
-        resizing.
-        ``"fit"`` is only supported for single and layered views that don't use
-        ``rangeStep``.
-
-        **Default value** : ``pad``
-    background : string
-        CSS color property to use as the background of visualization.
-
-        **Default value:** none (transparent)
-    config : :class:`Config`
-        Vega-Lite configuration object.  This property can only be defined at the top-level
-        of a specification.
-    data : :class:`Data`
-        An object describing the data source
-    datasets : :class:`Datasets`
-        A global data store for named datasets. This is a mapping from names to inline
-        datasets.
-        This can be an array of objects or primitive values or a string. Arrays of primitive
-        values are ingested as objects with a ``data`` property.
-    description : string
-        Description of this mark for commenting purpose.
-    encoding : :class:`Encoding`
-        A shared key-value mapping between encoding channels and definition of fields in the
-        underlying layers.
-    height : float
-        The height of a visualization.
-
-        **Default value:**
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its y-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
-          be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For y-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the height is `determined by the range step, paddings, and the
-          cardinality of the field mapped to y-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
-          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
-          ``rangeStep``.
-
-        **Note** : For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        height of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    name : string
-        Name of the visualization for later reference.
-    padding : :class:`Padding`
-        The default visualization padding, in pixels, from the edge of the visualization
-        canvas to the data rectangle.  If a number, specifies padding for all sides.
-        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}`` to specify padding for each side of the visualization.
-
-        **Default value** : ``5``
-    projection : :class:`Projection`
-        An object defining properties of the geographic projection shared by underlying
-        layers.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for layers.
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    width : float
-        The width of a visualization.
-
-        **Default value:** This will be determined by the following rules:
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its x-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
-          be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For x-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the width is `determined by the range step, paddings, and the
-          cardinality of the field mapped to x-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
-          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
-          `config.scale.textXRangeStep
-          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
-          ``text`` mark and the value of ``rangeStep`` for other marks.
-
-        **Note:** For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        width of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    $schema : string
-        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
-        Unless you have a reason to change this, use
-        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
-        property allows automatic validation and autocomplete in editors that support JSON
-        schema.
+    anyOf(:class:`TopLevelFacetedUnitSpec`, :class:`TopLevelFacetSpec`,
+    :class:`TopLevelLayerSpec`, :class:`TopLevelRepeatSpec`, :class:`TopLevelVConcatSpec`,
+    :class:`TopLevelHConcatSpec`)
     """
-    _schema = {'$ref': '#/definitions/TopLevelLayerSpec'}
+    _schema = {'$ref': '#/definitions/TopLevelSpec'}
     _rootschema = Root._schema
 
-    def __init__(self, layer=Undefined, autosize=Undefined, background=Undefined, config=Undefined,
-                 data=Undefined, datasets=Undefined, description=Undefined, encoding=Undefined,
-                 height=Undefined, name=Undefined, padding=Undefined, projection=Undefined,
-                 resolve=Undefined, title=Undefined, transform=Undefined, width=Undefined, **kwds):
-        super(TopLevelLayerSpec, self).__init__(layer=layer, autosize=autosize, background=background,
-                                                config=config, data=data, datasets=datasets,
-                                                description=description, encoding=encoding,
-                                                height=height, name=name, padding=padding,
-                                                projection=projection, resolve=resolve, title=title,
-                                                transform=transform, width=width, **kwds)
+    def __init__(self, *args, **kwds):
+        super(TopLevelSpec, self).__init__(*args, **kwds)
 
 
-class TopLevelHConcatSpec(VegaLiteSchema):
-    """TopLevelHConcatSpec schema wrapper
-
-    Mapping(required=[hconcat])
-
-    Attributes
-    ----------
-
-    hconcat : List(:class:`Spec`)
-        A list of views that should be concatenated and put into a row.
-    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
-        Sets how the visualization size should be determined. If a string, should be one of
-        ``"pad"``, ``"fit"`` or ``"none"``.
-        Object values can additionally specify parameters for content sizing and automatic
-        resizing.
-        ``"fit"`` is only supported for single and layered views that don't use
-        ``rangeStep``.
-
-        **Default value** : ``pad``
-    background : string
-        CSS color property to use as the background of visualization.
-
-        **Default value:** none (transparent)
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : boolean
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        **Default value:** ``false``
-    config : :class:`Config`
-        Vega-Lite configuration object.  This property can only be defined at the top-level
-        of a specification.
-    data : :class:`Data`
-        An object describing the data source
-    datasets : :class:`Datasets`
-        A global data store for named datasets. This is a mapping from names to inline
-        datasets.
-        This can be an array of objects or primitive values or a string. Arrays of primitive
-        values are ingested as objects with a ``data`` property.
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    padding : :class:`Padding`
-        The default visualization padding, in pixels, from the edge of the visualization
-        canvas to the data rectangle.  If a number, specifies padding for all sides.
-        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}`` to specify padding for each side of the visualization.
-
-        **Default value** : ``5``
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for horizontally concatenated charts.
-    spacing : float
-        The spacing in pixels between sub-views of the concat operator.
-
-        **Default value** : ``10``
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    $schema : string
-        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
-        Unless you have a reason to change this, use
-        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
-        property allows automatic validation and autocomplete in editors that support JSON
-        schema.
-    """
-    _schema = {'$ref': '#/definitions/TopLevelHConcatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, hconcat=Undefined, autosize=Undefined, background=Undefined, bounds=Undefined,
-                 center=Undefined, config=Undefined, data=Undefined, datasets=Undefined,
-                 description=Undefined, name=Undefined, padding=Undefined, resolve=Undefined,
-                 spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
-        super(TopLevelHConcatSpec, self).__init__(hconcat=hconcat, autosize=autosize,
-                                                  background=background, bounds=bounds, center=center,
-                                                  config=config, data=data, datasets=datasets,
-                                                  description=description, name=name, padding=padding,
-                                                  resolve=resolve, spacing=spacing, title=title,
-                                                  transform=transform, **kwds)
-
-
-class TopLevelRepeatSpec(VegaLiteSchema):
-    """TopLevelRepeatSpec schema wrapper
-
-    Mapping(required=[repeat, spec])
-
-    Attributes
-    ----------
-
-    repeat : :class:`Repeat`
-        An object that describes what fields should be repeated into views that are laid out
-        as a ``row`` or ``column``.
-    spec : :class:`Spec`
-
-    align : anyOf(:class:`VgLayoutAlign`, :class:`RowColVgLayoutAlign`)
-        The alignment to apply to grid rows and columns.
-        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
-
-
-        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
-          placed one after the other.
-        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
-          or column may be of variable size.
-        * For ``"all"``, subviews will be aligned and each row or column will be sized
-          identically based on the maximum observed size. String values for this property
-          will be applied to both grid rows and columns.
-
-        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
-        be used to supply different alignments for rows and columns.
-
-        **Default value:** ``"all"``.
-    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
-        Sets how the visualization size should be determined. If a string, should be one of
-        ``"pad"``, ``"fit"`` or ``"none"``.
-        Object values can additionally specify parameters for content sizing and automatic
-        resizing.
-        ``"fit"`` is only supported for single and layered views that don't use
-        ``rangeStep``.
-
-        **Default value** : ``pad``
-    background : string
-        CSS color property to use as the background of visualization.
-
-        **Default value:** none (transparent)
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : anyOf(boolean, :class:`RowColboolean`)
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
-        supply different centering values for rows and columns.
-
-        **Default value:** ``false``
-    config : :class:`Config`
-        Vega-Lite configuration object.  This property can only be defined at the top-level
-        of a specification.
-    data : :class:`Data`
-        An object describing the data source
-    datasets : :class:`Datasets`
-        A global data store for named datasets. This is a mapping from names to inline
-        datasets.
-        This can be an array of objects or primitive values or a string. Arrays of primitive
-        values are ingested as objects with a ``data`` property.
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    padding : :class:`Padding`
-        The default visualization padding, in pixels, from the edge of the visualization
-        canvas to the data rectangle.  If a number, specifies padding for all sides.
-        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}`` to specify padding for each side of the visualization.
-
-        **Default value** : ``5``
-    resolve : :class:`Resolve`
-        Scale and legend resolutions for repeated charts.
-    spacing : anyOf(float, :class:`RowColnumber`)
-        The spacing in pixels between sub-views of the composition operator.
-        An object of the form ``{"row": number, "column": number}`` can be used to set
-        different spacing values for rows and columns.
-
-        **Default value** : ``10``
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    $schema : string
-        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
-        Unless you have a reason to change this, use
-        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
-        property allows automatic validation and autocomplete in editors that support JSON
-        schema.
-    """
-    _schema = {'$ref': '#/definitions/TopLevelRepeatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, repeat=Undefined, spec=Undefined, align=Undefined, autosize=Undefined,
-                 background=Undefined, bounds=Undefined, center=Undefined, config=Undefined,
-                 data=Undefined, datasets=Undefined, description=Undefined, name=Undefined,
-                 padding=Undefined, resolve=Undefined, spacing=Undefined, title=Undefined,
-                 transform=Undefined, **kwds):
-        super(TopLevelRepeatSpec, self).__init__(repeat=repeat, spec=spec, align=align,
-                                                 autosize=autosize, background=background,
-                                                 bounds=bounds, center=center, config=config, data=data,
-                                                 datasets=datasets, description=description, name=name,
-                                                 padding=padding, resolve=resolve, spacing=spacing,
-                                                 title=title, transform=transform, **kwds)
-
-
-class TopLevelVConcatSpec(VegaLiteSchema):
-    """TopLevelVConcatSpec schema wrapper
-
-    Mapping(required=[vconcat])
-
-    Attributes
-    ----------
-
-    vconcat : List(:class:`Spec`)
-        A list of views that should be concatenated and put into a column.
-    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
-        Sets how the visualization size should be determined. If a string, should be one of
-        ``"pad"``, ``"fit"`` or ``"none"``.
-        Object values can additionally specify parameters for content sizing and automatic
-        resizing.
-        ``"fit"`` is only supported for single and layered views that don't use
-        ``rangeStep``.
-
-        **Default value** : ``pad``
-    background : string
-        CSS color property to use as the background of visualization.
-
-        **Default value:** none (transparent)
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : boolean
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        **Default value:** ``false``
-    config : :class:`Config`
-        Vega-Lite configuration object.  This property can only be defined at the top-level
-        of a specification.
-    data : :class:`Data`
-        An object describing the data source
-    datasets : :class:`Datasets`
-        A global data store for named datasets. This is a mapping from names to inline
-        datasets.
-        This can be an array of objects or primitive values or a string. Arrays of primitive
-        values are ingested as objects with a ``data`` property.
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    padding : :class:`Padding`
-        The default visualization padding, in pixels, from the edge of the visualization
-        canvas to the data rectangle.  If a number, specifies padding for all sides.
-        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}`` to specify padding for each side of the visualization.
-
-        **Default value** : ``5``
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for vertically concatenated charts.
-    spacing : float
-        The spacing in pixels between sub-views of the concat operator.
-
-        **Default value** : ``10``
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    $schema : string
-        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
-        Unless you have a reason to change this, use
-        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
-        property allows automatic validation and autocomplete in editors that support JSON
-        schema.
-    """
-    _schema = {'$ref': '#/definitions/TopLevelVConcatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, vconcat=Undefined, autosize=Undefined, background=Undefined, bounds=Undefined,
-                 center=Undefined, config=Undefined, data=Undefined, datasets=Undefined,
-                 description=Undefined, name=Undefined, padding=Undefined, resolve=Undefined,
-                 spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
-        super(TopLevelVConcatSpec, self).__init__(vconcat=vconcat, autosize=autosize,
-                                                  background=background, bounds=bounds, center=center,
-                                                  config=config, data=data, datasets=datasets,
-                                                  description=description, name=name, padding=padding,
-                                                  resolve=resolve, spacing=spacing, title=title,
-                                                  transform=transform, **kwds)
-
-
-class TopLevelFacetSpec(VegaLiteSchema):
+class TopLevelFacetSpec(TopLevelSpec):
     """TopLevelFacetSpec schema wrapper
 
     Mapping(required=[data, facet, spec])
@@ -8547,7 +7930,7 @@ class TopLevelFacetSpec(VegaLiteSchema):
                                                 transform=transform, **kwds)
 
 
-class TopLevelFacetedUnitSpec(VegaLiteSchema):
+class TopLevelFacetedUnitSpec(TopLevelSpec):
     """TopLevelFacetedUnitSpec schema wrapper
 
     Mapping(required=[data, mark])
@@ -8687,21 +8070,451 @@ class TopLevelFacetedUnitSpec(VegaLiteSchema):
                                                       transform=transform, width=width, **kwds)
 
 
-class TopLevelSpec(VegaLiteSchema):
-    """TopLevelSpec schema wrapper
+class TopLevelHConcatSpec(TopLevelSpec):
+    """TopLevelHConcatSpec schema wrapper
 
-    anyOf(:class:`TopLevelFacetedUnitSpec`, :class:`TopLevelFacetSpec`,
-    :class:`TopLevelLayerSpec`, :class:`TopLevelRepeatSpec`, :class:`TopLevelVConcatSpec`,
-    :class:`TopLevelHConcatSpec`)
+    Mapping(required=[hconcat])
+
+    Attributes
+    ----------
+
+    hconcat : List(:class:`Spec`)
+        A list of views that should be concatenated and put into a row.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : boolean
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        **Default value:** ``false``
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    data : :class:`Data`
+        An object describing the data source
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for horizontally concatenated charts.
+    spacing : float
+        The spacing in pixels between sub-views of the concat operator.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
     """
-    _schema = {'$ref': '#/definitions/TopLevelSpec'}
+    _schema = {'$ref': '#/definitions/TopLevelHConcatSpec'}
     _rootschema = Root._schema
 
-    def __init__(self, *args, **kwds):
-        super(TopLevelSpec, self).__init__(*args, **kwds)
+    def __init__(self, hconcat=Undefined, autosize=Undefined, background=Undefined, bounds=Undefined,
+                 center=Undefined, config=Undefined, data=Undefined, datasets=Undefined,
+                 description=Undefined, name=Undefined, padding=Undefined, resolve=Undefined,
+                 spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
+        super(TopLevelHConcatSpec, self).__init__(hconcat=hconcat, autosize=autosize,
+                                                  background=background, bounds=bounds, center=center,
+                                                  config=config, data=data, datasets=datasets,
+                                                  description=description, name=name, padding=padding,
+                                                  resolve=resolve, spacing=spacing, title=title,
+                                                  transform=transform, **kwds)
 
 
-class TopoDataFormat(VegaLiteSchema):
+class TopLevelLayerSpec(TopLevelSpec):
+    """TopLevelLayerSpec schema wrapper
+
+    Mapping(required=[layer])
+
+    Attributes
+    ----------
+
+    layer : List(anyOf(:class:`LayerSpec`, :class:`CompositeUnitSpec`))
+        Layer or single view specifications to be layered.
+
+        **Note** : Specifications inside ``layer`` cannot use ``row`` and ``column``
+        channels as layering facet specifications is not allowed.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    data : :class:`Data`
+        An object describing the data source
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`Encoding`
+        A shared key-value mapping between encoding channels and definition of fields in the
+        underlying layers.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    projection : :class:`Projection`
+        An object defining properties of the geographic projection shared by underlying
+        layers.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for layers.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
+    """
+    _schema = {'$ref': '#/definitions/TopLevelLayerSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, layer=Undefined, autosize=Undefined, background=Undefined, config=Undefined,
+                 data=Undefined, datasets=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, padding=Undefined, projection=Undefined,
+                 resolve=Undefined, title=Undefined, transform=Undefined, width=Undefined, **kwds):
+        super(TopLevelLayerSpec, self).__init__(layer=layer, autosize=autosize, background=background,
+                                                config=config, data=data, datasets=datasets,
+                                                description=description, encoding=encoding,
+                                                height=height, name=name, padding=padding,
+                                                projection=projection, resolve=resolve, title=title,
+                                                transform=transform, width=width, **kwds)
+
+
+class TopLevelRepeatSpec(TopLevelSpec):
+    """TopLevelRepeatSpec schema wrapper
+
+    Mapping(required=[repeat, spec])
+
+    Attributes
+    ----------
+
+    repeat : :class:`Repeat`
+        An object that describes what fields should be repeated into views that are laid out
+        as a ``row`` or ``column``.
+    spec : :class:`Spec`
+
+    align : anyOf(:class:`VgLayoutAlign`, :class:`RowColVgLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    data : :class:`Data`
+        An object describing the data source
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    resolve : :class:`Resolve`
+        Scale and legend resolutions for repeated charts.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
+    """
+    _schema = {'$ref': '#/definitions/TopLevelRepeatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, repeat=Undefined, spec=Undefined, align=Undefined, autosize=Undefined,
+                 background=Undefined, bounds=Undefined, center=Undefined, config=Undefined,
+                 data=Undefined, datasets=Undefined, description=Undefined, name=Undefined,
+                 padding=Undefined, resolve=Undefined, spacing=Undefined, title=Undefined,
+                 transform=Undefined, **kwds):
+        super(TopLevelRepeatSpec, self).__init__(repeat=repeat, spec=spec, align=align,
+                                                 autosize=autosize, background=background,
+                                                 bounds=bounds, center=center, config=config, data=data,
+                                                 datasets=datasets, description=description, name=name,
+                                                 padding=padding, resolve=resolve, spacing=spacing,
+                                                 title=title, transform=transform, **kwds)
+
+
+class TopLevelVConcatSpec(TopLevelSpec):
+    """TopLevelVConcatSpec schema wrapper
+
+    Mapping(required=[vconcat])
+
+    Attributes
+    ----------
+
+    vconcat : List(:class:`Spec`)
+        A list of views that should be concatenated and put into a column.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of visualization.
+
+        **Default value:** none (transparent)
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : boolean
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        **Default value:** ``false``
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    data : :class:`Data`
+        An object describing the data source
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for vertically concatenated charts.
+    spacing : float
+        The spacing in pixels between sub-views of the concat operator.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v2.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
+    """
+    _schema = {'$ref': '#/definitions/TopLevelVConcatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, vconcat=Undefined, autosize=Undefined, background=Undefined, bounds=Undefined,
+                 center=Undefined, config=Undefined, data=Undefined, datasets=Undefined,
+                 description=Undefined, name=Undefined, padding=Undefined, resolve=Undefined,
+                 spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
+        super(TopLevelVConcatSpec, self).__init__(vconcat=vconcat, autosize=autosize,
+                                                  background=background, bounds=bounds, center=center,
+                                                  config=config, data=data, datasets=datasets,
+                                                  description=description, name=name, padding=padding,
+                                                  resolve=resolve, spacing=spacing, title=title,
+                                                  transform=transform, **kwds)
+
+
+class TopoDataFormat(DataFormat):
     """TopoDataFormat schema wrapper
 
     Mapping(required=[])
@@ -8768,6 +8581,158 @@ class Transform(VegaLiteSchema):
         super(Transform, self).__init__(*args, **kwds)
 
 
+class AggregateTransform(Transform):
+    """AggregateTransform schema wrapper
+
+    Mapping(required=[aggregate])
+
+    Attributes
+    ----------
+
+    aggregate : List(:class:`AggregatedFieldDef`)
+        Array of objects that define fields to aggregate.
+    groupby : List(string)
+        The data fields to group by. If not specified, a single group containing all data
+        objects will be used.
+    """
+    _schema = {'$ref': '#/definitions/AggregateTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, aggregate=Undefined, groupby=Undefined, **kwds):
+        super(AggregateTransform, self).__init__(aggregate=aggregate, groupby=groupby, **kwds)
+
+
+class BinTransform(Transform):
+    """BinTransform schema wrapper
+
+    Mapping(required=[bin, field, as])
+
+    Attributes
+    ----------
+
+    bin : anyOf(boolean, :class:`BinParams`)
+        An object indicating bin properties, or simply ``true`` for using default bin
+        parameters.
+    field : string
+        The data field to bin.
+    as : anyOf(string, List(string))
+        The output fields at which to write the start and end bin values.
+    """
+    _schema = {'$ref': '#/definitions/BinTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, bin=Undefined, field=Undefined, **kwds):
+        super(BinTransform, self).__init__(bin=bin, field=field, **kwds)
+
+
+class CalculateTransform(Transform):
+    """CalculateTransform schema wrapper
+
+    Mapping(required=[calculate, as])
+
+    Attributes
+    ----------
+
+    calculate : string
+        A `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`__
+        string. Use the variable ``datum`` to refer to the current data object.
+    as : string
+        The field for storing the computed formula value.
+    """
+    _schema = {'$ref': '#/definitions/CalculateTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, calculate=Undefined, **kwds):
+        super(CalculateTransform, self).__init__(calculate=calculate, **kwds)
+
+
+class FilterTransform(Transform):
+    """FilterTransform schema wrapper
+
+    Mapping(required=[filter])
+
+    Attributes
+    ----------
+
+    filter : :class:`LogicalOperandPredicate`
+        The ``filter`` property must be one of the predicate definitions:
+
+        1) an `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`__
+        string,
+        where ``datum`` can be used to refer to the current data object
+
+        2) one of the field predicates: `equal
+        <https://vega.github.io/vega-lite/docs/filter.html#equal-predicate>`__,
+        `lt <https://vega.github.io/vega-lite/docs/filter.html#lt-predicate>`__,
+        `lte <https://vega.github.io/vega-lite/docs/filter.html#lte-predicate>`__,
+        `gt <https://vega.github.io/vega-lite/docs/filter.html#gt-predicate>`__,
+        `gte <https://vega.github.io/vega-lite/docs/filter.html#gte-predicate>`__,
+        `range <https://vega.github.io/vega-lite/docs/filter.html#range-predicate>`__,
+        or `oneOf <https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate>`__.
+
+        3) a `selection predicate
+        <https://vega.github.io/vega-lite/docs/filter.html#selection-predicate>`__
+
+        4) a logical operand that combines (1), (2), or (3).
+    """
+    _schema = {'$ref': '#/definitions/FilterTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, filter=Undefined, **kwds):
+        super(FilterTransform, self).__init__(filter=filter, **kwds)
+
+
+class LookupTransform(Transform):
+    """LookupTransform schema wrapper
+
+    Mapping(required=[lookup, from])
+
+    Attributes
+    ----------
+
+    lookup : string
+        Key in primary data source.
+    default : string
+        The default value to use if lookup fails.
+
+        **Default value:** ``null``
+    as : anyOf(string, List(string))
+        The field or fields for storing the computed formula value.
+        If ``from.fields`` is specified, the transform will use the same names for ``as``.
+        If ``from.fields`` is not specified, ``as`` has to be a string and we put the whole
+        object into the data under the specified name.
+    from : :class:`LookupData`
+        Secondary data reference.
+    """
+    _schema = {'$ref': '#/definitions/LookupTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, lookup=Undefined, default=Undefined, **kwds):
+        super(LookupTransform, self).__init__(lookup=lookup, default=default, **kwds)
+
+
+class TimeUnitTransform(Transform):
+    """TimeUnitTransform schema wrapper
+
+    Mapping(required=[timeUnit, field, as])
+
+    Attributes
+    ----------
+
+    field : string
+        The data field to apply time unit.
+    timeUnit : :class:`TimeUnit`
+        The timeUnit.
+    as : string
+        The output field to write the timeUnit value.
+    """
+    _schema = {'$ref': '#/definitions/TimeUnitTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, timeUnit=Undefined, **kwds):
+        super(TimeUnitTransform, self).__init__(field=field, timeUnit=timeUnit, **kwds)
+
+
 class Type(VegaLiteSchema):
     """Type schema wrapper
 
@@ -8782,7 +8747,31 @@ class Type(VegaLiteSchema):
         super(Type, self).__init__(*args, **kwds)
 
 
-class UrlData(VegaLiteSchema):
+class BasicType(Type):
+    """BasicType schema wrapper
+
+    enum('quantitative', 'ordinal', 'temporal', 'nominal')
+    """
+    _schema = {'$ref': '#/definitions/BasicType'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(BasicType, self).__init__(*args)
+
+
+class GeoType(Type):
+    """GeoType schema wrapper
+
+    enum('latitude', 'longitude', 'geojson')
+    """
+    _schema = {'$ref': '#/definitions/GeoType'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(GeoType, self).__init__(*args)
+
+
+class UrlData(Data):
     """UrlData schema wrapper
 
     Mapping(required=[url])
@@ -8805,7 +8794,7 @@ class UrlData(VegaLiteSchema):
         super(UrlData, self).__init__(url=url, format=format, name=name, **kwds)
 
 
-class UtcMultiTimeUnit(VegaLiteSchema):
+class UtcMultiTimeUnit(MultiTimeUnit):
     """UtcMultiTimeUnit schema wrapper
 
     enum('utcyearquarter', 'utcyearquartermonth', 'utcyearmonth', 'utcyearmonthdate',
@@ -8820,7 +8809,7 @@ class UtcMultiTimeUnit(VegaLiteSchema):
         super(UtcMultiTimeUnit, self).__init__(*args)
 
 
-class UtcSingleTimeUnit(VegaLiteSchema):
+class UtcSingleTimeUnit(SingleTimeUnit):
     """UtcSingleTimeUnit schema wrapper
 
     enum('utcyear', 'utcquarter', 'utcmonth', 'utcday', 'utcdate', 'utchours', 'utcminutes',
@@ -8831,6 +8820,61 @@ class UtcSingleTimeUnit(VegaLiteSchema):
 
     def __init__(self, *args):
         super(UtcSingleTimeUnit, self).__init__(*args)
+
+
+class VConcatSpec(Spec):
+    """VConcatSpec schema wrapper
+
+    Mapping(required=[vconcat])
+
+    Attributes
+    ----------
+
+    vconcat : List(:class:`Spec`)
+        A list of views that should be concatenated and put into a column.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : boolean
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        **Default value:** ``false``
+    data : :class:`Data`
+        An object describing the data source
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for vertically concatenated charts.
+    spacing : float
+        The spacing in pixels between sub-views of the concat operator.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/VConcatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, vconcat=Undefined, bounds=Undefined, center=Undefined, data=Undefined,
+                 description=Undefined, name=Undefined, resolve=Undefined, spacing=Undefined,
+                 title=Undefined, transform=Undefined, **kwds):
+        super(VConcatSpec, self).__init__(vconcat=vconcat, bounds=bounds, center=center, data=data,
+                                          description=description, name=name, resolve=resolve,
+                                          spacing=spacing, title=title, transform=transform, **kwds)
 
 
 class ValueDef(VegaLiteSchema):
@@ -8873,50 +8917,6 @@ class ValueDefWithCondition(VegaLiteSchema):
 
     def __init__(self, condition=Undefined, value=Undefined, **kwds):
         super(ValueDefWithCondition, self).__init__(condition=condition, value=value, **kwds)
-
-
-class MarkPropValueDefWithCondition(VegaLiteSchema):
-    """MarkPropValueDefWithCondition schema wrapper
-
-    Mapping(required=[])
-    A ValueDef with Condition<ValueDef | FieldDef>
-
-    Attributes
-    ----------
-
-    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalValueDef`,
-    List(:class:`ConditionalValueDef`))
-        A field definition or one or more value definition(s) with a selection predicate.
-    value : anyOf(float, string, boolean)
-        A constant value in visual domain.
-    """
-    _schema = {'$ref': '#/definitions/MarkPropValueDefWithCondition'}
-    _rootschema = Root._schema
-
-    def __init__(self, condition=Undefined, value=Undefined, **kwds):
-        super(MarkPropValueDefWithCondition, self).__init__(condition=condition, value=value, **kwds)
-
-
-class TextValueDefWithCondition(VegaLiteSchema):
-    """TextValueDefWithCondition schema wrapper
-
-    Mapping(required=[])
-    A ValueDef with Condition<ValueDef | FieldDef>
-
-    Attributes
-    ----------
-
-    condition : anyOf(:class:`ConditionalTextFieldDef`, :class:`ConditionalValueDef`,
-    List(:class:`ConditionalValueDef`))
-        A field definition or one or more value definition(s) with a selection predicate.
-    value : anyOf(float, string, boolean)
-        A constant value in visual domain.
-    """
-    _schema = {'$ref': '#/definitions/TextValueDefWithCondition'}
-    _rootschema = Root._schema
-
-    def __init__(self, condition=Undefined, value=Undefined, **kwds):
-        super(TextValueDefWithCondition, self).__init__(condition=condition, value=value, **kwds)
 
 
 class VerticalAlign(VegaLiteSchema):
@@ -9116,7 +9116,7 @@ class VgBinding(VegaLiteSchema):
         super(VgBinding, self).__init__(*args, **kwds)
 
 
-class VgCheckboxBinding(VegaLiteSchema):
+class VgCheckboxBinding(VgBinding):
     """VgCheckboxBinding schema wrapper
 
     Mapping(required=[input])
@@ -9136,7 +9136,7 @@ class VgCheckboxBinding(VegaLiteSchema):
         super(VgCheckboxBinding, self).__init__(input=input, element=element, **kwds)
 
 
-class VgComparatorOrder(VegaLiteSchema):
+class VgComparatorOrder(SortOrder):
     """VgComparatorOrder schema wrapper
 
     enum('ascending', 'descending')
@@ -9160,7 +9160,7 @@ class VgEventStream(VegaLiteSchema):
         super(VgEventStream, self).__init__(**kwds)
 
 
-class VgGenericBinding(VegaLiteSchema):
+class VgGenericBinding(VgBinding):
     """VgGenericBinding schema wrapper
 
     Mapping(required=[input])
@@ -9390,7 +9390,7 @@ class VgProjectionType(VegaLiteSchema):
         super(VgProjectionType, self).__init__(*args)
 
 
-class VgRadioBinding(VegaLiteSchema):
+class VgRadioBinding(VgBinding):
     """VgRadioBinding schema wrapper
 
     Mapping(required=[input, options])
@@ -9412,7 +9412,7 @@ class VgRadioBinding(VegaLiteSchema):
         super(VgRadioBinding, self).__init__(input=input, options=options, element=element, **kwds)
 
 
-class VgRangeBinding(VegaLiteSchema):
+class VgRangeBinding(VgBinding):
     """VgRangeBinding schema wrapper
 
     Mapping(required=[input])
@@ -9440,7 +9440,7 @@ class VgRangeBinding(VegaLiteSchema):
                                              **kwds)
 
 
-class VgScheme(VegaLiteSchema):
+class VgScheme(RangeConfigValue):
     """VgScheme schema wrapper
 
     Mapping(required=[scheme])
@@ -9462,7 +9462,7 @@ class VgScheme(VegaLiteSchema):
         super(VgScheme, self).__init__(scheme=scheme, count=count, extent=extent, **kwds)
 
 
-class VgSelectBinding(VegaLiteSchema):
+class VgSelectBinding(VgBinding):
     """VgSelectBinding schema wrapper
 
     Mapping(required=[input, options])
@@ -9659,7 +9659,7 @@ class WindowOnlyOp(VegaLiteSchema):
         super(WindowOnlyOp, self).__init__(*args)
 
 
-class WindowTransform(VegaLiteSchema):
+class WindowTransform(Transform):
     """WindowTransform schema wrapper
 
     Mapping(required=[window])

--- a/altair/vegalite/v3/api.py
+++ b/altair/vegalite/v3/api.py
@@ -1546,16 +1546,9 @@ class Chart(TopLevelMixin, _EncodingMixin, mixins.MarkMethodMixin,
         jsonschema.ValidationError :
             if validate=True and dct does not conform to the schema
         """
-        # First try from_dict for the Chart type
-        try:
-            return super(Chart, cls).from_dict(dct, validate=validate)
-        except jsonschema.ValidationError:
-            pass
-
-        # If this fails, try with all other top level types
         for class_ in TopLevelMixin.__subclasses__():
             if class_ is Chart:
-                continue
+                class_ = super(Chart, cls)
             try:
                 return class_.from_dict(dct, validate=validate)
             except jsonschema.ValidationError:

--- a/altair/vegalite/v3/api.py
+++ b/altair/vegalite/v3/api.py
@@ -92,10 +92,7 @@ def _prepare_data(data, context):
         data = _consolidate_data(data, context)
 
     # if data is still not a recognized type, then return
-    if not isinstance(data, (dict, core.Data, core.UrlData,
-                             core.InlineData, core.NamedData,
-                             core.GraticuleGenerator, core.SequenceGenerator,
-                             core.SphereGenerator)):
+    if not isinstance(data, (dict, core.Data)):
         warnings.warn("data of type {} not recognized".format(type(data)))
 
     return data
@@ -294,19 +291,12 @@ def condition(predicate, if_true, if_false, **kwargs):
     spec: dict or VegaLiteSchema
         the spec that describes the condition
     """
-    selection_predicates = (core.SelectionNot, core.SelectionOr,
-                            core.SelectionAnd, core.SelectionOperand)
-    test_predicates = (six.string_types, expr.Expression, core.Predicate,
-                       core.LogicalOperandPredicate, core.LogicalNotPredicate,
-                       core.LogicalOrPredicate, core.LogicalAndPredicate,
-                       core.FieldEqualPredicate, core.FieldOneOfPredicate,
-                       core.FieldRangePredicate, core.FieldLTPredicate,
-                       core.FieldGTPredicate, core.FieldLTEPredicate,
-                       core.FieldGTEPredicate, core.SelectionPredicate)
+    test_predicates = (six.string_types, expr.Expression, 
+                       core.LogicalOperandPredicate)
 
     if isinstance(predicate, Selection):
         condition = {'selection': predicate.name}
-    elif isinstance(predicate, selection_predicates):
+    elif isinstance(predicate, core.SelectionOperand):
         condition = {'selection': predicate}
     elif isinstance(predicate, test_predicates):
         condition = {'test': predicate}
@@ -971,11 +961,9 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         alt.FilterTransform : underlying transform object
 
         """
-        selection_predicates = (core.SelectionNot, core.SelectionOr,
-                                core.SelectionAnd, core.SelectionOperand)
         if isinstance(filter, Selection):
             filter = {'selection': filter.name}
-        elif isinstance(filter, selection_predicates):
+        elif isinstance(filter, core.SelectionOperand):
             filter = {'selection': filter}
         return self._add_transform(core.FilterTransform(filter=filter, **kwargs))
 

--- a/altair/vegalite/v3/schema/core.py
+++ b/altair/vegalite/v3/schema/core.py
@@ -3,7 +3,7 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
 
-from altair.utils.schemapi import SchemaBase, Undefined
+from altair.utils.schemapi import SchemaBase, Undefined, _subclasses
 
 import pkgutil
 import json
@@ -16,7 +16,7 @@ def load_schema():
 class VegaLiteSchema(SchemaBase):
     @classmethod
     def _default_wrapper_classes(cls):
-        return VegaLiteSchema.__subclasses__()
+        return _subclasses(VegaLiteSchema)
 
 
 class Root(VegaLiteSchema):
@@ -48,7 +48,7 @@ class Aggregate(VegaLiteSchema):
         super(Aggregate, self).__init__(*args, **kwds)
 
 
-class AggregateOp(VegaLiteSchema):
+class AggregateOp(Aggregate):
     """AggregateOp schema wrapper
 
     enum('argmax', 'argmin', 'average', 'count', 'distinct', 'max', 'mean', 'median', 'min',
@@ -60,27 +60,6 @@ class AggregateOp(VegaLiteSchema):
 
     def __init__(self, *args):
         super(AggregateOp, self).__init__(*args)
-
-
-class AggregateTransform(VegaLiteSchema):
-    """AggregateTransform schema wrapper
-
-    Mapping(required=[aggregate])
-
-    Attributes
-    ----------
-
-    aggregate : List(:class:`AggregatedFieldDef`)
-        Array of objects that define fields to aggregate.
-    groupby : List(:class:`FieldName`)
-        The data fields to group by. If not specified, a single group containing all data
-        objects will be used.
-    """
-    _schema = {'$ref': '#/definitions/AggregateTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, aggregate=Undefined, groupby=Undefined, **kwds):
-        super(AggregateTransform, self).__init__(aggregate=aggregate, groupby=groupby, **kwds)
 
 
 class AggregatedFieldDef(VegaLiteSchema):
@@ -418,7 +397,7 @@ class AreaConfig(VegaLiteSchema):
                                          y2=y2, **kwds)
 
 
-class ArgmaxDef(VegaLiteSchema):
+class ArgmaxDef(Aggregate):
     """ArgmaxDef schema wrapper
 
     Mapping(required=[argmax])
@@ -436,7 +415,7 @@ class ArgmaxDef(VegaLiteSchema):
         super(ArgmaxDef, self).__init__(argmax=argmax, **kwds)
 
 
-class ArgminDef(VegaLiteSchema):
+class ArgminDef(Aggregate):
     """ArgminDef schema wrapper
 
     Mapping(required=[argmin])
@@ -1462,18 +1441,6 @@ class BaseTitleConfig(VegaLiteSchema):
                                               offset=offset, orient=orient, **kwds)
 
 
-class Baseline(VegaLiteSchema):
-    """Baseline schema wrapper
-
-    enum('top', 'middle', 'bottom')
-    """
-    _schema = {'$ref': '#/definitions/Baseline'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args):
-        super(Baseline, self).__init__(*args)
-
-
 class BinParams(VegaLiteSchema):
     """BinParams schema wrapper
 
@@ -1532,30 +1499,20 @@ class BinParams(VegaLiteSchema):
                                         step=step, steps=steps, **kwds)
 
 
-class BinTransform(VegaLiteSchema):
-    """BinTransform schema wrapper
+class Binding(VegaLiteSchema):
+    """Binding schema wrapper
 
-    Mapping(required=[bin, field, as])
-
-    Attributes
-    ----------
-
-    bin : anyOf(enum(True), :class:`BinParams`)
-        An object indicating bin properties, or simply ``true`` for using default bin
-        parameters.
-    field : :class:`FieldName`
-        The data field to bin.
-    as : anyOf(:class:`FieldName`, List(:class:`FieldName`))
-        The output fields at which to write the start and end bin values.
+    anyOf(:class:`BindCheckbox`, :class:`BindRadioSelect`, :class:`BindRange`,
+    :class:`InputBinding`)
     """
-    _schema = {'$ref': '#/definitions/BinTransform'}
+    _schema = {'$ref': '#/definitions/Binding'}
     _rootschema = Root._schema
 
-    def __init__(self, bin=Undefined, field=Undefined, **kwds):
-        super(BinTransform, self).__init__(bin=bin, field=field, **kwds)
+    def __init__(self, *args, **kwds):
+        super(Binding, self).__init__(*args, **kwds)
 
 
-class BindCheckbox(VegaLiteSchema):
+class BindCheckbox(Binding):
     """BindCheckbox schema wrapper
 
     Mapping(required=[input])
@@ -1583,7 +1540,7 @@ class BindCheckbox(VegaLiteSchema):
                                            type=type, **kwds)
 
 
-class BindRadioSelect(VegaLiteSchema):
+class BindRadioSelect(Binding):
     """BindRadioSelect schema wrapper
 
     Mapping(required=[input, options])
@@ -1613,7 +1570,7 @@ class BindRadioSelect(VegaLiteSchema):
                                               element=element, name=name, type=type, **kwds)
 
 
-class BindRange(VegaLiteSchema):
+class BindRange(Binding):
     """BindRange schema wrapper
 
     Mapping(required=[input])
@@ -1645,31 +1602,6 @@ class BindRange(VegaLiteSchema):
                  min=Undefined, name=Undefined, step=Undefined, type=Undefined, **kwds):
         super(BindRange, self).__init__(input=input, debounce=debounce, element=element, max=max,
                                         min=min, name=name, step=step, type=type, **kwds)
-
-
-class Binding(VegaLiteSchema):
-    """Binding schema wrapper
-
-    anyOf(:class:`BindCheckbox`, :class:`BindRadioSelect`, :class:`BindRange`,
-    :class:`InputBinding`)
-    """
-    _schema = {'$ref': '#/definitions/Binding'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(Binding, self).__init__(*args, **kwds)
-
-
-class BoxPlot(VegaLiteSchema):
-    """BoxPlot schema wrapper
-
-    enum('boxplot')
-    """
-    _schema = {'$ref': '#/definitions/BoxPlot'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args):
-        super(BoxPlot, self).__init__(*args)
 
 
 class BoxPlotConfig(VegaLiteSchema):
@@ -1714,7 +1646,129 @@ class BoxPlotConfig(VegaLiteSchema):
                                             rule=rule, size=size, ticks=ticks, **kwds)
 
 
-class BoxPlotDef(VegaLiteSchema):
+class BrushConfig(VegaLiteSchema):
+    """BrushConfig schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    fill : :class:`Color`
+        The fill color of the interval mark.
+
+        **Default value:** ``#333333``
+    fillOpacity : float
+        The fill opacity of the interval mark (a value between 0 and 1).
+
+        **Default value:** ``0.125``
+    stroke : :class:`Color`
+        The stroke color of the interval mark.
+
+        **Default value:** ``#ffffff``
+    strokeDash : List(float)
+        An array of alternating stroke and space lengths,
+        for creating dashed or dotted lines.
+    strokeDashOffset : float
+        The offset (in pixels) with which to begin drawing the stroke dash array.
+    strokeOpacity : float
+        The stroke opacity of the interval mark (a value between 0 and 1).
+    strokeWidth : float
+        The stroke width of the interval mark.
+    """
+    _schema = {'$ref': '#/definitions/BrushConfig'}
+    _rootschema = Root._schema
+
+    def __init__(self, fill=Undefined, fillOpacity=Undefined, stroke=Undefined, strokeDash=Undefined,
+                 strokeDashOffset=Undefined, strokeOpacity=Undefined, strokeWidth=Undefined, **kwds):
+        super(BrushConfig, self).__init__(fill=fill, fillOpacity=fillOpacity, stroke=stroke,
+                                          strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
+                                          strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, **kwds)
+
+
+class Color(VegaLiteSchema):
+    """Color schema wrapper
+
+    anyOf(:class:`ColorName`, :class:`HexColor`, string)
+    """
+    _schema = {'$ref': '#/definitions/Color'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(Color, self).__init__(*args, **kwds)
+
+
+class ColorName(Color):
+    """ColorName schema wrapper
+
+    enum('black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green',
+    'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue',
+    'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet',
+    'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue',
+    'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray',
+    'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange',
+    'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray',
+    'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray',
+    'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro',
+    'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink',
+    'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen',
+    'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray',
+    'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue',
+    'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen',
+    'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple',
+    'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise',
+    'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite',
+    'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen',
+    'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum',
+    'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen',
+    'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow',
+    'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat',
+    'whitesmoke', 'yellowgreen', 'rebeccapurple')
+    """
+    _schema = {'$ref': '#/definitions/ColorName'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(ColorName, self).__init__(*args)
+
+
+class CompositeMark(AnyMark):
+    """CompositeMark schema wrapper
+
+    anyOf(:class:`BoxPlot`, :class:`ErrorBar`, :class:`ErrorBand`)
+    """
+    _schema = {'$ref': '#/definitions/CompositeMark'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(CompositeMark, self).__init__(*args, **kwds)
+
+
+class BoxPlot(CompositeMark):
+    """BoxPlot schema wrapper
+
+    enum('boxplot')
+    """
+    _schema = {'$ref': '#/definitions/BoxPlot'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(BoxPlot, self).__init__(*args)
+
+
+class CompositeMarkDef(AnyMark):
+    """CompositeMarkDef schema wrapper
+
+    anyOf(:class:`BoxPlotDef`, :class:`ErrorBarDef`, :class:`ErrorBandDef`)
+    """
+    _schema = {'$ref': '#/definitions/CompositeMarkDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(CompositeMarkDef, self).__init__(*args, **kwds)
+
+
+class BoxPlotDef(CompositeMarkDef):
     """BoxPlotDef schema wrapper
 
     Mapping(required=[type])
@@ -1782,330 +1836,6 @@ class BoxPlotDef(VegaLiteSchema):
                                          outliers=outliers, rule=rule, size=size, ticks=ticks, **kwds)
 
 
-class BrushConfig(VegaLiteSchema):
-    """BrushConfig schema wrapper
-
-    Mapping(required=[])
-
-    Attributes
-    ----------
-
-    fill : :class:`Color`
-        The fill color of the interval mark.
-
-        **Default value:** ``#333333``
-    fillOpacity : float
-        The fill opacity of the interval mark (a value between 0 and 1).
-
-        **Default value:** ``0.125``
-    stroke : :class:`Color`
-        The stroke color of the interval mark.
-
-        **Default value:** ``#ffffff``
-    strokeDash : List(float)
-        An array of alternating stroke and space lengths,
-        for creating dashed or dotted lines.
-    strokeDashOffset : float
-        The offset (in pixels) with which to begin drawing the stroke dash array.
-    strokeOpacity : float
-        The stroke opacity of the interval mark (a value between 0 and 1).
-    strokeWidth : float
-        The stroke width of the interval mark.
-    """
-    _schema = {'$ref': '#/definitions/BrushConfig'}
-    _rootschema = Root._schema
-
-    def __init__(self, fill=Undefined, fillOpacity=Undefined, stroke=Undefined, strokeDash=Undefined,
-                 strokeDashOffset=Undefined, strokeOpacity=Undefined, strokeWidth=Undefined, **kwds):
-        super(BrushConfig, self).__init__(fill=fill, fillOpacity=fillOpacity, stroke=stroke,
-                                          strokeDash=strokeDash, strokeDashOffset=strokeDashOffset,
-                                          strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, **kwds)
-
-
-class CalculateTransform(VegaLiteSchema):
-    """CalculateTransform schema wrapper
-
-    Mapping(required=[calculate, as])
-
-    Attributes
-    ----------
-
-    calculate : string
-        A `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`__
-        string. Use the variable ``datum`` to refer to the current data object.
-    as : :class:`FieldName`
-        The field for storing the computed formula value.
-    """
-    _schema = {'$ref': '#/definitions/CalculateTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, calculate=Undefined, **kwds):
-        super(CalculateTransform, self).__init__(calculate=calculate, **kwds)
-
-
-class Color(VegaLiteSchema):
-    """Color schema wrapper
-
-    anyOf(:class:`ColorName`, :class:`HexColor`, string)
-    """
-    _schema = {'$ref': '#/definitions/Color'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(Color, self).__init__(*args, **kwds)
-
-
-class ColorName(VegaLiteSchema):
-    """ColorName schema wrapper
-
-    enum('black', 'silver', 'gray', 'white', 'maroon', 'red', 'purple', 'fuchsia', 'green',
-    'lime', 'olive', 'yellow', 'navy', 'blue', 'teal', 'aqua', 'orange', 'aliceblue',
-    'antiquewhite', 'aquamarine', 'azure', 'beige', 'bisque', 'blanchedalmond', 'blueviolet',
-    'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue',
-    'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray',
-    'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange',
-    'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray',
-    'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray',
-    'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'gainsboro',
-    'ghostwhite', 'gold', 'goldenrod', 'greenyellow', 'grey', 'honeydew', 'hotpink',
-    'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen',
-    'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray',
-    'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue',
-    'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow', 'limegreen', 'linen',
-    'magenta', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple',
-    'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise',
-    'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite',
-    'oldlace', 'olivedrab', 'orangered', 'orchid', 'palegoldenrod', 'palegreen',
-    'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum',
-    'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen',
-    'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow',
-    'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat',
-    'whitesmoke', 'yellowgreen', 'rebeccapurple')
-    """
-    _schema = {'$ref': '#/definitions/ColorName'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args):
-        super(ColorName, self).__init__(*args)
-
-
-class Encoding(VegaLiteSchema):
-    """Encoding schema wrapper
-
-    Mapping(required=[])
-
-    Attributes
-    ----------
-
-    color : anyOf(:class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`)
-        Color of the marks – either fill or stroke color based on  the ``filled`` property
-        of mark definition.
-        By default, ``color`` represents fill color for ``"area"``, ``"bar"``, ``"tick"``,
-        ``"text"``, ``"trail"``, ``"circle"``, and ``"square"`` / stroke color for
-        ``"line"`` and ``"point"``.
-
-        **Default value:** If undefined, the default color depends on `mark config
-        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
-
-        *Note:*
-        1) For fine-grained control over both fill and stroke colors of the marks, please
-        use the ``fill`` and ``stroke`` channels.  If either ``fill`` or ``stroke`` channel
-        is specified, ``color`` channel will be ignored.
-        2) See the scale documentation for more information about customizing `color scheme
-        <https://vega.github.io/vega-lite/docs/scale.html#scheme>`__.
-    detail : anyOf(:class:`FieldDefWithoutScale`, List(:class:`FieldDefWithoutScale`))
-        Additional levels of detail for grouping data in aggregate views and
-        in line, trail, and area marks without mapping data to a specific visual channel.
-    fill : anyOf(:class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`)
-        Fill color of the marks.
-        **Default value:** If undefined, the default color depends on `mark config
-        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
-
-        *Note:* When using ``fill`` channel, ``color`` channel will be ignored. To customize
-        both fill and stroke, please use ``fill`` and ``stroke`` channels (not ``fill`` and
-        ``color`` ).
-    fillOpacity : anyOf(:class:`NumericFieldDefWithCondition`,
-    :class:`NumericValueDefWithCondition`)
-        Fill opacity of the marks.
-
-        **Default value:** If undefined, the default opacity depends on `mark config
-        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``fillOpacity``
-        property.
-    href : anyOf(:class:`TextFieldDefWithCondition`, :class:`TextValueDefWithCondition`)
-        A URL to load upon mouse click.
-    key : :class:`FieldDefWithoutScale`
-        A data field to use as a unique key for data binding. When a visualization’s data is
-        updated, the key value will be used to match data elements to existing mark
-        instances. Use a key channel to enable object constancy for transitions over dynamic
-        data.
-    latitude : anyOf(:class:`LatLongFieldDef`, :class:`NumberValueDef`)
-        Latitude position of geographically projected marks.
-    latitude2 : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
-        Latitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
-        ``"rect"``, and  ``"rule"``.
-    longitude : anyOf(:class:`LatLongFieldDef`, :class:`NumberValueDef`)
-        Longitude position of geographically projected marks.
-    longitude2 : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
-        Longitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
-        ``"rect"``, and  ``"rule"``.
-    opacity : anyOf(:class:`NumericFieldDefWithCondition`,
-    :class:`NumericValueDefWithCondition`)
-        Opacity of the marks.
-
-        **Default value:** If undefined, the default opacity depends on `mark config
-        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``opacity`` property.
-    order : anyOf(:class:`OrderFieldDef`, List(:class:`OrderFieldDef`), :class:`NumberValueDef`)
-        Order of the marks.
-
-
-        * For stacked marks, this ``order`` channel encodes `stack order
-          <https://vega.github.io/vega-lite/docs/stack.html#order>`__.
-        * For line and trail marks, this ``order`` channel encodes order of data points in
-          the lines. This can be useful for creating `a connected scatterplot
-          <https://vega.github.io/vega-lite/examples/connected_scatterplot.html>`__.
-          Setting ``order`` to ``{"value": null}`` makes the line marks use the original
-          order in the data sources.
-        * Otherwise, this ``order`` channel encodes layer order of the marks.
-
-        **Note** : In aggregate plots, ``order`` field should be ``aggregate`` d to avoid
-        creating additional aggregation grouping.
-    shape : anyOf(:class:`ShapeFieldDefWithCondition`, :class:`ShapeValueDefWithCondition`)
-        Shape of the mark.
-
-
-        #.
-        For ``point`` marks the supported values include:
-
-
-        * plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
-        ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
-        ``"triangle-left"``.
-        * the line symbol ``"stroke"``
-        * centered directional shapes ``"arrow"``, ``"wedge"``, or ``"triangle"``
-        * a custom `SVG path string
-        <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ (For correct
-        sizing, custom shape paths should be defined within a square bounding box with
-        coordinates ranging from -1 to 1 along both the x and y dimensions.)
-
-        #.
-        For ``geoshape`` marks it should be a field definition of the geojson data
-
-        **Default value:** If undefined, the default shape depends on `mark config
-        <https://vega.github.io/vega-lite/docs/config.html#point-config>`__ 's ``shape``
-        property. ( ``"circle"`` if unset.)
-    size : anyOf(:class:`NumericFieldDefWithCondition`, :class:`NumericValueDefWithCondition`)
-        Size of the mark.
-
-
-        * For ``"point"``, ``"square"`` and ``"circle"``, – the symbol size, or pixel area
-          of the mark.
-        * For ``"bar"`` and ``"tick"`` – the bar and tick's size.
-        * For ``"text"`` – the text's font size.
-        * Size is unsupported for ``"line"``, ``"area"``, and ``"rect"``. (Use ``"trail"``
-          instead of line with varying size)
-    stroke : anyOf(:class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`)
-        Stroke color of the marks.
-        **Default value:** If undefined, the default color depends on `mark config
-        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
-
-        *Note:* When using ``stroke`` channel, ``color`` channel will be ignored. To
-        customize both stroke and fill, please use ``stroke`` and ``fill`` channels (not
-        ``stroke`` and ``color`` ).
-    strokeOpacity : anyOf(:class:`NumericFieldDefWithCondition`,
-    :class:`NumericValueDefWithCondition`)
-        Stroke opacity of the marks.
-
-        **Default value:** If undefined, the default opacity depends on `mark config
-        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``strokeOpacity``
-        property.
-    strokeWidth : anyOf(:class:`NumericFieldDefWithCondition`,
-    :class:`NumericValueDefWithCondition`)
-        Stroke width of the marks.
-
-        **Default value:** If undefined, the default stroke width depends on `mark config
-        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``strokeWidth``
-        property.
-    text : anyOf(:class:`TextFieldDefWithCondition`, :class:`TextValueDefWithCondition`)
-        Text of the ``text`` mark.
-    tooltip : anyOf(:class:`TextFieldDefWithCondition`, :class:`TextValueDefWithCondition`,
-    List(:class:`TextFieldDef`), None)
-        The tooltip text to show upon mouse hover.
-    x : anyOf(:class:`PositionFieldDef`, :class:`XValueDef`)
-        X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"`` without
-        specified ``x2`` or ``width``.
-
-        The ``value`` of this channel can be a number or a string ``"width"`` for the width
-        of the plot.
-    x2 : anyOf(:class:`SecondaryFieldDef`, :class:`XValueDef`)
-        X2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
-
-        The ``value`` of this channel can be a number or a string ``"width"`` for the width
-        of the plot.
-    xError : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
-        Error value of x coordinates for error specified ``"errorbar"`` and ``"errorband"``.
-    xError2 : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
-        Secondary error value of x coordinates for error specified ``"errorbar"`` and
-        ``"errorband"``.
-    y : anyOf(:class:`PositionFieldDef`, :class:`YValueDef`)
-        Y coordinates of the marks, or height of vertical ``"bar"`` and ``"area"`` without
-        specified ``y2`` or ``height``.
-
-        The ``value`` of this channel can be a number or a string ``"height"`` for the
-        height of the plot.
-    y2 : anyOf(:class:`SecondaryFieldDef`, :class:`YValueDef`)
-        Y2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
-
-        The ``value`` of this channel can be a number or a string ``"height"`` for the
-        height of the plot.
-    yError : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
-        Error value of y coordinates for error specified ``"errorbar"`` and ``"errorband"``.
-    yError2 : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
-        Secondary error value of y coordinates for error specified ``"errorbar"`` and
-        ``"errorband"``.
-    """
-    _schema = {'$ref': '#/definitions/Encoding'}
-    _rootschema = Root._schema
-
-    def __init__(self, color=Undefined, detail=Undefined, fill=Undefined, fillOpacity=Undefined,
-                 href=Undefined, key=Undefined, latitude=Undefined, latitude2=Undefined,
-                 longitude=Undefined, longitude2=Undefined, opacity=Undefined, order=Undefined,
-                 shape=Undefined, size=Undefined, stroke=Undefined, strokeOpacity=Undefined,
-                 strokeWidth=Undefined, text=Undefined, tooltip=Undefined, x=Undefined, x2=Undefined,
-                 xError=Undefined, xError2=Undefined, y=Undefined, y2=Undefined, yError=Undefined,
-                 yError2=Undefined, **kwds):
-        super(Encoding, self).__init__(color=color, detail=detail, fill=fill, fillOpacity=fillOpacity,
-                                       href=href, key=key, latitude=latitude, latitude2=latitude2,
-                                       longitude=longitude, longitude2=longitude2, opacity=opacity,
-                                       order=order, shape=shape, size=size, stroke=stroke,
-                                       strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, text=text,
-                                       tooltip=tooltip, x=x, x2=x2, xError=xError, xError2=xError2, y=y,
-                                       y2=y2, yError=yError, yError2=yError2, **kwds)
-
-
-class CompositeMark(VegaLiteSchema):
-    """CompositeMark schema wrapper
-
-    anyOf(:class:`BoxPlot`, :class:`ErrorBar`, :class:`ErrorBand`)
-    """
-    _schema = {'$ref': '#/definitions/CompositeMark'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(CompositeMark, self).__init__(*args, **kwds)
-
-
-class CompositeMarkDef(VegaLiteSchema):
-    """CompositeMarkDef schema wrapper
-
-    anyOf(:class:`BoxPlotDef`, :class:`ErrorBarDef`, :class:`ErrorBandDef`)
-    """
-    _schema = {'$ref': '#/definitions/CompositeMarkDef'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(CompositeMarkDef, self).__init__(*args, **kwds)
-
-
 class CompositionConfig(VegaLiteSchema):
     """CompositionConfig schema wrapper
 
@@ -2171,43 +1901,6 @@ class ConditionalMarkPropFieldDefTypeForShape(VegaLiteSchema):
         super(ConditionalMarkPropFieldDefTypeForShape, self).__init__(*args, **kwds)
 
 
-class ConditionalTextFieldDef(VegaLiteSchema):
-    """ConditionalTextFieldDef schema wrapper
-
-    anyOf(:class:`ConditionalPredicateTextFieldDef`, :class:`ConditionalSelectionTextFieldDef`)
-    """
-    _schema = {'$ref': '#/definitions/ConditionalTextFieldDef'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(ConditionalTextFieldDef, self).__init__(*args, **kwds)
-
-
-class ConditionalStringValueDef(VegaLiteSchema):
-    """ConditionalStringValueDef schema wrapper
-
-    anyOf(:class:`ConditionalPredicateStringValueDef`,
-    :class:`ConditionalSelectionStringValueDef`)
-    """
-    _schema = {'$ref': '#/definitions/ConditionalStringValueDef'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(ConditionalStringValueDef, self).__init__(*args, **kwds)
-
-
-class ConditionalValueDef(VegaLiteSchema):
-    """ConditionalValueDef schema wrapper
-
-    anyOf(:class:`ConditionalPredicateValueDef`, :class:`ConditionalSelectionValueDef`)
-    """
-    _schema = {'$ref': '#/definitions/ConditionalValueDef'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(ConditionalValueDef, self).__init__(*args, **kwds)
-
-
 class ConditionalNumberValueDef(VegaLiteSchema):
     """ConditionalNumberValueDef schema wrapper
 
@@ -2221,7 +1914,7 @@ class ConditionalNumberValueDef(VegaLiteSchema):
         super(ConditionalNumberValueDef, self).__init__(*args, **kwds)
 
 
-class ConditionalPredicateMarkPropFieldDef(VegaLiteSchema):
+class ConditionalPredicateMarkPropFieldDef(ConditionalMarkPropFieldDef):
     """ConditionalPredicateMarkPropFieldDef schema wrapper
 
     Mapping(required=[test, type])
@@ -2413,7 +2106,7 @@ class ConditionalPredicateMarkPropFieldDef(VegaLiteSchema):
                                                                    **kwds)
 
 
-class ConditionalPredicateMarkPropFieldDefTypeForShape(VegaLiteSchema):
+class ConditionalPredicateMarkPropFieldDefTypeForShape(ConditionalMarkPropFieldDefTypeForShape):
     """ConditionalPredicateMarkPropFieldDefTypeForShape schema wrapper
 
     Mapping(required=[test, type])
@@ -2606,212 +2299,7 @@ class ConditionalPredicateMarkPropFieldDefTypeForShape(VegaLiteSchema):
                                                                                title=title, **kwds)
 
 
-class ConditionalPredicateTextFieldDef(VegaLiteSchema):
-    """ConditionalPredicateTextFieldDef schema wrapper
-
-    Mapping(required=[test, type])
-
-    Attributes
-    ----------
-
-    test : :class:`LogicalOperandPredicate`
-        Predicate for triggering the condition
-    type : :class:`StandardType`
-        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
-        ``"ordinal"``, or ``"nominal"`` ).
-        It can also be a ``"geojson"`` type for encoding `'geoshape'
-        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
-
-        **Note:**
-
-
-        * Data values for a temporal field can be either a date-time string (e.g.,
-          ``"2015-03-07 12:32:17"``, ``"17:01"``, ``"2015-03-16"``. ``"2015"`` ) or a
-          timestamp number (e.g., ``1552199579097`` ).
-        * Data ``type`` describes the semantics of the data rather than the primitive data
-          types ( ``number``, ``string``, etc.). The same primitive data type can have
-          different types of measurement. For example, numeric data can represent
-          quantitative, ordinal, or nominal data.
-        * When using with `bin <https://vega.github.io/vega-lite/docs/bin.html>`__, the
-          ``type`` property can be either ``"quantitative"`` (for using a linear bin scale)
-          or `"ordinal" (for using an ordinal bin scale)
-          <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
-        * When using with `timeUnit
-          <https://vega.github.io/vega-lite/docs/timeunit.html>`__, the ``type`` property
-          can be either ``"temporal"`` (for using a temporal scale) or `"ordinal" (for using
-          an ordinal scale) <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
-        * When using with `aggregate
-          <https://vega.github.io/vega-lite/docs/aggregate.html>`__, the ``type`` property
-          refers to the post-aggregation data type. For example, we can calculate count
-          ``distinct`` of a categorical field ``"cat"`` using ``{"aggregate": "distinct",
-          "field": "cat", "type": "quantitative"}``. The ``"type"`` of the aggregate output
-          is ``"quantitative"``.
-        * Secondary channels (e.g., ``x2``, ``y2``, ``xError``, ``yError`` ) do not have
-          ``type`` as they have exactly the same type as their primary channels (e.g.,
-          ``x``, ``y`` ).
-
-        **See also:** `type <https://vega.github.io/vega-lite/docs/type.html>`__
-        documentation.
-    aggregate : :class:`Aggregate`
-        Aggregation function for the field
-        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
-
-        **Default value:** ``undefined`` (None)
-
-        **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
-        documentation.
-    bin : anyOf(boolean, :class:`BinParams`, enum('binned'), None)
-        A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
-
-
-        If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
-
-        If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
-        already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
-        field to ``x2`` (or ``y2`` ). The scale and axis will be formatted similar to
-        binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also
-        set the axis's `tickMinStep
-        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
-
-        **Default value:** ``false``
-
-        **See also:** `bin <https://vega.github.io/vega-lite/docs/bin.html>`__
-        documentation.
-    field : :class:`Field`
-        **Required.** A string defining the name of the field from which to pull a data
-        value
-        or an object defining iterated values from the `repeat
-        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
-
-        **See also:** `field <https://vega.github.io/vega-lite/docs/field.html>`__
-        documentation.
-
-        **Notes:**
-        1)  Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested
-        objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
-        If field names contain dots or brackets but are not nested, you can use ``\\`` to
-        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
-        See more details about escaping in the `field documentation
-        <https://vega.github.io/vega-lite/docs/field.html>`__.
-        2) ``field`` is not required if ``aggregate`` is ``count``.
-    format : string
-        The text formatting pattern for labels of guides (axes, legends, headers) and text
-        marks.
-
-
-        * If the format type is ``"number"`` (e.g., for quantitative fields), this is D3's
-          `number format pattern <https://github.com/d3/d3-format#locale_format>`__.
-        * If the format type is ``"time"`` (e.g., for temporal fields), this is D3's `time
-          format pattern <https://github.com/d3/d3-time-format#locale_format>`__.
-
-        See the `format documentation <https://vega.github.io/vega-lite/docs/format.html>`__
-        for more examples.
-
-        **Default value:**  Derived from `numberFormat
-        <https://vega.github.io/vega-lite/docs/config.html#format>`__ config for number
-        format and from `timeFormat
-        <https://vega.github.io/vega-lite/docs/config.html#format>`__ config for time
-        format.
-    formatType : enum('number', 'time')
-        The format type for labels ( ``"number"`` or ``"time"`` ).
-
-        **Default value:**
-
-
-        * ``"time"`` for temporal fields and ordinal and nomimal fields with ``timeUnit``.
-        * ``"number"`` for quantitative fields as well as ordinal and nomimal fields without
-          ``timeUnit``.
-    timeUnit : :class:`TimeUnit`
-        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
-        field.
-        or `a temporal field that gets casted as ordinal
-        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
-
-        **Default value:** ``undefined`` (None)
-
-        **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
-        documentation.
-    title : anyOf(string, None)
-        A title for the field. If ``null``, the title will be removed.
-
-        **Default value:**  derived from the field's name and transformation function (
-        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
-        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
-        field is binned or has a time unit applied, the applied function is shown in
-        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
-        Otherwise, the title is simply the field name.
-
-        **Notes** :
-
-        1) You can customize the default field title format by providing the `fieldTitle
-        <https://vega.github.io/vega-lite/docs/config.html#top-level-config>`__ property in
-        the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or `fieldTitle
-        function via the compile function's options
-        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
-
-        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
-        defined, axis/header/legend title will be used.
-    """
-    _schema = {'$ref': '#/definitions/ConditionalPredicate<TextFieldDef>'}
-    _rootschema = Root._schema
-
-    def __init__(self, test=Undefined, type=Undefined, aggregate=Undefined, bin=Undefined,
-                 field=Undefined, format=Undefined, formatType=Undefined, timeUnit=Undefined,
-                 title=Undefined, **kwds):
-        super(ConditionalPredicateTextFieldDef, self).__init__(test=test, type=type,
-                                                               aggregate=aggregate, bin=bin,
-                                                               field=field, format=format,
-                                                               formatType=formatType, timeUnit=timeUnit,
-                                                               title=title, **kwds)
-
-
-class ConditionalPredicateStringValueDef(VegaLiteSchema):
-    """ConditionalPredicateStringValueDef schema wrapper
-
-    Mapping(required=[test, value])
-
-    Attributes
-    ----------
-
-    test : :class:`LogicalOperandPredicate`
-        Predicate for triggering the condition
-    value : anyOf(string, None)
-        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
-        between ``0`` to ``1`` for opacity).
-    """
-    _schema = {'$ref': '#/definitions/ConditionalPredicate<StringValueDef>'}
-    _rootschema = Root._schema
-
-    def __init__(self, test=Undefined, value=Undefined, **kwds):
-        super(ConditionalPredicateStringValueDef, self).__init__(test=test, value=value, **kwds)
-
-
-class ConditionalPredicateValueDef(VegaLiteSchema):
-    """ConditionalPredicateValueDef schema wrapper
-
-    Mapping(required=[test, value])
-
-    Attributes
-    ----------
-
-    test : :class:`LogicalOperandPredicate`
-        Predicate for triggering the condition
-    value : :class:`Value`
-        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
-        between ``0`` to ``1`` for opacity).
-    """
-    _schema = {'$ref': '#/definitions/ConditionalPredicate<ValueDef>'}
-    _rootschema = Root._schema
-
-    def __init__(self, test=Undefined, value=Undefined, **kwds):
-        super(ConditionalPredicateValueDef, self).__init__(test=test, value=value, **kwds)
-
-
-class ConditionalPredicateNumberValueDef(VegaLiteSchema):
+class ConditionalPredicateNumberValueDef(ConditionalNumberValueDef):
     """ConditionalPredicateNumberValueDef schema wrapper
 
     Mapping(required=[test, value])
@@ -2832,7 +2320,7 @@ class ConditionalPredicateNumberValueDef(VegaLiteSchema):
         super(ConditionalPredicateNumberValueDef, self).__init__(test=test, value=value, **kwds)
 
 
-class ConditionalSelectionMarkPropFieldDef(VegaLiteSchema):
+class ConditionalSelectionMarkPropFieldDef(ConditionalMarkPropFieldDef):
     """ConditionalSelectionMarkPropFieldDef schema wrapper
 
     Mapping(required=[selection, type])
@@ -3026,7 +2514,7 @@ class ConditionalSelectionMarkPropFieldDef(VegaLiteSchema):
                                                                    **kwds)
 
 
-class ConditionalSelectionMarkPropFieldDefTypeForShape(VegaLiteSchema):
+class ConditionalSelectionMarkPropFieldDefTypeForShape(ConditionalMarkPropFieldDefTypeForShape):
     """ConditionalSelectionMarkPropFieldDefTypeForShape schema wrapper
 
     Mapping(required=[selection, type])
@@ -3222,7 +2710,264 @@ class ConditionalSelectionMarkPropFieldDefTypeForShape(VegaLiteSchema):
                                                                                title=title, **kwds)
 
 
-class ConditionalSelectionTextFieldDef(VegaLiteSchema):
+class ConditionalSelectionNumberValueDef(ConditionalNumberValueDef):
+    """ConditionalSelectionNumberValueDef schema wrapper
+
+    Mapping(required=[selection, value])
+
+    Attributes
+    ----------
+
+    selection : :class:`SelectionOperand`
+        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`__, or a
+        series of `composed selections
+        <https://vega.github.io/vega-lite/docs/selection.html#compose>`__.
+    value : float
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _schema = {'$ref': '#/definitions/ConditionalSelection<NumberValueDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, selection=Undefined, value=Undefined, **kwds):
+        super(ConditionalSelectionNumberValueDef, self).__init__(selection=selection, value=value,
+                                                                 **kwds)
+
+
+class ConditionalStringValueDef(VegaLiteSchema):
+    """ConditionalStringValueDef schema wrapper
+
+    anyOf(:class:`ConditionalPredicateStringValueDef`,
+    :class:`ConditionalSelectionStringValueDef`)
+    """
+    _schema = {'$ref': '#/definitions/ConditionalStringValueDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(ConditionalStringValueDef, self).__init__(*args, **kwds)
+
+
+class ConditionalPredicateStringValueDef(ConditionalStringValueDef):
+    """ConditionalPredicateStringValueDef schema wrapper
+
+    Mapping(required=[test, value])
+
+    Attributes
+    ----------
+
+    test : :class:`LogicalOperandPredicate`
+        Predicate for triggering the condition
+    value : anyOf(string, None)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _schema = {'$ref': '#/definitions/ConditionalPredicate<StringValueDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, test=Undefined, value=Undefined, **kwds):
+        super(ConditionalPredicateStringValueDef, self).__init__(test=test, value=value, **kwds)
+
+
+class ConditionalSelectionStringValueDef(ConditionalStringValueDef):
+    """ConditionalSelectionStringValueDef schema wrapper
+
+    Mapping(required=[selection, value])
+
+    Attributes
+    ----------
+
+    selection : :class:`SelectionOperand`
+        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`__, or a
+        series of `composed selections
+        <https://vega.github.io/vega-lite/docs/selection.html#compose>`__.
+    value : anyOf(string, None)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _schema = {'$ref': '#/definitions/ConditionalSelection<StringValueDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, selection=Undefined, value=Undefined, **kwds):
+        super(ConditionalSelectionStringValueDef, self).__init__(selection=selection, value=value,
+                                                                 **kwds)
+
+
+class ConditionalTextFieldDef(VegaLiteSchema):
+    """ConditionalTextFieldDef schema wrapper
+
+    anyOf(:class:`ConditionalPredicateTextFieldDef`, :class:`ConditionalSelectionTextFieldDef`)
+    """
+    _schema = {'$ref': '#/definitions/ConditionalTextFieldDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(ConditionalTextFieldDef, self).__init__(*args, **kwds)
+
+
+class ConditionalPredicateTextFieldDef(ConditionalTextFieldDef):
+    """ConditionalPredicateTextFieldDef schema wrapper
+
+    Mapping(required=[test, type])
+
+    Attributes
+    ----------
+
+    test : :class:`LogicalOperandPredicate`
+        Predicate for triggering the condition
+    type : :class:`StandardType`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+
+        **Note:**
+
+
+        * Data values for a temporal field can be either a date-time string (e.g.,
+          ``"2015-03-07 12:32:17"``, ``"17:01"``, ``"2015-03-16"``. ``"2015"`` ) or a
+          timestamp number (e.g., ``1552199579097`` ).
+        * Data ``type`` describes the semantics of the data rather than the primitive data
+          types ( ``number``, ``string``, etc.). The same primitive data type can have
+          different types of measurement. For example, numeric data can represent
+          quantitative, ordinal, or nominal data.
+        * When using with `bin <https://vega.github.io/vega-lite/docs/bin.html>`__, the
+          ``type`` property can be either ``"quantitative"`` (for using a linear bin scale)
+          or `"ordinal" (for using an ordinal bin scale)
+          <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
+        * When using with `timeUnit
+          <https://vega.github.io/vega-lite/docs/timeunit.html>`__, the ``type`` property
+          can be either ``"temporal"`` (for using a temporal scale) or `"ordinal" (for using
+          an ordinal scale) <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
+        * When using with `aggregate
+          <https://vega.github.io/vega-lite/docs/aggregate.html>`__, the ``type`` property
+          refers to the post-aggregation data type. For example, we can calculate count
+          ``distinct`` of a categorical field ``"cat"`` using ``{"aggregate": "distinct",
+          "field": "cat", "type": "quantitative"}``. The ``"type"`` of the aggregate output
+          is ``"quantitative"``.
+        * Secondary channels (e.g., ``x2``, ``y2``, ``xError``, ``yError`` ) do not have
+          ``type`` as they have exactly the same type as their primary channels (e.g.,
+          ``x``, ``y`` ).
+
+        **See also:** `type <https://vega.github.io/vega-lite/docs/type.html>`__
+        documentation.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+
+        **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
+        documentation.
+    bin : anyOf(boolean, :class:`BinParams`, enum('binned'), None)
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
+        already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
+        field to ``x2`` (or ``y2`` ). The scale and axis will be formatted similar to
+        binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also
+        set the axis's `tickMinStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+
+        **See also:** `bin <https://vega.github.io/vega-lite/docs/bin.html>`__
+        documentation.
+    field : :class:`Field`
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **See also:** `field <https://vega.github.io/vega-lite/docs/field.html>`__
+        documentation.
+
+        **Notes:**
+        1)  Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested
+        objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+        2) ``field`` is not required if ``aggregate`` is ``count``.
+    format : string
+        The text formatting pattern for labels of guides (axes, legends, headers) and text
+        marks.
+
+
+        * If the format type is ``"number"`` (e.g., for quantitative fields), this is D3's
+          `number format pattern <https://github.com/d3/d3-format#locale_format>`__.
+        * If the format type is ``"time"`` (e.g., for temporal fields), this is D3's `time
+          format pattern <https://github.com/d3/d3-time-format#locale_format>`__.
+
+        See the `format documentation <https://vega.github.io/vega-lite/docs/format.html>`__
+        for more examples.
+
+        **Default value:**  Derived from `numberFormat
+        <https://vega.github.io/vega-lite/docs/config.html#format>`__ config for number
+        format and from `timeFormat
+        <https://vega.github.io/vega-lite/docs/config.html#format>`__ config for time
+        format.
+    formatType : enum('number', 'time')
+        The format type for labels ( ``"number"`` or ``"time"`` ).
+
+        **Default value:**
+
+
+        * ``"time"`` for temporal fields and ordinal and nomimal fields with ``timeUnit``.
+        * ``"number"`` for quantitative fields as well as ordinal and nomimal fields without
+          ``timeUnit``.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+
+        **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
+        documentation.
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the `fieldTitle
+        <https://vega.github.io/vega-lite/docs/config.html#top-level-config>`__ property in
+        the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or `fieldTitle
+        function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/ConditionalPredicate<TextFieldDef>'}
+    _rootschema = Root._schema
+
+    def __init__(self, test=Undefined, type=Undefined, aggregate=Undefined, bin=Undefined,
+                 field=Undefined, format=Undefined, formatType=Undefined, timeUnit=Undefined,
+                 title=Undefined, **kwds):
+        super(ConditionalPredicateTextFieldDef, self).__init__(test=test, type=type,
+                                                               aggregate=aggregate, bin=bin,
+                                                               field=field, format=format,
+                                                               formatType=formatType, timeUnit=timeUnit,
+                                                               title=title, **kwds)
+
+
+class ConditionalSelectionTextFieldDef(ConditionalTextFieldDef):
     """ConditionalSelectionTextFieldDef schema wrapper
 
     Mapping(required=[selection, type])
@@ -3387,31 +3132,40 @@ class ConditionalSelectionTextFieldDef(VegaLiteSchema):
                                                                title=title, **kwds)
 
 
-class ConditionalSelectionStringValueDef(VegaLiteSchema):
-    """ConditionalSelectionStringValueDef schema wrapper
+class ConditionalValueDef(VegaLiteSchema):
+    """ConditionalValueDef schema wrapper
 
-    Mapping(required=[selection, value])
+    anyOf(:class:`ConditionalPredicateValueDef`, :class:`ConditionalSelectionValueDef`)
+    """
+    _schema = {'$ref': '#/definitions/ConditionalValueDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(ConditionalValueDef, self).__init__(*args, **kwds)
+
+
+class ConditionalPredicateValueDef(ConditionalValueDef):
+    """ConditionalPredicateValueDef schema wrapper
+
+    Mapping(required=[test, value])
 
     Attributes
     ----------
 
-    selection : :class:`SelectionOperand`
-        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`__, or a
-        series of `composed selections
-        <https://vega.github.io/vega-lite/docs/selection.html#compose>`__.
-    value : anyOf(string, None)
+    test : :class:`LogicalOperandPredicate`
+        Predicate for triggering the condition
+    value : :class:`Value`
         A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
         between ``0`` to ``1`` for opacity).
     """
-    _schema = {'$ref': '#/definitions/ConditionalSelection<StringValueDef>'}
+    _schema = {'$ref': '#/definitions/ConditionalPredicate<ValueDef>'}
     _rootschema = Root._schema
 
-    def __init__(self, selection=Undefined, value=Undefined, **kwds):
-        super(ConditionalSelectionStringValueDef, self).__init__(selection=selection, value=value,
-                                                                 **kwds)
+    def __init__(self, test=Undefined, value=Undefined, **kwds):
+        super(ConditionalPredicateValueDef, self).__init__(test=test, value=value, **kwds)
 
 
-class ConditionalSelectionValueDef(VegaLiteSchema):
+class ConditionalSelectionValueDef(ConditionalValueDef):
     """ConditionalSelectionValueDef schema wrapper
 
     Mapping(required=[selection, value])
@@ -3432,30 +3186,6 @@ class ConditionalSelectionValueDef(VegaLiteSchema):
 
     def __init__(self, selection=Undefined, value=Undefined, **kwds):
         super(ConditionalSelectionValueDef, self).__init__(selection=selection, value=value, **kwds)
-
-
-class ConditionalSelectionNumberValueDef(VegaLiteSchema):
-    """ConditionalSelectionNumberValueDef schema wrapper
-
-    Mapping(required=[selection, value])
-
-    Attributes
-    ----------
-
-    selection : :class:`SelectionOperand`
-        A `selection name <https://vega.github.io/vega-lite/docs/selection.html>`__, or a
-        series of `composed selections
-        <https://vega.github.io/vega-lite/docs/selection.html#compose>`__.
-    value : float
-        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
-        between ``0`` to ``1`` for opacity).
-    """
-    _schema = {'$ref': '#/definitions/ConditionalSelection<NumberValueDef>'}
-    _rootschema = Root._schema
-
-    def __init__(self, selection=Undefined, value=Undefined, **kwds):
-        super(ConditionalSelectionNumberValueDef, self).__init__(selection=selection, value=value,
-                                                                 **kwds)
 
 
 class Config(VegaLiteSchema):
@@ -3674,45 +3404,6 @@ class Config(VegaLiteSchema):
                                      timeFormat=timeFormat, title=title, trail=trail, view=view, **kwds)
 
 
-class CsvDataFormat(VegaLiteSchema):
-    """CsvDataFormat schema wrapper
-
-    Mapping(required=[])
-
-    Attributes
-    ----------
-
-    parse : anyOf(:class:`Parse`, None)
-        If set to ``null``, disable type inference based on the spec and only use type
-        inference based on the data.
-        Alternatively, a parsing directive object can be provided for explicit data types.
-        Each property of the object corresponds to a field name, and the value to the
-        desired data type (one of ``"number"``, ``"boolean"``, ``"date"``, or null (do not
-        parse the field)).
-        For example, ``"parse": {"modified_on": "date"}`` parses the ``modified_on`` field
-        in each input record a Date value.
-
-        For ``"date"``, we parse data based using Javascript's `Date.parse()
-        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse>`__.
-        For Specific date formats can be provided (e.g., ``{foo: "date:'%m%d%Y'"}`` ), using
-        the `d3-time-format syntax <https://github.com/d3/d3-time-format#locale_format>`__.
-        UTC date format parsing is supported similarly (e.g., ``{foo: "utc:'%m%d%Y'"}`` ).
-        See more about `UTC time
-        <https://vega.github.io/vega-lite/docs/timeunit.html#utc>`__
-    type : enum('csv', 'tsv')
-        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``, ``"dsv"``.
-
-        **Default value:**  The default format type is determined by the extension of the
-        file URL.
-        If no extension is detected, ``"json"`` will be used by default.
-    """
-    _schema = {'$ref': '#/definitions/CsvDataFormat'}
-    _rootschema = Root._schema
-
-    def __init__(self, parse=Undefined, type=Undefined, **kwds):
-        super(CsvDataFormat, self).__init__(parse=parse, type=type, **kwds)
-
-
 class Cursor(VegaLiteSchema):
     """Cursor schema wrapper
 
@@ -3754,7 +3445,46 @@ class DataFormat(VegaLiteSchema):
         super(DataFormat, self).__init__(*args, **kwds)
 
 
-class DataSource(VegaLiteSchema):
+class CsvDataFormat(DataFormat):
+    """CsvDataFormat schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    parse : anyOf(:class:`Parse`, None)
+        If set to ``null``, disable type inference based on the spec and only use type
+        inference based on the data.
+        Alternatively, a parsing directive object can be provided for explicit data types.
+        Each property of the object corresponds to a field name, and the value to the
+        desired data type (one of ``"number"``, ``"boolean"``, ``"date"``, or null (do not
+        parse the field)).
+        For example, ``"parse": {"modified_on": "date"}`` parses the ``modified_on`` field
+        in each input record a Date value.
+
+        For ``"date"``, we parse data based using Javascript's `Date.parse()
+        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse>`__.
+        For Specific date formats can be provided (e.g., ``{foo: "date:'%m%d%Y'"}`` ), using
+        the `d3-time-format syntax <https://github.com/d3/d3-time-format#locale_format>`__.
+        UTC date format parsing is supported similarly (e.g., ``{foo: "utc:'%m%d%Y'"}`` ).
+        See more about `UTC time
+        <https://vega.github.io/vega-lite/docs/timeunit.html#utc>`__
+    type : enum('csv', 'tsv')
+        Type of input data: ``"json"``, ``"csv"``, ``"tsv"``, ``"dsv"``.
+
+        **Default value:**  The default format type is determined by the extension of the
+        file URL.
+        If no extension is detected, ``"json"`` will be used by default.
+    """
+    _schema = {'$ref': '#/definitions/CsvDataFormat'}
+    _rootschema = Root._schema
+
+    def __init__(self, parse=Undefined, type=Undefined, **kwds):
+        super(CsvDataFormat, self).__init__(parse=parse, type=type, **kwds)
+
+
+class DataSource(Data):
     """DataSource schema wrapper
 
     anyOf(:class:`UrlData`, :class:`InlineData`, :class:`NamedData`)
@@ -3776,57 +3506,6 @@ class Datasets(VegaLiteSchema):
 
     def __init__(self, **kwds):
         super(Datasets, self).__init__(**kwds)
-
-
-class DateTime(VegaLiteSchema):
-    """DateTime schema wrapper
-
-    Mapping(required=[])
-    Object for defining datetime in Vega-Lite Filter.
-    If both month and quarter are provided, month has higher precedence.
-    ``day`` cannot be combined with other date.
-    We accept string for month and day names.
-
-    Attributes
-    ----------
-
-    date : float
-        Integer value representing the date from 1-31.
-    day : anyOf(:class:`Day`, string)
-        Value representing the day of a week.  This can be one of: (1) integer value --
-        ``1`` represents Monday; (2) case-insensitive day name (e.g., ``"Monday"`` );  (3)
-        case-insensitive, 3-character short day name (e.g., ``"Mon"`` ).   :raw-html:`<br/>`
-        **Warning:** A DateTime definition object with ``day`` ** should not be combined
-        with ``year``, ``quarter``, ``month``, or ``date``.
-    hours : float
-        Integer value representing the hour of a day from 0-23.
-    milliseconds : float
-        Integer value representing the millisecond segment of time.
-    minutes : float
-        Integer value representing the minute segment of time from 0-59.
-    month : anyOf(:class:`Month`, string)
-        One of: (1) integer value representing the month from ``1`` - ``12``. ``1``
-        represents January;  (2) case-insensitive month name (e.g., ``"January"`` );  (3)
-        case-insensitive, 3-character short month name (e.g., ``"Jan"`` ).
-    quarter : float
-        Integer value representing the quarter of the year (from 1-4).
-    seconds : float
-        Integer value representing the second segment (0-59) of a time value
-    utc : boolean
-        A boolean flag indicating if date time is in utc time. If false, the date time is in
-        local time
-    year : float
-        Integer value representing the year.
-    """
-    _schema = {'$ref': '#/definitions/DateTime'}
-    _rootschema = Root._schema
-
-    def __init__(self, date=Undefined, day=Undefined, hours=Undefined, milliseconds=Undefined,
-                 minutes=Undefined, month=Undefined, quarter=Undefined, seconds=Undefined,
-                 utc=Undefined, year=Undefined, **kwds):
-        super(DateTime, self).__init__(date=date, day=day, hours=hours, milliseconds=milliseconds,
-                                       minutes=minutes, month=month, quarter=quarter, seconds=seconds,
-                                       utc=utc, year=year, **kwds)
 
 
 class Day(VegaLiteSchema):
@@ -3865,7 +3544,7 @@ class Dir(VegaLiteSchema):
         super(Dir, self).__init__(*args)
 
 
-class DsvDataFormat(VegaLiteSchema):
+class DsvDataFormat(DataFormat):
     """DsvDataFormat schema wrapper
 
     Mapping(required=[delimiter])
@@ -3920,44 +3599,200 @@ class Element(VegaLiteSchema):
         super(Element, self).__init__(*args)
 
 
-class EncodingSortField(VegaLiteSchema):
-    """EncodingSortField schema wrapper
+class Encoding(VegaLiteSchema):
+    """Encoding schema wrapper
 
     Mapping(required=[])
-    A sort definition for sorting a discrete scale in an encoding field definition.
 
     Attributes
     ----------
 
-    field : :class:`Field`
-        The data `field <https://vega.github.io/vega-lite/docs/field.html>`__ to sort by.
+    color : anyOf(:class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`)
+        Color of the marks – either fill or stroke color based on  the ``filled`` property
+        of mark definition.
+        By default, ``color`` represents fill color for ``"area"``, ``"bar"``, ``"tick"``,
+        ``"text"``, ``"trail"``, ``"circle"``, and ``"square"`` / stroke color for
+        ``"line"`` and ``"point"``.
 
-        **Default value:** If unspecified, defaults to the field specified in the outer data
-        reference.
-    op : :class:`AggregateOp`
-        An `aggregate operation
-        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__ to perform on the
-        field prior to sorting (e.g., ``"count"``, ``"mean"`` and ``"median"`` ).
-        An aggregation is required when there are multiple values of the sort field for each
-        encoded data field.
-        The input data objects will be aggregated, grouped by the encoded data field.
+        **Default value:** If undefined, the default color depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
 
-        For a full list of operations, please see the documentation for `aggregate
-        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__.
+        *Note:*
+        1) For fine-grained control over both fill and stroke colors of the marks, please
+        use the ``fill`` and ``stroke`` channels.  If either ``fill`` or ``stroke`` channel
+        is specified, ``color`` channel will be ignored.
+        2) See the scale documentation for more information about customizing `color scheme
+        <https://vega.github.io/vega-lite/docs/scale.html#scheme>`__.
+    detail : anyOf(:class:`FieldDefWithoutScale`, List(:class:`FieldDefWithoutScale`))
+        Additional levels of detail for grouping data in aggregate views and
+        in line, trail, and area marks without mapping data to a specific visual channel.
+    fill : anyOf(:class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`)
+        Fill color of the marks.
+        **Default value:** If undefined, the default color depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
 
-        **Default value:** ``"sum"`` for stacked plots. Otherwise, ``"mean"``.
-    order : anyOf(:class:`SortOrder`, None)
-        The sort order. One of ``"ascending"`` (default), ``"descending"``, or ``null`` (no
-        not sort).
+        *Note:* When using ``fill`` channel, ``color`` channel will be ignored. To customize
+        both fill and stroke, please use ``fill`` and ``stroke`` channels (not ``fill`` and
+        ``color`` ).
+    fillOpacity : anyOf(:class:`NumericFieldDefWithCondition`,
+    :class:`NumericValueDefWithCondition`)
+        Fill opacity of the marks.
+
+        **Default value:** If undefined, the default opacity depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``fillOpacity``
+        property.
+    href : anyOf(:class:`TextFieldDefWithCondition`, :class:`TextValueDefWithCondition`)
+        A URL to load upon mouse click.
+    key : :class:`FieldDefWithoutScale`
+        A data field to use as a unique key for data binding. When a visualization’s data is
+        updated, the key value will be used to match data elements to existing mark
+        instances. Use a key channel to enable object constancy for transitions over dynamic
+        data.
+    latitude : anyOf(:class:`LatLongFieldDef`, :class:`NumberValueDef`)
+        Latitude position of geographically projected marks.
+    latitude2 : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
+        Latitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
+        ``"rect"``, and  ``"rule"``.
+    longitude : anyOf(:class:`LatLongFieldDef`, :class:`NumberValueDef`)
+        Longitude position of geographically projected marks.
+    longitude2 : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
+        Longitude-2 position for geographically projected ranged ``"area"``, ``"bar"``,
+        ``"rect"``, and  ``"rule"``.
+    opacity : anyOf(:class:`NumericFieldDefWithCondition`,
+    :class:`NumericValueDefWithCondition`)
+        Opacity of the marks.
+
+        **Default value:** If undefined, the default opacity depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``opacity`` property.
+    order : anyOf(:class:`OrderFieldDef`, List(:class:`OrderFieldDef`), :class:`NumberValueDef`)
+        Order of the marks.
+
+
+        * For stacked marks, this ``order`` channel encodes `stack order
+          <https://vega.github.io/vega-lite/docs/stack.html#order>`__.
+        * For line and trail marks, this ``order`` channel encodes order of data points in
+          the lines. This can be useful for creating `a connected scatterplot
+          <https://vega.github.io/vega-lite/examples/connected_scatterplot.html>`__.
+          Setting ``order`` to ``{"value": null}`` makes the line marks use the original
+          order in the data sources.
+        * Otherwise, this ``order`` channel encodes layer order of the marks.
+
+        **Note** : In aggregate plots, ``order`` field should be ``aggregate`` d to avoid
+        creating additional aggregation grouping.
+    shape : anyOf(:class:`ShapeFieldDefWithCondition`, :class:`ShapeValueDefWithCondition`)
+        Shape of the mark.
+
+
+        #.
+        For ``point`` marks the supported values include:
+
+
+        * plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
+        ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
+        ``"triangle-left"``.
+        * the line symbol ``"stroke"``
+        * centered directional shapes ``"arrow"``, ``"wedge"``, or ``"triangle"``
+        * a custom `SVG path string
+        <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ (For correct
+        sizing, custom shape paths should be defined within a square bounding box with
+        coordinates ranging from -1 to 1 along both the x and y dimensions.)
+
+        #.
+        For ``geoshape`` marks it should be a field definition of the geojson data
+
+        **Default value:** If undefined, the default shape depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#point-config>`__ 's ``shape``
+        property. ( ``"circle"`` if unset.)
+    size : anyOf(:class:`NumericFieldDefWithCondition`, :class:`NumericValueDefWithCondition`)
+        Size of the mark.
+
+
+        * For ``"point"``, ``"square"`` and ``"circle"``, – the symbol size, or pixel area
+          of the mark.
+        * For ``"bar"`` and ``"tick"`` – the bar and tick's size.
+        * For ``"text"`` – the text's font size.
+        * Size is unsupported for ``"line"``, ``"area"``, and ``"rect"``. (Use ``"trail"``
+          instead of line with varying size)
+    stroke : anyOf(:class:`StringFieldDefWithCondition`, :class:`StringValueDefWithCondition`)
+        Stroke color of the marks.
+        **Default value:** If undefined, the default color depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``color`` property.
+
+        *Note:* When using ``stroke`` channel, ``color`` channel will be ignored. To
+        customize both stroke and fill, please use ``stroke`` and ``fill`` channels (not
+        ``stroke`` and ``color`` ).
+    strokeOpacity : anyOf(:class:`NumericFieldDefWithCondition`,
+    :class:`NumericValueDefWithCondition`)
+        Stroke opacity of the marks.
+
+        **Default value:** If undefined, the default opacity depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``strokeOpacity``
+        property.
+    strokeWidth : anyOf(:class:`NumericFieldDefWithCondition`,
+    :class:`NumericValueDefWithCondition`)
+        Stroke width of the marks.
+
+        **Default value:** If undefined, the default stroke width depends on `mark config
+        <https://vega.github.io/vega-lite/docs/config.html#mark>`__ 's ``strokeWidth``
+        property.
+    text : anyOf(:class:`TextFieldDefWithCondition`, :class:`TextValueDefWithCondition`)
+        Text of the ``text`` mark.
+    tooltip : anyOf(:class:`TextFieldDefWithCondition`, :class:`TextValueDefWithCondition`,
+    List(:class:`TextFieldDef`), None)
+        The tooltip text to show upon mouse hover.
+    x : anyOf(:class:`PositionFieldDef`, :class:`XValueDef`)
+        X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"`` without
+        specified ``x2`` or ``width``.
+
+        The ``value`` of this channel can be a number or a string ``"width"`` for the width
+        of the plot.
+    x2 : anyOf(:class:`SecondaryFieldDef`, :class:`XValueDef`)
+        X2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
+
+        The ``value`` of this channel can be a number or a string ``"width"`` for the width
+        of the plot.
+    xError : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
+        Error value of x coordinates for error specified ``"errorbar"`` and ``"errorband"``.
+    xError2 : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
+        Secondary error value of x coordinates for error specified ``"errorbar"`` and
+        ``"errorband"``.
+    y : anyOf(:class:`PositionFieldDef`, :class:`YValueDef`)
+        Y coordinates of the marks, or height of vertical ``"bar"`` and ``"area"`` without
+        specified ``y2`` or ``height``.
+
+        The ``value`` of this channel can be a number or a string ``"height"`` for the
+        height of the plot.
+    y2 : anyOf(:class:`SecondaryFieldDef`, :class:`YValueDef`)
+        Y2 coordinates for ranged ``"area"``, ``"bar"``, ``"rect"``, and  ``"rule"``.
+
+        The ``value`` of this channel can be a number or a string ``"height"`` for the
+        height of the plot.
+    yError : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
+        Error value of y coordinates for error specified ``"errorbar"`` and ``"errorband"``.
+    yError2 : anyOf(:class:`SecondaryFieldDef`, :class:`NumberValueDef`)
+        Secondary error value of y coordinates for error specified ``"errorbar"`` and
+        ``"errorband"``.
     """
-    _schema = {'$ref': '#/definitions/EncodingSortField'}
+    _schema = {'$ref': '#/definitions/Encoding'}
     _rootschema = Root._schema
 
-    def __init__(self, field=Undefined, op=Undefined, order=Undefined, **kwds):
-        super(EncodingSortField, self).__init__(field=field, op=op, order=order, **kwds)
+    def __init__(self, color=Undefined, detail=Undefined, fill=Undefined, fillOpacity=Undefined,
+                 href=Undefined, key=Undefined, latitude=Undefined, latitude2=Undefined,
+                 longitude=Undefined, longitude2=Undefined, opacity=Undefined, order=Undefined,
+                 shape=Undefined, size=Undefined, stroke=Undefined, strokeOpacity=Undefined,
+                 strokeWidth=Undefined, text=Undefined, tooltip=Undefined, x=Undefined, x2=Undefined,
+                 xError=Undefined, xError2=Undefined, y=Undefined, y2=Undefined, yError=Undefined,
+                 yError2=Undefined, **kwds):
+        super(Encoding, self).__init__(color=color, detail=detail, fill=fill, fillOpacity=fillOpacity,
+                                       href=href, key=key, latitude=latitude, latitude2=latitude2,
+                                       longitude=longitude, longitude2=longitude2, opacity=opacity,
+                                       order=order, shape=shape, size=size, stroke=stroke,
+                                       strokeOpacity=strokeOpacity, strokeWidth=strokeWidth, text=text,
+                                       tooltip=tooltip, x=x, x2=x2, xError=xError, xError2=xError2, y=y,
+                                       y2=y2, yError=yError, yError2=yError2, **kwds)
 
 
-class ErrorBand(VegaLiteSchema):
+class ErrorBand(CompositeMark):
     """ErrorBand schema wrapper
 
     enum('errorband')
@@ -4028,7 +3863,7 @@ class ErrorBandConfig(VegaLiteSchema):
                                               interpolate=interpolate, tension=tension, **kwds)
 
 
-class ErrorBandDef(VegaLiteSchema):
+class ErrorBandDef(CompositeMarkDef):
     """ErrorBandDef schema wrapper
 
     Mapping(required=[type])
@@ -4110,7 +3945,7 @@ class ErrorBandDef(VegaLiteSchema):
                                            opacity=opacity, orient=orient, tension=tension, **kwds)
 
 
-class ErrorBar(VegaLiteSchema):
+class ErrorBar(CompositeMark):
     """ErrorBar schema wrapper
 
     enum('errorbar')
@@ -4154,7 +3989,7 @@ class ErrorBarConfig(VegaLiteSchema):
         super(ErrorBarConfig, self).__init__(extent=extent, rule=rule, ticks=ticks, **kwds)
 
 
-class ErrorBarDef(VegaLiteSchema):
+class ErrorBarDef(CompositeMarkDef):
     """ErrorBarDef schema wrapper
 
     Mapping(required=[type])
@@ -4615,185 +4450,6 @@ class FacetedEncoding(VegaLiteSchema):
                                               yError=yError, yError2=yError2, **kwds)
 
 
-class FacetedUnitSpec(VegaLiteSchema):
-    """FacetedUnitSpec schema wrapper
-
-    Mapping(required=[mark])
-    Unit spec that can have a composite mark and row or column channels (shorthand for a facet
-    spec).
-
-    Attributes
-    ----------
-
-    mark : :class:`AnyMark`
-        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
-        ``"tick"``, ``"line"``,
-        ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and ``"text"`` ) or a `mark
-        definition object <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
-    align : anyOf(:class:`LayoutAlign`, :class:`RowColLayoutAlign`)
-        The alignment to apply to grid rows and columns.
-        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
-
-
-        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
-          placed one after the other.
-        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
-          or column may be of variable size.
-        * For ``"all"``, subviews will be aligned and each row or column will be sized
-          identically based on the maximum observed size. String values for this property
-          will be applied to both grid rows and columns.
-
-        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
-        be used to supply different alignments for rows and columns.
-
-        **Default value:** ``"all"``.
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : anyOf(boolean, :class:`RowColboolean`)
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
-        supply different centering values for rows and columns.
-
-        **Default value:** ``false``
-    columns : float
-        The number of columns to include in the view composition layout.
-
-        **Default value** : ``undefined`` -- An infinite number of columns (a single row)
-        will be assumed. This is equivalent to
-        ``hconcat`` (for ``concat`` ) and to using the ``column`` channel (for ``facet`` and
-        ``repeat`` ).
-
-        **Note** :
-
-        1) This property is only for:
-
-
-        * the general (wrappable) ``concat`` operator (not ``hconcat`` / ``vconcat`` )
-        * the ``facet`` and ``repeat`` operator with one field/repetition definition
-          (without row/column nesting)
-
-        2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat`` )
-        and to using the ``row`` channel (for ``facet`` and ``repeat`` ).
-    data : anyOf(:class:`Data`, None)
-        An object describing the data source. Set to ``null`` to ignore the parent's data
-        source. If no data is set, it is derived from the parent.
-    description : string
-        Description of this mark for commenting purpose.
-    encoding : :class:`FacetedEncoding`
-        A key-value mapping between encoding channels and definition of fields.
-    height : float
-        The height of a visualization.
-
-        **Default value:**
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its y-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
-          be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For y-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the height is `determined by the range step, paddings, and the
-          cardinality of the field mapped to y-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
-          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
-          ``rangeStep``.
-
-        **Note** : For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        height of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    name : string
-        Name of the visualization for later reference.
-    projection : :class:`Projection`
-        An object defining properties of geographic projection, which will be applied to
-        ``shape`` path for ``"geoshape"`` marks
-        and to ``latitude`` and ``"longitude"`` channels for other marks.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for view composition specifications.
-    selection : Mapping(required=[])
-        A key-value mapping between selection names and definitions.
-    spacing : anyOf(float, :class:`RowColnumber`)
-        The spacing in pixels between sub-views of the composition operator.
-        An object of the form ``{"row": number, "column": number}`` can be used to set
-        different spacing values for rows and columns.
-
-        **Default value** : Depends on ``"spacing"`` property of `the view composition
-        configuration <https://vega.github.io/vega-lite/docs/config.html#view-config>`__ (
-        ``20`` by default)
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    view : :class:`ViewBackground`
-        An object defining the view background's fill and stroke.
-
-        **Default value:** none (transparent)
-    width : float
-        The width of a visualization.
-
-        **Default value:** This will be determined by the following rules:
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its x-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
-          be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For x-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the width is `determined by the range step, paddings, and the
-          cardinality of the field mapped to x-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
-          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
-          `config.scale.textXRangeStep
-          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
-          ``text`` mark and the value of ``rangeStep`` for other marks.
-
-        **Note:** For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        width of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    """
-    _schema = {'$ref': '#/definitions/FacetedUnitSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, mark=Undefined, align=Undefined, bounds=Undefined, center=Undefined,
-                 columns=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
-                 height=Undefined, name=Undefined, projection=Undefined, resolve=Undefined,
-                 selection=Undefined, spacing=Undefined, title=Undefined, transform=Undefined,
-                 view=Undefined, width=Undefined, **kwds):
-        super(FacetedUnitSpec, self).__init__(mark=mark, align=align, bounds=bounds, center=center,
-                                              columns=columns, data=data, description=description,
-                                              encoding=encoding, height=height, name=name,
-                                              projection=projection, resolve=resolve,
-                                              selection=selection, spacing=spacing, title=title,
-                                              transform=transform, view=view, width=width, **kwds)
-
-
 class Field(VegaLiteSchema):
     """Field schema wrapper
 
@@ -4804,408 +4460,6 @@ class Field(VegaLiteSchema):
 
     def __init__(self, *args, **kwds):
         super(Field, self).__init__(*args, **kwds)
-
-
-class FieldDefWithConditionMarkPropFieldDefstringnull(VegaLiteSchema):
-    """FieldDefWithConditionMarkPropFieldDefstringnull schema wrapper
-
-    Mapping(required=[type])
-    A FieldDef with Condition :raw-html:`<ValueDef>`
-
-    Attributes
-    ----------
-
-    type : :class:`StandardType`
-        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
-        ``"ordinal"``, or ``"nominal"`` ).
-        It can also be a ``"geojson"`` type for encoding `'geoshape'
-        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
-
-        **Note:**
-
-
-        * Data values for a temporal field can be either a date-time string (e.g.,
-          ``"2015-03-07 12:32:17"``, ``"17:01"``, ``"2015-03-16"``. ``"2015"`` ) or a
-          timestamp number (e.g., ``1552199579097`` ).
-        * Data ``type`` describes the semantics of the data rather than the primitive data
-          types ( ``number``, ``string``, etc.). The same primitive data type can have
-          different types of measurement. For example, numeric data can represent
-          quantitative, ordinal, or nominal data.
-        * When using with `bin <https://vega.github.io/vega-lite/docs/bin.html>`__, the
-          ``type`` property can be either ``"quantitative"`` (for using a linear bin scale)
-          or `"ordinal" (for using an ordinal bin scale)
-          <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
-        * When using with `timeUnit
-          <https://vega.github.io/vega-lite/docs/timeunit.html>`__, the ``type`` property
-          can be either ``"temporal"`` (for using a temporal scale) or `"ordinal" (for using
-          an ordinal scale) <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
-        * When using with `aggregate
-          <https://vega.github.io/vega-lite/docs/aggregate.html>`__, the ``type`` property
-          refers to the post-aggregation data type. For example, we can calculate count
-          ``distinct`` of a categorical field ``"cat"`` using ``{"aggregate": "distinct",
-          "field": "cat", "type": "quantitative"}``. The ``"type"`` of the aggregate output
-          is ``"quantitative"``.
-        * Secondary channels (e.g., ``x2``, ``y2``, ``xError``, ``yError`` ) do not have
-          ``type`` as they have exactly the same type as their primary channels (e.g.,
-          ``x``, ``y`` ).
-
-        **See also:** `type <https://vega.github.io/vega-lite/docs/type.html>`__
-        documentation.
-    aggregate : :class:`Aggregate`
-        Aggregation function for the field
-        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
-
-        **Default value:** ``undefined`` (None)
-
-        **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
-        documentation.
-    bin : anyOf(boolean, :class:`BinParams`, None)
-        A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
-
-
-        If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
-
-        If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
-        already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
-        field to ``x2`` (or ``y2`` ). The scale and axis will be formatted similar to
-        binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also
-        set the axis's `tickMinStep
-        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
-
-        **Default value:** ``false``
-
-        **See also:** `bin <https://vega.github.io/vega-lite/docs/bin.html>`__
-        documentation.
-    condition : anyOf(:class:`ConditionalStringValueDef`,
-    List(:class:`ConditionalStringValueDef`))
-        One or more value definition(s) with `a selection or a test predicate
-        <https://vega.github.io/vega-lite/docs/condition.html>`__.
-
-        **Note:** A field definition's ``condition`` property can only contain `conditional
-        value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
-        since Vega-Lite only allows at most one encoded field per encoding channel.
-    field : :class:`Field`
-        **Required.** A string defining the name of the field from which to pull a data
-        value
-        or an object defining iterated values from the `repeat
-        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
-
-        **See also:** `field <https://vega.github.io/vega-lite/docs/field.html>`__
-        documentation.
-
-        **Notes:**
-        1)  Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested
-        objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
-        If field names contain dots or brackets but are not nested, you can use ``\\`` to
-        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
-        See more details about escaping in the `field documentation
-        <https://vega.github.io/vega-lite/docs/field.html>`__.
-        2) ``field`` is not required if ``aggregate`` is ``count``.
-    legend : anyOf(:class:`Legend`, None)
-        An object defining properties of the legend.
-        If ``null``, the legend for the encoding channel will be removed.
-
-        **Default value:** If undefined, default `legend properties
-        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
-
-        **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
-        documentation.
-    scale : anyOf(:class:`Scale`, None)
-        An object defining properties of the channel's scale, which is the function that
-        transforms values in the data domain (numbers, dates, strings, etc) to visual values
-        (pixels, colors, sizes) of the encoding channels.
-
-        If ``null``, the scale will be `disabled and the data value will be directly encoded
-        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
-
-        **Default value:** If undefined, default `scale properties
-        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
-
-        **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
-        documentation.
-    sort : :class:`Sort`
-        Sort order for the encoded field.
-
-        For continuous fields (quantitative or temporal), ``sort`` can be either
-        ``"ascending"`` or ``"descending"``.
-
-        For discrete fields, ``sort`` can be one of the following:
-
-
-        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
-          Javascript.
-        * `A sort-by-encoding definition
-          <https://vega.github.io/vega-lite/docs/sort.html#sort-by-encoding>`__ for sorting
-          by another encoding channel. (This type of sort definition is not available for
-          ``row`` and ``column`` channels.)
-        * `A sort field definition
-          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
-          another field.
-        * `An array specifying the field values in preferred order
-          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
-          sort order will obey the values in the array, followed by any unspecified values
-          in their original order.  For discrete time field, values in the sort array can be
-          `date-time definition objects <types#datetime>`__. In addition, for time units
-          ``"month"`` and ``"day"``, the values can be the month or day names (case
-          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
-        * ``null`` indicating no sort.
-
-        **Default value:** ``"ascending"``
-
-        **Note:** ``null`` is not supported for ``row`` and ``column``.
-
-        **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
-        documentation.
-    timeUnit : :class:`TimeUnit`
-        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
-        field.
-        or `a temporal field that gets casted as ordinal
-        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
-
-        **Default value:** ``undefined`` (None)
-
-        **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
-        documentation.
-    title : anyOf(string, None)
-        A title for the field. If ``null``, the title will be removed.
-
-        **Default value:**  derived from the field's name and transformation function (
-        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
-        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
-        field is binned or has a time unit applied, the applied function is shown in
-        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
-        Otherwise, the title is simply the field name.
-
-        **Notes** :
-
-        1) You can customize the default field title format by providing the `fieldTitle
-        <https://vega.github.io/vega-lite/docs/config.html#top-level-config>`__ property in
-        the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or `fieldTitle
-        function via the compile function's options
-        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
-
-        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
-        defined, axis/header/legend title will be used.
-    """
-    _schema = {'$ref': '#/definitions/FieldDefWithCondition<MarkPropFieldDef,(string|null)>'}
-    _rootschema = Root._schema
-
-    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
-                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
-                 title=Undefined, **kwds):
-        super(FieldDefWithConditionMarkPropFieldDefstringnull, self).__init__(type=type,
-                                                                              aggregate=aggregate,
-                                                                              bin=bin,
-                                                                              condition=condition,
-                                                                              field=field,
-                                                                              legend=legend,
-                                                                              scale=scale, sort=sort,
-                                                                              timeUnit=timeUnit,
-                                                                              title=title, **kwds)
-
-
-class FieldDefWithConditionMarkPropFieldDefnumber(VegaLiteSchema):
-    """FieldDefWithConditionMarkPropFieldDefnumber schema wrapper
-
-    Mapping(required=[type])
-    A FieldDef with Condition :raw-html:`<ValueDef>`
-
-    Attributes
-    ----------
-
-    type : :class:`StandardType`
-        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
-        ``"ordinal"``, or ``"nominal"`` ).
-        It can also be a ``"geojson"`` type for encoding `'geoshape'
-        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
-
-        **Note:**
-
-
-        * Data values for a temporal field can be either a date-time string (e.g.,
-          ``"2015-03-07 12:32:17"``, ``"17:01"``, ``"2015-03-16"``. ``"2015"`` ) or a
-          timestamp number (e.g., ``1552199579097`` ).
-        * Data ``type`` describes the semantics of the data rather than the primitive data
-          types ( ``number``, ``string``, etc.). The same primitive data type can have
-          different types of measurement. For example, numeric data can represent
-          quantitative, ordinal, or nominal data.
-        * When using with `bin <https://vega.github.io/vega-lite/docs/bin.html>`__, the
-          ``type`` property can be either ``"quantitative"`` (for using a linear bin scale)
-          or `"ordinal" (for using an ordinal bin scale)
-          <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
-        * When using with `timeUnit
-          <https://vega.github.io/vega-lite/docs/timeunit.html>`__, the ``type`` property
-          can be either ``"temporal"`` (for using a temporal scale) or `"ordinal" (for using
-          an ordinal scale) <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
-        * When using with `aggregate
-          <https://vega.github.io/vega-lite/docs/aggregate.html>`__, the ``type`` property
-          refers to the post-aggregation data type. For example, we can calculate count
-          ``distinct`` of a categorical field ``"cat"`` using ``{"aggregate": "distinct",
-          "field": "cat", "type": "quantitative"}``. The ``"type"`` of the aggregate output
-          is ``"quantitative"``.
-        * Secondary channels (e.g., ``x2``, ``y2``, ``xError``, ``yError`` ) do not have
-          ``type`` as they have exactly the same type as their primary channels (e.g.,
-          ``x``, ``y`` ).
-
-        **See also:** `type <https://vega.github.io/vega-lite/docs/type.html>`__
-        documentation.
-    aggregate : :class:`Aggregate`
-        Aggregation function for the field
-        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
-
-        **Default value:** ``undefined`` (None)
-
-        **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
-        documentation.
-    bin : anyOf(boolean, :class:`BinParams`, None)
-        A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
-
-
-        If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
-
-        If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
-        already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
-        field to ``x2`` (or ``y2`` ). The scale and axis will be formatted similar to
-        binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also
-        set the axis's `tickMinStep
-        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
-
-        **Default value:** ``false``
-
-        **See also:** `bin <https://vega.github.io/vega-lite/docs/bin.html>`__
-        documentation.
-    condition : anyOf(:class:`ConditionalNumberValueDef`,
-    List(:class:`ConditionalNumberValueDef`))
-        One or more value definition(s) with `a selection or a test predicate
-        <https://vega.github.io/vega-lite/docs/condition.html>`__.
-
-        **Note:** A field definition's ``condition`` property can only contain `conditional
-        value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
-        since Vega-Lite only allows at most one encoded field per encoding channel.
-    field : :class:`Field`
-        **Required.** A string defining the name of the field from which to pull a data
-        value
-        or an object defining iterated values from the `repeat
-        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
-
-        **See also:** `field <https://vega.github.io/vega-lite/docs/field.html>`__
-        documentation.
-
-        **Notes:**
-        1)  Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested
-        objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
-        If field names contain dots or brackets but are not nested, you can use ``\\`` to
-        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
-        See more details about escaping in the `field documentation
-        <https://vega.github.io/vega-lite/docs/field.html>`__.
-        2) ``field`` is not required if ``aggregate`` is ``count``.
-    legend : anyOf(:class:`Legend`, None)
-        An object defining properties of the legend.
-        If ``null``, the legend for the encoding channel will be removed.
-
-        **Default value:** If undefined, default `legend properties
-        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
-
-        **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
-        documentation.
-    scale : anyOf(:class:`Scale`, None)
-        An object defining properties of the channel's scale, which is the function that
-        transforms values in the data domain (numbers, dates, strings, etc) to visual values
-        (pixels, colors, sizes) of the encoding channels.
-
-        If ``null``, the scale will be `disabled and the data value will be directly encoded
-        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
-
-        **Default value:** If undefined, default `scale properties
-        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
-
-        **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
-        documentation.
-    sort : :class:`Sort`
-        Sort order for the encoded field.
-
-        For continuous fields (quantitative or temporal), ``sort`` can be either
-        ``"ascending"`` or ``"descending"``.
-
-        For discrete fields, ``sort`` can be one of the following:
-
-
-        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
-          Javascript.
-        * `A sort-by-encoding definition
-          <https://vega.github.io/vega-lite/docs/sort.html#sort-by-encoding>`__ for sorting
-          by another encoding channel. (This type of sort definition is not available for
-          ``row`` and ``column`` channels.)
-        * `A sort field definition
-          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
-          another field.
-        * `An array specifying the field values in preferred order
-          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
-          sort order will obey the values in the array, followed by any unspecified values
-          in their original order.  For discrete time field, values in the sort array can be
-          `date-time definition objects <types#datetime>`__. In addition, for time units
-          ``"month"`` and ``"day"``, the values can be the month or day names (case
-          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
-        * ``null`` indicating no sort.
-
-        **Default value:** ``"ascending"``
-
-        **Note:** ``null`` is not supported for ``row`` and ``column``.
-
-        **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
-        documentation.
-    timeUnit : :class:`TimeUnit`
-        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
-        field.
-        or `a temporal field that gets casted as ordinal
-        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
-
-        **Default value:** ``undefined`` (None)
-
-        **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
-        documentation.
-    title : anyOf(string, None)
-        A title for the field. If ``null``, the title will be removed.
-
-        **Default value:**  derived from the field's name and transformation function (
-        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
-        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
-        field is binned or has a time unit applied, the applied function is shown in
-        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
-        Otherwise, the title is simply the field name.
-
-        **Notes** :
-
-        1) You can customize the default field title format by providing the `fieldTitle
-        <https://vega.github.io/vega-lite/docs/config.html#top-level-config>`__ property in
-        the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or `fieldTitle
-        function via the compile function's options
-        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
-
-        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
-        defined, axis/header/legend title will be used.
-    """
-    _schema = {'$ref': '#/definitions/FieldDefWithCondition<MarkPropFieldDef,number>'}
-    _rootschema = Root._schema
-
-    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
-                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
-                 title=Undefined, **kwds):
-        super(FieldDefWithConditionMarkPropFieldDefnumber, self).__init__(type=type,
-                                                                          aggregate=aggregate, bin=bin,
-                                                                          condition=condition,
-                                                                          field=field, legend=legend,
-                                                                          scale=scale, sort=sort,
-                                                                          timeUnit=timeUnit,
-                                                                          title=title, **kwds)
 
 
 class FieldDefWithConditionMarkPropFieldDefTypeForShapestringnull(VegaLiteSchema):
@@ -5410,6 +4664,408 @@ class FieldDefWithConditionMarkPropFieldDefTypeForShapestringnull(VegaLiteSchema
                                                                                           timeUnit=timeUnit,
                                                                                           title=title,
                                                                                           **kwds)
+
+
+class FieldDefWithConditionMarkPropFieldDefnumber(VegaLiteSchema):
+    """FieldDefWithConditionMarkPropFieldDefnumber schema wrapper
+
+    Mapping(required=[type])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    type : :class:`StandardType`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+
+        **Note:**
+
+
+        * Data values for a temporal field can be either a date-time string (e.g.,
+          ``"2015-03-07 12:32:17"``, ``"17:01"``, ``"2015-03-16"``. ``"2015"`` ) or a
+          timestamp number (e.g., ``1552199579097`` ).
+        * Data ``type`` describes the semantics of the data rather than the primitive data
+          types ( ``number``, ``string``, etc.). The same primitive data type can have
+          different types of measurement. For example, numeric data can represent
+          quantitative, ordinal, or nominal data.
+        * When using with `bin <https://vega.github.io/vega-lite/docs/bin.html>`__, the
+          ``type`` property can be either ``"quantitative"`` (for using a linear bin scale)
+          or `"ordinal" (for using an ordinal bin scale)
+          <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
+        * When using with `timeUnit
+          <https://vega.github.io/vega-lite/docs/timeunit.html>`__, the ``type`` property
+          can be either ``"temporal"`` (for using a temporal scale) or `"ordinal" (for using
+          an ordinal scale) <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
+        * When using with `aggregate
+          <https://vega.github.io/vega-lite/docs/aggregate.html>`__, the ``type`` property
+          refers to the post-aggregation data type. For example, we can calculate count
+          ``distinct`` of a categorical field ``"cat"`` using ``{"aggregate": "distinct",
+          "field": "cat", "type": "quantitative"}``. The ``"type"`` of the aggregate output
+          is ``"quantitative"``.
+        * Secondary channels (e.g., ``x2``, ``y2``, ``xError``, ``yError`` ) do not have
+          ``type`` as they have exactly the same type as their primary channels (e.g.,
+          ``x``, ``y`` ).
+
+        **See also:** `type <https://vega.github.io/vega-lite/docs/type.html>`__
+        documentation.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+
+        **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
+        documentation.
+    bin : anyOf(boolean, :class:`BinParams`, None)
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
+        already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
+        field to ``x2`` (or ``y2`` ). The scale and axis will be formatted similar to
+        binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also
+        set the axis's `tickMinStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+
+        **See also:** `bin <https://vega.github.io/vega-lite/docs/bin.html>`__
+        documentation.
+    condition : anyOf(:class:`ConditionalNumberValueDef`,
+    List(:class:`ConditionalNumberValueDef`))
+        One or more value definition(s) with `a selection or a test predicate
+        <https://vega.github.io/vega-lite/docs/condition.html>`__.
+
+        **Note:** A field definition's ``condition`` property can only contain `conditional
+        value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : :class:`Field`
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **See also:** `field <https://vega.github.io/vega-lite/docs/field.html>`__
+        documentation.
+
+        **Notes:**
+        1)  Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested
+        objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+        2) ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+
+        **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
+        documentation.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+
+        **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
+        documentation.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort-by-encoding definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-by-encoding>`__ for sorting
+          by another encoding channel. (This type of sort definition is not available for
+          ``row`` and ``column`` channels.)
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+
+        **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
+        documentation.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+
+        **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
+        documentation.
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the `fieldTitle
+        <https://vega.github.io/vega-lite/docs/config.html#top-level-config>`__ property in
+        the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or `fieldTitle
+        function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/FieldDefWithCondition<MarkPropFieldDef,number>'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, **kwds):
+        super(FieldDefWithConditionMarkPropFieldDefnumber, self).__init__(type=type,
+                                                                          aggregate=aggregate, bin=bin,
+                                                                          condition=condition,
+                                                                          field=field, legend=legend,
+                                                                          scale=scale, sort=sort,
+                                                                          timeUnit=timeUnit,
+                                                                          title=title, **kwds)
+
+
+class FieldDefWithConditionMarkPropFieldDefstringnull(VegaLiteSchema):
+    """FieldDefWithConditionMarkPropFieldDefstringnull schema wrapper
+
+    Mapping(required=[type])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    type : :class:`StandardType`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+
+        **Note:**
+
+
+        * Data values for a temporal field can be either a date-time string (e.g.,
+          ``"2015-03-07 12:32:17"``, ``"17:01"``, ``"2015-03-16"``. ``"2015"`` ) or a
+          timestamp number (e.g., ``1552199579097`` ).
+        * Data ``type`` describes the semantics of the data rather than the primitive data
+          types ( ``number``, ``string``, etc.). The same primitive data type can have
+          different types of measurement. For example, numeric data can represent
+          quantitative, ordinal, or nominal data.
+        * When using with `bin <https://vega.github.io/vega-lite/docs/bin.html>`__, the
+          ``type`` property can be either ``"quantitative"`` (for using a linear bin scale)
+          or `"ordinal" (for using an ordinal bin scale)
+          <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
+        * When using with `timeUnit
+          <https://vega.github.io/vega-lite/docs/timeunit.html>`__, the ``type`` property
+          can be either ``"temporal"`` (for using a temporal scale) or `"ordinal" (for using
+          an ordinal scale) <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
+        * When using with `aggregate
+          <https://vega.github.io/vega-lite/docs/aggregate.html>`__, the ``type`` property
+          refers to the post-aggregation data type. For example, we can calculate count
+          ``distinct`` of a categorical field ``"cat"`` using ``{"aggregate": "distinct",
+          "field": "cat", "type": "quantitative"}``. The ``"type"`` of the aggregate output
+          is ``"quantitative"``.
+        * Secondary channels (e.g., ``x2``, ``y2``, ``xError``, ``yError`` ) do not have
+          ``type`` as they have exactly the same type as their primary channels (e.g.,
+          ``x``, ``y`` ).
+
+        **See also:** `type <https://vega.github.io/vega-lite/docs/type.html>`__
+        documentation.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+
+        **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
+        documentation.
+    bin : anyOf(boolean, :class:`BinParams`, None)
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
+        already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
+        field to ``x2`` (or ``y2`` ). The scale and axis will be formatted similar to
+        binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also
+        set the axis's `tickMinStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+
+        **See also:** `bin <https://vega.github.io/vega-lite/docs/bin.html>`__
+        documentation.
+    condition : anyOf(:class:`ConditionalStringValueDef`,
+    List(:class:`ConditionalStringValueDef`))
+        One or more value definition(s) with `a selection or a test predicate
+        <https://vega.github.io/vega-lite/docs/condition.html>`__.
+
+        **Note:** A field definition's ``condition`` property can only contain `conditional
+        value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : :class:`Field`
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **See also:** `field <https://vega.github.io/vega-lite/docs/field.html>`__
+        documentation.
+
+        **Notes:**
+        1)  Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested
+        objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+        2) ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+
+        **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
+        documentation.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+
+        **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
+        documentation.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort-by-encoding definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-by-encoding>`__ for sorting
+          by another encoding channel. (This type of sort definition is not available for
+          ``row`` and ``column`` channels.)
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+
+        **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
+        documentation.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+
+        **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
+        documentation.
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the `fieldTitle
+        <https://vega.github.io/vega-lite/docs/config.html#top-level-config>`__ property in
+        the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or `fieldTitle
+        function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/FieldDefWithCondition<MarkPropFieldDef,(string|null)>'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, **kwds):
+        super(FieldDefWithConditionMarkPropFieldDefstringnull, self).__init__(type=type,
+                                                                              aggregate=aggregate,
+                                                                              bin=bin,
+                                                                              condition=condition,
+                                                                              field=field,
+                                                                              legend=legend,
+                                                                              scale=scale, sort=sort,
+                                                                              timeUnit=timeUnit,
+                                                                              title=title, **kwds)
 
 
 class FieldDefWithConditionTextFieldDefValue(VegaLiteSchema):
@@ -5713,117 +5369,7 @@ class FieldDefWithoutScale(VegaLiteSchema):
                                                    timeUnit=timeUnit, title=title, **kwds)
 
 
-class FieldEqualPredicate(VegaLiteSchema):
-    """FieldEqualPredicate schema wrapper
-
-    Mapping(required=[equal, field])
-
-    Attributes
-    ----------
-
-    equal : anyOf(string, float, boolean, :class:`DateTime`)
-        The value that the field should be equal to.
-    field : :class:`FieldName`
-        Field to be filtered.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldEqualPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, equal=Undefined, field=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldEqualPredicate, self).__init__(equal=equal, field=field, timeUnit=timeUnit, **kwds)
-
-
-class FieldGTEPredicate(VegaLiteSchema):
-    """FieldGTEPredicate schema wrapper
-
-    Mapping(required=[field, gte])
-
-    Attributes
-    ----------
-
-    field : :class:`FieldName`
-        Field to be filtered.
-    gte : anyOf(string, float, :class:`DateTime`)
-        The value that the field should be greater than or equals to.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldGTEPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, gte=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldGTEPredicate, self).__init__(field=field, gte=gte, timeUnit=timeUnit, **kwds)
-
-
-class FieldGTPredicate(VegaLiteSchema):
-    """FieldGTPredicate schema wrapper
-
-    Mapping(required=[field, gt])
-
-    Attributes
-    ----------
-
-    field : :class:`FieldName`
-        Field to be filtered.
-    gt : anyOf(string, float, :class:`DateTime`)
-        The value that the field should be greater than.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldGTPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, gt=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldGTPredicate, self).__init__(field=field, gt=gt, timeUnit=timeUnit, **kwds)
-
-
-class FieldLTEPredicate(VegaLiteSchema):
-    """FieldLTEPredicate schema wrapper
-
-    Mapping(required=[field, lte])
-
-    Attributes
-    ----------
-
-    field : :class:`FieldName`
-        Field to be filtered.
-    lte : anyOf(string, float, :class:`DateTime`)
-        The value that the field should be less than or equals to.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldLTEPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, lte=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldLTEPredicate, self).__init__(field=field, lte=lte, timeUnit=timeUnit, **kwds)
-
-
-class FieldLTPredicate(VegaLiteSchema):
-    """FieldLTPredicate schema wrapper
-
-    Mapping(required=[field, lt])
-
-    Attributes
-    ----------
-
-    field : :class:`FieldName`
-        Field to be filtered.
-    lt : anyOf(string, float, :class:`DateTime`)
-        The value that the field should be less than.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldLTPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, lt=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldLTPredicate, self).__init__(field=field, lt=lt, timeUnit=timeUnit, **kwds)
-
-
-class FieldName(VegaLiteSchema):
+class FieldName(Field):
     """FieldName schema wrapper
 
     string
@@ -5833,161 +5379,6 @@ class FieldName(VegaLiteSchema):
 
     def __init__(self, *args):
         super(FieldName, self).__init__(*args)
-
-
-class FieldOneOfPredicate(VegaLiteSchema):
-    """FieldOneOfPredicate schema wrapper
-
-    Mapping(required=[field, oneOf])
-
-    Attributes
-    ----------
-
-    field : :class:`FieldName`
-        Field to be filtered.
-    oneOf : anyOf(List(string), List(float), List(boolean), List(:class:`DateTime`))
-        A set of values that the ``field`` 's value should be a member of,
-        for a data item included in the filtered data.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldOneOfPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, oneOf=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldOneOfPredicate, self).__init__(field=field, oneOf=oneOf, timeUnit=timeUnit, **kwds)
-
-
-class FieldRangePredicate(VegaLiteSchema):
-    """FieldRangePredicate schema wrapper
-
-    Mapping(required=[field, range])
-
-    Attributes
-    ----------
-
-    field : :class:`FieldName`
-        Field to be filtered.
-    range : List(anyOf(float, :class:`DateTime`, None))
-        An array of inclusive minimum and maximum values
-        for a field value of a data item to be included in the filtered data.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldRangePredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, range=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldRangePredicate, self).__init__(field=field, range=range, timeUnit=timeUnit, **kwds)
-
-
-class FieldValidPredicate(VegaLiteSchema):
-    """FieldValidPredicate schema wrapper
-
-    Mapping(required=[field, valid])
-
-    Attributes
-    ----------
-
-    field : :class:`FieldName`
-        Field to be filtered.
-    valid : boolean
-        If set to true the field's value has to be valid, meaning both not ``null`` and not
-        `NaN
-        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN>`__.
-    timeUnit : :class:`TimeUnit`
-        Time unit for the field to be filtered.
-    """
-    _schema = {'$ref': '#/definitions/FieldValidPredicate'}
-    _rootschema = Root._schema
-
-    def __init__(self, field=Undefined, valid=Undefined, timeUnit=Undefined, **kwds):
-        super(FieldValidPredicate, self).__init__(field=field, valid=valid, timeUnit=timeUnit, **kwds)
-
-
-class FilterTransform(VegaLiteSchema):
-    """FilterTransform schema wrapper
-
-    Mapping(required=[filter])
-
-    Attributes
-    ----------
-
-    filter : :class:`LogicalOperandPredicate`
-        The ``filter`` property must be one of the predicate definitions:
-
-        1) an `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`__
-        string,
-        where ``datum`` can be used to refer to the current data object
-
-        2) one of the field predicates: `equal
-        <https://vega.github.io/vega-lite/docs/filter.html#equal-predicate>`__,
-        `lt <https://vega.github.io/vega-lite/docs/filter.html#lt-predicate>`__,
-        `lte <https://vega.github.io/vega-lite/docs/filter.html#lte-predicate>`__,
-        `gt <https://vega.github.io/vega-lite/docs/filter.html#gt-predicate>`__,
-        `gte <https://vega.github.io/vega-lite/docs/filter.html#gte-predicate>`__,
-        `range <https://vega.github.io/vega-lite/docs/filter.html#range-predicate>`__,
-        `oneOf <https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate>`__,
-        or `valid <https://vega.github.io/vega-lite/docs/filter.html#valid-predicate>`__,
-
-        3) a `selection predicate
-        <https://vega.github.io/vega-lite/docs/filter.html#selection-predicate>`__
-
-        4) a logical operand that combines (1), (2), or (3).
-    """
-    _schema = {'$ref': '#/definitions/FilterTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, filter=Undefined, **kwds):
-        super(FilterTransform, self).__init__(filter=filter, **kwds)
-
-
-class FlattenTransform(VegaLiteSchema):
-    """FlattenTransform schema wrapper
-
-    Mapping(required=[flatten])
-
-    Attributes
-    ----------
-
-    flatten : List(:class:`FieldName`)
-        An array of one or more data fields containing arrays to flatten.
-        If multiple fields are specified, their array values should have a parallel
-        structure, ideally with the same length.
-        If the lengths of parallel arrays do not match,
-        the longest array will be used with ``null`` values added for missing entries.
-    as : List(:class:`FieldName`)
-        The output field names for extracted array values.
-
-        **Default value:** The field name of the corresponding array field
-    """
-    _schema = {'$ref': '#/definitions/FlattenTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, flatten=Undefined, **kwds):
-        super(FlattenTransform, self).__init__(flatten=flatten, **kwds)
-
-
-class FoldTransform(VegaLiteSchema):
-    """FoldTransform schema wrapper
-
-    Mapping(required=[fold])
-
-    Attributes
-    ----------
-
-    fold : List(:class:`FieldName`)
-        An array of data fields indicating the properties to fold.
-    as : List([:class:`FieldName`, :class:`FieldName`])
-        The output field names for the key and value properties produced by the fold
-        transform.
-        **Default value:** ``["key", "value"]``
-    """
-    _schema = {'$ref': '#/definitions/FoldTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, fold=Undefined, **kwds):
-        super(FoldTransform, self).__init__(fold=fold, **kwds)
 
 
 class FontStyle(VegaLiteSchema):
@@ -6014,7 +5405,7 @@ class FontWeight(VegaLiteSchema):
         super(FontWeight, self).__init__(*args)
 
 
-class Generator(VegaLiteSchema):
+class Generator(Data):
     """Generator schema wrapper
 
     anyOf(:class:`SequenceGenerator`, :class:`SphereGenerator`, :class:`GraticuleGenerator`)
@@ -6024,395 +5415,6 @@ class Generator(VegaLiteSchema):
 
     def __init__(self, *args, **kwds):
         super(Generator, self).__init__(*args, **kwds)
-
-
-class ConcatSpec(VegaLiteSchema):
-    """ConcatSpec schema wrapper
-
-    Mapping(required=[concat])
-    Base interface for a generalized concatenation specification.
-
-    Attributes
-    ----------
-
-    concat : List(:class:`Spec`)
-        A list of views to be concatenated.
-    align : anyOf(:class:`LayoutAlign`, :class:`RowColLayoutAlign`)
-        The alignment to apply to grid rows and columns.
-        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
-
-
-        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
-          placed one after the other.
-        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
-          or column may be of variable size.
-        * For ``"all"``, subviews will be aligned and each row or column will be sized
-          identically based on the maximum observed size. String values for this property
-          will be applied to both grid rows and columns.
-
-        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
-        be used to supply different alignments for rows and columns.
-
-        **Default value:** ``"all"``.
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : anyOf(boolean, :class:`RowColboolean`)
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
-        supply different centering values for rows and columns.
-
-        **Default value:** ``false``
-    columns : float
-        The number of columns to include in the view composition layout.
-
-        **Default value** : ``undefined`` -- An infinite number of columns (a single row)
-        will be assumed. This is equivalent to
-        ``hconcat`` (for ``concat`` ) and to using the ``column`` channel (for ``facet`` and
-        ``repeat`` ).
-
-        **Note** :
-
-        1) This property is only for:
-
-
-        * the general (wrappable) ``concat`` operator (not ``hconcat`` / ``vconcat`` )
-        * the ``facet`` and ``repeat`` operator with one field/repetition definition
-          (without row/column nesting)
-
-        2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat`` )
-        and to using the ``row`` channel (for ``facet`` and ``repeat`` ).
-    data : anyOf(:class:`Data`, None)
-        An object describing the data source. Set to ``null`` to ignore the parent's data
-        source. If no data is set, it is derived from the parent.
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for view composition specifications.
-    spacing : anyOf(float, :class:`RowColnumber`)
-        The spacing in pixels between sub-views of the composition operator.
-        An object of the form ``{"row": number, "column": number}`` can be used to set
-        different spacing values for rows and columns.
-
-        **Default value** : Depends on ``"spacing"`` property of `the view composition
-        configuration <https://vega.github.io/vega-lite/docs/config.html#view-config>`__ (
-        ``20`` by default)
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    """
-    _schema = {'$ref': '#/definitions/ConcatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, concat=Undefined, align=Undefined, bounds=Undefined, center=Undefined,
-                 columns=Undefined, data=Undefined, description=Undefined, name=Undefined,
-                 resolve=Undefined, spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
-        super(ConcatSpec, self).__init__(concat=concat, align=align, bounds=bounds, center=center,
-                                         columns=columns, data=data, description=description, name=name,
-                                         resolve=resolve, spacing=spacing, title=title,
-                                         transform=transform, **kwds)
-
-
-class FacetSpec(VegaLiteSchema):
-    """FacetSpec schema wrapper
-
-    Mapping(required=[facet, spec])
-    Base interface for a facet specification.
-
-    Attributes
-    ----------
-
-    facet : anyOf(:class:`FacetFieldDef`, :class:`FacetMapping`)
-        Definition for how to facet the data.  One of:
-        1) `a field definition for faceting the plot by one field
-        <https://vega.github.io/vega-lite/docs/facet.html#field-def>`__
-        2) `An object that maps row and column channels to their field definitions
-        <https://vega.github.io/vega-lite/docs/facet.html#mapping>`__
-    spec : anyOf(:class:`LayerSpec`, :class:`FacetedUnitSpec`)
-        A specification of the view that gets faceted.
-    align : anyOf(:class:`LayoutAlign`, :class:`RowColLayoutAlign`)
-        The alignment to apply to grid rows and columns.
-        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
-
-
-        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
-          placed one after the other.
-        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
-          or column may be of variable size.
-        * For ``"all"``, subviews will be aligned and each row or column will be sized
-          identically based on the maximum observed size. String values for this property
-          will be applied to both grid rows and columns.
-
-        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
-        be used to supply different alignments for rows and columns.
-
-        **Default value:** ``"all"``.
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : anyOf(boolean, :class:`RowColboolean`)
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
-        supply different centering values for rows and columns.
-
-        **Default value:** ``false``
-    columns : float
-        The number of columns to include in the view composition layout.
-
-        **Default value** : ``undefined`` -- An infinite number of columns (a single row)
-        will be assumed. This is equivalent to
-        ``hconcat`` (for ``concat`` ) and to using the ``column`` channel (for ``facet`` and
-        ``repeat`` ).
-
-        **Note** :
-
-        1) This property is only for:
-
-
-        * the general (wrappable) ``concat`` operator (not ``hconcat`` / ``vconcat`` )
-        * the ``facet`` and ``repeat`` operator with one field/repetition definition
-          (without row/column nesting)
-
-        2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat`` )
-        and to using the ``row`` channel (for ``facet`` and ``repeat`` ).
-    data : anyOf(:class:`Data`, None)
-        An object describing the data source. Set to ``null`` to ignore the parent's data
-        source. If no data is set, it is derived from the parent.
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for view composition specifications.
-    spacing : anyOf(float, :class:`RowColnumber`)
-        The spacing in pixels between sub-views of the composition operator.
-        An object of the form ``{"row": number, "column": number}`` can be used to set
-        different spacing values for rows and columns.
-
-        **Default value** : Depends on ``"spacing"`` property of `the view composition
-        configuration <https://vega.github.io/vega-lite/docs/config.html#view-config>`__ (
-        ``20`` by default)
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    """
-    _schema = {'$ref': '#/definitions/FacetSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, facet=Undefined, spec=Undefined, align=Undefined, bounds=Undefined,
-                 center=Undefined, columns=Undefined, data=Undefined, description=Undefined,
-                 name=Undefined, resolve=Undefined, spacing=Undefined, title=Undefined,
-                 transform=Undefined, **kwds):
-        super(FacetSpec, self).__init__(facet=facet, spec=spec, align=align, bounds=bounds,
-                                        center=center, columns=columns, data=data,
-                                        description=description, name=name, resolve=resolve,
-                                        spacing=spacing, title=title, transform=transform, **kwds)
-
-
-class HConcatSpec(VegaLiteSchema):
-    """HConcatSpec schema wrapper
-
-    Mapping(required=[hconcat])
-    Base interface for a horizontal concatenation specification.
-
-    Attributes
-    ----------
-
-    hconcat : List(:class:`Spec`)
-        A list of views to be concatenated and put into a row.
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : boolean
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        **Default value:** ``false``
-    data : anyOf(:class:`Data`, None)
-        An object describing the data source. Set to ``null`` to ignore the parent's data
-        source. If no data is set, it is derived from the parent.
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for view composition specifications.
-    spacing : float
-        The spacing in pixels between sub-views of the concat operator.
-
-        **Default value** : ``10``
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    """
-    _schema = {'$ref': '#/definitions/HConcatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, hconcat=Undefined, bounds=Undefined, center=Undefined, data=Undefined,
-                 description=Undefined, name=Undefined, resolve=Undefined, spacing=Undefined,
-                 title=Undefined, transform=Undefined, **kwds):
-        super(HConcatSpec, self).__init__(hconcat=hconcat, bounds=bounds, center=center, data=data,
-                                          description=description, name=name, resolve=resolve,
-                                          spacing=spacing, title=title, transform=transform, **kwds)
-
-
-class RepeatSpec(VegaLiteSchema):
-    """RepeatSpec schema wrapper
-
-    Mapping(required=[repeat, spec])
-    Base interface for a repeat specification.
-
-    Attributes
-    ----------
-
-    repeat : anyOf(List(string), :class:`RepeatMapping`)
-        Definition for fields to be repeated.  One of:
-        1) An array of fields to be repeated.  If ``"repeat"`` is an array, the field can be
-        referred using ``{"repeat": "repeat"}``
-        2) An object that mapped ``"row"`` and/or ``"column"`` to the listed of fields to be
-        repeated along the particular orientations. The objects ``{"repeat": "row"}`` and
-        ``{"repeat": "column"}`` can be used to refer to the repeated field respectively.
-    spec : :class:`Spec`
-        A specification of the view that gets repeated.
-    align : anyOf(:class:`LayoutAlign`, :class:`RowColLayoutAlign`)
-        The alignment to apply to grid rows and columns.
-        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
-
-
-        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
-          placed one after the other.
-        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
-          or column may be of variable size.
-        * For ``"all"``, subviews will be aligned and each row or column will be sized
-          identically based on the maximum observed size. String values for this property
-          will be applied to both grid rows and columns.
-
-        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
-        be used to supply different alignments for rows and columns.
-
-        **Default value:** ``"all"``.
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : anyOf(boolean, :class:`RowColboolean`)
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
-        supply different centering values for rows and columns.
-
-        **Default value:** ``false``
-    columns : float
-        The number of columns to include in the view composition layout.
-
-        **Default value** : ``undefined`` -- An infinite number of columns (a single row)
-        will be assumed. This is equivalent to
-        ``hconcat`` (for ``concat`` ) and to using the ``column`` channel (for ``facet`` and
-        ``repeat`` ).
-
-        **Note** :
-
-        1) This property is only for:
-
-
-        * the general (wrappable) ``concat`` operator (not ``hconcat`` / ``vconcat`` )
-        * the ``facet`` and ``repeat`` operator with one field/repetition definition
-          (without row/column nesting)
-
-        2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat`` )
-        and to using the ``row`` channel (for ``facet`` and ``repeat`` ).
-    data : anyOf(:class:`Data`, None)
-        An object describing the data source. Set to ``null`` to ignore the parent's data
-        source. If no data is set, it is derived from the parent.
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for view composition specifications.
-    spacing : anyOf(float, :class:`RowColnumber`)
-        The spacing in pixels between sub-views of the composition operator.
-        An object of the form ``{"row": number, "column": number}`` can be used to set
-        different spacing values for rows and columns.
-
-        **Default value** : Depends on ``"spacing"`` property of `the view composition
-        configuration <https://vega.github.io/vega-lite/docs/config.html#view-config>`__ (
-        ``20`` by default)
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    """
-    _schema = {'$ref': '#/definitions/RepeatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, repeat=Undefined, spec=Undefined, align=Undefined, bounds=Undefined,
-                 center=Undefined, columns=Undefined, data=Undefined, description=Undefined,
-                 name=Undefined, resolve=Undefined, spacing=Undefined, title=Undefined,
-                 transform=Undefined, **kwds):
-        super(RepeatSpec, self).__init__(repeat=repeat, spec=spec, align=align, bounds=bounds,
-                                         center=center, columns=columns, data=data,
-                                         description=description, name=name, resolve=resolve,
-                                         spacing=spacing, title=title, transform=transform, **kwds)
-
-
-class Spec(VegaLiteSchema):
-    """Spec schema wrapper
-
-    anyOf(:class:`FacetedUnitSpec`, :class:`LayerSpec`, :class:`FacetSpec`, :class:`RepeatSpec`,
-    :class:`ConcatSpec`, :class:`VConcatSpec`, :class:`HConcatSpec`)
-    Any specification in Vega-Lite.
-    """
-    _schema = {'$ref': '#/definitions/Spec'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(Spec, self).__init__(*args, **kwds)
 
 
 class GenericUnitSpecEncodingAnyMark(VegaLiteSchema):
@@ -6525,64 +5527,7 @@ class GenericUnitSpecEncodingAnyMark(VegaLiteSchema):
                                                              view=view, width=width, **kwds)
 
 
-class VConcatSpec(VegaLiteSchema):
-    """VConcatSpec schema wrapper
-
-    Mapping(required=[vconcat])
-    Base interface for a vertical concatenation specification.
-
-    Attributes
-    ----------
-
-    vconcat : List(:class:`Spec`)
-        A list of views to be concatenated and put into a column.
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : boolean
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        **Default value:** ``false``
-    data : anyOf(:class:`Data`, None)
-        An object describing the data source. Set to ``null`` to ignore the parent's data
-        source. If no data is set, it is derived from the parent.
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for view composition specifications.
-    spacing : float
-        The spacing in pixels between sub-views of the concat operator.
-
-        **Default value** : ``10``
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    """
-    _schema = {'$ref': '#/definitions/VConcatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, vconcat=Undefined, bounds=Undefined, center=Undefined, data=Undefined,
-                 description=Undefined, name=Undefined, resolve=Undefined, spacing=Undefined,
-                 title=Undefined, transform=Undefined, **kwds):
-        super(VConcatSpec, self).__init__(vconcat=vconcat, bounds=bounds, center=center, data=data,
-                                          description=description, name=name, resolve=resolve,
-                                          spacing=spacing, title=title, transform=transform, **kwds)
-
-
-class GraticuleGenerator(VegaLiteSchema):
+class GraticuleGenerator(Generator):
     """GraticuleGenerator schema wrapper
 
     Mapping(required=[graticule])
@@ -6940,7 +5885,7 @@ class HeaderConfig(VegaLiteSchema):
                                            titleOrient=titleOrient, titlePadding=titlePadding, **kwds)
 
 
-class HexColor(VegaLiteSchema):
+class HexColor(Color):
     """HexColor schema wrapper
 
     string
@@ -7033,62 +5978,7 @@ class ImputeSequence(VegaLiteSchema):
         super(ImputeSequence, self).__init__(stop=stop, start=start, step=step, **kwds)
 
 
-class ImputeTransform(VegaLiteSchema):
-    """ImputeTransform schema wrapper
-
-    Mapping(required=[impute, key])
-
-    Attributes
-    ----------
-
-    impute : :class:`FieldName`
-        The data field for which the missing values should be imputed.
-    key : :class:`FieldName`
-        A key field that uniquely identifies data objects within a group.
-        Missing key values (those occurring in the data but not in the current group) will
-        be imputed.
-    frame : List(anyOf(None, float))
-        A frame specification as a two-element array used to control the window over which
-        the specified method is applied. The array entries should either be a number
-        indicating the offset from the current data object, or null to indicate unbounded
-        rows preceding or following the current data object.  For example, the value ``[-5,
-        5]`` indicates that the window should include five objects preceding and five
-        objects following the current object.
-
-        **Default value:** :  ``[null, null]`` indicating that the window includes all
-        objects.
-    groupby : List(:class:`FieldName`)
-        An optional array of fields by which to group the values.
-        Imputation will then be performed on a per-group basis.
-    keyvals : anyOf(List(Mapping(required=[])), :class:`ImputeSequence`)
-        Defines the key values that should be considered for imputation.
-        An array of key values or an object defining a `number sequence
-        <https://vega.github.io/vega-lite/docs/impute.html#sequence-def>`__.
-
-        If provided, this will be used in addition to the key values observed within the
-        input data.  If not provided, the values will be derived from all unique values of
-        the ``key`` field. For ``impute`` in ``encoding``, the key field is the x-field if
-        the y-field is imputed, or vice versa.
-
-        If there is no impute grouping, this property *must* be specified.
-    method : :class:`ImputeMethod`
-        The imputation method to use for the field value of imputed data objects.
-        One of ``value``, ``mean``, ``median``, ``max`` or ``min``.
-
-        **Default value:**  ``"value"``
-    value : Mapping(required=[])
-        The field value to use when the imputation ``method`` is ``"value"``.
-    """
-    _schema = {'$ref': '#/definitions/ImputeTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, impute=Undefined, key=Undefined, frame=Undefined, groupby=Undefined,
-                 keyvals=Undefined, method=Undefined, value=Undefined, **kwds):
-        super(ImputeTransform, self).__init__(impute=impute, key=key, frame=frame, groupby=groupby,
-                                              keyvals=keyvals, method=method, value=value, **kwds)
-
-
-class InlineData(VegaLiteSchema):
+class InlineData(DataSource):
     """InlineData schema wrapper
 
     Mapping(required=[values])
@@ -7126,7 +6016,7 @@ class InlineDataset(VegaLiteSchema):
         super(InlineDataset, self).__init__(*args, **kwds)
 
 
-class InputBinding(VegaLiteSchema):
+class InputBinding(Binding):
     """InputBinding schema wrapper
 
     Mapping(required=[])
@@ -7170,115 +6060,6 @@ class Interpolate(VegaLiteSchema):
 
     def __init__(self, *args):
         super(Interpolate, self).__init__(*args)
-
-
-class IntervalSelection(VegaLiteSchema):
-    """IntervalSelection schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('interval')
-        Determines the default event processing and data query for the selection. Vega-Lite
-        currently supports three selection types:
-
-
-        * ``single`` -- to select a single discrete data value on ``click``.
-        * ``multi`` -- to select multiple discrete data value; the first value is selected
-          on ``click`` and additional values toggled on shift- ``click``.
-        * ``interval`` -- to select a continuous range of data values on ``drag``.
-    bind : enum('scales')
-        Establishes a two-way binding between the interval selection and the scales
-        used within the same view. This allows a user to interactively pan and
-        zoom the view.
-
-        **See also:** `bind <https://vega.github.io/vega-lite/docs/bind.html>`__
-        documentation.
-    clear : anyOf(:class:`EventStream`, boolean)
-        Clears the selection, emptying it of all values. Can be an
-        `EventStream <https://vega.github.io/vega/docs/event-streams/>`__ or ``false`` to
-        disable.
-
-        **Default value:** ``dblclick``.
-
-        **See also:** `clear <https://vega.github.io/vega-lite/docs/clear.html>`__
-        documentation.
-    empty : enum('all', 'none')
-        By default, ``all`` data values are considered to lie within an empty selection.
-        When set to ``none``, empty selections contain no data values.
-    encodings : List(:class:`SingleDefUnitChannel`)
-        An array of encoding channels. The corresponding data field values
-        must match for a data tuple to fall within the selection.
-
-        **See also:** `encodings <https://vega.github.io/vega-lite/docs/project.html>`__
-        documentation.
-    fields : List(:class:`FieldName`)
-        An array of field names whose values must match for a data tuple to
-        fall within the selection.
-
-        **See also:** `fields <https://vega.github.io/vega-lite/docs/project.html>`__
-        documentation.
-    init : :class:`SelectionInitIntervalMapping`
-        Initialize the selection with a mapping between `projected channels or field names
-        <https://vega.github.io/vega-lite/docs/project.html>`__ and arrays of
-        initial values.
-
-        **See also:** `init <https://vega.github.io/vega-lite/docs/init.html>`__
-        documentation.
-    mark : :class:`BrushConfig`
-        An interval selection also adds a rectangle mark to depict the
-        extents of the interval. The ``mark`` property can be used to customize the
-        appearance of the mark.
-
-        **See also:** `mark <https://vega.github.io/vega-lite/docs/selection-mark.html>`__
-        documentation.
-    on : :class:`EventStream`
-        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
-        selector) that triggers the selection.
-        For interval selections, the event stream must specify a `start and end
-        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
-    resolve : :class:`SelectionResolution`
-        With layered and multi-view displays, a strategy that determines how
-        selections' data queries are resolved when applied in a filter transform,
-        conditional encoding rule, or scale domain.
-
-        **See also:** `resolve
-        <https://vega.github.io/vega-lite/docs/selection-resolve.html>`__ documentation.
-    translate : anyOf(string, boolean)
-        When truthy, allows a user to interactively move an interval selection
-        back-and-forth. Can be ``true``, ``false`` (to disable panning), or a
-        `Vega event stream definition <https://vega.github.io/vega/docs/event-streams/>`__
-        which must include a start and end event to trigger continuous panning.
-
-        **Default value:** ``true``, which corresponds to
-        ``[mousedown, window:mouseup] > window:mousemove!`` which corresponds to
-        clicks and dragging within an interval selection to reposition it.
-
-        **See also:** `translate <https://vega.github.io/vega-lite/docs/translate.html>`__
-        documentation.
-    zoom : anyOf(string, boolean)
-        When truthy, allows a user to interactively resize an interval selection.
-        Can be ``true``, ``false`` (to disable zooming), or a `Vega event stream
-        definition <https://vega.github.io/vega/docs/event-streams/>`__. Currently,
-        only ``wheel`` events are supported.
-
-        **Default value:** ``true``, which corresponds to ``wheel!``.
-
-        **See also:** `zoom <https://vega.github.io/vega-lite/docs/zoom.html>`__
-        documentation.
-    """
-    _schema = {'$ref': '#/definitions/IntervalSelection'}
-    _rootschema = Root._schema
-
-    def __init__(self, type=Undefined, bind=Undefined, clear=Undefined, empty=Undefined,
-                 encodings=Undefined, fields=Undefined, init=Undefined, mark=Undefined, on=Undefined,
-                 resolve=Undefined, translate=Undefined, zoom=Undefined, **kwds):
-        super(IntervalSelection, self).__init__(type=type, bind=bind, clear=clear, empty=empty,
-                                                encodings=encodings, fields=fields, init=init,
-                                                mark=mark, on=on, resolve=resolve, translate=translate,
-                                                zoom=zoom, **kwds)
 
 
 class IntervalSelectionConfig(VegaLiteSchema):
@@ -7406,29 +6187,7 @@ class JoinAggregateFieldDef(VegaLiteSchema):
         super(JoinAggregateFieldDef, self).__init__(op=op, field=field, **kwds)
 
 
-class JoinAggregateTransform(VegaLiteSchema):
-    """JoinAggregateTransform schema wrapper
-
-    Mapping(required=[joinaggregate])
-
-    Attributes
-    ----------
-
-    joinaggregate : List(:class:`JoinAggregateFieldDef`)
-        The definition of the fields in the join aggregate, and what calculations to use.
-    groupby : List(:class:`FieldName`)
-        The data fields for partitioning the data objects into separate groups. If
-        unspecified, all data points will be in a single group.
-    """
-    _schema = {'$ref': '#/definitions/JoinAggregateTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, joinaggregate=Undefined, groupby=Undefined, **kwds):
-        super(JoinAggregateTransform, self).__init__(joinaggregate=joinaggregate, groupby=groupby,
-                                                     **kwds)
-
-
-class JsonDataFormat(VegaLiteSchema):
+class JsonDataFormat(DataFormat):
     """JsonDataFormat schema wrapper
 
     Mapping(required=[])
@@ -7614,117 +6373,6 @@ class LatLongFieldDef(VegaLiteSchema):
                  title=Undefined, type=Undefined, **kwds):
         super(LatLongFieldDef, self).__init__(aggregate=aggregate, bin=bin, field=field,
                                               timeUnit=timeUnit, title=title, type=type, **kwds)
-
-
-class LayerSpec(VegaLiteSchema):
-    """LayerSpec schema wrapper
-
-    Mapping(required=[layer])
-    A full layered plot specification, which may contains ``encoding`` and ``projection``
-    properties that will be applied to underlying unit (single-view) specifications.
-
-    Attributes
-    ----------
-
-    layer : List(anyOf(:class:`LayerSpec`, :class:`UnitSpec`))
-        Layer or single view specifications to be layered.
-
-        **Note** : Specifications inside ``layer`` cannot use ``row`` and ``column``
-        channels as layering facet specifications is not allowed. Instead, use the `facet
-        operator <https://vega.github.io/vega-lite/docs/facet.html>`__ and place a layer
-        inside a facet.
-    data : anyOf(:class:`Data`, None)
-        An object describing the data source. Set to ``null`` to ignore the parent's data
-        source. If no data is set, it is derived from the parent.
-    description : string
-        Description of this mark for commenting purpose.
-    encoding : :class:`Encoding`
-        A shared key-value mapping between encoding channels and definition of fields in the
-        underlying layers.
-    height : float
-        The height of a visualization.
-
-        **Default value:**
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its y-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
-          be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For y-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the height is `determined by the range step, paddings, and the
-          cardinality of the field mapped to y-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
-          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
-          ``rangeStep``.
-
-        **Note** : For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        height of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    name : string
-        Name of the visualization for later reference.
-    projection : :class:`Projection`
-        An object defining properties of the geographic projection shared by underlying
-        layers.
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for view composition specifications.
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    view : :class:`ViewBackground`
-        An object defining the view background's fill and stroke.
-
-        **Default value:** none (transparent)
-    width : float
-        The width of a visualization.
-
-        **Default value:** This will be determined by the following rules:
-
-
-        * If a view's `autosize
-          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
-          its x-channel has a `continuous scale
-          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
-          be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * For x-axis with a band or point scale: if `rangeStep
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
-          unspecified, the width is `determined by the range step, paddings, and the
-          cardinality of the field mapped to x-channel
-          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
-          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
-          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
-        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
-          `config.scale.textXRangeStep
-          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
-          ``text`` mark and the value of ``rangeStep`` for other marks.
-
-        **Note:** For plots with `row and column channels
-        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
-        width of a single view.
-
-        **See also:** The documentation for `width and height
-        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
-    """
-    _schema = {'$ref': '#/definitions/LayerSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, layer=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
-                 height=Undefined, name=Undefined, projection=Undefined, resolve=Undefined,
-                 title=Undefined, transform=Undefined, view=Undefined, width=Undefined, **kwds):
-        super(LayerSpec, self).__init__(layer=layer, data=data, description=description,
-                                        encoding=encoding, height=height, name=name,
-                                        projection=projection, resolve=resolve, title=title,
-                                        transform=transform, view=view, width=width, **kwds)
 
 
 class LayoutAlign(VegaLiteSchema):
@@ -8746,35 +7394,20 @@ class LineConfig(VegaLiteSchema):
                                          y2=y2, **kwds)
 
 
-class LocalMultiTimeUnit(VegaLiteSchema):
-    """LocalMultiTimeUnit schema wrapper
+class LogicalOperandPredicate(VegaLiteSchema):
+    """LogicalOperandPredicate schema wrapper
 
-    enum('yearquarter', 'yearquartermonth', 'yearmonth', 'yearmonthdate', 'yearmonthdatehours',
-    'yearmonthdatehoursminutes', 'yearmonthdatehoursminutesseconds', 'quartermonth',
-    'monthdate', 'monthdatehours', 'hoursminutes', 'hoursminutesseconds', 'minutesseconds',
-    'secondsmilliseconds')
+    anyOf(:class:`LogicalNotPredicate`, :class:`LogicalAndPredicate`,
+    :class:`LogicalOrPredicate`, :class:`Predicate`)
     """
-    _schema = {'$ref': '#/definitions/LocalMultiTimeUnit'}
+    _schema = {'$ref': '#/definitions/LogicalOperand<Predicate>'}
     _rootschema = Root._schema
 
-    def __init__(self, *args):
-        super(LocalMultiTimeUnit, self).__init__(*args)
+    def __init__(self, *args, **kwds):
+        super(LogicalOperandPredicate, self).__init__(*args, **kwds)
 
 
-class LocalSingleTimeUnit(VegaLiteSchema):
-    """LocalSingleTimeUnit schema wrapper
-
-    enum('year', 'quarter', 'month', 'day', 'date', 'hours', 'minutes', 'seconds',
-    'milliseconds')
-    """
-    _schema = {'$ref': '#/definitions/LocalSingleTimeUnit'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args):
-        super(LocalSingleTimeUnit, self).__init__(*args)
-
-
-class LogicalAndPredicate(VegaLiteSchema):
+class LogicalAndPredicate(LogicalOperandPredicate):
     """LogicalAndPredicate schema wrapper
 
     Mapping(required=[and])
@@ -8792,25 +7425,7 @@ class LogicalAndPredicate(VegaLiteSchema):
         super(LogicalAndPredicate, self).__init__(**kwds)
 
 
-class SelectionAnd(VegaLiteSchema):
-    """SelectionAnd schema wrapper
-
-    Mapping(required=[and])
-
-    Attributes
-    ----------
-
-    and : List(:class:`SelectionOperand`)
-
-    """
-    _schema = {'$ref': '#/definitions/SelectionAnd'}
-    _rootschema = Root._schema
-
-    def __init__(self, **kwds):
-        super(SelectionAnd, self).__init__(**kwds)
-
-
-class LogicalNotPredicate(VegaLiteSchema):
+class LogicalNotPredicate(LogicalOperandPredicate):
     """LogicalNotPredicate schema wrapper
 
     Mapping(required=[not])
@@ -8828,50 +7443,7 @@ class LogicalNotPredicate(VegaLiteSchema):
         super(LogicalNotPredicate, self).__init__(**kwds)
 
 
-class SelectionNot(VegaLiteSchema):
-    """SelectionNot schema wrapper
-
-    Mapping(required=[not])
-
-    Attributes
-    ----------
-
-    not : :class:`SelectionOperand`
-
-    """
-    _schema = {'$ref': '#/definitions/SelectionNot'}
-    _rootschema = Root._schema
-
-    def __init__(self, **kwds):
-        super(SelectionNot, self).__init__(**kwds)
-
-
-class LogicalOperandPredicate(VegaLiteSchema):
-    """LogicalOperandPredicate schema wrapper
-
-    anyOf(:class:`LogicalNotPredicate`, :class:`LogicalAndPredicate`,
-    :class:`LogicalOrPredicate`, :class:`Predicate`)
-    """
-    _schema = {'$ref': '#/definitions/LogicalOperand<Predicate>'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(LogicalOperandPredicate, self).__init__(*args, **kwds)
-
-
-class SelectionOperand(VegaLiteSchema):
-    """SelectionOperand schema wrapper
-
-    anyOf(:class:`SelectionNot`, :class:`SelectionAnd`, :class:`SelectionOr`, string)
-    """
-    _schema = {'$ref': '#/definitions/SelectionOperand'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(SelectionOperand, self).__init__(*args, **kwds)
-
-
-class LogicalOrPredicate(VegaLiteSchema):
+class LogicalOrPredicate(LogicalOperandPredicate):
     """LogicalOrPredicate schema wrapper
 
     Mapping(required=[or])
@@ -8887,24 +7459,6 @@ class LogicalOrPredicate(VegaLiteSchema):
 
     def __init__(self, **kwds):
         super(LogicalOrPredicate, self).__init__(**kwds)
-
-
-class SelectionOr(VegaLiteSchema):
-    """SelectionOr schema wrapper
-
-    Mapping(required=[or])
-
-    Attributes
-    ----------
-
-    or : List(:class:`SelectionOperand`)
-
-    """
-    _schema = {'$ref': '#/definitions/SelectionOr'}
-    _rootschema = Root._schema
-
-    def __init__(self, **kwds):
-        super(SelectionOr, self).__init__(**kwds)
 
 
 class LookupData(VegaLiteSchema):
@@ -8930,36 +7484,7 @@ class LookupData(VegaLiteSchema):
         super(LookupData, self).__init__(data=data, key=key, fields=fields, **kwds)
 
 
-class LookupTransform(VegaLiteSchema):
-    """LookupTransform schema wrapper
-
-    Mapping(required=[lookup, from])
-
-    Attributes
-    ----------
-
-    lookup : :class:`FieldName`
-        Key in primary data source.
-    default : string
-        The default value to use if lookup fails.
-
-        **Default value:** ``null``
-    as : anyOf(:class:`FieldName`, List(:class:`FieldName`))
-        The field or fields for storing the computed formula value.
-        If ``from.fields`` is specified, the transform will use the same names for ``as``.
-        If ``from.fields`` is not specified, ``as`` has to be a string and we put the whole
-        object into the data under the specified name.
-    from : :class:`LookupData`
-        Secondary data reference.
-    """
-    _schema = {'$ref': '#/definitions/LookupTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, lookup=Undefined, default=Undefined, **kwds):
-        super(LookupTransform, self).__init__(lookup=lookup, default=default, **kwds)
-
-
-class Mark(VegaLiteSchema):
+class Mark(AnyMark):
     """Mark schema wrapper
 
     enum('area', 'bar', 'line', 'trail', 'point', 'text', 'tick', 'rect', 'rule', 'circle',
@@ -9230,7 +7755,7 @@ class MarkConfig(VegaLiteSchema):
                                          width=width, x=x, x2=x2, y=y, y2=y2, **kwds)
 
 
-class MarkDef(VegaLiteSchema):
+class MarkDef(AnyMark):
     """MarkDef schema wrapper
 
     Mapping(required=[type])
@@ -9569,94 +8094,6 @@ class Month(VegaLiteSchema):
         super(Month, self).__init__(*args)
 
 
-class MultiSelection(VegaLiteSchema):
-    """MultiSelection schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('multi')
-        Determines the default event processing and data query for the selection. Vega-Lite
-        currently supports three selection types:
-
-
-        * ``single`` -- to select a single discrete data value on ``click``.
-        * ``multi`` -- to select multiple discrete data value; the first value is selected
-          on ``click`` and additional values toggled on shift- ``click``.
-        * ``interval`` -- to select a continuous range of data values on ``drag``.
-    clear : anyOf(:class:`EventStream`, boolean)
-        Clears the selection, emptying it of all values. Can be an
-        `EventStream <https://vega.github.io/vega/docs/event-streams/>`__ or ``false`` to
-        disable.
-
-        **Default value:** ``dblclick``.
-
-        **See also:** `clear <https://vega.github.io/vega-lite/docs/clear.html>`__
-        documentation.
-    empty : enum('all', 'none')
-        By default, ``all`` data values are considered to lie within an empty selection.
-        When set to ``none``, empty selections contain no data values.
-    encodings : List(:class:`SingleDefUnitChannel`)
-        An array of encoding channels. The corresponding data field values
-        must match for a data tuple to fall within the selection.
-
-        **See also:** `encodings <https://vega.github.io/vega-lite/docs/project.html>`__
-        documentation.
-    fields : List(:class:`FieldName`)
-        An array of field names whose values must match for a data tuple to
-        fall within the selection.
-
-        **See also:** `fields <https://vega.github.io/vega-lite/docs/project.html>`__
-        documentation.
-    init : anyOf(:class:`SelectionInitMapping`, List(:class:`SelectionInitMapping`))
-        Initialize the selection with a mapping between `projected channels or field names
-        <https://vega.github.io/vega-lite/docs/project.html>`__ and an initial
-        value (or array of values).
-
-        **See also:** `init <https://vega.github.io/vega-lite/docs/init.html>`__
-        documentation.
-    nearest : boolean
-        When true, an invisible voronoi diagram is computed to accelerate discrete
-        selection. The data value *nearest* the mouse cursor is added to the selection.
-
-        **See also:** `nearest <https://vega.github.io/vega-lite/docs/nearest.html>`__
-        documentation.
-    on : :class:`EventStream`
-        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
-        selector) that triggers the selection.
-        For interval selections, the event stream must specify a `start and end
-        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
-    resolve : :class:`SelectionResolution`
-        With layered and multi-view displays, a strategy that determines how
-        selections' data queries are resolved when applied in a filter transform,
-        conditional encoding rule, or scale domain.
-
-        **See also:** `resolve
-        <https://vega.github.io/vega-lite/docs/selection-resolve.html>`__ documentation.
-    toggle : anyOf(string, boolean)
-        Controls whether data values should be toggled or only ever inserted into
-        multi selections. Can be ``true``, ``false`` (for insertion only), or a
-        `Vega expression <https://vega.github.io/vega/docs/expressions/>`__.
-
-        **Default value:** ``true``, which corresponds to ``event.shiftKey`` (i.e.,
-        data values are toggled when a user interacts with the shift-key pressed).
-
-        **See also:** `toggle <https://vega.github.io/vega-lite/docs/toggle.html>`__
-        documentation.
-    """
-    _schema = {'$ref': '#/definitions/MultiSelection'}
-    _rootschema = Root._schema
-
-    def __init__(self, type=Undefined, clear=Undefined, empty=Undefined, encodings=Undefined,
-                 fields=Undefined, init=Undefined, nearest=Undefined, on=Undefined, resolve=Undefined,
-                 toggle=Undefined, **kwds):
-        super(MultiSelection, self).__init__(type=type, clear=clear, empty=empty, encodings=encodings,
-                                             fields=fields, init=init, nearest=nearest, on=on,
-                                             resolve=resolve, toggle=toggle, **kwds)
-
-
 class MultiSelectionConfig(VegaLiteSchema):
     """MultiSelectionConfig schema wrapper
 
@@ -9736,19 +8173,7 @@ class MultiSelectionConfig(VegaLiteSchema):
                                                    resolve=resolve, toggle=toggle, **kwds)
 
 
-class MultiTimeUnit(VegaLiteSchema):
-    """MultiTimeUnit schema wrapper
-
-    anyOf(:class:`LocalMultiTimeUnit`, :class:`UtcMultiTimeUnit`)
-    """
-    _schema = {'$ref': '#/definitions/MultiTimeUnit'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(MultiTimeUnit, self).__init__(*args, **kwds)
-
-
-class NamedData(VegaLiteSchema):
+class NamedData(DataSource):
     """NamedData schema wrapper
 
     Mapping(required=[name])
@@ -9778,6 +8203,26 @@ class NiceTime(VegaLiteSchema):
 
     def __init__(self, *args):
         super(NiceTime, self).__init__(*args)
+
+
+class NumberValueDef(VegaLiteSchema):
+    """NumberValueDef schema wrapper
+
+    Mapping(required=[value])
+    Definition object for a constant value of an encoding channel.
+
+    Attributes
+    ----------
+
+    value : float
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _schema = {'$ref': '#/definitions/NumberValueDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, value=Undefined, **kwds):
+        super(NumberValueDef, self).__init__(value=value, **kwds)
 
 
 class NumericFieldDefWithCondition(VegaLiteSchema):
@@ -10774,7 +9219,7 @@ class PositionFieldDef(VegaLiteSchema):
                                                stack=stack, timeUnit=timeUnit, title=title, **kwds)
 
 
-class Predicate(VegaLiteSchema):
+class Predicate(LogicalOperandPredicate):
     """Predicate schema wrapper
 
     anyOf(:class:`FieldEqualPredicate`, :class:`FieldRangePredicate`,
@@ -10787,6 +9232,186 @@ class Predicate(VegaLiteSchema):
 
     def __init__(self, *args, **kwds):
         super(Predicate, self).__init__(*args, **kwds)
+
+
+class FieldEqualPredicate(Predicate):
+    """FieldEqualPredicate schema wrapper
+
+    Mapping(required=[equal, field])
+
+    Attributes
+    ----------
+
+    equal : anyOf(string, float, boolean, :class:`DateTime`)
+        The value that the field should be equal to.
+    field : :class:`FieldName`
+        Field to be filtered.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldEqualPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, equal=Undefined, field=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldEqualPredicate, self).__init__(equal=equal, field=field, timeUnit=timeUnit, **kwds)
+
+
+class FieldGTEPredicate(Predicate):
+    """FieldGTEPredicate schema wrapper
+
+    Mapping(required=[field, gte])
+
+    Attributes
+    ----------
+
+    field : :class:`FieldName`
+        Field to be filtered.
+    gte : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be greater than or equals to.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldGTEPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, gte=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldGTEPredicate, self).__init__(field=field, gte=gte, timeUnit=timeUnit, **kwds)
+
+
+class FieldGTPredicate(Predicate):
+    """FieldGTPredicate schema wrapper
+
+    Mapping(required=[field, gt])
+
+    Attributes
+    ----------
+
+    field : :class:`FieldName`
+        Field to be filtered.
+    gt : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be greater than.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldGTPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, gt=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldGTPredicate, self).__init__(field=field, gt=gt, timeUnit=timeUnit, **kwds)
+
+
+class FieldLTEPredicate(Predicate):
+    """FieldLTEPredicate schema wrapper
+
+    Mapping(required=[field, lte])
+
+    Attributes
+    ----------
+
+    field : :class:`FieldName`
+        Field to be filtered.
+    lte : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be less than or equals to.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldLTEPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, lte=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldLTEPredicate, self).__init__(field=field, lte=lte, timeUnit=timeUnit, **kwds)
+
+
+class FieldLTPredicate(Predicate):
+    """FieldLTPredicate schema wrapper
+
+    Mapping(required=[field, lt])
+
+    Attributes
+    ----------
+
+    field : :class:`FieldName`
+        Field to be filtered.
+    lt : anyOf(string, float, :class:`DateTime`)
+        The value that the field should be less than.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldLTPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, lt=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldLTPredicate, self).__init__(field=field, lt=lt, timeUnit=timeUnit, **kwds)
+
+
+class FieldOneOfPredicate(Predicate):
+    """FieldOneOfPredicate schema wrapper
+
+    Mapping(required=[field, oneOf])
+
+    Attributes
+    ----------
+
+    field : :class:`FieldName`
+        Field to be filtered.
+    oneOf : anyOf(List(string), List(float), List(boolean), List(:class:`DateTime`))
+        A set of values that the ``field`` 's value should be a member of,
+        for a data item included in the filtered data.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldOneOfPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, oneOf=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldOneOfPredicate, self).__init__(field=field, oneOf=oneOf, timeUnit=timeUnit, **kwds)
+
+
+class FieldRangePredicate(Predicate):
+    """FieldRangePredicate schema wrapper
+
+    Mapping(required=[field, range])
+
+    Attributes
+    ----------
+
+    field : :class:`FieldName`
+        Field to be filtered.
+    range : List(anyOf(float, :class:`DateTime`, None))
+        An array of inclusive minimum and maximum values
+        for a field value of a data item to be included in the filtered data.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldRangePredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, range=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldRangePredicate, self).__init__(field=field, range=range, timeUnit=timeUnit, **kwds)
+
+
+class FieldValidPredicate(Predicate):
+    """FieldValidPredicate schema wrapper
+
+    Mapping(required=[field, valid])
+
+    Attributes
+    ----------
+
+    field : :class:`FieldName`
+        Field to be filtered.
+    valid : boolean
+        If set to true the field's value has to be valid, meaning both not ``null`` and not
+        `NaN
+        <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN>`__.
+    timeUnit : :class:`TimeUnit`
+        Time unit for the field to be filtered.
+    """
+    _schema = {'$ref': '#/definitions/FieldValidPredicate'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, valid=Undefined, timeUnit=Undefined, **kwds):
+        super(FieldValidPredicate, self).__init__(field=field, valid=valid, timeUnit=timeUnit, **kwds)
 
 
 class Projection(VegaLiteSchema):
@@ -11313,7 +9938,7 @@ class RepeatMapping(VegaLiteSchema):
         super(RepeatMapping, self).__init__(column=column, row=row, **kwds)
 
 
-class RepeatRef(VegaLiteSchema):
+class RepeatRef(Field):
     """RepeatRef schema wrapper
 
     Mapping(required=[repeat])
@@ -11427,26 +10052,6 @@ class RowColnumber(VegaLiteSchema):
 
     def __init__(self, column=Undefined, row=Undefined, **kwds):
         super(RowColnumber, self).__init__(column=column, row=row, **kwds)
-
-
-class SampleTransform(VegaLiteSchema):
-    """SampleTransform schema wrapper
-
-    Mapping(required=[sample])
-
-    Attributes
-    ----------
-
-    sample : float
-        The maximum number of data objects to include in the sample.
-
-        **Default value:** ``1000``
-    """
-    _schema = {'$ref': '#/definitions/SampleTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, sample=Undefined, **kwds):
-        super(SampleTransform, self).__init__(sample=sample, **kwds)
 
 
 class Scale(VegaLiteSchema):
@@ -11940,7 +10545,7 @@ class ScaleType(VegaLiteSchema):
         super(ScaleType, self).__init__(*args)
 
 
-class SchemeConfig(VegaLiteSchema):
+class SchemeConfig(RangeConfigValue):
     """SchemeConfig schema wrapper
 
     Mapping(required=[scheme])
@@ -12141,6 +10746,203 @@ class SelectionDef(VegaLiteSchema):
         super(SelectionDef, self).__init__(*args, **kwds)
 
 
+class IntervalSelection(SelectionDef):
+    """IntervalSelection schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('interval')
+        Determines the default event processing and data query for the selection. Vega-Lite
+        currently supports three selection types:
+
+
+        * ``single`` -- to select a single discrete data value on ``click``.
+        * ``multi`` -- to select multiple discrete data value; the first value is selected
+          on ``click`` and additional values toggled on shift- ``click``.
+        * ``interval`` -- to select a continuous range of data values on ``drag``.
+    bind : enum('scales')
+        Establishes a two-way binding between the interval selection and the scales
+        used within the same view. This allows a user to interactively pan and
+        zoom the view.
+
+        **See also:** `bind <https://vega.github.io/vega-lite/docs/bind.html>`__
+        documentation.
+    clear : anyOf(:class:`EventStream`, boolean)
+        Clears the selection, emptying it of all values. Can be an
+        `EventStream <https://vega.github.io/vega/docs/event-streams/>`__ or ``false`` to
+        disable.
+
+        **Default value:** ``dblclick``.
+
+        **See also:** `clear <https://vega.github.io/vega-lite/docs/clear.html>`__
+        documentation.
+    empty : enum('all', 'none')
+        By default, ``all`` data values are considered to lie within an empty selection.
+        When set to ``none``, empty selections contain no data values.
+    encodings : List(:class:`SingleDefUnitChannel`)
+        An array of encoding channels. The corresponding data field values
+        must match for a data tuple to fall within the selection.
+
+        **See also:** `encodings <https://vega.github.io/vega-lite/docs/project.html>`__
+        documentation.
+    fields : List(:class:`FieldName`)
+        An array of field names whose values must match for a data tuple to
+        fall within the selection.
+
+        **See also:** `fields <https://vega.github.io/vega-lite/docs/project.html>`__
+        documentation.
+    init : :class:`SelectionInitIntervalMapping`
+        Initialize the selection with a mapping between `projected channels or field names
+        <https://vega.github.io/vega-lite/docs/project.html>`__ and arrays of
+        initial values.
+
+        **See also:** `init <https://vega.github.io/vega-lite/docs/init.html>`__
+        documentation.
+    mark : :class:`BrushConfig`
+        An interval selection also adds a rectangle mark to depict the
+        extents of the interval. The ``mark`` property can be used to customize the
+        appearance of the mark.
+
+        **See also:** `mark <https://vega.github.io/vega-lite/docs/selection-mark.html>`__
+        documentation.
+    on : :class:`EventStream`
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
+        selector) that triggers the selection.
+        For interval selections, the event stream must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
+    resolve : :class:`SelectionResolution`
+        With layered and multi-view displays, a strategy that determines how
+        selections' data queries are resolved when applied in a filter transform,
+        conditional encoding rule, or scale domain.
+
+        **See also:** `resolve
+        <https://vega.github.io/vega-lite/docs/selection-resolve.html>`__ documentation.
+    translate : anyOf(string, boolean)
+        When truthy, allows a user to interactively move an interval selection
+        back-and-forth. Can be ``true``, ``false`` (to disable panning), or a
+        `Vega event stream definition <https://vega.github.io/vega/docs/event-streams/>`__
+        which must include a start and end event to trigger continuous panning.
+
+        **Default value:** ``true``, which corresponds to
+        ``[mousedown, window:mouseup] > window:mousemove!`` which corresponds to
+        clicks and dragging within an interval selection to reposition it.
+
+        **See also:** `translate <https://vega.github.io/vega-lite/docs/translate.html>`__
+        documentation.
+    zoom : anyOf(string, boolean)
+        When truthy, allows a user to interactively resize an interval selection.
+        Can be ``true``, ``false`` (to disable zooming), or a `Vega event stream
+        definition <https://vega.github.io/vega/docs/event-streams/>`__. Currently,
+        only ``wheel`` events are supported.
+
+        **Default value:** ``true``, which corresponds to ``wheel!``.
+
+        **See also:** `zoom <https://vega.github.io/vega-lite/docs/zoom.html>`__
+        documentation.
+    """
+    _schema = {'$ref': '#/definitions/IntervalSelection'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, bind=Undefined, clear=Undefined, empty=Undefined,
+                 encodings=Undefined, fields=Undefined, init=Undefined, mark=Undefined, on=Undefined,
+                 resolve=Undefined, translate=Undefined, zoom=Undefined, **kwds):
+        super(IntervalSelection, self).__init__(type=type, bind=bind, clear=clear, empty=empty,
+                                                encodings=encodings, fields=fields, init=init,
+                                                mark=mark, on=on, resolve=resolve, translate=translate,
+                                                zoom=zoom, **kwds)
+
+
+class MultiSelection(SelectionDef):
+    """MultiSelection schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('multi')
+        Determines the default event processing and data query for the selection. Vega-Lite
+        currently supports three selection types:
+
+
+        * ``single`` -- to select a single discrete data value on ``click``.
+        * ``multi`` -- to select multiple discrete data value; the first value is selected
+          on ``click`` and additional values toggled on shift- ``click``.
+        * ``interval`` -- to select a continuous range of data values on ``drag``.
+    clear : anyOf(:class:`EventStream`, boolean)
+        Clears the selection, emptying it of all values. Can be an
+        `EventStream <https://vega.github.io/vega/docs/event-streams/>`__ or ``false`` to
+        disable.
+
+        **Default value:** ``dblclick``.
+
+        **See also:** `clear <https://vega.github.io/vega-lite/docs/clear.html>`__
+        documentation.
+    empty : enum('all', 'none')
+        By default, ``all`` data values are considered to lie within an empty selection.
+        When set to ``none``, empty selections contain no data values.
+    encodings : List(:class:`SingleDefUnitChannel`)
+        An array of encoding channels. The corresponding data field values
+        must match for a data tuple to fall within the selection.
+
+        **See also:** `encodings <https://vega.github.io/vega-lite/docs/project.html>`__
+        documentation.
+    fields : List(:class:`FieldName`)
+        An array of field names whose values must match for a data tuple to
+        fall within the selection.
+
+        **See also:** `fields <https://vega.github.io/vega-lite/docs/project.html>`__
+        documentation.
+    init : anyOf(:class:`SelectionInitMapping`, List(:class:`SelectionInitMapping`))
+        Initialize the selection with a mapping between `projected channels or field names
+        <https://vega.github.io/vega-lite/docs/project.html>`__ and an initial
+        value (or array of values).
+
+        **See also:** `init <https://vega.github.io/vega-lite/docs/init.html>`__
+        documentation.
+    nearest : boolean
+        When true, an invisible voronoi diagram is computed to accelerate discrete
+        selection. The data value *nearest* the mouse cursor is added to the selection.
+
+        **See also:** `nearest <https://vega.github.io/vega-lite/docs/nearest.html>`__
+        documentation.
+    on : :class:`EventStream`
+        A `Vega event stream <https://vega.github.io/vega/docs/event-streams/>`__ (object or
+        selector) that triggers the selection.
+        For interval selections, the event stream must specify a `start and end
+        <https://vega.github.io/vega/docs/event-streams/#between-filters>`__.
+    resolve : :class:`SelectionResolution`
+        With layered and multi-view displays, a strategy that determines how
+        selections' data queries are resolved when applied in a filter transform,
+        conditional encoding rule, or scale domain.
+
+        **See also:** `resolve
+        <https://vega.github.io/vega-lite/docs/selection-resolve.html>`__ documentation.
+    toggle : anyOf(string, boolean)
+        Controls whether data values should be toggled or only ever inserted into
+        multi selections. Can be ``true``, ``false`` (for insertion only), or a
+        `Vega expression <https://vega.github.io/vega/docs/expressions/>`__.
+
+        **Default value:** ``true``, which corresponds to ``event.shiftKey`` (i.e.,
+        data values are toggled when a user interacts with the shift-key pressed).
+
+        **See also:** `toggle <https://vega.github.io/vega-lite/docs/toggle.html>`__
+        documentation.
+    """
+    _schema = {'$ref': '#/definitions/MultiSelection'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, clear=Undefined, empty=Undefined, encodings=Undefined,
+                 fields=Undefined, init=Undefined, nearest=Undefined, on=Undefined, resolve=Undefined,
+                 toggle=Undefined, **kwds):
+        super(MultiSelection, self).__init__(type=type, clear=clear, empty=empty, encodings=encodings,
+                                             fields=fields, init=init, nearest=nearest, on=on,
+                                             resolve=resolve, toggle=toggle, **kwds)
+
+
 class SelectionDomain(VegaLiteSchema):
     """SelectionDomain schema wrapper
 
@@ -12163,6 +10965,57 @@ class SelectionInit(VegaLiteSchema):
 
     def __init__(self, *args, **kwds):
         super(SelectionInit, self).__init__(*args, **kwds)
+
+
+class DateTime(SelectionInit):
+    """DateTime schema wrapper
+
+    Mapping(required=[])
+    Object for defining datetime in Vega-Lite Filter.
+    If both month and quarter are provided, month has higher precedence.
+    ``day`` cannot be combined with other date.
+    We accept string for month and day names.
+
+    Attributes
+    ----------
+
+    date : float
+        Integer value representing the date from 1-31.
+    day : anyOf(:class:`Day`, string)
+        Value representing the day of a week.  This can be one of: (1) integer value --
+        ``1`` represents Monday; (2) case-insensitive day name (e.g., ``"Monday"`` );  (3)
+        case-insensitive, 3-character short day name (e.g., ``"Mon"`` ).   :raw-html:`<br/>`
+        **Warning:** A DateTime definition object with ``day`` ** should not be combined
+        with ``year``, ``quarter``, ``month``, or ``date``.
+    hours : float
+        Integer value representing the hour of a day from 0-23.
+    milliseconds : float
+        Integer value representing the millisecond segment of time.
+    minutes : float
+        Integer value representing the minute segment of time from 0-59.
+    month : anyOf(:class:`Month`, string)
+        One of: (1) integer value representing the month from ``1`` - ``12``. ``1``
+        represents January;  (2) case-insensitive month name (e.g., ``"January"`` );  (3)
+        case-insensitive, 3-character short month name (e.g., ``"Jan"`` ).
+    quarter : float
+        Integer value representing the quarter of the year (from 1-4).
+    seconds : float
+        Integer value representing the second segment (0-59) of a time value
+    utc : boolean
+        A boolean flag indicating if date time is in utc time. If false, the date time is in
+        local time
+    year : float
+        Integer value representing the year.
+    """
+    _schema = {'$ref': '#/definitions/DateTime'}
+    _rootschema = Root._schema
+
+    def __init__(self, date=Undefined, day=Undefined, hours=Undefined, milliseconds=Undefined,
+                 minutes=Undefined, month=Undefined, quarter=Undefined, seconds=Undefined,
+                 utc=Undefined, year=Undefined, **kwds):
+        super(DateTime, self).__init__(date=date, day=day, hours=hours, milliseconds=milliseconds,
+                                       minutes=minutes, month=month, quarter=quarter, seconds=seconds,
+                                       utc=utc, year=year, **kwds)
 
 
 class SelectionInitInterval(VegaLiteSchema):
@@ -12202,7 +11055,73 @@ class SelectionInitMapping(VegaLiteSchema):
         super(SelectionInitMapping, self).__init__(**kwds)
 
 
-class SelectionPredicate(VegaLiteSchema):
+class SelectionOperand(VegaLiteSchema):
+    """SelectionOperand schema wrapper
+
+    anyOf(:class:`SelectionNot`, :class:`SelectionAnd`, :class:`SelectionOr`, string)
+    """
+    _schema = {'$ref': '#/definitions/SelectionOperand'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(SelectionOperand, self).__init__(*args, **kwds)
+
+
+class SelectionAnd(SelectionOperand):
+    """SelectionAnd schema wrapper
+
+    Mapping(required=[and])
+
+    Attributes
+    ----------
+
+    and : List(:class:`SelectionOperand`)
+
+    """
+    _schema = {'$ref': '#/definitions/SelectionAnd'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(SelectionAnd, self).__init__(**kwds)
+
+
+class SelectionNot(SelectionOperand):
+    """SelectionNot schema wrapper
+
+    Mapping(required=[not])
+
+    Attributes
+    ----------
+
+    not : :class:`SelectionOperand`
+
+    """
+    _schema = {'$ref': '#/definitions/SelectionNot'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(SelectionNot, self).__init__(**kwds)
+
+
+class SelectionOr(SelectionOperand):
+    """SelectionOr schema wrapper
+
+    Mapping(required=[or])
+
+    Attributes
+    ----------
+
+    or : List(:class:`SelectionOperand`)
+
+    """
+    _schema = {'$ref': '#/definitions/SelectionOr'}
+    _rootschema = Root._schema
+
+    def __init__(self, **kwds):
+        super(SelectionOr, self).__init__(**kwds)
+
+
+class SelectionPredicate(Predicate):
     """SelectionPredicate schema wrapper
 
     Mapping(required=[selection])
@@ -12232,7 +11151,7 @@ class SelectionResolution(VegaLiteSchema):
         super(SelectionResolution, self).__init__(*args)
 
 
-class SequenceGenerator(VegaLiteSchema):
+class SequenceGenerator(Generator):
     """SequenceGenerator schema wrapper
 
     Mapping(required=[sequence])
@@ -12501,7 +11420,7 @@ class ShapeValueDefWithCondition(VegaLiteSchema):
         super(ShapeValueDefWithCondition, self).__init__(condition=condition, value=value, **kwds)
 
 
-class SignalRef(VegaLiteSchema):
+class SignalRef(LayoutBounds):
     """SignalRef schema wrapper
 
     Mapping(required=[signal])
@@ -12533,7 +11452,7 @@ class SingleDefUnitChannel(VegaLiteSchema):
         super(SingleDefUnitChannel, self).__init__(*args)
 
 
-class SingleSelection(VegaLiteSchema):
+class SingleSelection(SelectionDef):
     """SingleSelection schema wrapper
 
     Mapping(required=[type])
@@ -12696,18 +11615,6 @@ class SingleSelectionConfig(VegaLiteSchema):
                                                     nearest=nearest, on=on, resolve=resolve, **kwds)
 
 
-class SingleTimeUnit(VegaLiteSchema):
-    """SingleTimeUnit schema wrapper
-
-    anyOf(:class:`LocalSingleTimeUnit`, :class:`UtcSingleTimeUnit`)
-    """
-    _schema = {'$ref': '#/definitions/SingleTimeUnit'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(SingleTimeUnit, self).__init__(*args, **kwds)
-
-
 class Sort(VegaLiteSchema):
     """Sort schema wrapper
 
@@ -12721,7 +11628,44 @@ class Sort(VegaLiteSchema):
         super(Sort, self).__init__(*args, **kwds)
 
 
-class SortArray(VegaLiteSchema):
+class EncodingSortField(Sort):
+    """EncodingSortField schema wrapper
+
+    Mapping(required=[])
+    A sort definition for sorting a discrete scale in an encoding field definition.
+
+    Attributes
+    ----------
+
+    field : :class:`Field`
+        The data `field <https://vega.github.io/vega-lite/docs/field.html>`__ to sort by.
+
+        **Default value:** If unspecified, defaults to the field specified in the outer data
+        reference.
+    op : :class:`AggregateOp`
+        An `aggregate operation
+        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__ to perform on the
+        field prior to sorting (e.g., ``"count"``, ``"mean"`` and ``"median"`` ).
+        An aggregation is required when there are multiple values of the sort field for each
+        encoded data field.
+        The input data objects will be aggregated, grouped by the encoded data field.
+
+        For a full list of operations, please see the documentation for `aggregate
+        <https://vega.github.io/vega-lite/docs/aggregate.html#ops>`__.
+
+        **Default value:** ``"sum"`` for stacked plots. Otherwise, ``"mean"``.
+    order : anyOf(:class:`SortOrder`, None)
+        The sort order. One of ``"ascending"`` (default), ``"descending"``, or ``null`` (no
+        not sort).
+    """
+    _schema = {'$ref': '#/definitions/EncodingSortField'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, op=Undefined, order=Undefined, **kwds):
+        super(EncodingSortField, self).__init__(field=field, op=op, order=order, **kwds)
+
+
+class SortArray(Sort):
     """SortArray schema wrapper
 
     anyOf(List(float), List(string), List(boolean), List(:class:`DateTime`))
@@ -12733,7 +11677,7 @@ class SortArray(VegaLiteSchema):
         super(SortArray, self).__init__(*args, **kwds)
 
 
-class SortByEncoding(VegaLiteSchema):
+class SortByEncoding(Sort):
     """SortByEncoding schema wrapper
 
     Mapping(required=[encoding])
@@ -12778,7 +11722,7 @@ class SortField(VegaLiteSchema):
         super(SortField, self).__init__(field=field, order=order, **kwds)
 
 
-class SortOrder(VegaLiteSchema):
+class SortOrder(Sort):
     """SortOrder schema wrapper
 
     enum('ascending', 'descending')
@@ -12790,7 +11734,686 @@ class SortOrder(VegaLiteSchema):
         super(SortOrder, self).__init__(*args)
 
 
-class SphereGenerator(VegaLiteSchema):
+class Spec(VegaLiteSchema):
+    """Spec schema wrapper
+
+    anyOf(:class:`FacetedUnitSpec`, :class:`LayerSpec`, :class:`FacetSpec`, :class:`RepeatSpec`,
+    :class:`ConcatSpec`, :class:`VConcatSpec`, :class:`HConcatSpec`)
+    Any specification in Vega-Lite.
+    """
+    _schema = {'$ref': '#/definitions/Spec'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(Spec, self).__init__(*args, **kwds)
+
+
+class ConcatSpec(Spec):
+    """ConcatSpec schema wrapper
+
+    Mapping(required=[concat])
+    Base interface for a generalized concatenation specification.
+
+    Attributes
+    ----------
+
+    concat : List(:class:`Spec`)
+        A list of views to be concatenated.
+    align : anyOf(:class:`LayoutAlign`, :class:`RowColLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    columns : float
+        The number of columns to include in the view composition layout.
+
+        **Default value** : ``undefined`` -- An infinite number of columns (a single row)
+        will be assumed. This is equivalent to
+        ``hconcat`` (for ``concat`` ) and to using the ``column`` channel (for ``facet`` and
+        ``repeat`` ).
+
+        **Note** :
+
+        1) This property is only for:
+
+
+        * the general (wrappable) ``concat`` operator (not ``hconcat`` / ``vconcat`` )
+        * the ``facet`` and ``repeat`` operator with one field/repetition definition
+          (without row/column nesting)
+
+        2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat`` )
+        and to using the ``row`` channel (for ``facet`` and ``repeat`` ).
+    data : anyOf(:class:`Data`, None)
+        An object describing the data source. Set to ``null`` to ignore the parent's data
+        source. If no data is set, it is derived from the parent.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for view composition specifications.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : Depends on ``"spacing"`` property of `the view composition
+        configuration <https://vega.github.io/vega-lite/docs/config.html#view-config>`__ (
+        ``20`` by default)
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/ConcatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, concat=Undefined, align=Undefined, bounds=Undefined, center=Undefined,
+                 columns=Undefined, data=Undefined, description=Undefined, name=Undefined,
+                 resolve=Undefined, spacing=Undefined, title=Undefined, transform=Undefined, **kwds):
+        super(ConcatSpec, self).__init__(concat=concat, align=align, bounds=bounds, center=center,
+                                         columns=columns, data=data, description=description, name=name,
+                                         resolve=resolve, spacing=spacing, title=title,
+                                         transform=transform, **kwds)
+
+
+class FacetSpec(Spec):
+    """FacetSpec schema wrapper
+
+    Mapping(required=[facet, spec])
+    Base interface for a facet specification.
+
+    Attributes
+    ----------
+
+    facet : anyOf(:class:`FacetFieldDef`, :class:`FacetMapping`)
+        Definition for how to facet the data.  One of:
+        1) `a field definition for faceting the plot by one field
+        <https://vega.github.io/vega-lite/docs/facet.html#field-def>`__
+        2) `An object that maps row and column channels to their field definitions
+        <https://vega.github.io/vega-lite/docs/facet.html#mapping>`__
+    spec : anyOf(:class:`LayerSpec`, :class:`FacetedUnitSpec`)
+        A specification of the view that gets faceted.
+    align : anyOf(:class:`LayoutAlign`, :class:`RowColLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    columns : float
+        The number of columns to include in the view composition layout.
+
+        **Default value** : ``undefined`` -- An infinite number of columns (a single row)
+        will be assumed. This is equivalent to
+        ``hconcat`` (for ``concat`` ) and to using the ``column`` channel (for ``facet`` and
+        ``repeat`` ).
+
+        **Note** :
+
+        1) This property is only for:
+
+
+        * the general (wrappable) ``concat`` operator (not ``hconcat`` / ``vconcat`` )
+        * the ``facet`` and ``repeat`` operator with one field/repetition definition
+          (without row/column nesting)
+
+        2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat`` )
+        and to using the ``row`` channel (for ``facet`` and ``repeat`` ).
+    data : anyOf(:class:`Data`, None)
+        An object describing the data source. Set to ``null`` to ignore the parent's data
+        source. If no data is set, it is derived from the parent.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for view composition specifications.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : Depends on ``"spacing"`` property of `the view composition
+        configuration <https://vega.github.io/vega-lite/docs/config.html#view-config>`__ (
+        ``20`` by default)
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/FacetSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, facet=Undefined, spec=Undefined, align=Undefined, bounds=Undefined,
+                 center=Undefined, columns=Undefined, data=Undefined, description=Undefined,
+                 name=Undefined, resolve=Undefined, spacing=Undefined, title=Undefined,
+                 transform=Undefined, **kwds):
+        super(FacetSpec, self).__init__(facet=facet, spec=spec, align=align, bounds=bounds,
+                                        center=center, columns=columns, data=data,
+                                        description=description, name=name, resolve=resolve,
+                                        spacing=spacing, title=title, transform=transform, **kwds)
+
+
+class FacetedUnitSpec(Spec):
+    """FacetedUnitSpec schema wrapper
+
+    Mapping(required=[mark])
+    Unit spec that can have a composite mark and row or column channels (shorthand for a facet
+    spec).
+
+    Attributes
+    ----------
+
+    mark : :class:`AnyMark`
+        A string describing the mark type (one of ``"bar"``, ``"circle"``, ``"square"``,
+        ``"tick"``, ``"line"``,
+        ``"area"``, ``"point"``, ``"rule"``, ``"geoshape"``, and ``"text"`` ) or a `mark
+        definition object <https://vega.github.io/vega-lite/docs/mark.html#mark-def>`__.
+    align : anyOf(:class:`LayoutAlign`, :class:`RowColLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    columns : float
+        The number of columns to include in the view composition layout.
+
+        **Default value** : ``undefined`` -- An infinite number of columns (a single row)
+        will be assumed. This is equivalent to
+        ``hconcat`` (for ``concat`` ) and to using the ``column`` channel (for ``facet`` and
+        ``repeat`` ).
+
+        **Note** :
+
+        1) This property is only for:
+
+
+        * the general (wrappable) ``concat`` operator (not ``hconcat`` / ``vconcat`` )
+        * the ``facet`` and ``repeat`` operator with one field/repetition definition
+          (without row/column nesting)
+
+        2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat`` )
+        and to using the ``row`` channel (for ``facet`` and ``repeat`` ).
+    data : anyOf(:class:`Data`, None)
+        An object describing the data source. Set to ``null`` to ignore the parent's data
+        source. If no data is set, it is derived from the parent.
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`FacetedEncoding`
+        A key-value mapping between encoding channels and definition of fields.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    projection : :class:`Projection`
+        An object defining properties of geographic projection, which will be applied to
+        ``shape`` path for ``"geoshape"`` marks
+        and to ``latitude`` and ``"longitude"`` channels for other marks.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for view composition specifications.
+    selection : Mapping(required=[])
+        A key-value mapping between selection names and definitions.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : Depends on ``"spacing"`` property of `the view composition
+        configuration <https://vega.github.io/vega-lite/docs/config.html#view-config>`__ (
+        ``20`` by default)
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    view : :class:`ViewBackground`
+        An object defining the view background's fill and stroke.
+
+        **Default value:** none (transparent)
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    """
+    _schema = {'$ref': '#/definitions/FacetedUnitSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, mark=Undefined, align=Undefined, bounds=Undefined, center=Undefined,
+                 columns=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, projection=Undefined, resolve=Undefined,
+                 selection=Undefined, spacing=Undefined, title=Undefined, transform=Undefined,
+                 view=Undefined, width=Undefined, **kwds):
+        super(FacetedUnitSpec, self).__init__(mark=mark, align=align, bounds=bounds, center=center,
+                                              columns=columns, data=data, description=description,
+                                              encoding=encoding, height=height, name=name,
+                                              projection=projection, resolve=resolve,
+                                              selection=selection, spacing=spacing, title=title,
+                                              transform=transform, view=view, width=width, **kwds)
+
+
+class HConcatSpec(Spec):
+    """HConcatSpec schema wrapper
+
+    Mapping(required=[hconcat])
+    Base interface for a horizontal concatenation specification.
+
+    Attributes
+    ----------
+
+    hconcat : List(:class:`Spec`)
+        A list of views to be concatenated and put into a row.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : boolean
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        **Default value:** ``false``
+    data : anyOf(:class:`Data`, None)
+        An object describing the data source. Set to ``null`` to ignore the parent's data
+        source. If no data is set, it is derived from the parent.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for view composition specifications.
+    spacing : float
+        The spacing in pixels between sub-views of the concat operator.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/HConcatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, hconcat=Undefined, bounds=Undefined, center=Undefined, data=Undefined,
+                 description=Undefined, name=Undefined, resolve=Undefined, spacing=Undefined,
+                 title=Undefined, transform=Undefined, **kwds):
+        super(HConcatSpec, self).__init__(hconcat=hconcat, bounds=bounds, center=center, data=data,
+                                          description=description, name=name, resolve=resolve,
+                                          spacing=spacing, title=title, transform=transform, **kwds)
+
+
+class LayerSpec(Spec):
+    """LayerSpec schema wrapper
+
+    Mapping(required=[layer])
+    A full layered plot specification, which may contains ``encoding`` and ``projection``
+    properties that will be applied to underlying unit (single-view) specifications.
+
+    Attributes
+    ----------
+
+    layer : List(anyOf(:class:`LayerSpec`, :class:`UnitSpec`))
+        Layer or single view specifications to be layered.
+
+        **Note** : Specifications inside ``layer`` cannot use ``row`` and ``column``
+        channels as layering facet specifications is not allowed. Instead, use the `facet
+        operator <https://vega.github.io/vega-lite/docs/facet.html>`__ and place a layer
+        inside a facet.
+    data : anyOf(:class:`Data`, None)
+        An object describing the data source. Set to ``null`` to ignore the parent's data
+        source. If no data is set, it is derived from the parent.
+    description : string
+        Description of this mark for commenting purpose.
+    encoding : :class:`Encoding`
+        A shared key-value mapping between encoding channels and definition of fields in the
+        underlying layers.
+    height : float
+        The height of a visualization.
+
+        **Default value:**
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its y-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the height will
+          be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For y-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the height is `determined by the range step, paddings, and the
+          cardinality of the field mapped to y-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__. Otherwise, if the
+          ``rangeStep`` is ``null``, the height will be the value of `config.view.height
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``y`` channel, the ``height`` will be the value of
+          ``rangeStep``.
+
+        **Note** : For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        height of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    name : string
+        Name of the visualization for later reference.
+    projection : :class:`Projection`
+        An object defining properties of the geographic projection shared by underlying
+        layers.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for view composition specifications.
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    view : :class:`ViewBackground`
+        An object defining the view background's fill and stroke.
+
+        **Default value:** none (transparent)
+    width : float
+        The width of a visualization.
+
+        **Default value:** This will be determined by the following rules:
+
+
+        * If a view's `autosize
+          <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ type is ``"fit"`` or
+          its x-channel has a `continuous scale
+          <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__, the width will
+          be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * For x-axis with a band or point scale: if `rangeStep
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__ is a numeric value or
+          unspecified, the width is `determined by the range step, paddings, and the
+          cardinality of the field mapped to x-channel
+          <https://vega.github.io/vega-lite/docs/scale.html#band>`__.   Otherwise, if the
+          ``rangeStep`` is ``null``, the width will be the value of `config.view.width
+          <https://vega.github.io/vega-lite/docs/spec.html#config>`__.
+        * If no field is mapped to ``x`` channel, the ``width`` will be the value of
+          `config.scale.textXRangeStep
+          <https://vega.github.io/vega-lite/docs/size.html#default-width-and-height>`__ for
+          ``text`` mark and the value of ``rangeStep`` for other marks.
+
+        **Note:** For plots with `row and column channels
+        <https://vega.github.io/vega-lite/docs/encoding.html#facet>`__, this represents the
+        width of a single view.
+
+        **See also:** The documentation for `width and height
+        <https://vega.github.io/vega-lite/docs/size.html>`__ contains more examples.
+    """
+    _schema = {'$ref': '#/definitions/LayerSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, layer=Undefined, data=Undefined, description=Undefined, encoding=Undefined,
+                 height=Undefined, name=Undefined, projection=Undefined, resolve=Undefined,
+                 title=Undefined, transform=Undefined, view=Undefined, width=Undefined, **kwds):
+        super(LayerSpec, self).__init__(layer=layer, data=data, description=description,
+                                        encoding=encoding, height=height, name=name,
+                                        projection=projection, resolve=resolve, title=title,
+                                        transform=transform, view=view, width=width, **kwds)
+
+
+class RepeatSpec(Spec):
+    """RepeatSpec schema wrapper
+
+    Mapping(required=[repeat, spec])
+    Base interface for a repeat specification.
+
+    Attributes
+    ----------
+
+    repeat : anyOf(List(string), :class:`RepeatMapping`)
+        Definition for fields to be repeated.  One of:
+        1) An array of fields to be repeated.  If ``"repeat"`` is an array, the field can be
+        referred using ``{"repeat": "repeat"}``
+        2) An object that mapped ``"row"`` and/or ``"column"`` to the listed of fields to be
+        repeated along the particular orientations. The objects ``{"repeat": "row"}`` and
+        ``{"repeat": "column"}`` can be used to refer to the repeated field respectively.
+    spec : :class:`Spec`
+        A specification of the view that gets repeated.
+    align : anyOf(:class:`LayoutAlign`, :class:`RowColLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    columns : float
+        The number of columns to include in the view composition layout.
+
+        **Default value** : ``undefined`` -- An infinite number of columns (a single row)
+        will be assumed. This is equivalent to
+        ``hconcat`` (for ``concat`` ) and to using the ``column`` channel (for ``facet`` and
+        ``repeat`` ).
+
+        **Note** :
+
+        1) This property is only for:
+
+
+        * the general (wrappable) ``concat`` operator (not ``hconcat`` / ``vconcat`` )
+        * the ``facet`` and ``repeat`` operator with one field/repetition definition
+          (without row/column nesting)
+
+        2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat`` )
+        and to using the ``row`` channel (for ``facet`` and ``repeat`` ).
+    data : anyOf(:class:`Data`, None)
+        An object describing the data source. Set to ``null`` to ignore the parent's data
+        source. If no data is set, it is derived from the parent.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for view composition specifications.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : Depends on ``"spacing"`` property of `the view composition
+        configuration <https://vega.github.io/vega-lite/docs/config.html#view-config>`__ (
+        ``20`` by default)
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/RepeatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, repeat=Undefined, spec=Undefined, align=Undefined, bounds=Undefined,
+                 center=Undefined, columns=Undefined, data=Undefined, description=Undefined,
+                 name=Undefined, resolve=Undefined, spacing=Undefined, title=Undefined,
+                 transform=Undefined, **kwds):
+        super(RepeatSpec, self).__init__(repeat=repeat, spec=spec, align=align, bounds=bounds,
+                                         center=center, columns=columns, data=data,
+                                         description=description, name=name, resolve=resolve,
+                                         spacing=spacing, title=title, transform=transform, **kwds)
+
+
+class SphereGenerator(Generator):
     """SphereGenerator schema wrapper
 
     Mapping(required=[sphere])
@@ -12822,37 +12445,6 @@ class StackOffset(VegaLiteSchema):
         super(StackOffset, self).__init__(*args)
 
 
-class StackTransform(VegaLiteSchema):
-    """StackTransform schema wrapper
-
-    Mapping(required=[stack, groupby, as])
-
-    Attributes
-    ----------
-
-    groupby : List(:class:`FieldName`)
-        The data fields to group by.
-    stack : :class:`FieldName`
-        The field which is stacked.
-    offset : enum('zero', 'center', 'normalize')
-        Mode for stacking marks.
-        **Default value:** ``"zero"``
-    sort : List(:class:`SortField`)
-        Field that determines the order of leaves in the stacked charts.
-    as : anyOf(:class:`FieldName`, List(:class:`FieldName`))
-        Output field names. This can be either a string or an array of strings with
-        two elements denoting the name for the fields for stack start and stack end
-        respectively.
-        If a single string(eg."val") is provided, the end field will be "val_end".
-    """
-    _schema = {'$ref': '#/definitions/StackTransform'}
-    _rootschema = Root._schema
-
-    def __init__(self, groupby=Undefined, stack=Undefined, offset=Undefined, sort=Undefined, **kwds):
-        super(StackTransform, self).__init__(groupby=groupby, stack=stack, offset=offset, sort=sort,
-                                             **kwds)
-
-
 class StandardType(VegaLiteSchema):
     """StandardType schema wrapper
 
@@ -12863,6 +12455,203 @@ class StandardType(VegaLiteSchema):
 
     def __init__(self, *args):
         super(StandardType, self).__init__(*args)
+
+
+class StringFieldDefWithCondition(VegaLiteSchema):
+    """StringFieldDefWithCondition schema wrapper
+
+    Mapping(required=[type])
+    A FieldDef with Condition :raw-html:`<ValueDef>`
+
+    Attributes
+    ----------
+
+    type : :class:`StandardType`
+        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
+        ``"ordinal"``, or ``"nominal"`` ).
+        It can also be a ``"geojson"`` type for encoding `'geoshape'
+        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
+
+        **Note:**
+
+
+        * Data values for a temporal field can be either a date-time string (e.g.,
+          ``"2015-03-07 12:32:17"``, ``"17:01"``, ``"2015-03-16"``. ``"2015"`` ) or a
+          timestamp number (e.g., ``1552199579097`` ).
+        * Data ``type`` describes the semantics of the data rather than the primitive data
+          types ( ``number``, ``string``, etc.). The same primitive data type can have
+          different types of measurement. For example, numeric data can represent
+          quantitative, ordinal, or nominal data.
+        * When using with `bin <https://vega.github.io/vega-lite/docs/bin.html>`__, the
+          ``type`` property can be either ``"quantitative"`` (for using a linear bin scale)
+          or `"ordinal" (for using an ordinal bin scale)
+          <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
+        * When using with `timeUnit
+          <https://vega.github.io/vega-lite/docs/timeunit.html>`__, the ``type`` property
+          can be either ``"temporal"`` (for using a temporal scale) or `"ordinal" (for using
+          an ordinal scale) <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
+        * When using with `aggregate
+          <https://vega.github.io/vega-lite/docs/aggregate.html>`__, the ``type`` property
+          refers to the post-aggregation data type. For example, we can calculate count
+          ``distinct`` of a categorical field ``"cat"`` using ``{"aggregate": "distinct",
+          "field": "cat", "type": "quantitative"}``. The ``"type"`` of the aggregate output
+          is ``"quantitative"``.
+        * Secondary channels (e.g., ``x2``, ``y2``, ``xError``, ``yError`` ) do not have
+          ``type`` as they have exactly the same type as their primary channels (e.g.,
+          ``x``, ``y`` ).
+
+        **See also:** `type <https://vega.github.io/vega-lite/docs/type.html>`__
+        documentation.
+    aggregate : :class:`Aggregate`
+        Aggregation function for the field
+        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
+
+        **Default value:** ``undefined`` (None)
+
+        **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
+        documentation.
+    bin : anyOf(boolean, :class:`BinParams`, None)
+        A flag for binning a ``quantitative`` field, `an object defining binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
+        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
+        ``"binned"`` ).
+
+
+        If ``true``, default `binning parameters
+        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+
+        If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
+        already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
+        field to ``x2`` (or ``y2`` ). The scale and axis will be formatted similar to
+        binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also
+        set the axis's `tickMinStep
+        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
+
+        **Default value:** ``false``
+
+        **See also:** `bin <https://vega.github.io/vega-lite/docs/bin.html>`__
+        documentation.
+    condition : anyOf(:class:`ConditionalStringValueDef`,
+    List(:class:`ConditionalStringValueDef`))
+        One or more value definition(s) with `a selection or a test predicate
+        <https://vega.github.io/vega-lite/docs/condition.html>`__.
+
+        **Note:** A field definition's ``condition`` property can only contain `conditional
+        value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
+        since Vega-Lite only allows at most one encoded field per encoding channel.
+    field : :class:`Field`
+        **Required.** A string defining the name of the field from which to pull a data
+        value
+        or an object defining iterated values from the `repeat
+        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
+
+        **See also:** `field <https://vega.github.io/vega-lite/docs/field.html>`__
+        documentation.
+
+        **Notes:**
+        1)  Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested
+        objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
+        If field names contain dots or brackets but are not nested, you can use ``\\`` to
+        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
+        See more details about escaping in the `field documentation
+        <https://vega.github.io/vega-lite/docs/field.html>`__.
+        2) ``field`` is not required if ``aggregate`` is ``count``.
+    legend : anyOf(:class:`Legend`, None)
+        An object defining properties of the legend.
+        If ``null``, the legend for the encoding channel will be removed.
+
+        **Default value:** If undefined, default `legend properties
+        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
+
+        **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
+        documentation.
+    scale : anyOf(:class:`Scale`, None)
+        An object defining properties of the channel's scale, which is the function that
+        transforms values in the data domain (numbers, dates, strings, etc) to visual values
+        (pixels, colors, sizes) of the encoding channels.
+
+        If ``null``, the scale will be `disabled and the data value will be directly encoded
+        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
+
+        **Default value:** If undefined, default `scale properties
+        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
+
+        **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
+        documentation.
+    sort : :class:`Sort`
+        Sort order for the encoded field.
+
+        For continuous fields (quantitative or temporal), ``sort`` can be either
+        ``"ascending"`` or ``"descending"``.
+
+        For discrete fields, ``sort`` can be one of the following:
+
+
+        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
+          Javascript.
+        * `A sort-by-encoding definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-by-encoding>`__ for sorting
+          by another encoding channel. (This type of sort definition is not available for
+          ``row`` and ``column`` channels.)
+        * `A sort field definition
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
+          another field.
+        * `An array specifying the field values in preferred order
+          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
+          sort order will obey the values in the array, followed by any unspecified values
+          in their original order.  For discrete time field, values in the sort array can be
+          `date-time definition objects <types#datetime>`__. In addition, for time units
+          ``"month"`` and ``"day"``, the values can be the month or day names (case
+          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
+        * ``null`` indicating no sort.
+
+        **Default value:** ``"ascending"``
+
+        **Note:** ``null`` is not supported for ``row`` and ``column``.
+
+        **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
+        documentation.
+    timeUnit : :class:`TimeUnit`
+        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
+        field.
+        or `a temporal field that gets casted as ordinal
+        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
+
+        **Default value:** ``undefined`` (None)
+
+        **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
+        documentation.
+    title : anyOf(string, None)
+        A title for the field. If ``null``, the title will be removed.
+
+        **Default value:**  derived from the field's name and transformation function (
+        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
+        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
+        field is binned or has a time unit applied, the applied function is shown in
+        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
+        Otherwise, the title is simply the field name.
+
+        **Notes** :
+
+        1) You can customize the default field title format by providing the `fieldTitle
+        <https://vega.github.io/vega-lite/docs/config.html#top-level-config>`__ property in
+        the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or `fieldTitle
+        function via the compile function's options
+        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
+
+        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
+        defined, axis/header/legend title will be used.
+    """
+    _schema = {'$ref': '#/definitions/StringFieldDefWithCondition'}
+    _rootschema = Root._schema
+
+    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
+                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
+                 title=Undefined, **kwds):
+        super(StringFieldDefWithCondition, self).__init__(type=type, aggregate=aggregate, bin=bin,
+                                                          condition=condition, field=field,
+                                                          legend=legend, scale=scale, sort=sort,
+                                                          timeUnit=timeUnit, title=title, **kwds)
 
 
 class StringFieldDefWithConditionTypeForShape(VegaLiteSchema):
@@ -13064,201 +12853,28 @@ class StringFieldDefWithConditionTypeForShape(VegaLiteSchema):
                                                                       **kwds)
 
 
-class StringFieldDefWithCondition(VegaLiteSchema):
-    """StringFieldDefWithCondition schema wrapper
+class StringValueDefWithCondition(VegaLiteSchema):
+    """StringValueDefWithCondition schema wrapper
 
-    Mapping(required=[type])
-    A FieldDef with Condition :raw-html:`<ValueDef>`
+    Mapping(required=[])
+    A ValueDef with Condition<ValueDef | FieldDef> where either the condition or the value are
+    optional.
 
     Attributes
     ----------
 
-    type : :class:`StandardType`
-        The encoded field's type of measurement ( ``"quantitative"``, ``"temporal"``,
-        ``"ordinal"``, or ``"nominal"`` ).
-        It can also be a ``"geojson"`` type for encoding `'geoshape'
-        <https://vega.github.io/vega-lite/docs/geoshape.html>`__.
-
-        **Note:**
-
-
-        * Data values for a temporal field can be either a date-time string (e.g.,
-          ``"2015-03-07 12:32:17"``, ``"17:01"``, ``"2015-03-16"``. ``"2015"`` ) or a
-          timestamp number (e.g., ``1552199579097`` ).
-        * Data ``type`` describes the semantics of the data rather than the primitive data
-          types ( ``number``, ``string``, etc.). The same primitive data type can have
-          different types of measurement. For example, numeric data can represent
-          quantitative, ordinal, or nominal data.
-        * When using with `bin <https://vega.github.io/vega-lite/docs/bin.html>`__, the
-          ``type`` property can be either ``"quantitative"`` (for using a linear bin scale)
-          or `"ordinal" (for using an ordinal bin scale)
-          <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
-        * When using with `timeUnit
-          <https://vega.github.io/vega-lite/docs/timeunit.html>`__, the ``type`` property
-          can be either ``"temporal"`` (for using a temporal scale) or `"ordinal" (for using
-          an ordinal scale) <https://vega.github.io/vega-lite/docs/type.html#cast-bin>`__.
-        * When using with `aggregate
-          <https://vega.github.io/vega-lite/docs/aggregate.html>`__, the ``type`` property
-          refers to the post-aggregation data type. For example, we can calculate count
-          ``distinct`` of a categorical field ``"cat"`` using ``{"aggregate": "distinct",
-          "field": "cat", "type": "quantitative"}``. The ``"type"`` of the aggregate output
-          is ``"quantitative"``.
-        * Secondary channels (e.g., ``x2``, ``y2``, ``xError``, ``yError`` ) do not have
-          ``type`` as they have exactly the same type as their primary channels (e.g.,
-          ``x``, ``y`` ).
-
-        **See also:** `type <https://vega.github.io/vega-lite/docs/type.html>`__
-        documentation.
-    aggregate : :class:`Aggregate`
-        Aggregation function for the field
-        (e.g., ``mean``, ``sum``, ``median``, ``min``, ``max``, ``count`` ).
-
-        **Default value:** ``undefined`` (None)
-
-        **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
-        documentation.
-    bin : anyOf(boolean, :class:`BinParams`, None)
-        A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
-
-
-        If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
-
-        If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
-        already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
-        field to ``x2`` (or ``y2`` ). The scale and axis will be formatted similar to
-        binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also
-        set the axis's `tickMinStep
-        <https://vega.github.io/vega-lite/docs/axis.html#ticks>`__ property.
-
-        **Default value:** ``false``
-
-        **See also:** `bin <https://vega.github.io/vega-lite/docs/bin.html>`__
-        documentation.
-    condition : anyOf(:class:`ConditionalStringValueDef`,
+    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalStringValueDef`,
     List(:class:`ConditionalStringValueDef`))
-        One or more value definition(s) with `a selection or a test predicate
-        <https://vega.github.io/vega-lite/docs/condition.html>`__.
-
-        **Note:** A field definition's ``condition`` property can only contain `conditional
-        value definitions <https://vega.github.io/vega-lite/docs/condition.html#value>`__
-        since Vega-Lite only allows at most one encoded field per encoding channel.
-    field : :class:`Field`
-        **Required.** A string defining the name of the field from which to pull a data
-        value
-        or an object defining iterated values from the `repeat
-        <https://vega.github.io/vega-lite/docs/repeat.html>`__ operator.
-
-        **See also:** `field <https://vega.github.io/vega-lite/docs/field.html>`__
-        documentation.
-
-        **Notes:**
-        1)  Dots ( ``.`` ) and brackets ( ``[`` and ``]`` ) can be used to access nested
-        objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"`` ).
-        If field names contain dots or brackets but are not nested, you can use ``\\`` to
-        escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"`` ).
-        See more details about escaping in the `field documentation
-        <https://vega.github.io/vega-lite/docs/field.html>`__.
-        2) ``field`` is not required if ``aggregate`` is ``count``.
-    legend : anyOf(:class:`Legend`, None)
-        An object defining properties of the legend.
-        If ``null``, the legend for the encoding channel will be removed.
-
-        **Default value:** If undefined, default `legend properties
-        <https://vega.github.io/vega-lite/docs/legend.html>`__ are applied.
-
-        **See also:** `legend <https://vega.github.io/vega-lite/docs/legend.html>`__
-        documentation.
-    scale : anyOf(:class:`Scale`, None)
-        An object defining properties of the channel's scale, which is the function that
-        transforms values in the data domain (numbers, dates, strings, etc) to visual values
-        (pixels, colors, sizes) of the encoding channels.
-
-        If ``null``, the scale will be `disabled and the data value will be directly encoded
-        <https://vega.github.io/vega-lite/docs/scale.html#disable>`__.
-
-        **Default value:** If undefined, default `scale properties
-        <https://vega.github.io/vega-lite/docs/scale.html>`__ are applied.
-
-        **See also:** `scale <https://vega.github.io/vega-lite/docs/scale.html>`__
-        documentation.
-    sort : :class:`Sort`
-        Sort order for the encoded field.
-
-        For continuous fields (quantitative or temporal), ``sort`` can be either
-        ``"ascending"`` or ``"descending"``.
-
-        For discrete fields, ``sort`` can be one of the following:
-
-
-        * ``"ascending"`` or ``"descending"`` -- for sorting by the values' natural order in
-          Javascript.
-        * `A sort-by-encoding definition
-          <https://vega.github.io/vega-lite/docs/sort.html#sort-by-encoding>`__ for sorting
-          by another encoding channel. (This type of sort definition is not available for
-          ``row`` and ``column`` channels.)
-        * `A sort field definition
-          <https://vega.github.io/vega-lite/docs/sort.html#sort-field>`__ for sorting by
-          another field.
-        * `An array specifying the field values in preferred order
-          <https://vega.github.io/vega-lite/docs/sort.html#sort-array>`__. In this case, the
-          sort order will obey the values in the array, followed by any unspecified values
-          in their original order.  For discrete time field, values in the sort array can be
-          `date-time definition objects <types#datetime>`__. In addition, for time units
-          ``"month"`` and ``"day"``, the values can be the month or day names (case
-          insensitive) or their 3-letter initials (e.g., ``"Mon"``, ``"Tue"`` ).
-        * ``null`` indicating no sort.
-
-        **Default value:** ``"ascending"``
-
-        **Note:** ``null`` is not supported for ``row`` and ``column``.
-
-        **See also:** `sort <https://vega.github.io/vega-lite/docs/sort.html>`__
-        documentation.
-    timeUnit : :class:`TimeUnit`
-        Time unit (e.g., ``year``, ``yearmonth``, ``month``, ``hours`` ) for a temporal
-        field.
-        or `a temporal field that gets casted as ordinal
-        <https://vega.github.io/vega-lite/docs/type.html#cast>`__.
-
-        **Default value:** ``undefined`` (None)
-
-        **See also:** `timeUnit <https://vega.github.io/vega-lite/docs/timeunit.html>`__
-        documentation.
-    title : anyOf(string, None)
-        A title for the field. If ``null``, the title will be removed.
-
-        **Default value:**  derived from the field's name and transformation function (
-        ``aggregate``, ``bin`` and ``timeUnit`` ).  If the field has an aggregate function,
-        the function is displayed as part of the title (e.g., ``"Sum of Profit"`` ). If the
-        field is binned or has a time unit applied, the applied function is shown in
-        parentheses (e.g., ``"Profit (binned)"``, ``"Transaction Date (year-month)"`` ).
-        Otherwise, the title is simply the field name.
-
-        **Notes** :
-
-        1) You can customize the default field title format by providing the `fieldTitle
-        <https://vega.github.io/vega-lite/docs/config.html#top-level-config>`__ property in
-        the `config <https://vega.github.io/vega-lite/docs/config.html>`__ or `fieldTitle
-        function via the compile function's options
-        <https://vega.github.io/vega-lite/docs/compile.html#field-title>`__.
-
-        2) If both field definition's ``title`` and axis, header, or legend ``title`` are
-        defined, axis/header/legend title will be used.
+        A field definition or one or more value definition(s) with a selection predicate.
+    value : anyOf(string, None)
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
     """
-    _schema = {'$ref': '#/definitions/StringFieldDefWithCondition'}
+    _schema = {'$ref': '#/definitions/StringValueDefWithCondition'}
     _rootschema = Root._schema
 
-    def __init__(self, type=Undefined, aggregate=Undefined, bin=Undefined, condition=Undefined,
-                 field=Undefined, legend=Undefined, scale=Undefined, sort=Undefined, timeUnit=Undefined,
-                 title=Undefined, **kwds):
-        super(StringFieldDefWithCondition, self).__init__(type=type, aggregate=aggregate, bin=bin,
-                                                          condition=condition, field=field,
-                                                          legend=legend, scale=scale, sort=sort,
-                                                          timeUnit=timeUnit, title=title, **kwds)
+    def __init__(self, condition=Undefined, value=Undefined, **kwds):
+        super(StringValueDefWithCondition, self).__init__(condition=condition, value=value, **kwds)
 
 
 class StringValueDefWithConditionTypeForShape(VegaLiteSchema):
@@ -13284,30 +12900,6 @@ class StringValueDefWithConditionTypeForShape(VegaLiteSchema):
     def __init__(self, condition=Undefined, value=Undefined, **kwds):
         super(StringValueDefWithConditionTypeForShape, self).__init__(condition=condition, value=value,
                                                                       **kwds)
-
-
-class StringValueDefWithCondition(VegaLiteSchema):
-    """StringValueDefWithCondition schema wrapper
-
-    Mapping(required=[])
-    A ValueDef with Condition<ValueDef | FieldDef> where either the condition or the value are
-    optional.
-
-    Attributes
-    ----------
-
-    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalStringValueDef`,
-    List(:class:`ConditionalStringValueDef`))
-        A field definition or one or more value definition(s) with a selection predicate.
-    value : anyOf(string, None)
-        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
-        between ``0`` to ``1`` for opacity).
-    """
-    _schema = {'$ref': '#/definitions/StringValueDefWithCondition'}
-    _rootschema = Root._schema
-
-    def __init__(self, condition=Undefined, value=Undefined, **kwds):
-        super(StringValueDefWithCondition, self).__init__(condition=condition, value=value, **kwds)
 
 
 class StrokeCap(VegaLiteSchema):
@@ -13368,6 +12960,18 @@ class TextBaseline(VegaLiteSchema):
 
     def __init__(self, *args, **kwds):
         super(TextBaseline, self).__init__(*args, **kwds)
+
+
+class Baseline(TextBaseline):
+    """Baseline schema wrapper
+
+    enum('top', 'middle', 'bottom')
+    """
+    _schema = {'$ref': '#/definitions/Baseline'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(Baseline, self).__init__(*args)
 
 
 class TextConfig(VegaLiteSchema):
@@ -14259,26 +13863,56 @@ class TimeUnit(VegaLiteSchema):
         super(TimeUnit, self).__init__(*args, **kwds)
 
 
-class TimeUnitTransform(VegaLiteSchema):
-    """TimeUnitTransform schema wrapper
+class MultiTimeUnit(TimeUnit):
+    """MultiTimeUnit schema wrapper
 
-    Mapping(required=[timeUnit, field, as])
-
-    Attributes
-    ----------
-
-    field : :class:`FieldName`
-        The data field to apply time unit.
-    timeUnit : :class:`TimeUnit`
-        The timeUnit.
-    as : :class:`FieldName`
-        The output field to write the timeUnit value.
+    anyOf(:class:`LocalMultiTimeUnit`, :class:`UtcMultiTimeUnit`)
     """
-    _schema = {'$ref': '#/definitions/TimeUnitTransform'}
+    _schema = {'$ref': '#/definitions/MultiTimeUnit'}
     _rootschema = Root._schema
 
-    def __init__(self, field=Undefined, timeUnit=Undefined, **kwds):
-        super(TimeUnitTransform, self).__init__(field=field, timeUnit=timeUnit, **kwds)
+    def __init__(self, *args, **kwds):
+        super(MultiTimeUnit, self).__init__(*args, **kwds)
+
+
+class LocalMultiTimeUnit(MultiTimeUnit):
+    """LocalMultiTimeUnit schema wrapper
+
+    enum('yearquarter', 'yearquartermonth', 'yearmonth', 'yearmonthdate', 'yearmonthdatehours',
+    'yearmonthdatehoursminutes', 'yearmonthdatehoursminutesseconds', 'quartermonth',
+    'monthdate', 'monthdatehours', 'hoursminutes', 'hoursminutesseconds', 'minutesseconds',
+    'secondsmilliseconds')
+    """
+    _schema = {'$ref': '#/definitions/LocalMultiTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(LocalMultiTimeUnit, self).__init__(*args)
+
+
+class SingleTimeUnit(TimeUnit):
+    """SingleTimeUnit schema wrapper
+
+    anyOf(:class:`LocalSingleTimeUnit`, :class:`UtcSingleTimeUnit`)
+    """
+    _schema = {'$ref': '#/definitions/SingleTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(SingleTimeUnit, self).__init__(*args, **kwds)
+
+
+class LocalSingleTimeUnit(SingleTimeUnit):
+    """LocalSingleTimeUnit schema wrapper
+
+    enum('year', 'quarter', 'month', 'day', 'date', 'hours', 'minutes', 'seconds',
+    'milliseconds')
+    """
+    _schema = {'$ref': '#/definitions/LocalSingleTimeUnit'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args):
+        super(LocalSingleTimeUnit, self).__init__(*args)
 
 
 class TitleAnchor(VegaLiteSchema):
@@ -14486,7 +14120,24 @@ class TooltipContent(VegaLiteSchema):
         super(TooltipContent, self).__init__(content=content, **kwds)
 
 
-class TopLevelConcatSpec(VegaLiteSchema):
+class TopLevelSpec(VegaLiteSchema):
+    """TopLevelSpec schema wrapper
+
+    anyOf(:class:`TopLevelUnitSpec`, :class:`TopLevelFacetSpec`, :class:`TopLevelLayerSpec`,
+    :class:`TopLevelRepeatSpec`, :class:`TopLevelConcatSpec`, :class:`TopLevelVConcatSpec`,
+    :class:`TopLevelHConcatSpec`)
+    A Vega-Lite top-level specification.
+    This is the root class for all Vega-Lite specifications.
+    (The json schema is generated from this type.)
+    """
+    _schema = {'$ref': '#/definitions/TopLevelSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, *args, **kwds):
+        super(TopLevelSpec, self).__init__(*args, **kwds)
+
+
+class TopLevelConcatSpec(TopLevelSpec):
     """TopLevelConcatSpec schema wrapper
 
     Mapping(required=[concat])
@@ -14629,7 +14280,156 @@ class TopLevelConcatSpec(VegaLiteSchema):
                                                  **kwds)
 
 
-class TopLevelHConcatSpec(VegaLiteSchema):
+class TopLevelFacetSpec(TopLevelSpec):
+    """TopLevelFacetSpec schema wrapper
+
+    Mapping(required=[data, facet, spec])
+
+    Attributes
+    ----------
+
+    data : anyOf(:class:`Data`, None)
+        An object describing the data source. Set to ``null`` to ignore the parent's data
+        source. If no data is set, it is derived from the parent.
+    facet : anyOf(:class:`FacetFieldDef`, :class:`FacetMapping`)
+        Definition for how to facet the data.  One of:
+        1) `a field definition for faceting the plot by one field
+        <https://vega.github.io/vega-lite/docs/facet.html#field-def>`__
+        2) `An object that maps row and column channels to their field definitions
+        <https://vega.github.io/vega-lite/docs/facet.html#mapping>`__
+    spec : anyOf(:class:`LayerSpec`, :class:`FacetedUnitSpec`)
+        A specification of the view that gets faceted.
+    align : anyOf(:class:`LayoutAlign`, :class:`RowColLayoutAlign`)
+        The alignment to apply to grid rows and columns.
+        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
+
+
+        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
+          placed one after the other.
+        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
+          or column may be of variable size.
+        * For ``"all"``, subviews will be aligned and each row or column will be sized
+          identically based on the maximum observed size. String values for this property
+          will be applied to both grid rows and columns.
+
+        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
+        be used to supply different alignments for rows and columns.
+
+        **Default value:** ``"all"``.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of the entire view.
+
+        **Default value:** none (transparent)
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : anyOf(boolean, :class:`RowColboolean`)
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
+        supply different centering values for rows and columns.
+
+        **Default value:** ``false``
+    columns : float
+        The number of columns to include in the view composition layout.
+
+        **Default value** : ``undefined`` -- An infinite number of columns (a single row)
+        will be assumed. This is equivalent to
+        ``hconcat`` (for ``concat`` ) and to using the ``column`` channel (for ``facet`` and
+        ``repeat`` ).
+
+        **Note** :
+
+        1) This property is only for:
+
+
+        * the general (wrappable) ``concat`` operator (not ``hconcat`` / ``vconcat`` )
+        * the ``facet`` and ``repeat`` operator with one field/repetition definition
+          (without row/column nesting)
+
+        2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat`` )
+        and to using the ``row`` channel (for ``facet`` and ``repeat`` ).
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for view composition specifications.
+    spacing : anyOf(float, :class:`RowColnumber`)
+        The spacing in pixels between sub-views of the composition operator.
+        An object of the form ``{"row": number, "column": number}`` can be used to set
+        different spacing values for rows and columns.
+
+        **Default value** : Depends on ``"spacing"`` property of `the view composition
+        configuration <https://vega.github.io/vega-lite/docs/config.html#view-config>`__ (
+        ``20`` by default)
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    usermeta : Mapping(required=[])
+        Optional metadata that will be passed to Vega.
+        This object is completely ignored by Vega and Vega-Lite and can be used for custom
+        metadata.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v3.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
+    """
+    _schema = {'$ref': '#/definitions/TopLevelFacetSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, data=Undefined, facet=Undefined, spec=Undefined, align=Undefined,
+                 autosize=Undefined, background=Undefined, bounds=Undefined, center=Undefined,
+                 columns=Undefined, config=Undefined, datasets=Undefined, description=Undefined,
+                 name=Undefined, padding=Undefined, resolve=Undefined, spacing=Undefined,
+                 title=Undefined, transform=Undefined, usermeta=Undefined, **kwds):
+        super(TopLevelFacetSpec, self).__init__(data=data, facet=facet, spec=spec, align=align,
+                                                autosize=autosize, background=background, bounds=bounds,
+                                                center=center, columns=columns, config=config,
+                                                datasets=datasets, description=description, name=name,
+                                                padding=padding, resolve=resolve, spacing=spacing,
+                                                title=title, transform=transform, usermeta=usermeta,
+                                                **kwds)
+
+
+class TopLevelHConcatSpec(TopLevelSpec):
     """TopLevelHConcatSpec schema wrapper
 
     Mapping(required=[hconcat])
@@ -14727,255 +14527,7 @@ class TopLevelHConcatSpec(VegaLiteSchema):
                                                   transform=transform, usermeta=usermeta, **kwds)
 
 
-class TopLevelRepeatSpec(VegaLiteSchema):
-    """TopLevelRepeatSpec schema wrapper
-
-    Mapping(required=[repeat, spec])
-
-    Attributes
-    ----------
-
-    repeat : anyOf(List(string), :class:`RepeatMapping`)
-        Definition for fields to be repeated.  One of:
-        1) An array of fields to be repeated.  If ``"repeat"`` is an array, the field can be
-        referred using ``{"repeat": "repeat"}``
-        2) An object that mapped ``"row"`` and/or ``"column"`` to the listed of fields to be
-        repeated along the particular orientations. The objects ``{"repeat": "row"}`` and
-        ``{"repeat": "column"}`` can be used to refer to the repeated field respectively.
-    spec : :class:`Spec`
-        A specification of the view that gets repeated.
-    align : anyOf(:class:`LayoutAlign`, :class:`RowColLayoutAlign`)
-        The alignment to apply to grid rows and columns.
-        The supported string values are ``"all"``, ``"each"``, and ``"none"``.
-
-
-        * For ``"none"``, a flow layout will be used, in which adjacent subviews are simply
-          placed one after the other.
-        * For ``"each"``, subviews will be aligned into a clean grid structure, but each row
-          or column may be of variable size.
-        * For ``"all"``, subviews will be aligned and each row or column will be sized
-          identically based on the maximum observed size. String values for this property
-          will be applied to both grid rows and columns.
-
-        Alternatively, an object value of the form ``{"row": string, "column": string}`` can
-        be used to supply different alignments for rows and columns.
-
-        **Default value:** ``"all"``.
-    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
-        Sets how the visualization size should be determined. If a string, should be one of
-        ``"pad"``, ``"fit"`` or ``"none"``.
-        Object values can additionally specify parameters for content sizing and automatic
-        resizing.
-        ``"fit"`` is only supported for single and layered views that don't use
-        ``rangeStep``.
-
-        **Default value** : ``pad``
-    background : string
-        CSS color property to use as the background of the entire view.
-
-        **Default value:** none (transparent)
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : anyOf(boolean, :class:`RowColboolean`)
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        An object value of the form ``{"row": boolean, "column": boolean}`` can be used to
-        supply different centering values for rows and columns.
-
-        **Default value:** ``false``
-    columns : float
-        The number of columns to include in the view composition layout.
-
-        **Default value** : ``undefined`` -- An infinite number of columns (a single row)
-        will be assumed. This is equivalent to
-        ``hconcat`` (for ``concat`` ) and to using the ``column`` channel (for ``facet`` and
-        ``repeat`` ).
-
-        **Note** :
-
-        1) This property is only for:
-
-
-        * the general (wrappable) ``concat`` operator (not ``hconcat`` / ``vconcat`` )
-        * the ``facet`` and ``repeat`` operator with one field/repetition definition
-          (without row/column nesting)
-
-        2) Setting the ``columns`` to ``1`` is equivalent to ``vconcat`` (for ``concat`` )
-        and to using the ``row`` channel (for ``facet`` and ``repeat`` ).
-    config : :class:`Config`
-        Vega-Lite configuration object.  This property can only be defined at the top-level
-        of a specification.
-    data : anyOf(:class:`Data`, None)
-        An object describing the data source. Set to ``null`` to ignore the parent's data
-        source. If no data is set, it is derived from the parent.
-    datasets : :class:`Datasets`
-        A global data store for named datasets. This is a mapping from names to inline
-        datasets.
-        This can be an array of objects or primitive values or a string. Arrays of primitive
-        values are ingested as objects with a ``data`` property.
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    padding : :class:`Padding`
-        The default visualization padding, in pixels, from the edge of the visualization
-        canvas to the data rectangle.  If a number, specifies padding for all sides.
-        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}`` to specify padding for each side of the visualization.
-
-        **Default value** : ``5``
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for view composition specifications.
-    spacing : anyOf(float, :class:`RowColnumber`)
-        The spacing in pixels between sub-views of the composition operator.
-        An object of the form ``{"row": number, "column": number}`` can be used to set
-        different spacing values for rows and columns.
-
-        **Default value** : Depends on ``"spacing"`` property of `the view composition
-        configuration <https://vega.github.io/vega-lite/docs/config.html#view-config>`__ (
-        ``20`` by default)
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    usermeta : Mapping(required=[])
-        Optional metadata that will be passed to Vega.
-        This object is completely ignored by Vega and Vega-Lite and can be used for custom
-        metadata.
-    $schema : string
-        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
-        Unless you have a reason to change this, use
-        ``https://vega.github.io/schema/vega-lite/v3.json``. Setting the ``$schema``
-        property allows automatic validation and autocomplete in editors that support JSON
-        schema.
-    """
-    _schema = {'$ref': '#/definitions/TopLevelRepeatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, repeat=Undefined, spec=Undefined, align=Undefined, autosize=Undefined,
-                 background=Undefined, bounds=Undefined, center=Undefined, columns=Undefined,
-                 config=Undefined, data=Undefined, datasets=Undefined, description=Undefined,
-                 name=Undefined, padding=Undefined, resolve=Undefined, spacing=Undefined,
-                 title=Undefined, transform=Undefined, usermeta=Undefined, **kwds):
-        super(TopLevelRepeatSpec, self).__init__(repeat=repeat, spec=spec, align=align,
-                                                 autosize=autosize, background=background,
-                                                 bounds=bounds, center=center, columns=columns,
-                                                 config=config, data=data, datasets=datasets,
-                                                 description=description, name=name, padding=padding,
-                                                 resolve=resolve, spacing=spacing, title=title,
-                                                 transform=transform, usermeta=usermeta, **kwds)
-
-
-class TopLevelVConcatSpec(VegaLiteSchema):
-    """TopLevelVConcatSpec schema wrapper
-
-    Mapping(required=[vconcat])
-
-    Attributes
-    ----------
-
-    vconcat : List(:class:`Spec`)
-        A list of views to be concatenated and put into a column.
-    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
-        Sets how the visualization size should be determined. If a string, should be one of
-        ``"pad"``, ``"fit"`` or ``"none"``.
-        Object values can additionally specify parameters for content sizing and automatic
-        resizing.
-        ``"fit"`` is only supported for single and layered views that don't use
-        ``rangeStep``.
-
-        **Default value** : ``pad``
-    background : string
-        CSS color property to use as the background of the entire view.
-
-        **Default value:** none (transparent)
-    bounds : enum('full', 'flush')
-        The bounds calculation method to use for determining the extent of a sub-plot. One
-        of ``full`` (the default) or ``flush``.
-
-
-        * If set to ``full``, the entire calculated bounds (including axes, title, and
-          legend) will be used.
-        * If set to ``flush``, only the specified width and height values for the sub-view
-          will be used. The ``flush`` setting can be useful when attempting to place
-          sub-plots without axes or legends into a uniform grid structure.
-
-        **Default value:** ``"full"``
-    center : boolean
-        Boolean flag indicating if subviews should be centered relative to their respective
-        rows or columns.
-
-        **Default value:** ``false``
-    config : :class:`Config`
-        Vega-Lite configuration object.  This property can only be defined at the top-level
-        of a specification.
-    data : anyOf(:class:`Data`, None)
-        An object describing the data source. Set to ``null`` to ignore the parent's data
-        source. If no data is set, it is derived from the parent.
-    datasets : :class:`Datasets`
-        A global data store for named datasets. This is a mapping from names to inline
-        datasets.
-        This can be an array of objects or primitive values or a string. Arrays of primitive
-        values are ingested as objects with a ``data`` property.
-    description : string
-        Description of this mark for commenting purpose.
-    name : string
-        Name of the visualization for later reference.
-    padding : :class:`Padding`
-        The default visualization padding, in pixels, from the edge of the visualization
-        canvas to the data rectangle.  If a number, specifies padding for all sides.
-        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}`` to specify padding for each side of the visualization.
-
-        **Default value** : ``5``
-    resolve : :class:`Resolve`
-        Scale, axis, and legend resolutions for view composition specifications.
-    spacing : float
-        The spacing in pixels between sub-views of the concat operator.
-
-        **Default value** : ``10``
-    title : anyOf(string, :class:`TitleParams`)
-        Title for the plot.
-    transform : List(:class:`Transform`)
-        An array of data transformations such as filter and new field calculation.
-    usermeta : Mapping(required=[])
-        Optional metadata that will be passed to Vega.
-        This object is completely ignored by Vega and Vega-Lite and can be used for custom
-        metadata.
-    $schema : string
-        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
-        Unless you have a reason to change this, use
-        ``https://vega.github.io/schema/vega-lite/v3.json``. Setting the ``$schema``
-        property allows automatic validation and autocomplete in editors that support JSON
-        schema.
-    """
-    _schema = {'$ref': '#/definitions/TopLevelVConcatSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, vconcat=Undefined, autosize=Undefined, background=Undefined, bounds=Undefined,
-                 center=Undefined, config=Undefined, data=Undefined, datasets=Undefined,
-                 description=Undefined, name=Undefined, padding=Undefined, resolve=Undefined,
-                 spacing=Undefined, title=Undefined, transform=Undefined, usermeta=Undefined, **kwds):
-        super(TopLevelVConcatSpec, self).__init__(vconcat=vconcat, autosize=autosize,
-                                                  background=background, bounds=bounds, center=center,
-                                                  config=config, data=data, datasets=datasets,
-                                                  description=description, name=name, padding=padding,
-                                                  resolve=resolve, spacing=spacing, title=title,
-                                                  transform=transform, usermeta=usermeta, **kwds)
-
-
-class TopLevelLayerSpec(VegaLiteSchema):
+class TopLevelLayerSpec(TopLevelSpec):
     """TopLevelLayerSpec schema wrapper
 
     Mapping(required=[layer])
@@ -15127,25 +14679,23 @@ class TopLevelLayerSpec(VegaLiteSchema):
                                                 width=width, **kwds)
 
 
-class TopLevelFacetSpec(VegaLiteSchema):
-    """TopLevelFacetSpec schema wrapper
+class TopLevelRepeatSpec(TopLevelSpec):
+    """TopLevelRepeatSpec schema wrapper
 
-    Mapping(required=[data, facet, spec])
+    Mapping(required=[repeat, spec])
 
     Attributes
     ----------
 
-    data : anyOf(:class:`Data`, None)
-        An object describing the data source. Set to ``null`` to ignore the parent's data
-        source. If no data is set, it is derived from the parent.
-    facet : anyOf(:class:`FacetFieldDef`, :class:`FacetMapping`)
-        Definition for how to facet the data.  One of:
-        1) `a field definition for faceting the plot by one field
-        <https://vega.github.io/vega-lite/docs/facet.html#field-def>`__
-        2) `An object that maps row and column channels to their field definitions
-        <https://vega.github.io/vega-lite/docs/facet.html#mapping>`__
-    spec : anyOf(:class:`LayerSpec`, :class:`FacetedUnitSpec`)
-        A specification of the view that gets faceted.
+    repeat : anyOf(List(string), :class:`RepeatMapping`)
+        Definition for fields to be repeated.  One of:
+        1) An array of fields to be repeated.  If ``"repeat"`` is an array, the field can be
+        referred using ``{"repeat": "repeat"}``
+        2) An object that mapped ``"row"`` and/or ``"column"`` to the listed of fields to be
+        repeated along the particular orientations. The objects ``{"repeat": "row"}`` and
+        ``{"repeat": "column"}`` can be used to refer to the repeated field respectively.
+    spec : :class:`Spec`
+        A specification of the view that gets repeated.
     align : anyOf(:class:`LayoutAlign`, :class:`RowColLayoutAlign`)
         The alignment to apply to grid rows and columns.
         The supported string values are ``"all"``, ``"each"``, and ``"none"``.
@@ -15218,6 +14768,9 @@ class TopLevelFacetSpec(VegaLiteSchema):
     config : :class:`Config`
         Vega-Lite configuration object.  This property can only be defined at the top-level
         of a specification.
+    data : anyOf(:class:`Data`, None)
+        An object describing the data source. Set to ``null`` to ignore the parent's data
+        source. If no data is set, it is derived from the parent.
     datasets : :class:`Datasets`
         A global data store for named datasets. This is a mapping from names to inline
         datasets.
@@ -15259,41 +14812,24 @@ class TopLevelFacetSpec(VegaLiteSchema):
         property allows automatic validation and autocomplete in editors that support JSON
         schema.
     """
-    _schema = {'$ref': '#/definitions/TopLevelFacetSpec'}
+    _schema = {'$ref': '#/definitions/TopLevelRepeatSpec'}
     _rootschema = Root._schema
 
-    def __init__(self, data=Undefined, facet=Undefined, spec=Undefined, align=Undefined,
-                 autosize=Undefined, background=Undefined, bounds=Undefined, center=Undefined,
-                 columns=Undefined, config=Undefined, datasets=Undefined, description=Undefined,
+    def __init__(self, repeat=Undefined, spec=Undefined, align=Undefined, autosize=Undefined,
+                 background=Undefined, bounds=Undefined, center=Undefined, columns=Undefined,
+                 config=Undefined, data=Undefined, datasets=Undefined, description=Undefined,
                  name=Undefined, padding=Undefined, resolve=Undefined, spacing=Undefined,
                  title=Undefined, transform=Undefined, usermeta=Undefined, **kwds):
-        super(TopLevelFacetSpec, self).__init__(data=data, facet=facet, spec=spec, align=align,
-                                                autosize=autosize, background=background, bounds=bounds,
-                                                center=center, columns=columns, config=config,
-                                                datasets=datasets, description=description, name=name,
-                                                padding=padding, resolve=resolve, spacing=spacing,
-                                                title=title, transform=transform, usermeta=usermeta,
-                                                **kwds)
+        super(TopLevelRepeatSpec, self).__init__(repeat=repeat, spec=spec, align=align,
+                                                 autosize=autosize, background=background,
+                                                 bounds=bounds, center=center, columns=columns,
+                                                 config=config, data=data, datasets=datasets,
+                                                 description=description, name=name, padding=padding,
+                                                 resolve=resolve, spacing=spacing, title=title,
+                                                 transform=transform, usermeta=usermeta, **kwds)
 
 
-class TopLevelSpec(VegaLiteSchema):
-    """TopLevelSpec schema wrapper
-
-    anyOf(:class:`TopLevelUnitSpec`, :class:`TopLevelFacetSpec`, :class:`TopLevelLayerSpec`,
-    :class:`TopLevelRepeatSpec`, :class:`TopLevelConcatSpec`, :class:`TopLevelVConcatSpec`,
-    :class:`TopLevelHConcatSpec`)
-    A Vega-Lite top-level specification.
-    This is the root class for all Vega-Lite specifications.
-    (The json schema is generated from this type.)
-    """
-    _schema = {'$ref': '#/definitions/TopLevelSpec'}
-    _rootschema = Root._schema
-
-    def __init__(self, *args, **kwds):
-        super(TopLevelSpec, self).__init__(*args, **kwds)
-
-
-class TopLevelUnitSpec(VegaLiteSchema):
+class TopLevelUnitSpec(TopLevelSpec):
     """TopLevelUnitSpec schema wrapper
 
     Mapping(required=[data, mark])
@@ -15512,7 +15048,105 @@ class TopLevelUnitSpec(VegaLiteSchema):
                                                width=width, **kwds)
 
 
-class TopoDataFormat(VegaLiteSchema):
+class TopLevelVConcatSpec(TopLevelSpec):
+    """TopLevelVConcatSpec schema wrapper
+
+    Mapping(required=[vconcat])
+
+    Attributes
+    ----------
+
+    vconcat : List(:class:`Spec`)
+        A list of views to be concatenated and put into a column.
+    autosize : anyOf(:class:`AutosizeType`, :class:`AutoSizeParams`)
+        Sets how the visualization size should be determined. If a string, should be one of
+        ``"pad"``, ``"fit"`` or ``"none"``.
+        Object values can additionally specify parameters for content sizing and automatic
+        resizing.
+        ``"fit"`` is only supported for single and layered views that don't use
+        ``rangeStep``.
+
+        **Default value** : ``pad``
+    background : string
+        CSS color property to use as the background of the entire view.
+
+        **Default value:** none (transparent)
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : boolean
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        **Default value:** ``false``
+    config : :class:`Config`
+        Vega-Lite configuration object.  This property can only be defined at the top-level
+        of a specification.
+    data : anyOf(:class:`Data`, None)
+        An object describing the data source. Set to ``null`` to ignore the parent's data
+        source. If no data is set, it is derived from the parent.
+    datasets : :class:`Datasets`
+        A global data store for named datasets. This is a mapping from names to inline
+        datasets.
+        This can be an array of objects or primitive values or a string. Arrays of primitive
+        values are ingested as objects with a ``data`` property.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    padding : :class:`Padding`
+        The default visualization padding, in pixels, from the edge of the visualization
+        canvas to the data rectangle.  If a number, specifies padding for all sides.
+        If an object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.
+
+        **Default value** : ``5``
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for view composition specifications.
+    spacing : float
+        The spacing in pixels between sub-views of the concat operator.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    usermeta : Mapping(required=[])
+        Optional metadata that will be passed to Vega.
+        This object is completely ignored by Vega and Vega-Lite and can be used for custom
+        metadata.
+    $schema : string
+        URL to `JSON schema <http://json-schema.org/>`__ for a Vega-Lite specification.
+        Unless you have a reason to change this, use
+        ``https://vega.github.io/schema/vega-lite/v3.json``. Setting the ``$schema``
+        property allows automatic validation and autocomplete in editors that support JSON
+        schema.
+    """
+    _schema = {'$ref': '#/definitions/TopLevelVConcatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, vconcat=Undefined, autosize=Undefined, background=Undefined, bounds=Undefined,
+                 center=Undefined, config=Undefined, data=Undefined, datasets=Undefined,
+                 description=Undefined, name=Undefined, padding=Undefined, resolve=Undefined,
+                 spacing=Undefined, title=Undefined, transform=Undefined, usermeta=Undefined, **kwds):
+        super(TopLevelVConcatSpec, self).__init__(vconcat=vconcat, autosize=autosize,
+                                                  background=background, bounds=bounds, center=center,
+                                                  config=config, data=data, datasets=datasets,
+                                                  description=description, name=name, padding=padding,
+                                                  resolve=resolve, spacing=spacing, title=title,
+                                                  transform=transform, usermeta=usermeta, **kwds)
+
+
+class TopoDataFormat(DataFormat):
     """TopoDataFormat schema wrapper
 
     Mapping(required=[])
@@ -15579,6 +15213,335 @@ class Transform(VegaLiteSchema):
 
     def __init__(self, *args, **kwds):
         super(Transform, self).__init__(*args, **kwds)
+
+
+class AggregateTransform(Transform):
+    """AggregateTransform schema wrapper
+
+    Mapping(required=[aggregate])
+
+    Attributes
+    ----------
+
+    aggregate : List(:class:`AggregatedFieldDef`)
+        Array of objects that define fields to aggregate.
+    groupby : List(:class:`FieldName`)
+        The data fields to group by. If not specified, a single group containing all data
+        objects will be used.
+    """
+    _schema = {'$ref': '#/definitions/AggregateTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, aggregate=Undefined, groupby=Undefined, **kwds):
+        super(AggregateTransform, self).__init__(aggregate=aggregate, groupby=groupby, **kwds)
+
+
+class BinTransform(Transform):
+    """BinTransform schema wrapper
+
+    Mapping(required=[bin, field, as])
+
+    Attributes
+    ----------
+
+    bin : anyOf(enum(True), :class:`BinParams`)
+        An object indicating bin properties, or simply ``true`` for using default bin
+        parameters.
+    field : :class:`FieldName`
+        The data field to bin.
+    as : anyOf(:class:`FieldName`, List(:class:`FieldName`))
+        The output fields at which to write the start and end bin values.
+    """
+    _schema = {'$ref': '#/definitions/BinTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, bin=Undefined, field=Undefined, **kwds):
+        super(BinTransform, self).__init__(bin=bin, field=field, **kwds)
+
+
+class CalculateTransform(Transform):
+    """CalculateTransform schema wrapper
+
+    Mapping(required=[calculate, as])
+
+    Attributes
+    ----------
+
+    calculate : string
+        A `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`__
+        string. Use the variable ``datum`` to refer to the current data object.
+    as : :class:`FieldName`
+        The field for storing the computed formula value.
+    """
+    _schema = {'$ref': '#/definitions/CalculateTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, calculate=Undefined, **kwds):
+        super(CalculateTransform, self).__init__(calculate=calculate, **kwds)
+
+
+class FilterTransform(Transform):
+    """FilterTransform schema wrapper
+
+    Mapping(required=[filter])
+
+    Attributes
+    ----------
+
+    filter : :class:`LogicalOperandPredicate`
+        The ``filter`` property must be one of the predicate definitions:
+
+        1) an `expression <https://vega.github.io/vega-lite/docs/types.html#expression>`__
+        string,
+        where ``datum`` can be used to refer to the current data object
+
+        2) one of the field predicates: `equal
+        <https://vega.github.io/vega-lite/docs/filter.html#equal-predicate>`__,
+        `lt <https://vega.github.io/vega-lite/docs/filter.html#lt-predicate>`__,
+        `lte <https://vega.github.io/vega-lite/docs/filter.html#lte-predicate>`__,
+        `gt <https://vega.github.io/vega-lite/docs/filter.html#gt-predicate>`__,
+        `gte <https://vega.github.io/vega-lite/docs/filter.html#gte-predicate>`__,
+        `range <https://vega.github.io/vega-lite/docs/filter.html#range-predicate>`__,
+        `oneOf <https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate>`__,
+        or `valid <https://vega.github.io/vega-lite/docs/filter.html#valid-predicate>`__,
+
+        3) a `selection predicate
+        <https://vega.github.io/vega-lite/docs/filter.html#selection-predicate>`__
+
+        4) a logical operand that combines (1), (2), or (3).
+    """
+    _schema = {'$ref': '#/definitions/FilterTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, filter=Undefined, **kwds):
+        super(FilterTransform, self).__init__(filter=filter, **kwds)
+
+
+class FlattenTransform(Transform):
+    """FlattenTransform schema wrapper
+
+    Mapping(required=[flatten])
+
+    Attributes
+    ----------
+
+    flatten : List(:class:`FieldName`)
+        An array of one or more data fields containing arrays to flatten.
+        If multiple fields are specified, their array values should have a parallel
+        structure, ideally with the same length.
+        If the lengths of parallel arrays do not match,
+        the longest array will be used with ``null`` values added for missing entries.
+    as : List(:class:`FieldName`)
+        The output field names for extracted array values.
+
+        **Default value:** The field name of the corresponding array field
+    """
+    _schema = {'$ref': '#/definitions/FlattenTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, flatten=Undefined, **kwds):
+        super(FlattenTransform, self).__init__(flatten=flatten, **kwds)
+
+
+class FoldTransform(Transform):
+    """FoldTransform schema wrapper
+
+    Mapping(required=[fold])
+
+    Attributes
+    ----------
+
+    fold : List(:class:`FieldName`)
+        An array of data fields indicating the properties to fold.
+    as : List([:class:`FieldName`, :class:`FieldName`])
+        The output field names for the key and value properties produced by the fold
+        transform.
+        **Default value:** ``["key", "value"]``
+    """
+    _schema = {'$ref': '#/definitions/FoldTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, fold=Undefined, **kwds):
+        super(FoldTransform, self).__init__(fold=fold, **kwds)
+
+
+class ImputeTransform(Transform):
+    """ImputeTransform schema wrapper
+
+    Mapping(required=[impute, key])
+
+    Attributes
+    ----------
+
+    impute : :class:`FieldName`
+        The data field for which the missing values should be imputed.
+    key : :class:`FieldName`
+        A key field that uniquely identifies data objects within a group.
+        Missing key values (those occurring in the data but not in the current group) will
+        be imputed.
+    frame : List(anyOf(None, float))
+        A frame specification as a two-element array used to control the window over which
+        the specified method is applied. The array entries should either be a number
+        indicating the offset from the current data object, or null to indicate unbounded
+        rows preceding or following the current data object.  For example, the value ``[-5,
+        5]`` indicates that the window should include five objects preceding and five
+        objects following the current object.
+
+        **Default value:** :  ``[null, null]`` indicating that the window includes all
+        objects.
+    groupby : List(:class:`FieldName`)
+        An optional array of fields by which to group the values.
+        Imputation will then be performed on a per-group basis.
+    keyvals : anyOf(List(Mapping(required=[])), :class:`ImputeSequence`)
+        Defines the key values that should be considered for imputation.
+        An array of key values or an object defining a `number sequence
+        <https://vega.github.io/vega-lite/docs/impute.html#sequence-def>`__.
+
+        If provided, this will be used in addition to the key values observed within the
+        input data.  If not provided, the values will be derived from all unique values of
+        the ``key`` field. For ``impute`` in ``encoding``, the key field is the x-field if
+        the y-field is imputed, or vice versa.
+
+        If there is no impute grouping, this property *must* be specified.
+    method : :class:`ImputeMethod`
+        The imputation method to use for the field value of imputed data objects.
+        One of ``value``, ``mean``, ``median``, ``max`` or ``min``.
+
+        **Default value:**  ``"value"``
+    value : Mapping(required=[])
+        The field value to use when the imputation ``method`` is ``"value"``.
+    """
+    _schema = {'$ref': '#/definitions/ImputeTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, impute=Undefined, key=Undefined, frame=Undefined, groupby=Undefined,
+                 keyvals=Undefined, method=Undefined, value=Undefined, **kwds):
+        super(ImputeTransform, self).__init__(impute=impute, key=key, frame=frame, groupby=groupby,
+                                              keyvals=keyvals, method=method, value=value, **kwds)
+
+
+class JoinAggregateTransform(Transform):
+    """JoinAggregateTransform schema wrapper
+
+    Mapping(required=[joinaggregate])
+
+    Attributes
+    ----------
+
+    joinaggregate : List(:class:`JoinAggregateFieldDef`)
+        The definition of the fields in the join aggregate, and what calculations to use.
+    groupby : List(:class:`FieldName`)
+        The data fields for partitioning the data objects into separate groups. If
+        unspecified, all data points will be in a single group.
+    """
+    _schema = {'$ref': '#/definitions/JoinAggregateTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, joinaggregate=Undefined, groupby=Undefined, **kwds):
+        super(JoinAggregateTransform, self).__init__(joinaggregate=joinaggregate, groupby=groupby,
+                                                     **kwds)
+
+
+class LookupTransform(Transform):
+    """LookupTransform schema wrapper
+
+    Mapping(required=[lookup, from])
+
+    Attributes
+    ----------
+
+    lookup : :class:`FieldName`
+        Key in primary data source.
+    default : string
+        The default value to use if lookup fails.
+
+        **Default value:** ``null``
+    as : anyOf(:class:`FieldName`, List(:class:`FieldName`))
+        The field or fields for storing the computed formula value.
+        If ``from.fields`` is specified, the transform will use the same names for ``as``.
+        If ``from.fields`` is not specified, ``as`` has to be a string and we put the whole
+        object into the data under the specified name.
+    from : :class:`LookupData`
+        Secondary data reference.
+    """
+    _schema = {'$ref': '#/definitions/LookupTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, lookup=Undefined, default=Undefined, **kwds):
+        super(LookupTransform, self).__init__(lookup=lookup, default=default, **kwds)
+
+
+class SampleTransform(Transform):
+    """SampleTransform schema wrapper
+
+    Mapping(required=[sample])
+
+    Attributes
+    ----------
+
+    sample : float
+        The maximum number of data objects to include in the sample.
+
+        **Default value:** ``1000``
+    """
+    _schema = {'$ref': '#/definitions/SampleTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, sample=Undefined, **kwds):
+        super(SampleTransform, self).__init__(sample=sample, **kwds)
+
+
+class StackTransform(Transform):
+    """StackTransform schema wrapper
+
+    Mapping(required=[stack, groupby, as])
+
+    Attributes
+    ----------
+
+    groupby : List(:class:`FieldName`)
+        The data fields to group by.
+    stack : :class:`FieldName`
+        The field which is stacked.
+    offset : enum('zero', 'center', 'normalize')
+        Mode for stacking marks.
+        **Default value:** ``"zero"``
+    sort : List(:class:`SortField`)
+        Field that determines the order of leaves in the stacked charts.
+    as : anyOf(:class:`FieldName`, List(:class:`FieldName`))
+        Output field names. This can be either a string or an array of strings with
+        two elements denoting the name for the fields for stack start and stack end
+        respectively.
+        If a single string(eg."val") is provided, the end field will be "val_end".
+    """
+    _schema = {'$ref': '#/definitions/StackTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, groupby=Undefined, stack=Undefined, offset=Undefined, sort=Undefined, **kwds):
+        super(StackTransform, self).__init__(groupby=groupby, stack=stack, offset=offset, sort=sort,
+                                             **kwds)
+
+
+class TimeUnitTransform(Transform):
+    """TimeUnitTransform schema wrapper
+
+    Mapping(required=[timeUnit, field, as])
+
+    Attributes
+    ----------
+
+    field : :class:`FieldName`
+        The data field to apply time unit.
+    timeUnit : :class:`TimeUnit`
+        The timeUnit.
+    as : :class:`FieldName`
+        The output field to write the timeUnit value.
+    """
+    _schema = {'$ref': '#/definitions/TimeUnitTransform'}
+    _rootschema = Root._schema
+
+    def __init__(self, field=Undefined, timeUnit=Undefined, **kwds):
+        super(TimeUnitTransform, self).__init__(field=field, timeUnit=timeUnit, **kwds)
 
 
 class TypeForShape(VegaLiteSchema):
@@ -15832,7 +15795,7 @@ class UnitSpec(VegaLiteSchema):
                                        width=width, **kwds)
 
 
-class UrlData(VegaLiteSchema):
+class UrlData(DataSource):
     """UrlData schema wrapper
 
     Mapping(required=[url])
@@ -15855,7 +15818,7 @@ class UrlData(VegaLiteSchema):
         super(UrlData, self).__init__(url=url, format=format, name=name, **kwds)
 
 
-class UtcMultiTimeUnit(VegaLiteSchema):
+class UtcMultiTimeUnit(MultiTimeUnit):
     """UtcMultiTimeUnit schema wrapper
 
     enum('utcyearquarter', 'utcyearquartermonth', 'utcyearmonth', 'utcyearmonthdate',
@@ -15871,7 +15834,7 @@ class UtcMultiTimeUnit(VegaLiteSchema):
         super(UtcMultiTimeUnit, self).__init__(*args)
 
 
-class UtcSingleTimeUnit(VegaLiteSchema):
+class UtcSingleTimeUnit(SingleTimeUnit):
     """UtcSingleTimeUnit schema wrapper
 
     enum('utcyear', 'utcquarter', 'utcmonth', 'utcday', 'utcdate', 'utchours', 'utcminutes',
@@ -15882,6 +15845,63 @@ class UtcSingleTimeUnit(VegaLiteSchema):
 
     def __init__(self, *args):
         super(UtcSingleTimeUnit, self).__init__(*args)
+
+
+class VConcatSpec(Spec):
+    """VConcatSpec schema wrapper
+
+    Mapping(required=[vconcat])
+    Base interface for a vertical concatenation specification.
+
+    Attributes
+    ----------
+
+    vconcat : List(:class:`Spec`)
+        A list of views to be concatenated and put into a column.
+    bounds : enum('full', 'flush')
+        The bounds calculation method to use for determining the extent of a sub-plot. One
+        of ``full`` (the default) or ``flush``.
+
+
+        * If set to ``full``, the entire calculated bounds (including axes, title, and
+          legend) will be used.
+        * If set to ``flush``, only the specified width and height values for the sub-view
+          will be used. The ``flush`` setting can be useful when attempting to place
+          sub-plots without axes or legends into a uniform grid structure.
+
+        **Default value:** ``"full"``
+    center : boolean
+        Boolean flag indicating if subviews should be centered relative to their respective
+        rows or columns.
+
+        **Default value:** ``false``
+    data : anyOf(:class:`Data`, None)
+        An object describing the data source. Set to ``null`` to ignore the parent's data
+        source. If no data is set, it is derived from the parent.
+    description : string
+        Description of this mark for commenting purpose.
+    name : string
+        Name of the visualization for later reference.
+    resolve : :class:`Resolve`
+        Scale, axis, and legend resolutions for view composition specifications.
+    spacing : float
+        The spacing in pixels between sub-views of the concat operator.
+
+        **Default value** : ``10``
+    title : anyOf(string, :class:`TitleParams`)
+        Title for the plot.
+    transform : List(:class:`Transform`)
+        An array of data transformations such as filter and new field calculation.
+    """
+    _schema = {'$ref': '#/definitions/VConcatSpec'}
+    _rootschema = Root._schema
+
+    def __init__(self, vconcat=Undefined, bounds=Undefined, center=Undefined, data=Undefined,
+                 description=Undefined, name=Undefined, resolve=Undefined, spacing=Undefined,
+                 title=Undefined, transform=Undefined, **kwds):
+        super(VConcatSpec, self).__init__(vconcat=vconcat, bounds=bounds, center=center, data=data,
+                                          description=description, name=name, resolve=resolve,
+                                          spacing=spacing, title=title, transform=transform, **kwds)
 
 
 class Value(VegaLiteSchema):
@@ -15896,68 +15916,8 @@ class Value(VegaLiteSchema):
         super(Value, self).__init__(*args)
 
 
-class YValueDef(VegaLiteSchema):
-    """YValueDef schema wrapper
-
-    Mapping(required=[value])
-    Definition object for a constant value of an encoding channel.
-
-    Attributes
-    ----------
-
-    value : anyOf(float, enum('height'))
-        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
-        between ``0`` to ``1`` for opacity).
-    """
-    _schema = {'$ref': '#/definitions/YValueDef'}
-    _rootschema = Root._schema
-
-    def __init__(self, value=Undefined, **kwds):
-        super(YValueDef, self).__init__(value=value, **kwds)
-
-
-class XValueDef(VegaLiteSchema):
-    """XValueDef schema wrapper
-
-    Mapping(required=[value])
-    Definition object for a constant value of an encoding channel.
-
-    Attributes
-    ----------
-
-    value : anyOf(float, enum('width'))
-        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
-        between ``0`` to ``1`` for opacity).
-    """
-    _schema = {'$ref': '#/definitions/XValueDef'}
-    _rootschema = Root._schema
-
-    def __init__(self, value=Undefined, **kwds):
-        super(XValueDef, self).__init__(value=value, **kwds)
-
-
-class NumberValueDef(VegaLiteSchema):
-    """NumberValueDef schema wrapper
-
-    Mapping(required=[value])
-    Definition object for a constant value of an encoding channel.
-
-    Attributes
-    ----------
-
-    value : float
-        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
-        between ``0`` to ``1`` for opacity).
-    """
-    _schema = {'$ref': '#/definitions/NumberValueDef'}
-    _rootschema = Root._schema
-
-    def __init__(self, value=Undefined, **kwds):
-        super(NumberValueDef, self).__init__(value=value, **kwds)
-
-
-class ValueDefWithConditionMarkPropFieldDefstringnull(VegaLiteSchema):
-    """ValueDefWithConditionMarkPropFieldDefstringnull schema wrapper
+class ValueDefWithConditionMarkPropFieldDefTypeForShapestringnull(VegaLiteSchema):
+    """ValueDefWithConditionMarkPropFieldDefTypeForShapestringnull schema wrapper
 
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef> where either the condition or the value are
@@ -15966,19 +15926,20 @@ class ValueDefWithConditionMarkPropFieldDefstringnull(VegaLiteSchema):
     Attributes
     ----------
 
-    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalStringValueDef`,
-    List(:class:`ConditionalStringValueDef`))
+    condition : anyOf(:class:`ConditionalMarkPropFieldDefTypeForShape`,
+    :class:`ConditionalStringValueDef`, List(:class:`ConditionalStringValueDef`))
         A field definition or one or more value definition(s) with a selection predicate.
     value : anyOf(string, None)
         A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
         between ``0`` to ``1`` for opacity).
     """
-    _schema = {'$ref': '#/definitions/ValueDefWithCondition<MarkPropFieldDef,(string|null)>'}
+    _schema = {'$ref': '#/definitions/ValueDefWithCondition<MarkPropFieldDef<TypeForShape>,(string|null)>'}
     _rootschema = Root._schema
 
     def __init__(self, condition=Undefined, value=Undefined, **kwds):
-        super(ValueDefWithConditionMarkPropFieldDefstringnull, self).__init__(condition=condition,
-                                                                              value=value, **kwds)
+        super(ValueDefWithConditionMarkPropFieldDefTypeForShapestringnull, self).__init__(condition=condition,
+                                                                                          value=value,
+                                                                                          **kwds)
 
 
 class ValueDefWithConditionMarkPropFieldDefnumber(VegaLiteSchema):
@@ -16006,8 +15967,8 @@ class ValueDefWithConditionMarkPropFieldDefnumber(VegaLiteSchema):
                                                                           value=value, **kwds)
 
 
-class ValueDefWithConditionMarkPropFieldDefTypeForShapestringnull(VegaLiteSchema):
-    """ValueDefWithConditionMarkPropFieldDefTypeForShapestringnull schema wrapper
+class ValueDefWithConditionMarkPropFieldDefstringnull(VegaLiteSchema):
+    """ValueDefWithConditionMarkPropFieldDefstringnull schema wrapper
 
     Mapping(required=[])
     A ValueDef with Condition<ValueDef | FieldDef> where either the condition or the value are
@@ -16016,20 +15977,19 @@ class ValueDefWithConditionMarkPropFieldDefTypeForShapestringnull(VegaLiteSchema
     Attributes
     ----------
 
-    condition : anyOf(:class:`ConditionalMarkPropFieldDefTypeForShape`,
-    :class:`ConditionalStringValueDef`, List(:class:`ConditionalStringValueDef`))
+    condition : anyOf(:class:`ConditionalMarkPropFieldDef`, :class:`ConditionalStringValueDef`,
+    List(:class:`ConditionalStringValueDef`))
         A field definition or one or more value definition(s) with a selection predicate.
     value : anyOf(string, None)
         A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
         between ``0`` to ``1`` for opacity).
     """
-    _schema = {'$ref': '#/definitions/ValueDefWithCondition<MarkPropFieldDef<TypeForShape>,(string|null)>'}
+    _schema = {'$ref': '#/definitions/ValueDefWithCondition<MarkPropFieldDef,(string|null)>'}
     _rootschema = Root._schema
 
     def __init__(self, condition=Undefined, value=Undefined, **kwds):
-        super(ValueDefWithConditionMarkPropFieldDefTypeForShapestringnull, self).__init__(condition=condition,
-                                                                                          value=value,
-                                                                                          **kwds)
+        super(ValueDefWithConditionMarkPropFieldDefstringnull, self).__init__(condition=condition,
+                                                                              value=value, **kwds)
 
 
 class ValueDefWithConditionTextFieldDefValue(VegaLiteSchema):
@@ -16258,7 +16218,7 @@ class WindowOnlyOp(VegaLiteSchema):
         super(WindowOnlyOp, self).__init__(*args)
 
 
-class WindowTransform(VegaLiteSchema):
+class WindowTransform(Transform):
     """WindowTransform schema wrapper
 
     Mapping(required=[window])
@@ -16311,4 +16271,44 @@ class WindowTransform(VegaLiteSchema):
                  sort=Undefined, **kwds):
         super(WindowTransform, self).__init__(window=window, frame=frame, groupby=groupby,
                                               ignorePeers=ignorePeers, sort=sort, **kwds)
+
+
+class XValueDef(VegaLiteSchema):
+    """XValueDef schema wrapper
+
+    Mapping(required=[value])
+    Definition object for a constant value of an encoding channel.
+
+    Attributes
+    ----------
+
+    value : anyOf(float, enum('width'))
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _schema = {'$ref': '#/definitions/XValueDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, value=Undefined, **kwds):
+        super(XValueDef, self).__init__(value=value, **kwds)
+
+
+class YValueDef(VegaLiteSchema):
+    """YValueDef schema wrapper
+
+    Mapping(required=[value])
+    Definition object for a constant value of an encoding channel.
+
+    Attributes
+    ----------
+
+    value : anyOf(float, enum('height'))
+        A constant value in visual domain (e.g., ``"red"`` / "#0099ff" for color, values
+        between ``0`` to ``1`` for opacity).
+    """
+    _schema = {'$ref': '#/definitions/YValueDef'}
+    _rootschema = Root._schema
+
+    def __init__(self, value=Undefined, **kwds):
+        super(YValueDef, self).__init__(value=value, **kwds)
 

--- a/doc/user_guide/API.rst
+++ b/doc/user_guide/API.rst
@@ -105,6 +105,7 @@ API Functions
    binding_select
    concat
    condition
+   graticule
    hconcat
    layer
    pipe
@@ -113,6 +114,8 @@ API Functions
    selection_interval
    selection_multi
    selection_single
+   sequence
+   sphere
    topo_feature
    value
    vconcat

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -308,7 +308,7 @@ def generate_vega_schema_wrapper(schema_file):
     with open(schema_file, encoding='utf8') as f:
         rootschema = json.load(f)
     contents = [HEADER,
-                "from altair.utils.schemapi import SchemaBase, Undefined",
+                "from altair.utils.schemapi import SchemaBase, Undefined, _subclasses",
                 LOAD_SCHEMA.format(schemafile='vega-schema.json')]
     contents.append(BASE_SCHEMA.format(basename=basename))
     contents.append(schema_class('Root', schema=rootschema, basename=basename,

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -62,7 +62,7 @@ BASE_SCHEMA = """
 class {basename}(SchemaBase):
     @classmethod
     def _default_wrapper_classes(cls):
-        return {basename}.__subclasses__()
+        return _subclasses({basename})
 """
 
 LOAD_SCHEMA = '''
@@ -223,6 +223,32 @@ def copy_schemapi_util():
             dest.writelines(source.readlines())
 
 
+def toposort(graph):
+    """Topological sort of a directed acyclic graph.
+
+    Parameters
+    ----------
+    graph : dict of lists
+        Mapping of node labels to list of child node labels.
+        This is assumed to represent a graph with no cycles.
+        
+    Returns
+    -------
+    order : list
+        topological order of input graph.
+    """
+    stack = []
+    visited = {}
+    def visit(nodes):
+        for node in sorted(nodes, reverse=True):
+            if not visited.get(node):
+                visited[node] = True
+                visit(graph.get(node, []))
+                stack.insert(0, node)
+    visit(graph)
+    return stack
+
+
 def generate_vegalite_schema_wrapper(schema_file):
     """Generate a schema wrapper at the given path."""
     # TODO: generate simple tests for each wrapper
@@ -230,21 +256,46 @@ def generate_vegalite_schema_wrapper(schema_file):
 
     with open(schema_file, encoding='utf8') as f:
         rootschema = json.load(f)
-    contents = [HEADER,
-                "from altair.utils.schemapi import SchemaBase, Undefined",
-                LOAD_SCHEMA.format(schemafile='vega-lite-schema.json')]
-    contents.append(BASE_SCHEMA.format(basename=basename))
-    contents.append(schema_class('Root', schema=rootschema, basename=basename,
-                                 schemarepr=CodeSnippet('load_schema()')))
+
+    definitions = {}
 
     for name in rootschema['definitions']:
         defschema = {'$ref': '#/definitions/' + name}
         defschema_repr = {'$ref': '#/definitions/' + name}
+        name = get_valid_identifier(name)
+        definitions[name] = SchemaGenerator(
+            name, schema=defschema, schemarepr=defschema_repr,
+            rootschema=rootschema, basename=basename,
+            rootschemarepr=CodeSnippet("Root._schema"),
+        )
 
-        contents.append(schema_class(get_valid_identifier(name),
-                                     schema=defschema, schemarepr=defschema_repr,
-                                     rootschema=rootschema, basename=basename,
-                                     rootschemarepr=CodeSnippet("Root._schema")))
+    graph = {}
+
+    for name, schema in definitions.items():
+        graph[name] = []
+        for child in schema.subclasses():
+            child = get_valid_identifier(child)
+            graph[name].append(child)
+            child = definitions[child]
+            if child.basename == basename:
+                child.basename = [name]
+            else:
+                child.basename.append(name)
+
+    contents = [HEADER,
+                "from altair.utils.schemapi import SchemaBase, Undefined, _subclasses",
+                LOAD_SCHEMA.format(schemafile='vega-lite-schema.json')]
+    contents.append(BASE_SCHEMA.format(basename=basename))
+    contents.append(schema_class('Root',
+            schema=rootschema,
+            basename=basename,
+            schemarepr=CodeSnippet('load_schema()')
+        )
+    )
+
+    for name in toposort(graph):
+        contents.append(definitions[name].schema_class())
+
     contents.append('')  # end with newline
     return '\n'.join(contents)
 

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -65,8 +65,8 @@ class SchemaGenerator(object):
         The dictionary defining the schema class
     rootschema : dict (optional)
         The root schema for the class
-    basename : string (default: "SchemaBase")
-        The name of the base class to use in the class definition
+    basename : string or tuple (default: "SchemaBase")
+        The name(s) of the base class(es) to use in the class definition
     schemarepr : CodeSnippet or object, optional
         An object whose repr will be used in the place of the explicit schema.
         This can be useful, for example, when the generated code should reference
@@ -107,6 +107,11 @@ class SchemaGenerator(object):
         self.nodefault = nodefault
         self.kwargs = kwargs
 
+    def subclasses(self):
+        """Return a list of subclass names, if any."""
+        info = SchemaInfo(self.schema, self.rootschema)
+        return [child.refname for child in info.anyOf if child.is_reference()]
+
     def schema_class(self):
         """Generate code for a schema class"""
         rootschema = self.rootschema if self.rootschema is not None else self.schema
@@ -117,9 +122,13 @@ class SchemaGenerator(object):
                 rootschemarepr = CodeSnippet('_schema')
             else:
                 rootschemarepr = rootschema
+        if isinstance(self.basename, str):
+            basename = self.basename
+        else:
+            basename = ', '.join(self.basename)
         return self.schema_class_template.format(
             classname=self.classname,
-            basename=self.basename,
+            basename=basename,
             schema=schemarepr,
             rootschema=rootschemarepr,
             docstring=self.docstring(indent=4),

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -36,6 +36,17 @@ def debug_mode(arg):
         DEBUG_MODE = original
 
 
+def _subclasses(cls):
+    """Breadth-first sequence of classes which inherit from cls."""
+    seen = set()
+    current_set = {cls}
+    while current_set:
+        seen |= current_set
+        current_set = set.union(*(set(cls.__subclasses__()) for cls in current_set))
+        for cls in current_set - seen:
+            yield cls
+
+
 def _todict(obj, validate, context):
     """Convert an object to a dict representation."""
     if isinstance(obj, SchemaBase):
@@ -333,7 +344,7 @@ class SchemaBase(object):
     @classmethod
     def _default_wrapper_classes(cls):
         """Return the set of classes used within cls.from_dict()"""
-        return SchemaBase.__subclasses__()
+        return _subclasses(SchemaBase)
 
     @classmethod
     def from_dict(cls, dct, validate=True, _wrapper_classes=None):


### PR DESCRIPTION
The set of schema definitions in Vega-Lite have a hierarchical structure, but up until now Altair's class structure constructed from them has been flat. This PR uses the structure declared by the schema definitions to infer a hierarchical structure for the classes, which simplifies instances of type checking within the API code.