### PR TITLE
DOC: refactor some examples which use EncodingSortField

### DIFF
--- a/altair/examples/bar_chart_sorted.py
+++ b/altair/examples/bar_chart_sorted.py
@@ -11,12 +11,5 @@ source = data.barley()
 
 alt.Chart(source).mark_bar().encode(
     x='sum(yield):Q',
-    y=alt.Y(
-        'site:N',
-        sort=alt.EncodingSortField(
-            field="yield",  # The field to use for the sort
-            op="sum",  # The operation to run on the field prior to sorting
-            order="descending"  # The order to sort in
-        )
-    )
+    y=alt.Y('site:N', sort='-x')
 )

--- a/altair/examples/beckers_barley_trellis_plot.py
+++ b/altair/examples/beckers_barley_trellis_plot.py
@@ -19,7 +19,7 @@ alt.Chart(source, title="The Morris Mistake").mark_point().encode(
     alt.Y(
         'variety:N',
         title="",
-        sort=alt.EncodingSortField(field='yield', op='sum', order='descending'),
+        sort='-x',
         axis=alt.Axis(grid=True)
     ),
     color=alt.Color('year:N', legend=alt.Legend(title="Year")),

--- a/altair/examples/top_k_items.py
+++ b/altair/examples/top_k_items.py
@@ -3,8 +3,6 @@ Top K Items
 -----------
 This example shows how to use the window and transformation filter to display
 the Top items of a long list of items in decreasing order.
-The sorting of the x-axis is needed for vega-lite and for the example does
-not do anything since we already have a unique value.
 Here we sort the top 10 highest ranking movies of IMDB.
 """
 # category: case studies
@@ -17,10 +15,7 @@ source = data.movies.url
 alt.Chart(
     source,
 ).mark_bar().encode(
-    x=alt.X(
-        'Title:N', 
-        sort=alt.EncodingSortField(field="IMDB_Rating", op="mean", order='descending')
-    ),
+    x=alt.X('Title:N', sort='-y'),
     y=alt.Y('IMDB_Rating:Q'),
     color=alt.Color('IMDB_Rating:Q')
     

--- a/altair/examples/top_k_letters.py
+++ b/altair/examples/top_k_letters.py
@@ -35,8 +35,6 @@ alt.Chart(source).transform_aggregate(
 ).transform_filter(
     alt.datum.rank < 10
 ).mark_bar().encode(
-    y=alt.Y('letters:N',
-        sort=alt.EncodingSortField(field='count', op='sum', order='descending')
-    ),
+    y=alt.Y('letters:N', sort='-x'),
     x='count:Q',
 )


### PR DESCRIPTION
I read in `changes.rst` that now you can sort by an encoding channel directly. I thought a few of the examples could be refactored to reflect this. 

Note there were two places where I couldn't replace `EncodingSortField`

- in `beckers_barley_trellis_plot.py` it didn't seem to work with the row encoding. 
- in `sorted_error_bars_with_ci.py` I had trouble because the x encoding was being used twice. 

After going through this process I think the sorting documentation could use an update. Maybe I will make an issue.  