### PR TITLE
Add strict option to sphinx extension

### DIFF
--- a/altair/sphinxext/altairgallery.py
+++ b/altair/sphinxext/altairgallery.py
@@ -102,6 +102,7 @@ EXAMPLE_TEMPLATE = jinja2.Template(
 
 .. altair-plot::
     {% if code_below %}:code-below:{% endif %}
+    {% if strict %}:strict:{% endif %}
 
     {{ code | indent(4) }}
 
@@ -253,7 +254,7 @@ def main(app):
 
     gallery_ref = app.builder.config.altair_gallery_ref
     gallery_title = app.builder.config.altair_gallery_title
-    examples = populate_examples(gallery_ref=gallery_ref, code_below=True)
+    examples = populate_examples(gallery_ref=gallery_ref, code_below=True, strict=False)
 
     if not os.path.exists(target_dir):
         os.makedirs(target_dir)

--- a/altair/sphinxext/altairplot.py
+++ b/altair/sphinxext/altairplot.py
@@ -220,11 +220,9 @@ def html_visit_altair_plot(self, node):
             chart = eval_block(node["code"], namespace)
         stdout = f.getvalue()
     except Exception as e:
-        message = (
-            "altair-plot: {}:{} Code Execution failed:"
-                "{}: {}".format(
-                    node["rst_source"], node["rst_lineno"], e.__class__.__name__, str(e)
-                ))
+        message = "altair-plot: {}:{} Code Execution failed:" "{}: {}".format(
+            node["rst_source"], node["rst_lineno"], e.__class__.__name__, str(e)
+        )
         if node["strict"]:
             raise ValueError(message)
         else:

--- a/altair/sphinxext/altairplot.py
+++ b/altair/sphinxext/altairplot.py
@@ -224,7 +224,7 @@ def html_visit_altair_plot(self, node):
             node["rst_source"], node["rst_lineno"], e.__class__.__name__, str(e)
         )
         if node["strict"]:
-            raise ValueError(message)
+            raise ValueError(message) from e
         else:
             warnings.warn(message)
             raise nodes.SkipNode


### PR DESCRIPTION
Closes #2550 

This adds a `:strict:` option to the altair sphinx extension. When set, it ensures that the documentation build fails when a code snippet can't be run. This is meant to prevent code snippets in the documentation from going stale. It is less restrictive than building the documentation with `-W` because warnings for other reasons won't cause the build of the documentation to fail.


