### PR TITLE
Typo correction in scatter_linked_table

### DIFF
--- a/altair/examples/scatter_linked_table.py
+++ b/altair/examples/scatter_linked_table.py
@@ -2,7 +2,7 @@
 Brushing Scatter Plot to show data on a table
 ---------------------------------------------
 A scatter plot of the cars dataset, with data tables for horsepower, MPG, and origin. 
-The tables update toreflect the selection on the scatter plot.
+The tables update to reflect the selection on the scatter plot.
 """
 # category: scatter plots
 


### PR DESCRIPTION
Since the contents of this repository are automatically generated, I hope this is the correct place to make this change.