### PR TITLE
Bump chart example

### DIFF
--- a/altair/examples/bump_chart.py
+++ b/altair/examples/bump_chart.py
@@ -1,0 +1,29 @@
+"""
+Bump Chart
+----------
+This example shows a bump chart.  The data is first grouped into six-month
+intervals using pandas. The ranks are computed by Altair using a 
+window transform.
+"""
+# category: line charts
+
+import altair as alt
+from vega_datasets import data
+import pandas as pd
+
+stocks = data.stocks()
+source = stocks.groupby([pd.Grouper(key="date", freq="6M"),"symbol"]).mean().reset_index()
+
+alt.Chart(source).mark_line(point = True).encode(
+    x = alt.X("date:O", timeUnit="yearmonth", title="date"),
+    y="rank:O",
+    color=alt.Color("symbol:N")
+).transform_window(
+    rank="rank()",
+    sort=[alt.SortField("price", order="descending")],
+    groupby=["date"]
+).properties(
+    title="Bump Chart for Stock Prices",
+    width=600,
+    height=150,
+)


### PR DESCRIPTION
I made a bump chart for the example gallery.  It's a mix of this Vega example [Bump Chart](https://vega.github.io/vega-lite/examples/line_bump.html), which I don't think has a direct analogue in the Altair gallery, and this example from the Altair gallery [Window Rank Line Chart](https://altair-viz.github.io/gallery/window_rank.html).

This is my first contribution (to any repository) so I'm very happy for any feedback.

![bump](https://user-images.githubusercontent.com/82750240/129931603-388cc615-fbc0-406a-8ff7-7fa37822978d.png)
