### PR TITLE
Update URLs and field names to match new vega datasets

### DIFF
--- a/altair/examples/weather_heatmap.py
+++ b/altair/examples/weather_heatmap.py
@@ -8,7 +8,7 @@ import altair as alt
 from vega_datasets import data
 
 # Since the data is more than 5,000 rows we'll import it from a URL
-source = data.seattle_temps.url
+source = data.seattle_weather_hourly_normals.url
 
 alt.Chart(
     source,
@@ -16,9 +16,9 @@ alt.Chart(
 ).mark_rect().encode(
     x='date(date):O',
     y='month(date):O',
-    color=alt.Color('max(temp):Q', scale=alt.Scale(scheme="inferno")),
+    color=alt.Color('max(temperature):Q', scale=alt.Scale(scheme="inferno")),
     tooltip=[
         alt.Tooltip('monthdate(date):T', title='Date'),
-        alt.Tooltip('max(temp):Q', title='Max Temp')
+        alt.Tooltip('max(temperature):Q', title='Max Temp')
     ]
 ).properties(width=550)

--- a/doc/user_guide/times_and_dates.rst
+++ b/doc/user_guide/times_and_dates.rst
@@ -89,7 +89,7 @@ containing hourly temperatures measured in Seattle:
     import altair as alt
     from vega_datasets import data
 
-    temps = data.seattle_temps()
+    temps = data.seattle_weather_hourly_normals.url
     temps.head()
 
 We can see from the ``dtypes`` attribute that the times are encoded as a standard
@@ -109,7 +109,7 @@ example, we'll limit ourselves to the first two weeks of data:
 
     alt.Chart(temps).mark_line().encode(
         x='date:T',
-        y='temp:Q'
+        y='temperature:Q'
     )
 
 (notice that for date/time values we use the ``T`` to indicate a temporal
@@ -128,7 +128,7 @@ x-axis, and day of the month on the y-axis:
     alt.Chart(temps).mark_rect().encode(
         alt.X('hoursminutes(date):O', title='hour of day'),
         alt.Y('monthdate(date):O', title='date'),
-        alt.Color('temp:Q', title='temperature (F)')
+        alt.Color('temperature:Q', title='temperature (F)')
     )
 
 Unless you are using a non-ES6 browser (See :ref:`note-browser-compliance`),
@@ -167,7 +167,7 @@ render **according to the timezone of the browser rendering it**:
     alt.Chart(temps).mark_rect().encode(
         alt.X('hoursminutes(date_pacific):O', title='hour of day'),
         alt.Y('monthdate(date_pacific):O', title='date'),
-        alt.Color('temp:Q', title='temperature (F)')
+        alt.Color('temperature:Q', title='temperature (F)')
     )
 
 If you are viewing this chart on a computer whose time is set to the west coast
@@ -195,7 +195,7 @@ regardless of the system location:
     alt.Chart(temps).mark_rect().encode(
         alt.X('utchoursminutes(date_pacific):O', title='UTC hour of day'),
         alt.Y('utcmonthdate(date_pacific):O', title='UTC date'),
-        alt.Color('temp:Q', title='temperature (F)')
+        alt.Color('temperature:Q', title='temperature (F)')
     )
 
 To make your charts as portable as possible (even in non-ES6 browsers which parse
@@ -210,7 +210,7 @@ in UTC time, both on the Pandas side and on the Vega-Lite side:
    alt.Chart(temps).mark_rect().encode(
        alt.X('utchoursminutes(date_utc):O', title='hour of day'),
        alt.Y('utcmonthdate(date_utc):O', title='date'),
-       alt.Color('temp:Q', title='temperature (F)')
+       alt.Color('temperature:Q', title='temperature (F)')
    )
 
 This is somewhat less convenient than the default behavior for timezone-agnostic

--- a/doc/user_guide/transform/timeunit.rst
+++ b/doc/user_guide/transform/timeunit.rst
@@ -36,11 +36,11 @@ measurements in Seattle during the year 2010:
     import altair as alt
     from vega_datasets import data
 
-    temps = data.seattle_temps.url
+    temps = data.seattle_weather_hourly_normals.url
 
     alt.Chart(temps).mark_line().encode(
         x='date:T',
-        y='temp:Q'
+        y='temperature:Q'
     )
 
 The plot is too busy due to the amount of data points squeezed into the short
@@ -51,7 +51,7 @@ and plotting only the mean monthly temperature:
 
     alt.Chart(temps).mark_line().encode(
         x='month(date):T',
-        y='mean(temp):Q'
+        y='mean(temperature):Q'
     )
 
 Notice that by default timeUnit output is a continuous quantity; if you would
@@ -63,7 +63,7 @@ This can be useful when plotting a bar chart or other discrete chart type:
 
     alt.Chart(temps).mark_bar().encode(
         x='month(date):O',
-        y='mean(temp):Q'
+        y='mean(temperature):Q'
     )
 
 Multiple time units can be combined within a single plot to yield interesting
@@ -75,7 +75,7 @@ to give a profile of Seattle temperatures through the year:
     alt.Chart(temps).mark_rect().encode(
         alt.X('date(date):O', title='day'),
         alt.Y('month(date):O', title='month'),
-        color='max(temp):Q'
+        color='max(temperature):Q'
     ).properties(
         title="2010 Daily High Temperatures in Seattle (F)"
     )
@@ -91,7 +91,7 @@ method. For example:
 
     alt.Chart(temps).mark_line().encode(
         alt.X('month:T', axis=alt.Axis(format='%b')),
-        y='mean(temp):Q'
+        y='mean(temperature):Q'
     ).transform_timeunit(
         month='month(date)'
     )


### PR DESCRIPTION
This fixes the broken weather sections in the docs mentioned in https://github.com/altair-viz/altair/issues/2213. I upated based on my understanding of https://github.com/altair-viz/vega_datasets/pull/40.