### PR TITLE
Update renderer descriptions for 4.0 and fix mimebundle typo

### DIFF
--- a/doc/user_guide/custom_renderers.rst
+++ b/doc/user_guide/custom_renderers.rst
@@ -45,8 +45,11 @@ The renderers built-in to Altair are the following:
 - ``"default"``: default rendering, using the
   ``'application/vnd.vegalite.v2+json'`` MIME type which is supported
   by JupyterLab and nteract.
-- ``"jupyterlab"``: identical to ``"default"``
-- ``"nteract"``: identical to ``"default"``
+- ``"html"``: identical to ``"default"``
+- ``"mimetype"``: outputs a vega-lite specific mimetype together with a PNG
+  representation.
+- ``"jupyterlab"``: identical to ``"mimetype"``
+- ``"nteract"``: identical to ``"mimetype"``
 - ``"colab"``: renderer for Google's Colab notebook, using the
   ``"text/html"`` MIME type.
 - ``"notebook"``: renderer for the classic notebook, provided by the ipyvega_

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -32,11 +32,13 @@ Some of the built-in renderers are:
   as well as Jupyter ecosystem tools like nbviewer_ and nbconvert_ HTML output.
   It requires a web connection in order to load relevant Javascript libraries.
 
-``alt.renderers.enable('mimebundle')``
+``alt.renderers.enable('mimetype')``
   *(default prior to Altair 4.0):* Output a vega-lite specific mimetype that can be
-  interpreted by appropriate frontend extensions to display charts.
-  It works with newer versions of JupyterLab_, nteract_, and `VSCode-Python`_, but does
-  not work with the `Jupyter Notebook`_, or with tools like nbviewer_ and nbconvert_.
+  interpreted by appropriate frontend extensions to display charts. This also outputs
+  a PNG representation of the plot, which is useful to view plots offline or on
+  platforms that don't support rendering vegaspecs, such as GitHub. It works with
+  newer versions of JupyterLab_, nteract_, and `VSCode-Python`_, but does not work
+  with the `Jupyter Notebook`_, or with tools like nbviewer_ and nbconvert_.
 
 Other renderers can be installed by third-party packages via Python's entrypoints_ system;
 see :ref:`renderer-api`.
@@ -143,7 +145,7 @@ Examples are:
 - The `VSCode-Python`_ extension, which supports native Altair and Vega-Lite
   chart display as of November 2019.
 - The Hydrogen_ project, which is built on nteract_ and renders Altair charts
-  via the ``mimebundle`` renderer.
+  via the ``mimetype`` renderer.
 
 Altair Viewer
 ~~~~~~~~~~~~~
@@ -247,7 +249,8 @@ a given one. To return the registered renderers as a Python list::
 
     >>> import altair as alt
     >>> alt.renderers.names()
-    ['html', 'mimebundle', 'json', ...]
+    ['colab', 'default', 'html', 'json', 'jupyterlab', 'kaggle', 'mimetype',
+    'nteract', 'png', 'svg', 'zeppelin']
 
 To enable the JSON renderer, which results in a collapsible JSON tree view
 in JupyterLab/nteract::

--- a/doc/user_guide/troubleshooting.rst
+++ b/doc/user_guide/troubleshooting.rst
@@ -197,7 +197,7 @@ If you are using JupyterLab (not Jupyter notebook) and see the following output:
 
     <VegaLite 4 object>
 
-This means that you have enabled the ``mimebundle`` renderer, but that your JupyterLab
+This means that you have enabled the ``mimetype`` renderer, but that your JupyterLab
 frontend does not support the VegaLite 4 mimetype.
 
 The easiest solution is to use the default renderer::
@@ -334,7 +334,7 @@ If you are using Jupyter Notebook (not JupyterLab) and see the following output:
 
     <VegaLite 4 object>
 
-This means that you have enabled the ``mimebundle`` renderer.
+This means that you have enabled the ``mimetype`` renderer.
 
 The easiest solution is to use the default renderer::
 


### PR DESCRIPTION
This is based of my understanding of [your comment here](https://github.com/altair-viz/altair/issues/2311#issuecomment-705877316) and issue https://github.com/altair-viz/altair/issues/2234. If `'colab'` is the same as `'html'` I can change to reflect that.

close https://github.com/altair-viz/altair/issues/2234 