### PR TITLE
MAINT: Fix GH actions issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ jobs:
     - name: Check formatting with black
       run: |
         pip install black
+        black --diff --color .
         black --check .
     - name: Lint with flake8
       run: |

--- a/altair/utils/tests/test_plugin_registry.py
+++ b/altair/utils/tests/test_plugin_registry.py
@@ -26,7 +26,7 @@ def test_plugin_registry():
     assert plugins.get() is None
     assert repr(plugins) == "TypedCallableRegistry(active='', registered=[])"
 
-    plugins.register("new_plugin", lambda x: x ** 2)
+    plugins.register("new_plugin", lambda x: x**2)
     assert plugins.names() == ["new_plugin"]
     assert plugins.active == ""
     assert plugins.get() is None
@@ -46,7 +46,7 @@ def test_plugin_registry():
 def test_plugin_registry_extra_options():
     plugins = GeneralCallableRegistry()
 
-    plugins.register("metadata_plugin", lambda x, p=2: x ** p)
+    plugins.register("metadata_plugin", lambda x, p=2: x**p)
     plugins.enable("metadata_plugin")
     assert plugins.get()(3) == 9
 
@@ -86,7 +86,7 @@ def test_plugin_registry_global_settings():
 def test_plugin_registry_context():
     plugins = GeneralCallableRegistry()
 
-    plugins.register("default", lambda x, p=2: x ** p)
+    plugins.register("default", lambda x, p=2: x**p)
 
     # At first there is no plugin enabled
     assert plugins.active == ""

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@ jinja2
 numpydoc
 pillow
 sphinx_rtd_theme
+mistune<=0.8.4


### PR DESCRIPTION
- Pin mistune since newer versions raise an error. It appears to be unmaintained https://github.com/miyakogi/m2r/issues/66
- Show which files fail black linting by running `black --diff` in the action workflow.
- Fix spacing around exponent operator to pass black linting
