### PR TITLE
Fixed test_save by closing file descriptor

### DIFF
--- a/altair/vegalite/v3/tests/test_api.py
+++ b/altair/vegalite/v3/tests/test_api.py
@@ -238,8 +238,10 @@ def test_save(format, basic_chart):
     else:
         out = io.BytesIO()
         mode = 'rb'
+    
     fid, filename = tempfile.mkstemp(suffix='.' + format)
-
+    os.close(fid)
+    
     try:
         try:
             basic_chart.save(out, format=format)


### PR DESCRIPTION
All test conditions of vegalite/v3/test_api/test_save were previously failing when run. Determined that an open file descriptor automatically returned by tempfile.mkstemp() was blocking read/write access to temp file in question, preventing test from running nominally.

Added line to immediately close the file descriptor to resolve this; afterward all tests in vegalite/v3/test_api.py run and passed.