### PR TITLE
Added example of bar chart with rolling mean

### DIFF
--- a/altair/examples/bar_with_rolling_mean.py
+++ b/altair/examples/bar_with_rolling_mean.py
@@ -3,7 +3,7 @@ Bar Chart with Rolling Mean
 ---------------------------
 A bar chart overlayed with a rolling mean. In this example the average of values over the previous decade is displayed as a line.
 """
-# category: bar plots
+# category: bar charts
 import altair as alt
 from vega_datasets import data
 

--- a/altair/examples/bar_with_rolling_mean.py
+++ b/altair/examples/bar_with_rolling_mean.py
@@ -1,0 +1,27 @@
+"""
+Bar Chart with Rolling Mean
+---------------------------
+A bar chart overlayed with a rolling mean. In this example the average of values over the previous decade is displayed as a line.
+"""
+# category: bar plots
+import altair as alt
+from vega_datasets import data
+
+source = data.wheat()
+
+bar = alt.Chart(source).mark_bar().encode(
+    x='year:O',
+    y='wheat:Q'
+)
+
+line = alt.Chart(source).mark_line(color='red').transform_window(
+    # The field to average
+    rolling_mean='mean(wheat)',
+    # The number of values before and after the current value to include.
+    frame=[-9, 0]
+).encode(
+    x='year:O',
+    y='rolling_mean:Q'
+)
+
+(bar + line).properties(width=600)


### PR DESCRIPTION
```python
import altair as alt
from vega_datasets import data

source = data.wheat()

bar = alt.Chart(source).mark_bar().encode(
    x='year:O',
    y='wheat:Q'
)

line = alt.Chart(source).mark_line(color='red').transform_window(
    # The field to average
    rolling_mean='mean(wheat)',
    # The number of values before and after the current value to include.
    frame=[-9, 0]
).encode(
    x='year:O',
    y='rolling_mean:Q'
)

(bar + line).properties(width=600)
```

![visualization (5)](https://user-images.githubusercontent.com/9993/79131881-2dfa5600-7d5e-11ea-985a-d376deaf2921.png)
