### PR TITLE
MAINT: remove altair_viewer dev install from CI scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
         pip install altair_saver
-        pip install git+git://github.com/altair-viz/altair_viewer.git
     - name: Test with pytest
       run: |
         pytest --doctest-modules altair

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -18,7 +18,6 @@ jobs:
         pip install .[dev]
         pip install altair_saver
         pip install -r doc/requirements.txt
-        pip install git+git://github.com/altair-viz/altair_viewer.git
     - name: Build docs
       run: |
         cd doc && make html


### PR DESCRIPTION
With the [0.3 release](https://github.com/altair-viz/altair_viewer/releases/tag/v0.3.0), this is no longer necessary