### PR TITLE
Added altair_saver to doc/requirements.txt

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -19,7 +19,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
-        pip install altair_saver
         pip install -r doc/requirements.txt
     - name: Run docbuild
       run: |

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@ jinja2
 numpydoc
 pillow
 sphinx_rtd_theme
+altair_saver


### PR DESCRIPTION
Building the docs requires the `altair_saver` package. PR adds it as a requirement to `doc/requirements.txt`. I think there's an argument for adding it to `requirements_dev.txt` instead/as well since non doc-specific contributions might require new documentation.