### PR TITLE
Added example of a cumulative line chart

### DIFF
--- a/altair/examples/line_chart_with_cumsum.py
+++ b/altair/examples/line_chart_with_cumsum.py
@@ -1,0 +1,23 @@
+"""
+Line Chart with Cumulative Sum
+------------------------------
+This chart creates a simple line chart from the cumulative sum of a fields.
+"""
+# category: line charts
+import altair as alt
+from vega_datasets import data
+
+source = data.wheat()
+
+alt.Chart(source).mark_line().transform_window(
+    # Sort the data chronologically in this case
+    sort=[{'field': 'year'}],
+    # Include all previous records before the current record and none after
+    frame=[None, 0],
+    # What we want to add up
+    cumulative_wheat='sum(wheat)',
+).encode(
+    x='year:O',
+    # Plot the calculated field created by the transformation
+    y='cumulative_wheat:Q'
+)

--- a/altair/examples/line_chart_with_cumsum.py
+++ b/altair/examples/line_chart_with_cumsum.py
@@ -15,7 +15,7 @@ alt.Chart(source).mark_line().transform_window(
     # Include all previous records before the current record and none after
     frame=[None, 0],
     # What to add up as you go
-    cumulative_wheat='sum(wheat)',
+    cumulative_wheat='sum(wheat)'
 ).encode(
     x='year:O',
     # Plot the calculated field created by the transformation

--- a/altair/examples/line_chart_with_cumsum.py
+++ b/altair/examples/line_chart_with_cumsum.py
@@ -14,7 +14,7 @@ alt.Chart(source).mark_line().transform_window(
     sort=[{'field': 'year'}],
     # Include all previous records before the current record and none after
     frame=[None, 0],
-    # What we want to add up
+    # What to add up as you go
     cumulative_wheat='sum(wheat)',
 ).encode(
     x='year:O',

--- a/altair/examples/line_chart_with_cumsum.py
+++ b/altair/examples/line_chart_with_cumsum.py
@@ -13,6 +13,7 @@ alt.Chart(source).mark_line().transform_window(
     # Sort the data chronologically
     sort=[{'field': 'year'}],
     # Include all previous records before the current record and none after
+    # (This is the default value so you could skip it and it would still work.)
     frame=[None, 0],
     # What to add up as you go
     cumulative_wheat='sum(wheat)'

--- a/altair/examples/line_chart_with_cumsum.py
+++ b/altair/examples/line_chart_with_cumsum.py
@@ -20,4 +20,4 @@ alt.Chart(source).mark_line().transform_window(
     x='year:O',
     # Plot the calculated field created by the transformation
     y='cumulative_wheat:Q'
-)
+).properties(width=600)

--- a/altair/examples/line_chart_with_cumsum.py
+++ b/altair/examples/line_chart_with_cumsum.py
@@ -10,7 +10,7 @@ from vega_datasets import data
 source = data.wheat()
 
 alt.Chart(source).mark_line().transform_window(
-    # Sort the data chronologically in this case
+    # Sort the data chronologically
     sort=[{'field': 'year'}],
     # Include all previous records before the current record and none after
     frame=[None, 0],


### PR DESCRIPTION
```python
import altair as alt
from vega_datasets import data

source = data.wheat()

alt.Chart(source).mark_line().transform_window(
    # Sort the data chronologically in this case
    sort=[{'field': 'year'}],
    # Include all previous records before the current record and none after
    frame=[None, 0],
    # What we want to add up
    cumulative_wheat='sum(wheat)',
).encode(
    x='year:O',
    # Plot the calculated field created by the transformation
    y='cumulative_wheat:Q'
).properties(width=600)
```

![visualization (6)](https://user-images.githubusercontent.com/9993/79183957-caa50e00-7dc7-11ea-8f7f-0d19d4dc444d.png)
