### PR TITLE
MAINT: deprecate alt.curry and alt.pipe

### DIFF
--- a/altair/_magics.py
+++ b/altair/_magics.py
@@ -9,7 +9,7 @@ import warnings
 import IPython
 from IPython.core import magic_arguments
 import pandas as pd
-from toolz import pipe
+from toolz import curried
 
 from altair.vegalite import v3 as vegalite_v3
 from altair.vegalite import v4 as vegalite_v4
@@ -46,7 +46,7 @@ def _prepare_data(data, data_transformers):
     if data is None or isinstance(data, dict):
         return data
     elif isinstance(data, pd.DataFrame):
-        return pipe(data, data_transformers.get())
+        return curried.pipe(data, data_transformers.get())
     elif isinstance(data, str):
         return {"url": data}
     else:

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -2,13 +2,15 @@ import json
 import os
 import random
 import hashlib
+import warnings
 
 import pandas as pd
-from toolz.curried import curry, pipe  # noqa
+from toolz import curried
 from typing import Callable
 
 from .core import sanitize_dataframe
 from .core import sanitize_geo_interface
+from .deprecation import AltairDeprecationWarning
 from .plugin_registry import PluginRegistry
 
 
@@ -55,7 +57,7 @@ class MaxRowsError(Exception):
     pass
 
 
