### PR TITLE
docs: correcting regression equations

### DIFF
--- a/doc/user_guide/transform/regression.rst
+++ b/doc/user_guide/transform/regression.rst
@@ -15,10 +15,10 @@ This transform supports parametric models for the following functional forms:
 
 - linear (``linear``): *y = a + b * x*
 - logarithmic (``log``): *y = a + b * log(x)*
-- exponential (``exp``): *y = a + eb * x*
-- power (``pow``): *y = a * xb*
-- quadratic (``quad``): *y = a + b * x + c * x2*
-- polynomial (``poly``): *y = a + b * x + … + k * xorder*
+- exponential (``exp``): * y = a * e^(b * x)*
+- power (``pow``): *y = a * x^b*
+- quadratic (``quad``): *y = a + b * x + c * x^2*
+- polynomial (``poly``): *y = a + b * x + … + k * x^(order)*
 
 All models are fit using ordinary least squares.
 For non-parametric locally weighted regression, see the


### PR DESCRIPTION
I assume the addition in the exponential regression is a mistake and instead should be calculated as y = a * e^(b * x), which is also what can be found on the respective vega lite doc page: https://vega.github.io/vega-lite/docs/regression.html where it appears that the same correction was comitted due to a PR by @jakevdp [44123d888fff30c9d975b16f219d63c94e20ede2](https://github.com/vega/vega-lite/pull/5742/commits/44123d888fff30c9d975b16f219d63c94e20ede2)
Similarly, also in some of the other equations there were some typos to be fixed.