### PR TITLE
Change naming to alt.param and alt.add_params

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ points = alt.Chart(source).mark_point().encode(
     x='Horsepower',
     y='Miles_per_Gallon',
     color=alt.condition(brush, 'Origin', alt.value('lightgray'))
-).add_parameter(
+).add_params(
     brush
 )
 

--- a/altair/examples/airport_connections.py
+++ b/altair/examples/airport_connections.py
@@ -63,7 +63,7 @@ points = alt.Chart(flights_airport).mark_circle().encode(
     from_=lookup_data
 ).transform_filter(
     (alt.datum.state != "PR") & (alt.datum.state != "VI")
-).add_parameter(
+).add_params(
     select_city
 )
 

--- a/altair/examples/dot_dash_plot.py
+++ b/altair/examples/dot_dash_plot.py
@@ -12,7 +12,7 @@ source = data.cars()
 
 # Configure the options common to all layers
 brush = alt.selection(type='interval')
-base = alt.Chart(source).add_parameter(brush)
+base = alt.Chart(source).add_params(brush)
 
 # Configure the points
 points = base.mark_point().encode(

--- a/altair/examples/histogram_responsive.py
+++ b/altair/examples/histogram_responsive.py
@@ -31,5 +31,5 @@ alt.vconcat(
   ),
   base.encode(
     alt.X('time:Q', bin=alt.Bin(maxbins=30)),
-  ).add_parameter(brush)
+  ).add_params(brush)
 )

--- a/altair/examples/interactive_brush.py
+++ b/altair/examples/interactive_brush.py
@@ -16,4 +16,4 @@ alt.Chart(source).mark_point().encode(
     x='Horsepower:Q',
     y='Miles_per_Gallon:Q',
     color=alt.condition(brush, 'Cylinders:O', alt.value('grey')),
-).add_parameter(brush)
+).add_params(brush)

