### PR TITLE
formatted rst list correctly

### DIFF
--- a/doc/user_guide/data.rst
+++ b/doc/user_guide/data.rst
@@ -310,8 +310,9 @@ store geo-spatial vector data.
 
 To make working with Geospatial Data as similar as working with long-form structured data
 the geo_interface is serialized in order to:
+
 - make it be correctly interpreted by Altair
-- provide users a similar experience as when working with tabular data such as Pandas.
+- provide users a similar experience as when working with tabular data such as Pandas
 
 Altair can interpret a spatial bounded entity (a Feature) or a list of Features
 (FeatureCollection). In order for correct interpretation it is made sure that all records


### PR DESCRIPTION
Fixed a formatting error within the documentation (user_guide -> data.rst).
Deleted the point after "Pandas" so as to make it consistent with the writing style of the other lists inside the same document.

Although I did not make any code changes, this change passes all tests, and I also followed the black formatting step.