### PR TITLE
Avoid confusing Python by returning generic objects for magic attributes.

### DIFF
--- a/altair/expr/core.py
+++ b/altair/expr/core.py
@@ -8,6 +8,8 @@ class DatumType(object):
         return "datum"
 
     def __getattr__(self, attr):
+        if attr.startswith("__") and attr.endswith("__"):
+            raise AttributeError(attr)
         return GetAttrExpression("datum", attr)
 
     def __getitem__(self, attr):

--- a/altair/expr/tests/test_expr.py
+++ b/altair/expr/tests/test_expr.py
@@ -1,5 +1,7 @@
 import operator
 
+import pytest
+
 from ... import expr
 from .. import datum
 
@@ -94,6 +96,9 @@ def test_copy():
 def test_datum_getattr():
     x = datum["foo"]
     assert repr(x) == "datum['foo']"
+
+    with pytest.raises(AttributeError):
+        datum.__magic__
 
 
 def test_expression_getitem():

--- a/altair/vegalite/v3/api.py
+++ b/altair/vegalite/v3/api.py
@@ -194,6 +194,8 @@ class Selection(object):
         return Selection(core.SelectionOr(**{"or": [self.name, other]}), self.selection)
 
     def __getattr__(self, field_name):
+        if field_name.startswith("__") and field_name.endswith("__"):
+            raise AttributeError(field_name)
         return expr.core.GetAttrExpression(self.name, field_name)
 
     def __getitem__(self, field_name):

--- a/altair/vegalite/v3/tests/test_api.py
+++ b/altair/vegalite/v3/tests/test_api.py
@@ -249,6 +249,9 @@ def test_selection_expression():
     assert isinstance(selection["value"], alt.expr.Expression)
     assert selection["value"].to_dict() == "{0}['value']".format(selection.name)
 
+    with pytest.raises(AttributeError):
+        selection.__magic__
+
 
 @pytest.mark.parametrize("format", ["html", "json", "png", "svg", "pdf"])
 def test_save(format, basic_chart):

--- a/altair/vegalite/v4/api.py
+++ b/altair/vegalite/v4/api.py
@@ -194,6 +194,8 @@ class Selection(object):
         return Selection(core.SelectionOr(**{"or": [self.name, other]}), self.selection)
 
     def __getattr__(self, field_name):
+        if field_name.startswith("__") and field_name.endswith("__"):
+            raise AttributeError(field_name)
         return expr.core.GetAttrExpression(self.name, field_name)
 
     def __getitem__(self, field_name):

--- a/altair/vegalite/v4/tests/test_api.py
+++ b/altair/vegalite/v4/tests/test_api.py
@@ -249,6 +249,9 @@ def test_selection_expression():
     assert isinstance(selection["value"], alt.expr.Expression)
     assert selection["value"].to_dict() == "{0}['value']".format(selection.name)
 
+    with pytest.raises(AttributeError):
+        selection.__magic__
+
 
 @pytest.mark.parametrize("format", ["html", "json", "png", "svg", "pdf"])
 def test_save(format, basic_chart):


### PR DESCRIPTION
As reported in #2402 , we recently came up against an issue whereby Altair charts could not be deep-copied. The issue is that in three locations a `__getattr__` method is implemented in such a way that it returns a object for any named attribute. This is usually helpful, but it sometimes confuses Python when it coincides with a Python "magic" method/attribute (which are always of form `__<name>__`; and in this case in particular, `__deepcopy__` is looked up but then doesn't behave in the way `copy.deepcopy` expects.

This patch causes Altair to avoid returning generic objects as attributes for Python magic names, fixing this (and other similar) issue(s).

closes #2402 