### PR TITLE
MAINT: provide default values for _repr_mimebundle_ include/exclude

### DIFF
--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -128,7 +128,7 @@ class Displayable(object):
         schema_dict = json.loads(pkgutil.get_data(*self.schema_path).decode("utf-8"))
         validate(self.spec, schema_dict)
 
-    def _repr_mimebundle_(self, include, exclude):
+    def _repr_mimebundle_(self, include=None, exclude=None):
         """Return a MIME bundle for display in Jupyter frontends."""
         if self.renderers is not None:
             return self.renderers.get()(self.spec)

--- a/altair/vegalite/v3/api.py
+++ b/altair/vegalite/v3/api.py
@@ -1400,7 +1400,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
     # Display-related methods
 
-    def _repr_mimebundle_(self, include, exclude):
+    def _repr_mimebundle_(self, include=None, exclude=None):
         """Return a MIME bundle for display in Jupyter frontends."""
         # Catch errors explicitly to get around issues in Jupyter frontend
         # see https://github.com/ipython/ipython/issues/11038

--- a/altair/vegalite/v4/api.py
+++ b/altair/vegalite/v4/api.py
@@ -1641,7 +1641,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
     # Display-related methods
 
-    def _repr_mimebundle_(self, include, exclude):
+    def _repr_mimebundle_(self, include=None, exclude=None):
         """Return a MIME bundle for display in Jupyter frontends."""
         # Catch errors explicitly to get around issues in Jupyter frontend
         # see https://github.com/ipython/ipython/issues/11038


### PR DESCRIPTION
Some non-standard Python kernels fail to pass ``include`` and ``exclude`` arguments when calling ``_repr_mimebundle_``. This causes issues like https://github.com/altair-viz/altair/issues/2042

This PR should fix the problem, without causing side-effects for standard kernels.