### PR TITLE
DOC: Fix wilkinson link

### DIFF
--- a/altair/examples/wilkinson-dot-plot.py
+++ b/altair/examples/wilkinson-dot-plot.py
@@ -1,7 +1,7 @@
 """
 Wilkinson Dot Plot
 ------------------
-An example of a [Wilkinson Dot Plot](https://en.wikipedia.org/wiki/Dot_plot_(statistics))
+An example of a `Wilkinson Dot Plot <https://en.wikipedia.org/wiki/Dot_plot_(statistics)>`_
 """
 # category: other charts
 


### PR DESCRIPTION
I noticed the link in the wilkinson example wasn't properly formatted. 