### PR TITLE
Use colors specified in line_scale

### DIFF
--- a/altair/examples/london_tube.py
+++ b/altair/examples/london_tube.py
@@ -35,7 +35,7 @@ labels = alt.Chart(centroids).mark_text().encode(
 
 line_scale = alt.Scale(domain=["Bakerloo", "Central", "Circle", "District", "DLR",
                                "Hammersmith & City", "Jubilee", "Metropolitan", "Northern",
-                               "Piccadilly", "Victoria", "Waterloo & City" ],
+                               "Piccadilly", "Victoria", "Waterloo & City"],
                        range=["rgb(137,78,36)", "rgb(220,36,30)", "rgb(255,206,0)",
                               "rgb(1,114,41)", "rgb(0,175,173)", "rgb(215,153,175)",
                               "rgb(106,114,120)", "rgb(114,17,84)", "rgb(0,0,0)",
@@ -51,7 +51,8 @@ lines = alt.Chart(tubelines).mark_geoshape(
             title=None,
             orient='bottom-right',
             offset=0
-        )
+        ),
+        scale=line_scale
     )
 )
 


### PR DESCRIPTION
This change will use the colors specified in `line_scale`. Previously `line_scale` was never used.