### PR TITLE
DOC: fix candlestick example

### DIFF
--- a/altair/examples/candlestick_chart.py
+++ b/altair/examples/candlestick_chart.py
@@ -215,10 +215,8 @@ open_close_color = alt.condition("datum.open < datum.close",
 
 rule = alt.Chart(source).mark_rule().encode(
     alt.X(
-        'yearmonthdate(date):T',
-        scale=alt.Scale(domain=[{"month": 5, "date": 31, "year": 2009},
-                                {"month": 7, "date": 1, "year": 2009}]),
-        axis=alt.Axis(format='%m/%d', title='Date in 2009')
+        'yearmonthdate(date):O',
+        axis=alt.Axis(format='%m/%d', labelAngle=-45, title='Date in 2009')
     ),
     alt.Y(
         'low',
@@ -229,8 +227,8 @@ rule = alt.Chart(source).mark_rule().encode(
     color=open_close_color
 )
 
-bar = alt.Chart(source).mark_bar().encode(
-    x='yearmonthdate(date):T',
+bar = alt.Chart(source).mark_bar(width=10).encode(
+    x='yearmonthdate(date):O',
     y='open',
     y2='close',
     color=open_close_color


### PR DESCRIPTION
Something caught my eye today while browsing the website this morning

![Screen Shot 2019-12-11 at 11 59 16 AM](https://user-images.githubusercontent.com/2041969/70643747-8b936000-1c0f-11ea-87c6-d37ae9fa0eba.png)

I think the candlestick example is incorrect. 

![visualization (31)](https://user-images.githubusercontent.com/2041969/70643756-8fbf7d80-1c0f-11ea-963b-69b3a376d928.png)

I wasn't quite sure why, but changing the encoding type from temporal `T` to ordinal `O` and removing the scale seemed to fix things. A few other cosmetic details were also changed

![visualization (32)](https://user-images.githubusercontent.com/2041969/70643760-92ba6e00-1c0f-11ea-9995-6c67f1b353fe.png)

I am still unsure why the temporal encoding doesn't work. I tried `mark_bar(align='center')` but that didn't help.

A related issue is I don't like having to include the data. I might submit a PR to include an "Open High Low Close" data set into [vega-datasets](https://github.com/vega/vega-datasets) as it is a common dataset format. 
