### PR TITLE
Deprecation Warning Cleanup

### DIFF
--- a/altair/_magics.py
+++ b/altair/_magics.py
@@ -118,7 +118,7 @@ def vega(line, cell):
             raise ValueError("%%vega: spec is not valid JSON. "
                              "Install pyyaml to parse spec as yaml")
     else:
-        spec = yaml.load(cell)
+        spec = yaml.load(cell, Loader=yaml.FullLoader)
 
     if data:
         spec['data'] = []
@@ -163,7 +163,7 @@ def vegalite(line, cell):
             raise ValueError("%%vegalite: spec is not valid JSON. "
                              "Install pyyaml to parse spec as yaml")
     else:
-        spec = yaml.load(cell)
+        spec = yaml.load(cell, Loader=yaml.FullLoader)
 
     if args.data is not None:
         data = _get_variable(args.data)

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -1,7 +1,7 @@
 """
 Utility routines
 """
-import collections
+from collections.abc import Mapping
 from copy import deepcopy
 import json
 import itertools
@@ -454,9 +454,9 @@ def update_nested(original, update, copy=False):
     if copy:
         original = deepcopy(original)
     for key, val in update.items():
-        if isinstance(val, collections.Mapping):
+        if isinstance(val, Mapping):
             orig_val = original.get(key, {})
-            if isinstance(orig_val, collections.Mapping):
+            if isinstance(orig_val, Mapping):
                 original[key] = update_nested(orig_val, val)
             else:
                 original[key] = val

--- a/tools/schemapi/tests/test_decorator.py
+++ b/tools/schemapi/tests/test_decorator.py
@@ -36,11 +36,11 @@ def test_myschema_decorator():
     assert myschema.to_dict() == {'a': {'foo': 'bar'}, 'b': ['foo', 'bar']}
 
     assert MySchema.__doc__.startswith('MySchema schema wrapper')
-    argspec = inspect.getargspec(MySchema.__init__)
+    argspec = inspect.getfullargspec(MySchema.__init__)
     assert argspec.args == ['self', 'a' ,'b', 'a2', 'b2', 'c', 'd']
     assert argspec.defaults == 6 * (Undefined,)
     assert argspec.varargs is None
-    assert argspec.keywords == 'kwds'
+    assert argspec.varkw == 'kwds'
 
 
 def test_stringarray_decorator():
@@ -51,7 +51,7 @@ def test_stringarray_decorator():
     assert arr.to_dict() == ['a', 'b', 'c']
 
     assert arr.__doc__.startswith('StringArray schema wrapper')
-    argspec = inspect.getargspec(StringArray.__init__)
+    argspec = inspect.getfullargspec(StringArray.__init__)
     assert argspec.args == ['self']
     assert argspec.varargs == 'args'
-    assert argspec.keywords is None
+    assert argspec.varkw is None


### PR DESCRIPTION
Cleaned up a few deprecation warnings I found when running `pytest`.

Specifically:
1. Added a `Loader` parameter when loading `yaml`
2. Changed `getargspec` to `getfullargspec` and the `keywords` attribute to `varkw`
3. Changed `import collections` to `from collections.abc import Mapping` and modified the corresponding `Mapping` calls.