### PR TITLE
BUG: html renderer: support multiple views in JupyterLab

### DIFF
--- a/altair/utils/html.py
+++ b/altair/utils/html.py
@@ -85,7 +85,10 @@ HTML_TEMPLATE_UNIVERSAL = jinja2.Template("""
 <div id="{{ output_div }}"></div>
 <script type="text/javascript">
   (function(spec, embedOpt){
-    const outputDiv = document.getElementById("{{ output_div }}");
+    let outputDiv = document.currentScript.previousElementSibling;
+    if (outputDiv.id !== "{{ output_div }}") {
+      outputDiv = document.getElementById("{{ output_div }}");
+    }
     const paths = {
       "vega": "{{ base_url }}/vega@{{ vega_version }}?noext",
       "vega-lib": "{{ base_url }}/vega-lib?noext",


### PR DESCRIPTION
Fixes #1984 

The fallback after ``getPreviousElementSibling`` is because in classic Notebook, the script is executed with ``"<head>"`` as the parent node, so the div cannot be located in this manner.

I've tested this in JupyterLab (with multiple views), Jupyter Notebook, Colab, and nbconvert HTML, all work correctly.

@jasongrout, please let me know if you see any issues with this.