### PR TITLE
fixed typo in transform_filter documentation 

### DIFF
--- a/doc/user_guide/transform/filter.rst
+++ b/doc/user_guide/transform/filter.rst
@@ -172,7 +172,7 @@ selection. This can be accomplished using the various logical operand classes:
 These are not yet part of the Altair interface
 (see `Issue 695 <https://github.com/altair-viz/altair/issues/695>`_)
 but can be constructed explicitly; for example, here we plot US population
-distributions for all data *except* the years 1900-1950,
+distributions for all data *except* the years 1950-1960,
 by applying a ``LogicalNotPredicate`` schema to a ``FieldRangePredicate``:
 
 .. altair-plot::
@@ -189,7 +189,7 @@ by applying a ``LogicalNotPredicate`` schema to a ``FieldRangePredicate``:
     ).properties(
         width=600, height=200
     ).transform_filter(
-        {'not': alt.FieldRangePredicate(field='year', range=[1900, 1950])}
+        {'not': alt.FieldRangePredicate(field='year', range=[1950, 1960])}
     )
 
 Transform Options

--- a/doc/user_guide/transform/filter.rst
+++ b/doc/user_guide/transform/filter.rst
@@ -172,7 +172,7 @@ selection. This can be accomplished using the various logical operand classes:
 These are not yet part of the Altair interface
 (see `Issue 695 <https://github.com/altair-viz/altair/issues/695>`_)
 but can be constructed explicitly; for example, here we plot US population
-distributions for all data *except* the years 1950-1960,
+distributions for all data *except* the years 1900-1950,
 by applying a ``LogicalNotPredicate`` schema to a ``FieldRangePredicate``:
 
 .. altair-plot::


### PR DESCRIPTION
There is a a typo in the [documentation](https://altair-viz.github.io/user_guide/transform/filter.html#user-guide-filter-transform) for `.filter_transform()` as  mentioned in #2434, where the description of a chart doesn't match the specification. 

The specification states "here we plot US population distributions for all data except the years 1950-1960...", but the code removes the years 1900-1950 with following filter:

```python
.transform_filter(
    {'not': alt.FieldRangePredicate(field='year', range=[1900, 1950])}
)
```

At first, I had fixed the typo by changing the text to say "1900-1950".  But for some reason, I decided it seemed more reasonable to remove the years 1950-1960 rather than 1900-1950. 

