### PR TITLE
Pin selenium to avoid doctest breakage from deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
+        pip install 'selenium<4.3.0'
         pip install altair_saver
         pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Test with pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
-        pip install 'selenium<4.3.0'
+        pip install "selenium<4.3.0"
         pip install altair_saver
         pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Test with pytest

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
-        pip install 'selenium<4.3.0'
+        pip install "selenium<4.3.0"
         pip install altair_saver
         pip install -r doc/requirements.txt
         pip install git+https://github.com/altair-viz/altair_viewer.git

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -19,6 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
+        pip install 'selenium<4.3.0'
         pip install altair_saver
         pip install -r doc/requirements.txt
         pip install git+https://github.com/altair-viz/altair_viewer.git


### PR DESCRIPTION
Altair's doctests are currently failing due to a deprecation in Selenium 4.3.0 which is a dependency of `altair-saver` (as reported in https://github.com/altair-viz/altair_saver/issues/104). Until there is a new release of `altair-saver` that addresses this (maybe with https://github.com/altair-viz/altair_saver/pull/105), this PR make sure we can run doctests by pinning the version of `selenium`. 

There will likely still be confusion among people who use the altair-saver library directly until it sees a new release since selenium 4.3.0 seems to be the default version installed with `altair-saver` currently.