### PR TITLE
Don't cast pandas.Categorical to object

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -282,10 +282,7 @@ def sanitize_dataframe(df):  # noqa: C901
 
     for col_name, dtype in df.dtypes.iteritems():
         if str(dtype) == "category":
-            # XXXX: work around bug in to_json for categorical types
-            # https://github.com/pydata/pandas/issues/10778
-            col = df[col_name].astype(object)
-            df[col_name] = col.where(col.notnull(), None)
+            continue
         elif str(dtype) == "string":
             # dedicated string datatype (since 1.0)
             # https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html#dedicated-string-data-type


### PR DESCRIPTION
I think the pandas bug mentioned in this comment is fixed so it may be possible to skip the conversion to object entirely

https://github.com/altair-viz/altair/issues/245#issuecomment-633165346