### PR TITLE
Fix broken test: test_api.test_save()

### DIFF
--- a/altair/vegalite/v4/tests/test_api.py
+++ b/altair/vegalite/v4/tests/test_api.py
@@ -237,7 +237,9 @@ def test_save(format, basic_chart):
     else:
         out = io.BytesIO()
         mode = 'rb'
+    
     fid, filename = tempfile.mkstemp(suffix='.' + format)
+    os.close(fid)
 
     try:
         try:


### PR DESCRIPTION
All test conditions of vegalite/v4/test_api/test_save were previously failing when run. Determined that an open file descriptor automatically returned by tempfile.mkstemp() was blocking read/write access to temp file in question, preventing test from running nominally.

Added line to immediately close the file descriptor to resolve this; afterward all tests in vegalite/v4/test_api.py run and passed.