### PR TITLE
Switch to non-deprecated methods in sphinx extension

### DIFF
--- a/altair/sphinxext/altairplot.py
+++ b/altair/sphinxext/altairplot.py
@@ -304,9 +304,9 @@ def depart_altair_plot(self, node):
 
 
 def builder_inited(app):
-    app.add_javascript(app.config.altairplot_vega_js_url)
-    app.add_javascript(app.config.altairplot_vegalite_js_url)
-    app.add_javascript(app.config.altairplot_vegaembed_js_url)
+    app.add_js_file(app.config.altairplot_vega_js_url)
+    app.add_js_file(app.config.altairplot_vegalite_js_url)
+    app.add_js_file(app.config.altairplot_vegaembed_js_url)
 
 
 def setup(app):
@@ -324,7 +324,7 @@ def setup(app):
 
     app.add_directive("altair-plot", AltairPlotDirective)
 
-    app.add_stylesheet("altair-plot.css")
+    app.add_css_file("altair-plot.css")
 
     app.add_node(
         altair_plot,


### PR DESCRIPTION
The methods ```add_stylesheet``` and ```add_javascript``` in sphinx are deprecated and have started to give warnings. Using Sphinx version 3.2.1 I get:

```../.tox/run/lib/python3.7/site-packages/altair/sphinxext/altairplot.py:327: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet("altair-plot.css")
../.tox/run/lib/python3.7/site-packages/altair/sphinxext/altairplot.py:307: RemovedInSphinx40Warning: The app.add_javascript() is deprecated. Please use app.add_js_file() instead.
  app.add_javascript(app.config.altairplot_vega_js_url)
../.tox/run/lib/python3.7/site-packages/altair/sphinxext/altairplot.py:308: RemovedInSphinx40Warning: The app.add_javascript() is deprecated. Please use app.add_js_file() instead.
  app.add_javascript(app.config.altairplot_vegalite_js_url)
../.tox/run/lib/python3.7/site-packages/altair/sphinxext/altairplot.py:309: RemovedInSphinx40Warning: The app.add_javascript() is deprecated. Please use app.add_js_file() instead.
  app.add_javascript(app.config.altairplot_vegaembed_js_url)
```

This PR will switch to using the new methods. See sphinx documentation for info on methods and deprecation: https://www.sphinx-doc.org/en/master/extdev/appapi.html