### PR TITLE
Fixed movie dataset columns in examples and docs

### DIFF
--- a/altair/examples/binned_heatmap.py
+++ b/altair/examples/binned_heatmap.py
@@ -10,7 +10,7 @@ from vega_datasets import data
 source = data.movies.url
 
 alt.Chart(source).mark_rect().encode(
-    alt.X('IMDB_Rating:Q', bin=alt.Bin(maxbins=60)),
-    alt.Y('Rotten_Tomatoes_Rating:Q', bin=alt.Bin(maxbins=40)),
-    alt.Color('count(IMDB_Rating):Q', scale=alt.Scale(scheme='greenblue'))
+    alt.X('IMDB Rating:Q', bin=alt.Bin(maxbins=60)),
+    alt.Y('Rotten Tomatoes Rating:Q', bin=alt.Bin(maxbins=40)),
+    alt.Color('count(IMDB Rating):Q', scale=alt.Scale(scheme='greenblue'))
 )

--- a/altair/examples/binned_scatterplot.py
+++ b/altair/examples/binned_scatterplot.py
@@ -10,7 +10,7 @@ from vega_datasets import data
 source = data.movies.url
 
 alt.Chart(source).mark_circle().encode(
-    alt.X('IMDB_Rating:Q', bin=True),
-    alt.Y('Rotten_Tomatoes_Rating:Q', bin=True),
+    alt.X('IMDB Rating:Q', bin=True),
+    alt.Y('Rotten Tomatoes Rating:Q', bin=True),
     size='count()'
 )

--- a/altair/examples/cumulative_count_chart.py
+++ b/altair/examples/cumulative_count_chart.py
@@ -14,8 +14,8 @@ source = data.movies.url
 
 alt.Chart(source).transform_window(
     cumulative_count="count()",
-    sort=[{"field": "IMDB_Rating"}],
+    sort=[{"field": "IMDB Rating"}],
 ).mark_area().encode(
-    x="IMDB_Rating:Q",
+    x="IMDB Rating:Q",
     y="cumulative_count:Q"
 )

--- a/altair/examples/histogram_with_a_global_mean_overlay.py
+++ b/altair/examples/histogram_with_a_global_mean_overlay.py
@@ -12,12 +12,12 @@ source = data.movies.url
 base = alt.Chart(source)
 
 bar = base.mark_bar().encode(
-    x=alt.X('IMDB_Rating:Q', bin=True, axis=None),
+    x=alt.X('IMDB Rating:Q', bin=True, axis=None),
     y='count()'
 )
 
 rule = base.mark_rule(color='red').encode(
-    x='mean(IMDB_Rating):Q',
+    x='mean(IMDB Rating):Q',
     size=alt.value(5)
 )
 

