### PR TITLE
support serializing nullable float data

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -329,6 +329,8 @@ def sanitize_dataframe(df):  # noqa: C901
             "UInt16",
             "UInt32",
             "UInt64",
+            "Float32",
+            "Float64"
         }:  # nullable integer datatypes (since 24.0)
             # https://pandas.pydata.org/pandas-docs/version/0.25/whatsnew/v0.24.0.html#optional-integer-na-support
             col = df[col_name].astype(object)

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -330,8 +330,8 @@ def sanitize_dataframe(df):  # noqa: C901
             "UInt32",
             "UInt64",
             "Float32",
-            "Float64"
-        }:  # nullable integer datatypes (since 24.0)
+            "Float64",
+        }:  # nullable integer datatypes (since 24.0) and nullable float datatypes (since 1.2.0)
             # https://pandas.pydata.org/pandas-docs/version/0.25/whatsnew/v0.24.0.html#optional-integer-na-support
             col = df[col_name].astype(object)
             df[col_name] = col.where(col.notnull(), None)


### PR DESCRIPTION
Fixes #2398. 
This PR introduces support for serialising pandas nullable data types for float data (`Float32Dtype` and `Float64Dtype`) that were [introduced](https://pandas.pydata.org/pandas-docs/dev/whatsnew/v1.2.0.html#experimental-nullable-data-types-for-float-data) in pandas 1.2.0.

```python
import pandas as pd
import altair as alt

df = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6, 7], 'y': [10, 30, None, 15, None, 40, 20]}, 
                  dtype=pd.Float32Dtype()) # pd.Float64Dtype()

alt.Chart(df).mark_line(point=True).encode(x='x', y='y')
```
<img width="153" alt="image" src="https://user-images.githubusercontent.com/5186265/106954489-2adcb600-6734-11eb-8303-6ebf7b45dc70.png">
