### PR TITLE
MAINT: Update actions' links to use https

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
         pip install altair_saver
-        pip install git+git://github.com/altair-viz/altair_viewer.git
+        pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Test with pytest
       run: |
         pytest --doctest-modules altair

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -21,7 +21,7 @@ jobs:
         pip install .[dev]
         pip install altair_saver
         pip install -r doc/requirements.txt
-        pip install git+git://github.com/altair-viz/altair_viewer.git
+        pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Run docbuild
       run: |
         cd doc && make ${{ matrix.build-type }}


### PR DESCRIPTION
These pip installs were added in #2528 for installing the dev version of altair viewer. As per https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported, git will only support secure links in its build files since recently