--- a/altair/examples/interactive_cross_highlight.py
+++ b/altair/examples/interactive_cross_highlight.py
@@ -14,8 +14,8 @@ source = data.movies.url
 pts = alt.selection(type="single", encodings=['x'])
 
 rect = alt.Chart(data.movies.url).mark_rect().encode(
-    alt.X('IMDB_Rating:Q', bin=True),
-    alt.Y('Rotten_Tomatoes_Rating:Q', bin=True),
+    alt.X('IMDB Rating:Q', bin=True),
+    alt.Y('Rotten Tomatoes Rating:Q', bin=True),
     alt.Color('count()',
         scale=alt.Scale(scheme='greenblue'),
         legend=alt.Legend(title='Total Records')
@@ -32,7 +32,7 @@ circ = rect.mark_point().encode(
 )
 
 bar = alt.Chart(source).mark_bar().encode(
-    x='Major_Genre:N',
+    x='Major Genre:N',
     y='count()',
     color=alt.condition(pts, alt.ColorValue("steelblue"), alt.ColorValue("grey"))
 ).properties(

--- a/altair/examples/simple_histogram.py
+++ b/altair/examples/simple_histogram.py
@@ -11,6 +11,6 @@ from vega_datasets import data
 source = data.movies.url
 
 alt.Chart(source).mark_bar().encode(
-    alt.X("IMDB_Rating:Q", bin=True),
+    alt.X("IMDB Rating:Q", bin=True),
     y='count()',
 )

--- a/altair/examples/stripplot.py
+++ b/altair/examples/stripplot.py
@@ -16,10 +16,10 @@ stripplot =  alt.Chart(source, width=40).mark_circle(size=8).encode(
         axis=alt.Axis(values=[0], ticks=True, grid=False, labels=False),
         scale=alt.Scale(),
     ),
-    y=alt.Y('IMDB_Rating:Q'),
-    color=alt.Color('Major_Genre:N', legend=None),
+    y=alt.Y('IMDB Rating:Q'),
+    color=alt.Color('Major Genre:N', legend=None),
     column=alt.Column(
-        'Major_Genre:N',
+        'Major Genre:N',
         header=alt.Header(
             labelAngle=-90,
             titleOrient='top',

--- a/altair/examples/top_k_items.py
+++ b/altair/examples/top_k_items.py
@@ -16,12 +16,12 @@ alt.Chart(
     source,
 ).mark_bar().encode(
     x=alt.X('Title:N', sort='-y'),
-    y=alt.Y('IMDB_Rating:Q'),
-    color=alt.Color('IMDB_Rating:Q')
+    y=alt.Y('IMDB Rating:Q'),
+    color=alt.Color('IMDB Rating:Q')
     
 ).transform_window(
-    rank='rank(IMDB_Rating)',
-    sort=[alt.SortField('IMDB_Rating', order='descending')]
+    rank='rank(IMDB Rating)',
+    sort=[alt.SortField('IMDB Rating', order='descending')]
 ).transform_filter(
     (alt.datum.rank < 10)
 )

--- a/altair/examples/top_k_with_others.py
+++ b/altair/examples/top_k_with_others.py
@@ -19,7 +19,7 @@ alt.Chart(source).mark_bar().encode(
         title=None,
     ),
 ).transform_aggregate(
-    aggregate_gross='mean(Worldwide_Gross)',
+    aggregate_gross='mean(Worldwide Gross)',
     groupby=["Director"],
 ).transform_window(
     rank='row_number()',

--- a/doc/user_guide/transform/bin.rst
+++ b/doc/user_guide/transform/bin.rst
@@ -18,7 +18,7 @@ An common application of a bin transform is when creating a histogram:
     movies = data.movies.url
 
     alt.Chart(movies).mark_bar().encode(
-        alt.X("IMDB_Rating:Q", bin=True),
+        alt.X("IMDB Rating:Q", bin=True),
         y='count()',
     )
 
@@ -59,7 +59,7 @@ Here is the above histogram created using a top-level bin transform:
         x='binned_rating:O',
         y='count()',
     ).transform_bin(
-        'binned_rating', field='IMDB_Rating'
+        'binned_rating', field='IMDB Rating'
     )
 
 And here is the transformed color scale using a top-level bin transform:

--- a/doc/user_guide/transform/density.rst
+++ b/doc/user_guide/transform/density.rst
@@ -17,10 +17,10 @@ dataset:
    from vega_datasets import data
    
    alt.Chart(data.movies.url).transform_density(
-       'IMDB_Rating',
-       as_=['IMDB_Rating', 'density'],
+       'IMDB Rating',
+       as_=['IMDB Rating', 'density'],
    ).mark_area().encode(
-       x="IMDB_Rating:Q",
+       x="IMDB Rating:Q",
        y='density:Q',
    )
 
@@ -37,17 +37,17 @@ argument. Here we split the above density computation across movie genres:
        width=120,
        height=80
    ).transform_filter(
-       'isValid(datum.Major_Genre)'
+       "isValid(datum['Major Genre'])"
    ).transform_density(
-       'IMDB_Rating',
-       groupby=['Major_Genre'],
-       as_=['IMDB_Rating', 'density'],
+       'IMDB Rating',
+       groupby=['Major Genre'],
+       as_=['IMDB Rating', 'density'],
        extent=[1, 10],
    ).mark_area().encode(
-       x="IMDB_Rating:Q",
+       x="IMDB Rating:Q",
        y='density:Q',
    ).facet(
-       'Major_Genre:N',
+       'Major Genre:N',
        columns=4
    )
 

--- a/doc/user_guide/transform/joinaggregate.rst
+++ b/doc/user_guide/transform/joinaggregate.rst
@@ -52,15 +52,15 @@ standard deviation, which requires calculations on the joined data:
    from vega_datasets import data
 
    alt.Chart(data.movies.url).transform_filter(
-       'datum.IMDB_Rating != null  && datum.Rotten_Tomatoes_Rating != null'
+       "datum['IMDB Rating'] != null  && datum['Rotten Tomatoes Rating'] != null"
    ).transform_joinaggregate(
-       IMDB_mean='mean(IMDB_Rating)',
-       IMDB_std='stdev(IMDB_Rating)',
-       RT_mean='mean(Rotten_Tomatoes_Rating)',
-       RT_std='stdev(Rotten_Tomatoes_Rating)'
+       IMDB_mean='mean(IMDB Rating)',
+       IMDB_std='stdev(IMDB Rating)',
+       RT_mean='mean(Rotten Tomatoes Rating)',
+       RT_std='stdev(Rotten Tomatoes Rating)'
    ).transform_calculate(
-       IMDB_Deviation="(datum.IMDB_Rating - datum.IMDB_mean) / datum.IMDB_std",
-       Rotten_Tomatoes_Deviation="(datum.Rotten_Tomatoes_Rating - datum.RT_mean) / datum.RT_std"
+       IMDB_Deviation="(datum['IMDB Rating'] - datum.IMDB_mean) / datum.IMDB_std",
+       Rotten_Tomatoes_Deviation="(datum['Rotten Tomatoes Rating'] - datum.RT_mean) / datum.RT_std"
    ).mark_point().encode(
        x='IMDB_Deviation:Q',
        y="Rotten_Tomatoes_Deviation:Q"

--- a/doc/user_guide/transform/window.rst
+++ b/doc/user_guide/transform/window.rst
@@ -16,11 +16,11 @@ For example, consider the following cumulative frequency distribution:
     from vega_datasets import data
 
     alt.Chart(data.movies.url).transform_window(
-        sort=[{'field': 'IMDB_Rating'}],
+        sort=[{'field': 'IMDB Rating'}],
         frame=[None, 0],
         cumulative_count='count(*)',
     ).mark_area().encode(
-        x='IMDB_Rating:Q',
+        x='IMDB Rating:Q',
         y='cumulative_count:Q',
     )
 


### PR DESCRIPTION
Hey, awesome library! 

I updated a few of the broken examples and docs mentioned here https://github.com/altair-viz/altair/issues/2213#issuecomment-651164633 (that use the movie dataset).

I wasn't able to build the docs locally so I looked them over in a jupyter notebook using `altair=4.1.0` and `vega_datasets=0.8.0` and they looked fine.

I started looking at `altair/examples/multiple_interactions.py` as well but I ran into this upstream issue https://github.com/vega/vega-lite/issues/4870 so I left it alone