### PR TITLE
MAINT: Update from v4 to v5 in some additional files

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@
 5. Double-check that all vega-lite/vega/vega-embed versions are up-to-date:
 
    - URLs in ``doc/conf.py``
-   - versions in ``altair/vegalite/v4/display.py``
+   - versions in ``altair/vegalite/v5/display.py``
 
 6. Commit change and push to master
 

--- a/altair/_magics.py
+++ b/altair/_magics.py
@@ -13,6 +13,7 @@ from toolz import curried
 
 from altair.vegalite import v3 as vegalite_v3
 from altair.vegalite import v4 as vegalite_v4
+from altair.vegalite import v5 as vegalite_v5
 from altair.vega import v5 as vega_v5
 
 try:
@@ -25,18 +26,23 @@ except ImportError:
 
 RENDERERS = {
     "vega": {"5": vega_v5.Vega},
-    "vega-lite": {"3": vegalite_v3.VegaLite, "4": vegalite_v4.VegaLite},
+    "vega-lite": {
+        "3": vegalite_v3.VegaLite,
+        "4": vegalite_v4.VegaLite,
+        "5": vegalite_v5.VegaLite,
+    },
 }
 
 
 TRANSFORMERS = {
     "vega": {
         # Vega doesn't yet have specific data transformers; use vegalite
-        "5": vegalite_v4.data_transformers,
+        "5": vegalite_v5.data_transformers,
     },
     "vega-lite": {
         "3": vegalite_v3.data_transformers,
         "4": vegalite_v4.data_transformers,
+        "5": vegalite_v5.data_transformers,
     },
 }
 
@@ -76,12 +82,12 @@ def _get_variable(name):
     nargs="*",
     help="local variable name of a pandas DataFrame to be used as the dataset",
 )
-@magic_arguments.argument("-v", "--version", dest="version", default="5")
+@magic_arguments.argument("-v", "--version", dest="version", default="v5")
 @magic_arguments.argument("-j", "--json", dest="json", action="store_true")
 def vega(line, cell):
     """Cell magic for displaying Vega visualizations in CoLab.
 
-    %%vega [name1:variable1 name2:variable2 ...] [--json] [--version='5']
+    %%vega [name1:variable1 name2:variable2 ...] [--json] [--version='v5']
 
     Visualize the contents of the cell using Vega, optionally specifying
     one or more pandas DataFrame objects to be used as the datasets.
@@ -90,7 +96,8 @@ def vega(line, cell):
     """
     args = magic_arguments.parse_argstring(vega, line)
 
-    version = args.version
+    existing_versions = {"v5": "5"}
+    version = existing_versions[args.version]
     assert version in RENDERERS["vega"]
     Vega = RENDERERS["vega"][version]
     data_transformers = TRANSFORMERS["vega"][version]
@@ -139,12 +146,12 @@ def vega(line, cell):
     nargs="?",
     help="local variablename of a pandas DataFrame to be used as the dataset",
 )
-@magic_arguments.argument("-v", "--version", dest="version", default="4")
+@magic_arguments.argument("-v", "--version", dest="version", default="v5")
 @magic_arguments.argument("-j", "--json", dest="json", action="store_true")
 def vegalite(line, cell):
     """Cell magic for displaying vega-lite visualizations in CoLab.
 
-    %%vegalite [dataframe] [--json] [--version=3]
+    %%vegalite [dataframe] [--json] [--version='v3']
 
     Visualize the contents of the cell using Vega-Lite, optionally
     specifying a pandas DataFrame object to be used as the dataset.
@@ -152,7 +159,8 @@ def vegalite(line, cell):
     if --json is passed, then input is parsed as json rather than yaml.
     """
     args = magic_arguments.parse_argstring(vegalite, line)
-    version = args.version
+    existing_versions = {"v3": "3", "v4": "4", "v5": "5"}
+    version = existing_versions[args.version]
     assert version in RENDERERS["vega-lite"]
     VegaLite = RENDERERS["vega-lite"][version]
     data_transformers = TRANSFORMERS["vega-lite"][version]

