### PR TITLE
Docs: Flip extent='max-min' to extent='min-max'

### DIFF
--- a/doc/user_guide/marks.rst
+++ b/doc/user_guide/marks.rst
@@ -146,7 +146,7 @@ Users can adjust this threshold using the ``extent`` property of the mark.
   )
 
 
-The outliers can be ignored completely using ``extent='max-min'``
+The outliers can be ignored completely using ``extent='min-max'``
 
 
 .. altair-plot::


### PR DESCRIPTION
Fixed a small mistake in user_guide/marks

- extent='max-min' is not a valid argument -> Changed to extent='min-max'