--- a/altair/examples/interactive_cross_highlight.py
+++ b/altair/examples/interactive_cross_highlight.py
@@ -38,7 +38,7 @@ bar = alt.Chart(source).mark_bar().encode(
 ).properties(
     width=550,
     height=200
-).add_parameter(pts)
+).add_params(pts)
 
 alt.vconcat(
     rect + circ,

--- a/altair/examples/interactive_layered_crossfilter.py
+++ b/altair/examples/interactive_layered_crossfilter.py
@@ -29,7 +29,7 @@ base = alt.Chart().mark_bar().encode(
 # gray background with selection
 background = base.encode(
     color=alt.value('#ddd')
-).add_parameter(brush)
+).add_params(brush)
 
 # blue highlights on the transformed data
 highlight = base.transform_filter(brush)

--- a/altair/examples/interactive_legend.py
+++ b/altair/examples/interactive_legend.py
@@ -18,6 +18,6 @@ alt.Chart(source).mark_area().encode(
     alt.Y('sum(count):Q', stack='center', axis=None),
     alt.Color('series:N', scale=alt.Scale(scheme='category20b')),
     opacity=alt.condition(selection, alt.value(1), alt.value(0.2))
-).add_parameter(
+).add_params(
     selection
 )

--- a/altair/examples/interval_selection.py
+++ b/altair/examples/interval_selection.py
@@ -27,6 +27,6 @@ upper = base.encode(
 
 lower = base.properties(
     height=60
-).add_parameter(brush)
+).add_params(brush)
 
 upper & lower

--- a/altair/examples/multiline_highlight.py
+++ b/altair/examples/multiline_highlight.py
@@ -23,7 +23,7 @@ base = alt.Chart(source).encode(
 
 points = base.mark_circle().encode(
     opacity=alt.value(0)
-).add_parameter(
+).add_params(
     highlight
 ).properties(
     width=600

--- a/altair/examples/multiline_tooltip.py
+++ b/altair/examples/multiline_tooltip.py
@@ -38,7 +38,7 @@ line = alt.Chart(source).mark_line(interpolate='basis').encode(
 selectors = alt.Chart(source).mark_point().encode(
     x='x:Q',
     opacity=alt.value(0),
-).add_parameter(
+).add_params(
     nearest
 )
 

--- a/altair/examples/multiple_interactions.py
+++ b/altair/examples/multiple_interactions.py
@@ -42,7 +42,7 @@ year_slider = alt.binding_range(min=1969, max=2018, step=1)
 slider_selection = alt.selection_point(bind=year_slider, fields=['Release_Year'], name="Release Year_")
 
 
-filter_year = base.add_parameter(
+filter_year = base.add_params(
     slider_selection
 ).transform_filter(
     slider_selection
@@ -52,7 +52,7 @@ filter_year = base.add_parameter(
 genre_dropdown = alt.binding_select(options=genres)
 genre_select = alt.selection_point(fields=['Major_Genre'], bind=genre_dropdown, name="Genre")
 
-filter_genres = base.add_parameter(
+filter_genres = base.add_params(
     genre_select
 ).transform_filter(
     genre_select
@@ -66,7 +66,7 @@ rating_color_condition = alt.condition(rating_select,
                       alt.Color('MPAA_Rating:N', legend=None),
                       alt.value('lightgray'))
 
-highlight_ratings = base.add_parameter(
+highlight_ratings = base.add_params(
     rating_select
 ).encode(
     color=rating_color_condition
@@ -81,7 +81,7 @@ size_checkbox_condition = alt.condition(checkbox_selection,
                                         alt.Size('Hundred_Million_Production:Q')
                                        )
 
-budget_sizing = base.add_parameter(
+budget_sizing = base.add_params(
     checkbox_selection
 ).encode(
     size=size_checkbox_condition

--- a/altair/examples/scatter_linked_brush.py
+++ b/altair/examples/scatter_linked_brush.py
@@ -15,7 +15,7 @@ brush = alt.selection(type='interval', resolve='global')
 base = alt.Chart(source).mark_point().encode(
     y='Miles_per_Gallon',
     color=alt.condition(brush, 'Origin', alt.ColorValue('gray')),
-).add_parameter(
+).add_params(
     brush
 ).properties(
     width=250,

--- a/altair/examples/scatter_linked_table.py
+++ b/altair/examples/scatter_linked_table.py
@@ -19,7 +19,7 @@ points = alt.Chart(source).mark_point().encode(
     x='Horsepower:Q',
     y='Miles_per_Gallon:Q',
     color=alt.condition(brush, 'Cylinders:O', alt.value('grey'))
-).add_parameter(brush)
+).add_params(brush)
 
 # Base chart for data tables
 ranked_text = alt.Chart(source).mark_text().encode(

--- a/altair/examples/scatter_with_histogram.py
+++ b/altair/examples/scatter_with_histogram.py
@@ -46,7 +46,7 @@ mag = alt.Chart().mark_bar().encode(
 ).properties(
     width=300,
     height=300
-).add_parameter(pts)
+).add_params(pts)
 
 # build the chart:
 alt.hconcat(

--- a/altair/examples/scatter_with_layered_histogram.py
+++ b/altair/examples/scatter_with_layered_histogram.py
@@ -34,7 +34,7 @@ color_scale = alt.Scale(domain=['M', 'F'],
 base = alt.Chart(source).properties(
     width=250,
     height=250
-).add_parameter(selector)
+).add_params(selector)
 
 points = base.mark_point(filled=True, size=200).encode(
     x=alt.X('mean(height):Q', scale=alt.Scale(domain=[0,84])),

--- a/altair/examples/scatter_with_minimap.py
+++ b/altair/examples/scatter_with_minimap.py
@@ -17,7 +17,7 @@ zoom = alt.selection_interval(encodings=["x", "y"])
 minimap = (
     alt.Chart(source)
     .mark_point()
-    .add_parameter(zoom)
+    .add_params(zoom)
     .encode(
         x="date:T",
         y="temp_max:Q",

--- a/altair/examples/seattle_weather_interactive.py
+++ b/altair/examples/seattle_weather_interactive.py
@@ -33,7 +33,7 @@ points = alt.Chart().mark_point().encode(
 ).properties(
     width=550,
     height=300
-).add_parameter(
+).add_params(
     brush
 ).transform_filter(
     click
@@ -48,7 +48,7 @@ bars = alt.Chart().mark_bar().encode(
     brush
 ).properties(
     width=550,
-).add_parameter(
+).add_params(
     click
 )
 

--- a/altair/examples/select_detail.py
+++ b/altair/examples/select_detail.py
@@ -46,7 +46,7 @@ selector = alt.selection_point(fields=['id'])
 base = alt.Chart(data).properties(
     width=250,
     height=250
-).add_parameter(selector)
+).add_params(selector)
 
 points = base.mark_point(filled=True, size=200).encode(
     x='mean(x)',

--- a/altair/examples/select_mark_area.py
+++ b/altair/examples/select_mark_area.py
@@ -24,7 +24,7 @@ base = alt.Chart(source).mark_area(
 )
 
 brush = alt.selection_interval(encodings=['x'])
-background = base.add_parameter(brush)
+background = base.add_params(brush)
 selected = base.transform_filter(brush).mark_area(color='goldenrod')
 
 background + selected

--- a/altair/examples/selection_histogram.py
+++ b/altair/examples/selection_histogram.py
@@ -17,7 +17,7 @@ points = alt.Chart(source).mark_point().encode(
     x='Horsepower:Q',
     y='Miles_per_Gallon:Q',
     color=alt.condition(brush, 'Origin:N', alt.value('lightgray'))
-).add_parameter(
+).add_params(
     brush
 )
 

--- a/altair/examples/selection_layer_bar_month.py
+++ b/altair/examples/selection_layer_bar_month.py
@@ -16,7 +16,7 @@ bars = alt.Chart().mark_bar().encode(
     x='month(date):O',
     y='mean(precipitation):Q',
     opacity=alt.condition(brush, alt.OpacityValue(1), alt.OpacityValue(0.7)),
-).add_parameter(
+).add_params(
     brush
 )
 

--- a/altair/examples/slider_cutoff.py
+++ b/altair/examples/slider_cutoff.py
@@ -16,7 +16,7 @@ df = pd.DataFrame({
 })
 
 slider = alt.binding_range(min=0, max=100, step=1)
-cutoff = alt.parameter(bind=slider, value=50)
+cutoff = alt.param(bind=slider, value=50)
 
 alt.Chart(df).mark_point().encode(
     x='xval',
@@ -25,6 +25,6 @@ alt.Chart(df).mark_point().encode(
         alt.datum.xval < cutoff,
         alt.value('red'), alt.value('blue')
     )
-).add_parameter(
+).add_params(
     cutoff
 )

--- a/altair/examples/us_population_over_time.py
+++ b/altair/examples/us_population_over_time.py
@@ -30,7 +30,7 @@ alt.Chart(source).mark_bar().encode(
 ).properties(
     width=20,
     title="U.S. Population by Age and Sex"
-).add_parameter(
+).add_params(
     select_year
 ).transform_calculate(
     "sex", alt.expr.if_(alt.datum.sex == 1, "Male", "Female")

--- a/altair/examples/us_population_pyramid_over_time.py
+++ b/altair/examples/us_population_pyramid_over_time.py
@@ -15,7 +15,7 @@ slider = alt.binding_range(min=1850, max=2000, step=10)
 select_year = alt.selection_point(name='year', fields=['year'],
                                    bind=slider, value={'year': 2000})
 
-base = alt.Chart(source).add_parameter(
+base = alt.Chart(source).add_params(
     select_year
 ).transform_filter(
     select_year

--- a/altair/examples/us_state_capitals.py
+++ b/altair/examples/us_state_capitals.py
@@ -38,6 +38,6 @@ text = base.mark_text(dy=-5, align='right').encode(
 points = base.mark_point().encode(
     color=alt.value('black'),
     size=alt.condition(~hover, alt.value(30), alt.value(100))
-).add_parameter(hover)
+).add_params(hover)
 
 background + points + text

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2226,9 +2226,7 @@ class Chart(
             encodings.append("x")
         if bind_y:
             encodings.append("y")
-        return self.add_params(
-            selection_interval(bind="scales", encodings=encodings)
-        )
+        return self.add_params(selection_interval(bind="scales", encodings=encodings))
 
 
 def _check_if_valid_subspec(spec, classname):

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -214,7 +214,7 @@ class Parameter(expr.core.OperatorMixin, object):
             return self.param.expr
 
     def _from_expr(self, expr):
-        return parameter(expr=expr)
+        return param(expr=expr)
 
     def __getattr__(self, field_name):
         if field_name.startswith("__") and field_name.endswith("__"):

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -278,7 +278,7 @@ def value(value, **kwargs):
     return dict(value=value, **kwargs)
 
 
-def parameter(name=None, select=None, **kwds):
+def param(name=None, select=None, **kwds):
     """Create a named parameter.
 
     Parameters
@@ -379,7 +379,7 @@ def selection(type=Undefined, **kwds):
     else:
         raise ValueError("""'type' must be 'point' or 'interval'""")
 
-    return parameter(select=select, **param_kwds)
+    return param(select=select, **param_kwds)
 
 
 @utils.use_signature(core.IntervalSelectionConfig)
@@ -2184,7 +2184,7 @@ class Chart(
             return super(Chart, copy).to_dict(*args, **kwargs)
         return super().to_dict(*args, **kwargs)
 
-    def add_parameter(self, *params):
+    def add_params(self, *params):
         """Add one or more parameters to the chart."""
         if not params:
             return self
@@ -2197,10 +2197,10 @@ class Chart(
         return copy
 
     @utils.deprecation.deprecated(
-        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+        message="'add_selection' is deprecated. Use 'add_params' instead."
     )
     def add_selection(self, *params):
-        return self.add_parameter(*params)
+        return self.add_params(*params)
 
     def interactive(self, name=None, bind_x=True, bind_y=True):
         """Make chart axes scales interactive
@@ -2226,7 +2226,7 @@ class Chart(
             encodings.append("x")
         if bind_y:
             encodings.append("y")
-        return self.add_parameter(
+        return self.add_params(
             selection_interval(bind="scales", encodings=encodings)
         )
 
@@ -2364,19 +2364,19 @@ class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
         copy.spec = copy.spec.interactive(name=name, bind_x=bind_x, bind_y=bind_y)
         return copy
 
-    def add_parameter(self, *params):
+    def add_params(self, *params):
         """Add one or more parameters to the chart."""
         if not params or self.spec is Undefined:
             return self
         copy = self.copy()
-        copy.spec = copy.spec.add_parameter(*params)
+        copy.spec = copy.spec.add_params(*params)
         return copy
 
     @utils.deprecation.deprecated(
-        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+        message="'add_selection' is deprecated. Use 'add_params' instead."
     )
     def add_selection(self, *selections):
-        return self.add_parameter(*selections)
+        return self.add_params(*selections)
 
 
 def repeat(repeater="repeat"):
@@ -2423,19 +2423,19 @@ class ConcatChart(TopLevelMixin, core.TopLevelConcatSpec):
         copy |= other
         return copy
 
-    def add_parameter(self, *params):
+    def add_params(self, *params):
         """Add one or more parameters to the chart."""
         if not params or not self.concat:
             return self
         copy = self.copy()
-        copy.concat = [chart.add_parameter(*params) for chart in copy.concat]
+        copy.concat = [chart.add_params(*params) for chart in copy.concat]
         return copy
 
     @utils.deprecation.deprecated(
-        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+        message="'add_selection' is deprecated. Use 'add_params' instead."
     )
     def add_selection(self, *selections):
-        return self.add_parameter(*selections)
+        return self.add_params(*selections)
 
 
 def concat(*charts, **kwargs):
@@ -2465,19 +2465,19 @@ class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):
         copy |= other
         return copy
 
-    def add_parameter(self, *params):
+    def add_params(self, *params):
         """Add one or more parameters to the chart."""
         if not params or not self.hconcat:
             return self
         copy = self.copy()
-        copy.hconcat = [chart.add_parameter(*params) for chart in copy.hconcat]
+        copy.hconcat = [chart.add_params(*params) for chart in copy.hconcat]
         return copy
 
     @utils.deprecation.deprecated(
-        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+        message="'add_selection' is deprecated. Use 'add_params' instead."
     )
     def add_selection(self, *selections):
-        return self.add_parameter(*selections)
+        return self.add_params(*selections)
 
 
 def hconcat(*charts, **kwargs):
@@ -2507,19 +2507,19 @@ class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
         copy &= other
         return copy
 
-    def add_parameter(self, *params):
+    def add_params(self, *params):
         """Add one or more parameters to the chart."""
         if not params or not self.vconcat:
             return self
         copy = self.copy()
-        copy.vconcat = [chart.add_parameter(*params) for chart in copy.vconcat]
+        copy.vconcat = [chart.add_params(*params) for chart in copy.vconcat]
         return copy
 
     @utils.deprecation.deprecated(
-        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+        message="'add_selection' is deprecated. Use 'add_params' instead."
     )
     def add_selection(self, *selections):
-        return self.add_parameter(*selections)
+        return self.add_params(*selections)
 
 
 def vconcat(*charts, **kwargs):
@@ -2594,19 +2594,19 @@ class LayerChart(TopLevelMixin, _EncodingMixin, core.TopLevelLayerSpec):
         )
         return copy
 
-    def add_parameter(self, *params):
+    def add_params(self, *params):
         """Add one or more parameters to the chart."""
         if not params or not self.layer:
             return self
         copy = self.copy()
-        copy.layer[0] = copy.layer[0].add_parameter(*params)
+        copy.layer[0] = copy.layer[0].add_params(*params)
         return copy
 
     @utils.deprecation.deprecated(
-        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+        message="'add_selection' is deprecated. Use 'add_params' instead."
     )
     def add_selection(self, *selections):
-        return self.add_parameter(*selections)
+        return self.add_params(*selections)
 
 
 def layer(*charts, **kwargs):
@@ -2645,19 +2645,19 @@ class FacetChart(TopLevelMixin, core.TopLevelFacetSpec):
         copy.spec = copy.spec.interactive(name=name, bind_x=bind_x, bind_y=bind_y)
         return copy
 
-    def add_parameter(self, *params):
+    def add_params(self, *params):
         """Add one or more parameters to the chart."""
         if not params or self.spec is Undefined:
             return self
         copy = self.copy()
-        copy.spec = copy.spec.add_parameter(*params)
+        copy.spec = copy.spec.add_params(*params)
         return copy
 
     @utils.deprecation.deprecated(
-        message="'add_selection' is deprecated. Use 'add_parameter' instead."
+        message="'add_selection' is deprecated. Use 'add_params' instead."
     )
     def add_selection(self, *selections):
-        return self.add_parameter(*selections)
+        return self.add_params(*selections)
 
 
 def topo_feature(url, feature, **kwargs):

--- a/altair/vegalite/v5/tests/test_api.py
+++ b/altair/vegalite/v5/tests/test_api.py
@@ -394,8 +394,8 @@ def test_selection():
     assert multi.name == "selec_3"
 
     # test adding to chart
-    chart = alt.Chart().add_parameter(single)
-    chart = chart.add_parameter(multi, interval)
+    chart = alt.Chart().add_params(single)
+    chart = chart.add_params(multi, interval)
     assert set(x.name for x in chart.params) == {"selec_1", "selec_2", "selec_3"}
 
     # test logical operations
@@ -596,8 +596,8 @@ def test_add_selection():
     chart = (
         alt.Chart()
         .mark_point()
-        .add_parameter(selections[0])
-        .add_parameter(selections[1], selections[2])
+        .add_params(selections[0])
+        .add_params(selections[1], selections[2])
     )
     expected = [s.param for s in selections]
     assert chart.params == expected
@@ -606,24 +606,24 @@ def test_add_selection():
 def test_repeat_add_selections():
     base = alt.Chart("data.csv").mark_point()
     selection = alt.selection_point()
-    chart1 = base.add_parameter(selection).repeat(list("ABC"))
-    chart2 = base.repeat(list("ABC")).add_parameter(selection)
+    chart1 = base.add_params(selection).repeat(list("ABC"))
+    chart2 = base.repeat(list("ABC")).add_params(selection)
     assert chart1.to_dict() == chart2.to_dict()
 
 
 def test_facet_add_selections():
     base = alt.Chart("data.csv").mark_point()
     selection = alt.selection_point()
-    chart1 = base.add_parameter(selection).facet("val:Q")
-    chart2 = base.facet("val:Q").add_parameter(selection)
+    chart1 = base.add_params(selection).facet("val:Q")
+    chart2 = base.facet("val:Q").add_params(selection)
     assert chart1.to_dict() == chart2.to_dict()
 
 
 def test_layer_add_selection():
     base = alt.Chart("data.csv").mark_point()
     selection = alt.selection_point()
-    chart1 = alt.layer(base.add_parameter(selection), base)
-    chart2 = alt.layer(base, base).add_parameter(selection)
+    chart1 = alt.layer(base.add_params(selection), base)
+    chart2 = alt.layer(base, base).add_params(selection)
     assert chart1.to_dict() == chart2.to_dict()
 
 
@@ -631,8 +631,8 @@ def test_layer_add_selection():
 def test_compound_add_selections(charttype):
     base = alt.Chart("data.csv").mark_point()
     selection = alt.selection_point()
-    chart1 = charttype(base.add_parameter(selection), base.add_parameter(selection))
-    chart2 = charttype(base, base).add_parameter(selection)
+    chart1 = charttype(base.add_params(selection), base.add_params(selection))
+    chart2 = charttype(base, base).add_params(selection)
     assert chart1.to_dict() == chart2.to_dict()
 
 

--- a/doc/case_studies/exploring-weather.rst
+++ b/doc/case_studies/exploring-weather.rst
@@ -237,7 +237,7 @@ of the selection (for more information on selections, see
     ).properties(
         width=600,
         height=400
-    ).add_parameter(
+    ).add_params(
         brush
     )
 

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -15,7 +15,7 @@ Enhancements
 Grammar Changes
 ~~~~~~~~~~~~~~~
 - ``selection_single`` and ``selection_multi`` are now deprecated; use ``selection_point`` instead.  Similarly, ``type=point`` should be used instead of ``type=single`` and ``type=multi``.
-- ``add_selection`` is deprecated; use ``add_parameter`` instead.
+- ``add_selection`` is deprecated; use ``add_params`` instead.
 - The ``selection`` keyword argument must in many cases be replaced by ``param`` (e.g., when specifying a filter transform).
 - The ``empty`` keyword argument for a selection parameter should be specified as ``True`` or ``False`` instead of ``all`` or ``none``, respectively.
 - The ``init`` keyword argument for a parameter is deprecated; use ``value`` instead.

--- a/doc/user_guide/compound_charts.rst
+++ b/doc/user_guide/compound_charts.rst
@@ -195,7 +195,7 @@ with a ``brush`` selection to add interaction:
 
     lower = base.properties(
         height=60
-    ).add_parameter(brush)
+    ).add_params(brush)
 
     alt.vconcat(upper, lower)
 
@@ -373,7 +373,7 @@ layered chart with a hover selection:
         height=180,
     )
 
-    points = base.mark_point().add_parameter(
+    points = base.mark_point().add_params(
         hover
     )
 

--- a/doc/user_guide/interactions.rst
+++ b/doc/user_guide/interactions.rst
@@ -60,9 +60,9 @@ We can create a variable parameter using :func:`parameter`, and assign that para
 .. altair-plot::
     :output: none
 
-    op_var = alt.parameter(value=0.1)
+    op_var = alt.param(value=0.1)
 
-In order to use this variable in the chart specification, we explicitly add it to the chart using the :meth:`Chart.add_parameter` method, and we can then reference the variable within the chart specification.  Here we set the opacity using our ``op_var`` parameter.
+In order to use this variable in the chart specification, we explicitly add it to the chart using the :meth:`Chart.add_params` method, and we can then reference the variable within the chart specification.  Here we set the opacity using our ``op_var`` parameter.
 
 .. altair-plot::
 
@@ -71,17 +71,17 @@ In order to use this variable in the chart specification, we explicitly add it t
 
     cars = data.cars.url
 
-    op_var = alt.parameter(value=0.1)
+    op_var = alt.param(value=0.1)
 
     alt.Chart(cars).mark_circle(opacity=op_var).encode(
         x='Miles_per_Gallon:Q',
         y='Horsepower:Q',
         color='Origin:N'
-    ).add_parameter(
+    ).add_params(
         op_var
     )
 
-It's reasonable to ask whether all this effort is necessary.  Here is a more natural way to accomplish the same thing.  We avoid the use of both :func:`alt.parameter` and ``add_parameter``.
+It's reasonable to ask whether all this effort is necessary.  Here is a more natural way to accomplish the same thing.  We avoid the use of both :func:`alt.param` and ``add_params``.
 
 .. altair-plot::
 
@@ -98,7 +98,7 @@ It's reasonable to ask whether all this effort is necessary.  Here is a more nat
         color='Origin:N'
     )
 
-The benefit of using :func:`alt.parameter` doesn't become apparent until we incorporate an additional component, such as in the following, where we use the ``bind`` property of the parameter, so that the parameter becomes bound to an input element.  In this example, that input element is a slider widget.
+The benefit of using :func:`alt.param` doesn't become apparent until we incorporate an additional component, such as in the following, where we use the ``bind`` property of the parameter, so that the parameter becomes bound to an input element.  In this example, that input element is a slider widget.
 
 .. altair-plot::
 
@@ -108,13 +108,13 @@ The benefit of using :func:`alt.parameter` doesn't become apparent until we inco
     cars = data.cars.url
 
     slider = alt.binding_range(min=0, max=1, step=0.05, name='opacity:')
-    op_var = alt.parameter(value=0.1, bind=slider)
+    op_var = alt.param(value=0.1, bind=slider)
 
     alt.Chart(cars).mark_circle(opacity=op_var).encode(
         x='Miles_per_Gallon:Q',
         y='Horsepower:Q',
         color='Origin:N'
-    ).add_parameter(
+    ).add_params(
         op_var
     )
 
@@ -123,7 +123,7 @@ Now we can dynamically change the opacity of the points in our chart using the s
 The above example includes some aspects which occur frequently when creating interactive charts in Altair:
 
 1. Creating a variable parameter using :func:`parameter`.
-2. Attaching the parameter to a chart using the :meth:`Chart.add_parameter` method.
+2. Attaching the parameter to a chart using the :meth:`Chart.add_params` method.
 3. Binding the parameter to an input widget (such as the slider above) using the parameter's ``bind`` property.
 
 
@@ -137,7 +137,7 @@ There are two types of selections:
 :func:`selection_interval` and :func:`selection_point`.
 
 Here we will create a simple chart and then add an selection interval to it.
-We could create a selection interval via ``alt.parameter(select="interval")``,
+We could create a selection interval via ``alt.param(select="interval")``,
 but it is more convenient to use the shorter ``alt.selection_interval``
 (and this also matches the syntax that was used in Altair 4).
 
@@ -173,7 +173,7 @@ property:
         x='Miles_per_Gallon:Q',
         y='Horsepower:Q',
         color='Origin:N'
-    ).add_parameter(
+    ).add_params(
         brush
     )
 
@@ -182,7 +182,7 @@ a selection region, and to move this region once the region is created.
 
 So far this example is very similar to what we did in the :ref:`variable example <basic variable>`:
 we created a selection parameter using ``brush = alt.selection_interval()``,
-and we attached that parameter to the chart using ``add_parameter``.
+and we attached that parameter to the chart using ``add_params``.
 
 Conditions: Making the Chart Respond
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -200,7 +200,7 @@ for points outside the selection:
         x='Miles_per_Gallon:Q',
         y='Horsepower:Q',
         color=alt.condition(brush, 'Origin:N', alt.value('lightgray'))
-    ).add_parameter(
+    ).add_params(
         brush
     )
 
@@ -231,7 +231,7 @@ tied to ``"Miles_per_Gallon"``
     ).properties(
         width=250,
         height=250
-    ).add_parameter(
+    ).add_params(
         brush
     )
 
@@ -257,7 +257,7 @@ We can modify the brush definition, and leave the rest of the code unchanged:
     ).properties(
         width=250,
         height=250
-    ).add_parameter(
+    ).add_params(
         brush
     )
 
@@ -287,7 +287,7 @@ selection:
         ).properties(
             width=300,
             height=180
-        ).add_parameter(
+        ).add_params(
             selector
         )
 
@@ -326,7 +326,7 @@ chart scales; this is how Altair plots can be made interactive:
         x='Horsepower:Q',
         y='Miles_per_Gallon:Q',
         color='Origin:N'
-    ).add_parameter(
+    ).add_params(
         scales
     )
 
@@ -401,7 +401,7 @@ selection.
         x='Cylinders:O',
         y='Origin:O',
         color=alt.condition(alex | morgan, 'count()', alt.ColorValue("grey"))
-    ).add_parameter(
+    ).add_params(
         alex, morgan
     ).properties(
         width=300,
@@ -446,7 +446,7 @@ with a matching ``Origin``.
     legend = alt.Chart(cars).mark_point().encode(
         y=alt.Y('Origin:N', axis=alt.Axis(orient='right')),
         color=color
-    ).add_parameter(
+    ).add_params(
         selection
     )
 
@@ -480,7 +480,7 @@ cylinders:
         y=alt.Y('Origin:N', axis=alt.Axis(orient='right')),
         x='Cylinders:O',
         color=color
-    ).add_parameter(
+    ).add_params(
         selection
     )
 
@@ -516,7 +516,7 @@ depending on the size and position of the selection in the scatter plot.
         x='Horsepower:Q',
         y='Miles_per_Gallon:Q',
         color='Origin:N'
-    ).add_parameter(
+    ).add_params(
         brush
     )
 
@@ -557,7 +557,7 @@ For instance, using our example from above a dropdown can be used to highlight c
         y='Miles_per_Gallon:Q',
         color=color,
         tooltip='Name:N'
-    ).add_parameter(
+    ).add_params(
         selection
     )
 
@@ -591,7 +591,7 @@ Bindings and input elements can also be used to filter data on the client side. 
         y='Miles_per_Gallon:Q',
         color='Origin:N',
         tooltip='Name:N'
-    ).add_parameter(
+    ).add_params(
         selection
     ).transform_filter(
         selection
@@ -611,7 +611,7 @@ With interval selections, the ``bind`` property can be set to the value of ``"sc
         y='Miles_per_Gallon:Q',
         color='Origin:N',
         tooltip='Name:N'
-    ).add_parameter(
+    ).add_params(
         selection
     )
 
@@ -651,7 +651,7 @@ points based on whether they are smaller or larger than the value:
            # 'datum.xval < SelectorName.cutoff',  # An equivalent alternative
            alt.value('red'), alt.value('blue')
        )
-   ).add_parameter(
+   ).add_params(
        selector
    )
 
@@ -673,7 +673,7 @@ since they can also be accessed in expression strings:
 .. altair-plot::
 
     slider = alt.binding_range(min=0, max=100, step=1, name='Cutoff ')
-    selector = alt.parameter(name='SelectorName', value=50, bind=slider)
+    selector = alt.param(name='SelectorName', value=50, bind=slider)
 
     alt.Chart(df).mark_point().encode(
        x='xval',
@@ -683,7 +683,7 @@ since they can also be accessed in expression strings:
            # 'datum.xval < SelectorName',  # An equivalent alternative
            alt.value('red'), alt.value('blue')
        )
-    ).add_parameter(
+    ).add_params(
        selector
     )
 
@@ -741,7 +741,7 @@ Taking advantage of the parameter interface introduced in Altair 5, we can expre
         options=['Miles_per_Gallon', 'Displacement', 'Weight_in_lbs', 'Acceleration'],
         name='X-axis column '
     )
-    param = alt.parameter(
+    param = alt.param(
         name='selected_column',
         value='Miles_per_Gallon',
         bind=dropdown
@@ -753,6 +753,6 @@ Taking advantage of the parameter interface introduced in Altair 5, we can expre
         color='Origin:N'
     ).transform_calculate(
         x='datum[selected_column]'
-    ).add_parameter(
+    ).add_params(
         param
     )

--- a/doc/user_guide/transform/filter.rst
+++ b/doc/user_guide/transform/filter.rst
@@ -151,7 +151,7 @@ to select the data to be shown in the top chart:
         color=alt.condition(selection, alt.value('steelblue'), alt.value('lightgray'))
     ).properties(
         width=600, height=100
-    ).add_parameter(
+    ).add_params(
         selection
     )
 

--- a/doc/user_guide/transform/pivot.rst
+++ b/doc/user_guide/transform/pivot.rst
@@ -61,7 +61,7 @@ values on multiple lines:
    ).mark_rule().encode(
        opacity=alt.condition(selection, alt.value(0.3), alt.value(0)),
        tooltip=[alt.Tooltip(c, type='quantitative') for c in columns]
-   ).add_parameter(selection)
+   ).add_params(selection)
    
    lines + points + rule
 


### PR DESCRIPTION
I believe this pull request incorporates the naming changes suggested by @mattijn in #2598.  I didn't come across anything subtle in making these changes; I mostly just used Find and Replace.  Please let me know if there are aspects that need to be thought through more carefully!

Needless to say, this will break the code of anyone currently using `alt.parameter` or `alt.add_parameter`.