### PR TITLE
customization example - how to remove axis labels

### DIFF
--- a/doc/user_guide/customization.rst
+++ b/doc/user_guide/customization.rst
@@ -226,6 +226,14 @@ the y labels as a dollar value:
        y=alt.Y('y', axis=alt.Axis(format='$', title='dollar amount'))
    )
 
+Axis labels can also be easily removed:
+
+.. altair-plot::
+
+   alt.Chart(df).mark_circle().encode(
+       x=alt.X('x', axis=alt.Axis(labels=False)),
+       y=alt.Y('y', axis=alt.Axis(labels=False))
+   )
 
 Additional formatting codes are available; for a listing of these see the
 `d3 Format Code Documentation <https://github.com/d3/d3-format/blob/master/README.md#format>`_.


### PR DESCRIPTION
When plots have categorical data on one or both axis, and when there are a lot of categories, the axis labels may not be useful.  So this is an easy way to remove them.

For this example, I'm just using the same plot from the above example.  If this is too contrived an example, I could come up with something more reasonable.

#1899 