### PR TITLE
MAINT: Make sure that deprecation warnings are displayed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
         pip install altair_saver
-        pip install git+git://github.com/altair-viz/altair_viewer.git
+        pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Test with pytest
       run: |
         pytest --doctest-modules altair

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -21,7 +21,7 @@ jobs:
         pip install .[dev]
         pip install altair_saver
         pip install -r doc/requirements.txt
-        pip install git+git://github.com/altair-viz/altair_viewer.git
+        pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Run docbuild
       run: |
         cd doc && make ${{ matrix.build-type }}

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -304,13 +304,13 @@ def parameter(name=None, select=None, **kwds):
         if parameter.empty == "none":
             warnings.warn(
                 """The value of 'empty' should be True or False.""",
-                DeprecationWarning,
+                utils.AltairDeprecationWarning,
             )
             parameter.empty = False
         elif parameter.empty == "all":
             warnings.warn(
                 """The value of 'empty' should be True or False.""",
-                DeprecationWarning,
+                utils.AltairDeprecationWarning,
             )
             parameter.empty = True
         elif (parameter.empty is False) or (parameter.empty is True):
@@ -321,7 +321,7 @@ def parameter(name=None, select=None, **kwds):
     if "init" in kwds:
         warnings.warn(
             """Use 'value' instead of 'init'.""",
-            DeprecationWarning,
+            utils.AltairDeprecationWarning,
         )
         if "value" not in kwds:
             kwds["value"] = kwds.pop("init")
@@ -374,7 +374,7 @@ def selection(type=Undefined, **kwds):
         warnings.warn(
             """The types 'single' and 'multi' are now
         combined and should be specified using "type='point'".""",
-            DeprecationWarning,
+            utils.AltairDeprecationWarning,
         )
     else:
         raise ValueError("""'type' must be 'point' or 'interval'""")
@@ -394,21 +394,19 @@ def selection_point(**kwargs):
     return selection(type="point", **kwargs)
 
 
+@utils.deprecation.deprecated(
+    message="'selection_multi' is deprecated.  Use 'selection_point'"
+)
 @utils.use_signature(core.PointSelectionConfig)
 def selection_multi(**kwargs):
-    warnings.warn(
-        """'selection_multi' is deprecated.  Use 'selection_point'""",
-        DeprecationWarning,
-    )
     return selection(type="point", **kwargs)
 
 
+@utils.deprecation.deprecated(
+    message="'selection_single' is deprecated.  Use 'selection_point'"
+)
 @utils.use_signature(core.PointSelectionConfig)
 def selection_single(**kwargs):
-    warnings.warn(
-        """'selection_single' is deprecated.  Use 'selection_point'""",
-        DeprecationWarning,
-    )
     return selection(type="point", **kwargs)
 
 
@@ -1882,7 +1880,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         else:
             display(self)
 
-    @utils.deprecation.deprecated(message="serve() is deprecated. Use show() instead.")
+    @utils.deprecation.deprecated(message="'serve' is deprecated. Use 'show' instead.")
     def serve(
         self,
         ip="127.0.0.1",
@@ -1956,7 +1954,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             import altair_viewer  # type: ignore
         except ImportError:
             raise ValueError(
-                "show() method requires the altair_viewer package. "
+                "'show' method requires the altair_viewer package. "
                 "See http://github.com/altair-viz/altair_viewer"
             )
         altair_viewer.show(self, embed_opt=embed_opt, open_browser=open_browser)
@@ -2198,11 +2196,10 @@ class Chart(
             copy.params.append(s.param)
         return copy
 
+    @utils.deprecation.deprecated(
+        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+    )
     def add_selection(self, *params):
-        warnings.warn(
-            """'add_selection' is deprecated. Use 'add_parameter'.""",
-            DeprecationWarning,
-        )
         return self.add_parameter(*params)
 
     def interactive(self, name=None, bind_x=True, bind_y=True):
@@ -2375,11 +2372,10 @@ class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
         copy.spec = copy.spec.add_parameter(*params)
         return copy
 
+    @utils.deprecation.deprecated(
+        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+    )
     def add_selection(self, *selections):
-        warnings.warn(
-            """'add_selection' is deprecated.  Use 'add_parameter'""",
-            DeprecationWarning,
-        )
         return self.add_parameter(*selections)
 
 
@@ -2435,11 +2431,10 @@ class ConcatChart(TopLevelMixin, core.TopLevelConcatSpec):
         copy.concat = [chart.add_parameter(*params) for chart in copy.concat]
         return copy
 
+    @utils.deprecation.deprecated(
+        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+    )
     def add_selection(self, *selections):
-        warnings.warn(
-            """'add_selection' is deprecated.  Use 'add_parameter'""",
-            DeprecationWarning,
-        )
         return self.add_parameter(*selections)
 
 
@@ -2478,11 +2473,10 @@ class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):
         copy.hconcat = [chart.add_parameter(*params) for chart in copy.hconcat]
         return copy
 
+    @utils.deprecation.deprecated(
+        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+    )
     def add_selection(self, *selections):
-        warnings.warn(
-            """'add_selection' is deprecated.  Use 'add_parameter'""",
-            DeprecationWarning,
-        )
         return self.add_parameter(*selections)
 
 
@@ -2521,11 +2515,10 @@ class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
         copy.vconcat = [chart.add_parameter(*params) for chart in copy.vconcat]
         return copy
 
+    @utils.deprecation.deprecated(
+        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+    )
     def add_selection(self, *selections):
-        warnings.warn(
-            """'add_selection' is deprecated.  Use 'add_parameter'""",
-            DeprecationWarning,
-        )
         return self.add_parameter(*selections)
 
 
@@ -2609,11 +2602,10 @@ class LayerChart(TopLevelMixin, _EncodingMixin, core.TopLevelLayerSpec):
         copy.layer[0] = copy.layer[0].add_parameter(*params)
         return copy
 
+    @utils.deprecation.deprecated(
+        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+    )
     def add_selection(self, *selections):
-        warnings.warn(
-            """'add_selection' is deprecated.  Use 'add_parameter'""",
-            DeprecationWarning,
-        )
         return self.add_parameter(*selections)
 
 
@@ -2661,11 +2653,10 @@ class FacetChart(TopLevelMixin, core.TopLevelFacetSpec):
         copy.spec = copy.spec.add_parameter(*params)
         return copy
 
+    @utils.deprecation.deprecated(
+        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+    )
     def add_selection(self, *selections):
-        warnings.warn(
-            """'add_selection' is deprecated.  Use 'add_parameter'""",
-            DeprecationWarning,
-        )
         return self.add_parameter(*selections)
 
 


### PR DESCRIPTION
Deprecation warnings do not display for me in the notebook; I think we have to use the special `AltairDeprecationWarning` or the decorator (as is done for 'show' and 'serve'). After this change I get the expected output when trying to use deprecated functionality:

![image](https://user-images.githubusercontent.com/4560057/160063200-e73ce2de-2303-40db-ac9f-4be94b0714a6.png)
