### PR TITLE
MAINT: bump minimum Python version to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: pip
 
 matrix:
   include:
-    - python: 3.5
     - python: 3.6
     - python: 3.7
     - python: 3.8

--- a/NOTES_FOR_MAINTAINERS.md
+++ b/NOTES_FOR_MAINTAINERS.md
@@ -17,9 +17,6 @@ the following script from the root of the repository:
 $ python tools/generate_schema_wrapper.py
 ```
 
-Running this script requires Python 3.6 or newer, though it generates package
-code that is compatible with Python 2.7 and 3.5+.
-
 This script does a couple things:
 
 - downloads the appropriate schema files from the specified vega and vega-lite

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -23,7 +23,7 @@ Dependencies
 Altair has the following dependencies, all of which are installed automatically
 with the above installation commands:
 
-- python 3.5 or newer
+- python 3.6 or newer
 - entrypoints_
 - jsonschema_
 - NumPy_

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -3,8 +3,19 @@
 Altair Change Log
 =================
 
-Version 4.0.0 (unreleased)
-----------------------------
+Version 4.1.0 (unreleased)
+--------------------------
+- Minimum Python version is now 3.6
+
+Version 4.0.1 (released Jan 14, 2020)
+-------------------------------------
+Bug Fixes
+~~~~~~~~~
+- Update Vega-Lite version to 4.0.2
+- Fix issue with duplicate chart divs in HTML renderer (#1888)
+
+Version 4.0.0 (released Dec 10, 2019)
+-------------------------------------
 Version 4.0.0 is based on Vega-Lite version 4.0, which you can read about at
 https://github.com/vega/vega-lite/releases/tag/v4.0.0.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ jsonschema
 numpy
 pandas
 toolz
-typing>=3.6;python_version<"3.5"

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ URL                 = 'http://altair-viz.github.io'
 DOWNLOAD_URL        = 'http://github.com/altair-viz/altair/'
 LICENSE             = 'BSD 3-clause'
 INSTALL_REQUIRES    = get_install_requirements("requirements.txt")
-PYTHON_REQUIRES     = ">=3.5"
+PYTHON_REQUIRES     = ">=3.6"
 DEV_REQUIRES        = get_install_requirements("requirements_dev.txt")
 VERSION             = version('altair/__init__.py')
 
@@ -97,7 +97,6 @@ setup(name=NAME,
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
Following [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html)

This will also unblock a number of nice features, such as f-strings, type hints, code formatting with black, etc.