### PR TITLE
Added argmax example

### DIFF
--- a/altair/examples/line_chart_with_custom_legend.py
+++ b/altair/examples/line_chart_with_custom_legend.py
@@ -1,0 +1,37 @@
+"""
+Line Chart with Custom Legend
+-----------------------------
+This example uses the argmax aggregation function in order to create a custom
+legend for a line chart.
+"""
+# category: line charts
+import altair as alt
+from vega_datasets import data
+
+
+source = data.stocks()
+
+base = (
+    alt.Chart(source)
+    .transform_filter("datum.symbol !== 'IBM'")
+    .encode(color=alt.Color("symbol", legend=None))
+    .properties(width=500)
+)
+
+line = base.mark_line().encode(x="date", y="price")
+
+
+last_price = (
+    base.mark_circle()
+    .transform_aggregate(last_date="argmax(date)", groupby=["symbol"])
+    .encode(x=alt.X("last_date['date']:T"), y=alt.Y("last_date['price']:Q"))
+)
+
+company_name = last_price.mark_text(align="left", dx=4).encode(text="symbol")
+
+chart = (line + last_price + company_name).encode(
+    x=alt.X(title="date"),
+    y=alt.X(title="price"),
+)
+
+chart

--- a/altair/examples/line_chart_with_custom_legend.py
+++ b/altair/examples/line_chart_with_custom_legend.py
@@ -31,7 +31,7 @@ company_name = last_price.mark_text(align="left", dx=4).encode(text="symbol")
 
 chart = (line + last_price + company_name).encode(
     x=alt.X(title="date"),
-    y=alt.X(title="price"),
+    y=alt.Y(title="price"),
 )
 
 chart

--- a/altair/examples/line_chart_with_custom_legend.py
+++ b/altair/examples/line_chart_with_custom_legend.py
@@ -22,10 +22,12 @@ base = alt.Chart(source).encode(
 line = base.mark_line().encode(x="date", y="price")
 
 
-last_price = (
-    base.mark_circle()
-    .transform_aggregate(last_date="argmax(date)", groupby=["symbol"])
-    .encode(x=alt.X("last_date['date']:T"), y=alt.Y("last_date['price']:Q"))
+last_price = base.mark_circle().encode(
+    x=alt.X("last_date['date']:T"),
+    y=alt.Y("last_date['price']:Q")
+).transform_aggregate(
+    last_date="argmax(date)",
+    groupby=["symbol"]
 )
 
 company_name = last_price.mark_text(align="left", dx=4).encode(text="symbol")

--- a/altair/examples/line_chart_with_custom_legend.py
+++ b/altair/examples/line_chart_with_custom_legend.py
@@ -11,11 +11,12 @@ from vega_datasets import data
 
 source = data.stocks()
 
-base = (
-    alt.Chart(source)
-    .transform_filter("datum.symbol !== 'IBM'")
-    .encode(color=alt.Color("symbol", legend=None))
-    .properties(width=500)
+base = alt.Chart(source).encode(
+    color=alt.Color("symbol", legend=None)
+).transform_filter(
+    "datum.symbol !== 'IBM'"
+).properties(
+    width=500
 )
 
 line = base.mark_line().encode(x="date", y="price")
@@ -31,7 +32,7 @@ company_name = last_price.mark_text(align="left", dx=4).encode(text="symbol")
 
 chart = (line + last_price + company_name).encode(
     x=alt.X(title="date"),
-    y=alt.Y(title="price"),
+    y=alt.Y(title="price")
 )
 
 chart

--- a/doc/user_guide/encoding.rst
+++ b/doc/user_guide/encoding.rst
@@ -426,7 +426,7 @@ aggregation functions built into Altair; they are listed in the following table:
 Aggregate  Description                                                                  Example
 =========  ===========================================================================  =====================================
 argmin     An input data object containing the minimum field value.                     N/A
-argmax     An input data object containing the maximum field value.                     N/A
+argmax     An input data object containing the maximum field value.                     :ref:`gallery_line_chart_with_custom_legend`
 average    The mean (average) field value. Identical to mean.                           :ref:`gallery_layer_line_color_rule`
 count      The total count of data objects in the group.                                :ref:`gallery_simple_heatmap`
 distinct   The count of distinct field values.                                          N/A


### PR DESCRIPTION
Replicated [this](https://vega.github.io/vega-lite/docs/aggregate.html#example-labeling-line-chart) example from vega-lite's site.

The motivation for this is #2645, however I don't know whether to

* leave it as an example for it to be used in the gallery (and be referenced in the [aggregation functions table](https://joelostblom.github.io/altair-docs/user_guide/encoding.html#aggregation-functions)), or
* put it directly under the [Aggregate Transforms](https://joelostblom.github.io/altair-docs/user_guide/encoding.html#aggregation-functions) section, the same way that vega-lite's site does.