### PR TITLE
docs: Fix a few typos

### DIFF
--- a/altair/sphinxext/altairplot.py
+++ b/altair/sphinxext/altairplot.py
@@ -265,7 +265,7 @@ def html_visit_altair_plot(self, node):
                 raise ValueError("Invalid chart: {0}".format(node["code"]))
             actions = node["links"]
 
-            # TODO: add an option to save aspects to file & load from there.
+            # TODO: add an option to save chart specs to file & load from there.
             # TODO: add renderer option
 
             # Write spec to a *.vl.json file

--- a/altair/sphinxext/altairplot.py
+++ b/altair/sphinxext/altairplot.py
@@ -265,7 +265,7 @@ def html_visit_altair_plot(self, node):
                 raise ValueError("Invalid chart: {0}".format(node["code"]))
             actions = node["links"]
 
-            # TODO: add an option to save spects to file & load from there.
+            # TODO: add an option to save aspects to file & load from there.
             # TODO: add renderer option
 
             # Write spec to a *.vl.json file

--- a/altair/sphinxext/schematable.py
+++ b/altair/sphinxext/schematable.py
@@ -134,7 +134,7 @@ def build_row(item):
 
 
 def build_schema_tabel(items):
-    """Return schema table of items (iterator of prop, schema.item, requred)"""
+    """Return schema table of items (iterator of prop, schema.item, required)"""
     table, tbody = prepare_table_header(
         ["Property", "Type", "Description"], [10, 20, 50]
     )
@@ -145,7 +145,7 @@ def build_schema_tabel(items):
 
 
 def select_items_from_schema(schema, props=None):
-    """Return iterator  (prop, schema.item, requred) on prop, return all in None"""
+    """Return iterator  (prop, schema.item, required) on prop, return all in None"""
     properties = schema.get("properties", {})
     required = schema.get("required", [])
     if not props:

--- a/altair/utils/tests/test_mimebundle.py
+++ b/altair/utils/tests/test_mimebundle.py
@@ -166,7 +166,7 @@ def vega_spec():
 
 
 def test_vegalite_to_vega_mimebundle(require_altair_saver, vegalite_spec, vega_spec):
-    # temporay fix for https://github.com/vega/vega-lite/issues/7776
+    # temporary fix for https://github.com/vega/vega-lite/issues/7776
     def delete_none(axes):
         for axis in axes:
             for key, value in list(axis.items()):

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -212,7 +212,7 @@ JSON). The type signature of a renderer is thus::
     def renderer(spec: dict) -> dict:
         ...
 
-Altair's default ``html`` render returns a cross-platform HTML representation using
+Altair's default ``html`` renderer returns a cross-platform HTML representation using
 the ``"text/html"`` mimetype; schematically it looks like this::
 
     def default_renderer(spec):

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -212,7 +212,7 @@ JSON). The type signature of a renderer is thus::
     def renderer(spec: dict) -> dict:
         ...
 
-Altair's default ``html`` rendeer returns a cross-platform HTML representation using
+Altair's default ``html`` render returns a cross-platform HTML representation using
 the ``"text/html"`` mimetype; schematically it looks like this::
 
     def default_renderer(spec):


### PR DESCRIPTION
There are small typos in:
- altair/sphinxext/altairplot.py
- altair/sphinxext/schematable.py
- altair/utils/tests/test_mimebundle.py
- doc/user_guide/display_frontends.rst

Fixes:
- Should read `required` rather than `requred`.
- Should read `temporary` rather than `temporay`.
- Should read `aspects` rather than `spects`.
- Should read `render` rather than `rendeer`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md