### PR TITLE
Fix typo in available time units doc

### DIFF
--- a/doc/user_guide/transform/timeunit.rst
+++ b/doc/user_guide/transform/timeunit.rst
@@ -13,7 +13,7 @@ These are the available time units:
 
 - ``"year"``, ``"yearquarter"``, ``"yearquartermonth"``, ``"yearmonth"``,
   ``"yearmonthdate"``, ``"yearmonthdatehours"``, ``"yearmonthdatehoursminutes"``,
-  ``"yearmonthdatehoursseconds"``.
+  ``"yearmonthdatehoursminutesseconds"``.
 - ``"quarter"``, ``"quartermonth"``
 - ``"month"``, ``"monthdate"``
 - ``"date"`` (Day of month, i.e., 1 - 31)


### PR DESCRIPTION
Changed yearmonthdatehoursseconds to yearmonthdatehours**minutes**seconds