### PR TITLE
FEAT: Include only referenced data columns in chart specs

### DIFF
--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -21,7 +21,9 @@ DataTransformerType = Callable
 
 
 class DataTransformerRegistry(PluginRegistry[DataTransformerType]):
-    _global_settings = {"consolidate_datasets": True}
+    _global_settings = {
+        "consolidate_datasets": True,
+    }
 
     @property
     def consolidate_datasets(self):
@@ -30,6 +32,40 @@ class DataTransformerRegistry(PluginRegistry[DataTransformerType]):
     @consolidate_datasets.setter
     def consolidate_datasets(self, value):
         self._global_settings["consolidate_datasets"] = value
+
+    def compress_datasets(self, enable=True, transformed_charts=False):
+        """Whether to remove data fields that do not occurr elsewhere in the chart spec
+
+        The approach taken here is conservative as it will
+        leave some of the data fields that should be removed because they
+        have a common or short name that happens to occur elsewhere in the
+        spec by coincidence.
+
+        Parameters
+        ----------
+
+        enable : bool
+            Whether compression is enabled.
+
+        transformed_charts : bool
+            Whether to enable compression for transformed charts.
+            Data compression can break charts with transforms where data
+            fields are referenced without the field name occurring
+            literally in the chart spec.
+        """
+        if transformed_charts:
+            warnings.warn(
+                "Data compression can break charts with transforms where data"
+                " fields are referenced without the field name occurring"
+                " literally in the chart spec. Please revert this option if you"
+                " are observing unexpected behavior with transformed charts."
+            )
+        self._compress_datasets = enable
+        self._compress_transformed_charts = transformed_charts
+        return
+
+    _compress_datasets = True
+    _compress_transformed_charts = False
 
 
 # ==============================================================================


### PR DESCRIPTION
This PR takes an inelegant and conservative approach to fix #2428. It converts the chart spec (without the data) to a string and removes each of the data field names that is not found in that string (i.e. the data fields not referenced anywhere in the spec). It will not work for short columns names such as 'x', or those that have the same name as a key in the VegaLite spec, e.g. 'field', but it is still likely useful for the vast majority of cases and can reduce the chart size significantly specification with many unused columns. For example, this chart

```python
import altair as alt
from vega_datasets import data

alt.data_transformers.disable_max_rows()
source = data.movies()

import sys
sys.getsizeof(alt.Chart(source).mark_rect().encode(
    alt.X('IMDB_Rating:Q', bin=alt.Bin(maxbins=60)),
    alt.Y('Rotten_Tomatoes_Rating:Q', bin=alt.Bin(maxbins=40)),
    alt.Color('count():Q', scale=alt.Scale(scheme='greenblue'))
).to_json())
```
has a size of 1873345 bytes because there is a lot of unused columns included in the data that are not in the spec:

```
{'data-d01e86a42596d3c55cbbce3d21a64616': [
   {'Title': 'The Land Girls',
   'US_Gross': 146083.0,
   'Worldwide_Gross': 146083.0,
   'US_DVD_Sales': None,
   'Production_Budget': 8000000.0,
   'Release_Date': 'Jun 12 1998',
   'MPAA_Rating': 'R',
   'Running_Time_min': None,
   'Distributor': 'Gramercy',
   'Source': None,
   'Major_Genre': None,
   'Creative_Type': None,
   'Director': None,
   'Rotten_Tomatoes_Rating': None,
   'IMDB_Rating': 6.1,
   'IMDB_Votes': 1071.0},
   ...
```

Creating the same chart with the changes in this PR reduces the chart size ~7x to 269838 bytes and successfully remove all the irrelevant columns since they have unique names not found anywhere in the spec:

```
{'data-d01e86a42596d3c55cbbce3d21a64616': [
  {'Rotten_Tomatoes_Rating': None, 'IMDB_Rating': 6.1},
  ...
```

This PR seems to pass all the tests, but I still want to run some benchmarks to see if the loops introduce any significant performance regressions for larger data sets.

I also need to move the change to the schema generation file instead of the automatically generated vegalite api file and this PR is not important as some of the other open PRs, but I started playing around with it and thought I would put this up in case anyone else wants to try or have better ideas of how to achieve the same results.
