### PR TITLE
add typehint Any to Undefined object

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -4,6 +4,7 @@ import collections
 import contextlib
 import inspect
 import json
+from typing import Any
 
 import jsonschema
 import numpy as np
@@ -137,7 +138,7 @@ class UndefinedType(object):
         return "Undefined"
 
 
-Undefined = UndefinedType()
+Undefined: Any = UndefinedType()
 
 
 class SchemaBase(object):


### PR DESCRIPTION
This PR adds the typehint `Any` to the undefined object, suppressing the many type errors described in https://github.com/microsoft/pylance-release/issues/3210

Candidly this is not a great solution and hardly sufficient to address https://github.com/altair-viz/altair/issues/2493 (I think a full set of type hints like https://github.com/altair-viz/altair/pull/2614 would be preferable) but it at least this removes the distraction.  

Very open to alternatives.  Thanks for your consideration!

cc: @thewchan