--- a/altair/tests/test_magics.py
+++ b/altair/tests/test_magics.py
@@ -9,7 +9,7 @@ except ImportError:
     IPYTHON_AVAILABLE = False
     pass
 
-from altair.vegalite.v4 import VegaLite
+from altair.vegalite.v5 import VegaLite
 from altair.vega.v5 import Vega
 
 
@@ -113,7 +113,7 @@ VEGA_SPEC = {
 
 
 VEGALITE_SPEC = {
-    "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
     "data": {"values": DATA_RECORDS},
     "description": "A simple bar chart with embedded data.",
     "encoding": {

--- a/altair/vegalite/api.py
+++ b/altair/vegalite/api.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-from .v4.api import *
+from .v5.api import *

--- a/altair/vegalite/tests/test_common.py
+++ b/altair/vegalite/tests/test_common.py
@@ -4,7 +4,7 @@ import pytest
 
 import pandas as pd
 
-from .. import v3, v4
+from .. import v3, v4, v5
 
 
 @pytest.fixture
@@ -38,7 +38,7 @@ def make_basic_chart(alt):
     return alt.Chart(data).mark_bar().encode(x="a", y="b")
 
 
-@pytest.mark.parametrize("alt", [v3, v4])
+@pytest.mark.parametrize("alt", [v3, v4, v5])
 def test_basic_chart_to_dict(alt, basic_spec):
     chart = (
         alt.Chart("data.csv")
@@ -54,7 +54,7 @@ def test_basic_chart_to_dict(alt, basic_spec):
     assert dct == make_final_spec(alt, basic_spec)
 
 
-@pytest.mark.parametrize("alt", [v3, v4])
+@pytest.mark.parametrize("alt", [v3, v4, v5])
 def test_basic_chart_from_dict(alt, basic_spec):
     chart = alt.Chart.from_dict(basic_spec)
     dct = chart.to_dict()
@@ -66,7 +66,7 @@ def test_basic_chart_from_dict(alt, basic_spec):
     assert dct == make_final_spec(alt, basic_spec)
 
 
-@pytest.mark.parametrize("alt", [v3, v4])
+@pytest.mark.parametrize("alt", [v3, v4, v5])
 def test_theme_enable(alt, basic_spec):
     active_theme = alt.themes.active
 
@@ -87,7 +87,7 @@ def test_theme_enable(alt, basic_spec):
         alt.themes.enable(active_theme)
 
 
-@pytest.mark.parametrize("alt", [v3, v4])
+@pytest.mark.parametrize("alt", [v3, v4, v5])
 def test_max_rows(alt):
     basic_chart = make_basic_chart(alt)
 

--- a/altair/vegalite/v5/data.py
+++ b/altair/vegalite/v5/data.py
@@ -13,11 +13,11 @@ from ..data import (
 
 
 # ==============================================================================
-# VegaLite 4 data transformers
+# VegaLite 5 data transformers
 # ==============================================================================
 
 
-ENTRY_POINT_GROUP = "altair.vegalite.v4.data_transformer"  # type: str
+ENTRY_POINT_GROUP = "altair.vegalite.v5.data_transformer"  # type: str
 
 
 data_transformers = DataTransformerRegistry(

--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -32,7 +32,7 @@ class VegaTheme(object):
 # The entry point group that can be used by other packages to declare other
 # renderers that will be auto-detected. Explicit registration is also
 # allowed by the PluginRegistery API.
-ENTRY_POINT_GROUP = "altair.vegalite.v4.theme"  # type: str
+ENTRY_POINT_GROUP = "altair.vegalite.v5.theme"  # type: str
 themes = ThemeRegistry(entry_point_group=ENTRY_POINT_GROUP)
 
 themes.register(

--- a/doc/_static/chart.html
+++ b/doc/_static/chart.html
@@ -2,14 +2,14 @@
 <html>
 <head>
   <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vega-lite@4"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
   <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
 </head>
 <body>
   <div id="vis"></div>
   <script type="text/javascript">
     var spec = {
-      "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+      "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
       "config": {
         "view": {
           "continuousHeight": 300,

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -64,7 +64,7 @@ Altair 4 this can be installed with:
     $ jupyter labextension install @jupyterlab/vega5-extension
 
 In JupyterLab version 2.0 or newer, this extension is installed by default, though the
-version available in the jupyterlab release often takes a few months to catch up with
+version available in the JupyterLab release often takes a few months to catch up with
 new Altair releases.
 
 
@@ -80,7 +80,7 @@ Optionally, for offline rendering in Jupyter Notebook, you can use the notebook 
     # Optional in Jupyter Notebook: requires an up-to-date vega nbextension.
     alt.renderers.enable('notebook')
     
-This renderer is provided by the `ipyvega`_ notebook extension. which can be
+This renderer is provided by the `ipyvega`_ notebook extension, which can be
 installed and enabled either using pip:
 
 .. code-block:: bash
@@ -106,7 +106,7 @@ Displaying in nteract
 ---------------------
 nteract_ cannot display HTML outputs natively, and so Altair's default ``html`` renderer
 will not work. However, nteract natively includes vega and vega-lite mimetype-based rendering.
-To use Altair in nteract, ensure you are using a version that supports the vega-lite v4
+To use Altair in nteract, ensure you are using a version that supports the Vega-Lite v5
 mimetype, and use::
 
     alt.renderers.enable('mimetype')
@@ -223,7 +223,7 @@ the ``"text/html"`` mimetype; schematically it looks like this::
 Propertly-configured Jupyter frontends know how to interpret and display charts using
 custom vega-specific mimetypes; for example:
 
-* Vega-Lite 4.x: ``application/vnd.vegalite.v4+json``
+* Vega-Lite 5.x: ``application/vnd.vegalite.v5+json``
 * Vega 5.x: ``application/vnd.vega.v5+json``
 
 Altair's ``mimetype`` renderer uses this mechanism to return the spec directly::
@@ -231,8 +231,8 @@ Altair's ``mimetype`` renderer uses this mechanism to return the spec directly::
     def default_renderer(spec):
         bundle = {}
         metadata = {}
-        bundle['text/plain'] = '<VegaLite 4 object>`
-        bundle['application/vnd.vegalite.v4+json'] = spec
+        bundle['text/plain'] = '<VegaLite 5 object>`
+        bundle['application/vnd.vegalite.v5+json'] = spec
         return bundle, metadata
 
 If a renderer needs to do custom display logic that doesn't use Jupyter's display

--- a/doc/user_guide/internals.rst
+++ b/doc/user_guide/internals.rst
@@ -127,7 +127,7 @@ For example, consider the
 from the Vega-Lite documentation, which has the following JSON specification::
 
     {
-      "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+      "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
       "description": "A simple bar chart with embedded data.",
       "data": {
         "values": [
@@ -152,7 +152,7 @@ construct an Altair chart object from this string of Vega-Lite JSON:
 
     alt.Chart.from_json("""
     {
-      "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+      "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
       "description": "A simple bar chart with embedded data.",
       "data": {
         "values": [
@@ -177,7 +177,7 @@ you can use the :meth:`~Chart.from_dict` method to construct the chart object:
     import altair as alt
 
     alt.Chart.from_dict({
-      "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+      "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
       "description": "A simple bar chart with embedded data.",
       "data": {
         "values": [

--- a/doc/user_guide/saving_charts.rst
+++ b/doc/user_guide/saving_charts.rst
@@ -37,7 +37,7 @@ The contents of the resulting file will look something like this:
 .. code-block:: json
 
     {
-      "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+      "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
       "config": {
         "view": {
           "continuousHeight": 300,
@@ -97,7 +97,7 @@ javascript-enabled web browser:
       <div id="vis"></div>
       <script type="text/javascript">
         var spec = {
-          "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+          "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
           "config": {
             "view": {
               "continuousHeight": 300,


### PR DESCRIPTION
I grepped the repo for `v4` and noticed a few places where I think it should be replaced with `v5`. I ran this locally with the updated tests in https://github.com/altair-viz/altair/pull/2576 and there are no failures introduced.