### PR TITLE
Force double_precision=15 in utils.data:_data_to_json_string

### DIFF
--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -185,7 +185,7 @@ def _data_to_json_string(data):
         return json.dumps(data)
     elif isinstance(data, pd.DataFrame):
         data = sanitize_dataframe(data)
-        return data.to_json(orient="records")
+        return data.to_json(orient="records", double_precision=15)
     elif isinstance(data, dict):
         if "values" not in data:
             raise KeyError("values expected in data dict, but not present.")


### PR DESCRIPTION
Leaving it implied at pandas' [default of 10](https://github.com/pandas-dev/pandas/blob/5d65e0a3092f3c30169d0c0a3d0227e985104a56/pandas/io/json/_json.py#L55) makes the altair_data_server that uses this method drop numbers between 9.999e-16 and 5e-11, leading to unexpected and imo bad behavior like in https://github.com/altair-viz/altair_data_server/issues/45.