-@curry
+@curried.curry
 def limit_rows(data, max_rows=5000):
     """Raise MaxRowsError if the data model has more than max_rows.
 
@@ -84,7 +86,7 @@ def limit_rows(data, max_rows=5000):
     return data
 
 
-@curry
+@curried.curry
 def sample(data, n=None, frac=None):
     """Reduce the size of the data model by sampling without replacement."""
     check_data_type(data)
@@ -98,7 +100,7 @@ def sample(data, n=None, frac=None):
             return {"values": values}
 
 
-@curry
+@curried.curry
 def to_json(
     data,
     prefix="altair-data",
@@ -117,7 +119,7 @@ def to_json(
     return {"url": os.path.join(urlpath, filename), "format": {"type": "json"}}
 
 
-@curry
+@curried.curry
 def to_csv(
     data,
     prefix="altair-data",
@@ -134,7 +136,7 @@ def to_csv(
     return {"url": os.path.join(urlpath, filename), "format": {"type": "csv"}}
 
 
-@curry
+@curried.curry
 def to_values(data):
     """Replace a DataFrame by a data model with values."""
     check_data_type(data)
@@ -213,3 +215,30 @@ def _data_to_csv_string(data):
         raise NotImplementedError(
             "to_csv only works with data expressed as " "a DataFrame or as a dict"
         )
+
+
+def pipe(data, *funcs):
+    """
+    Pipe a value through a sequence of functions
+
+    Deprecated: use toolz.curried.pipe() instead.
+    """
+    warnings.warn(
+        "alt.pipe() is deprecated, and will be removed in a future release. "
+        "Use toolz.curried.pipe() instead.",
+        AltairDeprecationWarning,
+    )
+    return curried.pipe(data, *funcs)
+
+
+def curry(*args, **kwargs):
+    """ Curry a callable function
+
+    Deprecated: use toolz.curried.curry() instead.
+    """
+    warnings.warn(
+        "alt.curry() is deprecated, and will be removed in a future release. "
+        "Use toolz.curried.curry() instead.",
+        AltairDeprecationWarning,
+    )
+    return curried.curry(*args, **kwargs)

--- a/altair/utils/tests/test_data.py
+++ b/altair/utils/tests/test_data.py
@@ -2,9 +2,9 @@ import os
 
 import pytest
 import pandas as pd
+from toolz import pipe
 
-
-from ..data import limit_rows, MaxRowsError, sample, pipe, to_values, to_json, to_csv
+from ..data import limit_rows, MaxRowsError, sample, to_values, to_json, to_csv
 
 
 def _create_dataframe(N):

--- a/altair/vega/data.py
+++ b/altair/vega/data.py
@@ -1,8 +1,10 @@
 import pandas as pd
-from toolz.curried import curry, pipe
+from toolz import curried
 from ..utils.core import sanitize_dataframe
 from ..utils.data import (
     MaxRowsError,
+    curry,
+    pipe,
     sample,
     to_csv,
     to_json,
@@ -11,7 +13,7 @@ from ..utils.data import (
 )
 
 
-@curry
+@curried.curry
 def limit_rows(data, max_rows=5000):
     """Raise MaxRowsError if the data model has more than max_rows."""
     if not isinstance(data, (list, pd.DataFrame)):
@@ -25,9 +27,9 @@ def limit_rows(data, max_rows=5000):
     return data
 
 
-@curry
+@curried.curry
 def default_data_transformer(data):
-    return pipe(data, limit_rows, to_values)
+    return curried.pipe(data, limit_rows, to_values)
 
 
 __all__ = (

--- a/altair/vegalite/data.py
+++ b/altair/vegalite/data.py
@@ -1,8 +1,10 @@
-from toolz.curried import curry, pipe
+from toolz import curried
 from ..utils.core import sanitize_dataframe
 from ..utils.data import (
     MaxRowsError,
+    curry,
     limit_rows,
+    pipe,
     sample,
     to_csv,
     to_json,
@@ -12,9 +14,9 @@ from ..utils.data import (
 from ..utils.data import DataTransformerRegistry as _DataTransformerRegistry
 
 
-@curry
+@curried.curry
 def default_data_transformer(data, max_rows=5000):
-    return pipe(data, limit_rows(max_rows=max_rows), to_values)
+    return curried.pipe(data, limit_rows(max_rows=max_rows), to_values)
 
 
 class DataTransformerRegistry(_DataTransformerRegistry):

--- a/altair/vegalite/v3/api.py
+++ b/altair/vegalite/v3/api.py
@@ -5,10 +5,11 @@ import io
 import json
 import jsonschema
 import pandas as pd
+from toolz.curried import pipe as _pipe
 
 from .schema import core, channels, mixins, Undefined, SCHEMA_URL
 
-from .data import data_transformers, pipe
+from .data import data_transformers
 from ... import utils, expr
 from .display import renderers, VEGALITE_VERSION, VEGAEMBED_VERSION, VEGA_VERSION
 from .theme import themes
@@ -80,7 +81,7 @@ def _prepare_data(data, context=None):
 
     # convert dataframes  or objects with __geo_interface__ to dict
     if isinstance(data, pd.DataFrame) or hasattr(data, "__geo_interface__"):
-        data = pipe(data, data_transformers.get())
+        data = _pipe(data, data_transformers.get())
 
     # convert string input to a URLData
     if isinstance(data, str):

--- a/altair/vegalite/v4/api.py
+++ b/altair/vegalite/v4/api.py
@@ -5,10 +5,11 @@ import io
 import json
 import jsonschema
 import pandas as pd
+from toolz.curried import pipe as _pipe
 
 from .schema import core, channels, mixins, Undefined, SCHEMA_URL
 
-from .data import data_transformers, pipe
+from .data import data_transformers
 from ... import utils, expr
 from .display import renderers, VEGALITE_VERSION, VEGAEMBED_VERSION, VEGA_VERSION
 from .theme import themes
@@ -80,7 +81,7 @@ def _prepare_data(data, context=None):
 
     # convert dataframes  or objects with __geo_interface__ to dict
     if isinstance(data, pd.DataFrame) or hasattr(data, "__geo_interface__"):
-        data = pipe(data, data_transformers.get())
+        data = _pipe(data, data_transformers.get())
 
     # convert string input to a URLData
     if isinstance(data, str):

--- a/doc/user_guide/data_transformers.rst
+++ b/doc/user_guide/data_transformers.rst
@@ -125,7 +125,8 @@ Piping
 
 Multiple data transformers can be piped together using ``pipe``::
 
-    from altair import pipe, limit_rows, to_values
+    from altair import limit_rows, to_values
+    from toolz.curried import pipe
     pipe(data, limit_rows(10000), to_values)
 
 Managing data transformers
@@ -182,11 +183,12 @@ custom data transformer that stores all JSON files in separate directory.::
 
     import os
     import altair as alt
+    from toolz.curried import pipe
 
 
     def json_dir(data, data_dir='altairdata'):
         os.makedirs(data_dir, exist_ok=True)
-        return alt.pipe(data, alt.to_json(filename=data_dir + '/{prefix}-{hash}.{extension}') )
+        return pipe(data, alt.to_json(filename=data_dir + '/{prefix}-{hash}.{extension}') )
 
 
     alt.data_transformers.register('json_dir', json_dir)


### PR DESCRIPTION
These are functions from ``toolz`` that are exposed in altair's top-level namespace. This PR marks those functions deprecated, so that they can be removed in a future release.