### PR TITLE
Added example with line chart on a logarithmic scale

### DIFF
--- a/altair/examples/line_with_log_scale.py
+++ b/altair/examples/line_with_log_scale.py
@@ -1,0 +1,18 @@
+"""
+Line Chart with Logarithmic Scale
+---------------------------------
+How to make a line chart on a `<Logarithmic scale> https://en.wikipedia.org/wiki/Logarithmic_scale`_.
+"""
+# category: line charts
+import altair as alt
+from vega_datasets import data
+
+source = data.population()
+
+alt.Chart(source).mark_line().encode(
+    x='year:O',
+    y=alt.Y(
+        'sum(people)',
+        scale=alt.Scale(type="log")  # Here the scale is applied
+    )
+)


### PR DESCRIPTION
A new line chart example that shows how to set [a log scale](https://en.wikipedia.org/wiki/Logarithmic_scale).

```python
import altair as alt
from vega_datasets import data

source = data.population()

alt.Chart(source).mark_line().encode(
    x='year:O',
    y=alt.Y(
        'sum(people)',
        scale=alt.Scale(type="log")  # Here the scale is applied
    )
)
```

![visualization (4)](https://user-images.githubusercontent.com/9993/79130149-52a0fe80-7d5b-11ea-8734-bac08d8d5892.png)
