### PR TITLE
DOC: add `mark_trail` to user guide's list of marks

### DIFF
--- a/doc/user_guide/marks.rst
+++ b/doc/user_guide/marks.rst
@@ -27,6 +27,7 @@ rule        :meth:`~Chart.mark_rule`      A vertical or horizontal line spanning
 square      :meth:`~Chart.mark_square`    A scatter plot with filled squares.                  N/A
 text        :meth:`~Chart.mark_text`      A scatter plot with points represented by text.      :ref:`gallery_bar_chart_with_labels`
 tick        :meth:`~Chart.mark_tick`      A vertical or horizontal tick mark.                  :ref:`gallery_strip_plot`
+trail       :meth:`~Chart.mark_trail`     A line with variable widths.                         :ref:`gallery_trail_marker`
 ==========  ============================  ===================================================  ====================================
 
 In addition, Altair provides the following compound marks:


### PR DESCRIPTION
I hope I'm not missing anything obvious, but it seems trail mark is missing from the [list of marks in the user guide](https://altair-viz.github.io/user_guide/marks.html).