### PR TITLE
Prevent marks from extending beyond the chart area in error bar example

### DIFF
--- a/altair/examples/simple_scatter_with_errorbars.py
+++ b/altair/examples/simple_scatter_with_errorbars.py
@@ -15,7 +15,7 @@ y = np.random.normal(10, 0.5, size=len(x))
 yerr = 0.2
 
 # set up data frame
-source = pd.DataFrame({"x":x, "y":y, "yerr":yerr})
+source = pd.DataFrame({"x": x, "y": y, "yerr": yerr})
 
 # the base chart
 base = alt.Chart(source).transform_calculate(
@@ -30,7 +30,7 @@ points = base.mark_point(
     color='black'
 ).encode(
     x=alt.X('x', scale=alt.Scale(domain=(0, 6))),
-    y=alt.Y('y', scale=alt.Scale(domain=(10, 11)))
+    y=alt.Y('y', scale=alt.Scale(zero=False))
 )
 
 # generate the error bars


### PR DESCRIPTION
This is a fix to [the simple error bar example](https://altair-viz.github.io/gallery/simple_scatter_with_errorbars.html). Currently the marks extend beyond chart area, like this:

![image](https://user-images.githubusercontent.com/4560057/108554413-e828eb00-72a8-11eb-86dd-24fd68e4afdc.png)

This changes it to:

![image](https://user-images.githubusercontent.com/4560057/108554376-d8110b80-72a8-11eb-9104-b9b140a145e9.png)

Btw, I started trying to help out with some of the support related aspect by replying to Altair questions here and on SO, please let me know if you generally prefer to reply yourself instead.

I can also go through the GitHub issues and ping the authors to close the ones that are resolved (or close them myself if you would be ok with that), but since this would generate quite some noise in your inbox, I thought I would ask first if you would like me to do that or not.
