### PR TITLE
WIP: Lifting parameters to the top level

### DIFF
--- a/altair/vega/v5/schema/__init__.py
+++ b/altair/vega/v5/schema/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 from .core import *
 
-SCHEMA_VERSION = 'v5.10.0'
-SCHEMA_URL = 'https://vega.github.io/schema/vega/v5.10.0.json'
+SCHEMA_VERSION = 'v5.22.1'
+SCHEMA_URL = 'https://vega.github.io/schema/vega/v5.22.1.json'

--- a/altair/vega/v5/schema/core.py
+++ b/altair/vega/v5/schema/core.py
@@ -41,9 +41,9 @@ class autosize(VegaSchema):
     """autosize schema wrapper
 
     oneOf(enum('pad', 'fit', 'fit-x', 'fit-y', 'none'), Mapping(required=[type]),
-    :class:`signal`)
+    :class:`signalRef`)
     """
-    _schema = {'$ref': '#/defs/autosize'}
+    _schema = {'$ref': '#/definitions/autosize'}
 
     def __init__(self, *args, **kwds):
         super(autosize, self).__init__(*args, **kwds)
@@ -57,13 +57,19 @@ class axis(VegaSchema):
     Attributes
     ----------
 
-    orient : enum('top', 'bottom', 'left', 'right')
+    orient : oneOf(enum('top', 'bottom', 'left', 'right'), :class:`signalRef`)
 
     scale : string
 
+    aria : boolean
+
     bandPosition : oneOf(float, :class:`numberValue`)
 
+    description : string
+
     domain : boolean
+
+    domainCap : oneOf(string, :class:`stringValue`)
 
     domainColor : oneOf(None, string, :class:`colorValue`)
 
@@ -77,11 +83,13 @@ class axis(VegaSchema):
 
     encode : Mapping(required=[])
 
-    format : oneOf(string, Mapping(required=[]), :class:`signal`)
+    format : oneOf(string, Mapping(required=[]), :class:`signalRef`)
 
-    formatType : oneOf(enum('number', 'time', 'utc'), :class:`signal`)
+    formatType : oneOf(enum('number', 'time', 'utc'), :class:`signalRef`)
 
     grid : boolean
+
+    gridCap : oneOf(string, :class:`stringValue`)
 
     gridColor : oneOf(None, string, :class:`colorValue`)
 
@@ -102,11 +110,11 @@ class axis(VegaSchema):
     labelBaseline : oneOf(enum('top', 'middle', 'bottom', 'alphabetic', 'line-top',
     'line-bottom'), :class:`baselineValue`)
 
-    labelBound : oneOf(boolean, float, :class:`signal`)
+    labelBound : oneOf(boolean, float, :class:`signalRef`)
 
     labelColor : oneOf(None, string, :class:`colorValue`)
 
-    labelFlush : oneOf(boolean, float, :class:`signal`)
+    labelFlush : oneOf(boolean, float, :class:`signalRef`)
 
     labelFlushOffset : :class:`numberOrSignal`
 
@@ -145,6 +153,8 @@ class axis(VegaSchema):
     position : oneOf(float, :class:`numberValue`)
 
     tickBand : :class:`tickBand`
+
+    tickCap : oneOf(string, :class:`stringValue`)
 
     tickColor : oneOf(None, string, :class:`colorValue`)
 
@@ -205,19 +215,20 @@ class axis(VegaSchema):
 
     titleY : oneOf(float, :class:`numberValue`)
 
-    translate : float
+    translate : oneOf(float, :class:`numberValue`)
 
     values : :class:`arrayOrSignal`
 
     zindex : float
 
     """
-    _schema = {'$ref': '#/defs/axis'}
+    _schema = {'$ref': '#/definitions/axis'}
 
-    def __init__(self, orient=Undefined, scale=Undefined, bandPosition=Undefined, domain=Undefined,
-                 domainColor=Undefined, domainDash=Undefined, domainDashOffset=Undefined,
-                 domainOpacity=Undefined, domainWidth=Undefined, encode=Undefined, format=Undefined,
-                 formatType=Undefined, grid=Undefined, gridColor=Undefined, gridDash=Undefined,
+    def __init__(self, orient=Undefined, scale=Undefined, aria=Undefined, bandPosition=Undefined,
+                 description=Undefined, domain=Undefined, domainCap=Undefined, domainColor=Undefined,
+                 domainDash=Undefined, domainDashOffset=Undefined, domainOpacity=Undefined,
+                 domainWidth=Undefined, encode=Undefined, format=Undefined, formatType=Undefined,
+                 grid=Undefined, gridCap=Undefined, gridColor=Undefined, gridDash=Undefined,
                  gridDashOffset=Undefined, gridOpacity=Undefined, gridScale=Undefined,
                  gridWidth=Undefined, labelAlign=Undefined, labelAngle=Undefined,
                  labelBaseline=Undefined, labelBound=Undefined, labelColor=Undefined,
@@ -226,26 +237,27 @@ class axis(VegaSchema):
                  labelLimit=Undefined, labelLineHeight=Undefined, labelOffset=Undefined,
                  labelOpacity=Undefined, labelOverlap=Undefined, labelPadding=Undefined,
                  labelSeparation=Undefined, labels=Undefined, maxExtent=Undefined, minExtent=Undefined,
-                 offset=Undefined, position=Undefined, tickBand=Undefined, tickColor=Undefined,
-                 tickCount=Undefined, tickDash=Undefined, tickDashOffset=Undefined, tickExtra=Undefined,
-                 tickMinStep=Undefined, tickOffset=Undefined, tickOpacity=Undefined,
-                 tickRound=Undefined, tickSize=Undefined, tickWidth=Undefined, ticks=Undefined,
-                 title=Undefined, titleAlign=Undefined, titleAnchor=Undefined, titleAngle=Undefined,
-                 titleBaseline=Undefined, titleColor=Undefined, titleFont=Undefined,
-                 titleFontSize=Undefined, titleFontStyle=Undefined, titleFontWeight=Undefined,
-                 titleLimit=Undefined, titleLineHeight=Undefined, titleOpacity=Undefined,
-                 titlePadding=Undefined, titleX=Undefined, titleY=Undefined, translate=Undefined,
-                 values=Undefined, zindex=Undefined, **kwds):
-        super(axis, self).__init__(orient=orient, scale=scale, bandPosition=bandPosition, domain=domain,
+                 offset=Undefined, position=Undefined, tickBand=Undefined, tickCap=Undefined,
+                 tickColor=Undefined, tickCount=Undefined, tickDash=Undefined, tickDashOffset=Undefined,
+                 tickExtra=Undefined, tickMinStep=Undefined, tickOffset=Undefined,
+                 tickOpacity=Undefined, tickRound=Undefined, tickSize=Undefined, tickWidth=Undefined,
+                 ticks=Undefined, title=Undefined, titleAlign=Undefined, titleAnchor=Undefined,
+                 titleAngle=Undefined, titleBaseline=Undefined, titleColor=Undefined,
+                 titleFont=Undefined, titleFontSize=Undefined, titleFontStyle=Undefined,
+                 titleFontWeight=Undefined, titleLimit=Undefined, titleLineHeight=Undefined,
+                 titleOpacity=Undefined, titlePadding=Undefined, titleX=Undefined, titleY=Undefined,
+                 translate=Undefined, values=Undefined, zindex=Undefined, **kwds):
+        super(axis, self).__init__(orient=orient, scale=scale, aria=aria, bandPosition=bandPosition,
+                                   description=description, domain=domain, domainCap=domainCap,
                                    domainColor=domainColor, domainDash=domainDash,
                                    domainDashOffset=domainDashOffset, domainOpacity=domainOpacity,
                                    domainWidth=domainWidth, encode=encode, format=format,
-                                   formatType=formatType, grid=grid, gridColor=gridColor,
-                                   gridDash=gridDash, gridDashOffset=gridDashOffset,
-                                   gridOpacity=gridOpacity, gridScale=gridScale, gridWidth=gridWidth,
-                                   labelAlign=labelAlign, labelAngle=labelAngle,
-                                   labelBaseline=labelBaseline, labelBound=labelBound,
-                                   labelColor=labelColor, labelFlush=labelFlush,
+                                   formatType=formatType, grid=grid, gridCap=gridCap,
+                                   gridColor=gridColor, gridDash=gridDash,
+                                   gridDashOffset=gridDashOffset, gridOpacity=gridOpacity,
+                                   gridScale=gridScale, gridWidth=gridWidth, labelAlign=labelAlign,
+                                   labelAngle=labelAngle, labelBaseline=labelBaseline,
+                                   labelBound=labelBound, labelColor=labelColor, labelFlush=labelFlush,
                                    labelFlushOffset=labelFlushOffset, labelFont=labelFont,
                                    labelFontSize=labelFontSize, labelFontStyle=labelFontStyle,
                                    labelFontWeight=labelFontWeight, labelLimit=labelLimit,
@@ -253,7 +265,7 @@ class axis(VegaSchema):
                                    labelOpacity=labelOpacity, labelOverlap=labelOverlap,
                                    labelPadding=labelPadding, labelSeparation=labelSeparation,
                                    labels=labels, maxExtent=maxExtent, minExtent=minExtent,
-                                   offset=offset, position=position, tickBand=tickBand,
+                                   offset=offset, position=position, tickBand=tickBand, tickCap=tickCap,
                                    tickColor=tickColor, tickCount=tickCount, tickDash=tickDash,
                                    tickDashOffset=tickDashOffset, tickExtra=tickExtra,
                                    tickMinStep=tickMinStep, tickOffset=tickOffset,
@@ -269,12 +281,46 @@ class axis(VegaSchema):
                                    **kwds)
 
 
+class labelOverlap(VegaSchema):
+    """labelOverlap schema wrapper
+
+    oneOf(boolean, enum('parity', 'greedy'), :class:`signalRef`)
+    """
+    _schema = {'$ref': '#/definitions/labelOverlap'}
+
+    def __init__(self, *args, **kwds):
+        super(labelOverlap, self).__init__(*args, **kwds)
+
+
+class tickBand(VegaSchema):
+    """tickBand schema wrapper
+
+    oneOf(enum('center', 'extent'), :class:`signalRef`)
+    """
+    _schema = {'$ref': '#/definitions/tickBand'}
+
+    def __init__(self, *args, **kwds):
+        super(tickBand, self).__init__(*args, **kwds)
+
+
+class tickCount(VegaSchema):
+    """tickCount schema wrapper
+
+    oneOf(float, enum('millisecond', 'second', 'minute', 'hour', 'day', 'week', 'month',
+    'year'), Mapping(required=[interval]), :class:`signalRef`)
+    """
+    _schema = {'$ref': '#/definitions/tickCount'}
+
+    def __init__(self, *args, **kwds):
+        super(tickCount, self).__init__(*args, **kwds)
+
+
 class background(VegaSchema):
     """background schema wrapper
 
-    oneOf(string, :class:`signal`)
+    oneOf(string, :class:`signalRef`)
     """
-    _schema = {'$ref': '#/defs/background'}
+    _schema = {'$ref': '#/definitions/background'}
 
     def __init__(self, *args, **kwds):
         super(background, self).__init__(*args, **kwds)
@@ -284,12 +330,23 @@ class bind(VegaSchema):
     """bind schema wrapper
 
     oneOf(Mapping(required=[input]), Mapping(required=[input, options]),
-    Mapping(required=[input]), Mapping(required=[input]))
+    Mapping(required=[input]), Mapping(required=[input]), Mapping(required=[element]))
     """
-    _schema = {'$ref': '#/defs/bind'}
+    _schema = {'$ref': '#/definitions/bind'}
 
     def __init__(self, *args, **kwds):
         super(bind, self).__init__(*args, **kwds)
+
+
+class element(VegaSchema):
+    """element schema wrapper
+
+    string
+    """
+    _schema = {'$ref': '#/definitions/element'}
+
+    def __init__(self, *args):
+        super(element, self).__init__(*args)
 
 
 class data(VegaSchema):
@@ -298,10 +355,29 @@ class data(VegaSchema):
     oneOf(Mapping(required=[name]), Mapping(required=[source, name]), Mapping(required=[url,
     name]), Mapping(required=[values, name]))
     """
-    _schema = {'$ref': '#/defs/data'}
+    _schema = {'$ref': '#/definitions/data'}
 
     def __init__(self, *args, **kwds):
         super(data, self).__init__(*args, **kwds)
+
+
+class paramField(VegaSchema):
+    """paramField schema wrapper
+
+    Mapping(required=[field])
+
+    Attributes
+    ----------
+
+    field : string
+
+    as : string
+
+    """
+    _schema = {'$ref': '#/definitions/paramField'}
+
+    def __init__(self, field=Undefined, **kwds):
+        super(paramField, self).__init__(field=field, **kwds)
 
 
 class rule(VegaSchema):
@@ -315,7 +391,7 @@ class rule(VegaSchema):
     test : string
 
     """
-    _schema = {'$ref': '#/defs/rule'}
+    _schema = {'$ref': '#/definitions/rule'}
 
     def __init__(self, test=Undefined, **kwds):
         super(rule, self).__init__(test=test, **kwds)
@@ -332,6 +408,12 @@ class encodeEntry(VegaSchema):
     align : :class:`alignValue`
 
     angle : :class:`numberValue`
+
+    aria : :class:`booleanValue`
+
+    ariaRole : :class:`stringValue`
+
+    ariaRoleDescription : :class:`stringValue`
 
     aspect : :class:`booleanValue`
 
@@ -354,6 +436,8 @@ class encodeEntry(VegaSchema):
     cursor : :class:`stringValue`
 
     defined : :class:`booleanValue`
+
+    description : :class:`stringValue`
 
     dir : :class:`stringValue`
 
@@ -460,13 +544,14 @@ class encodeEntry(VegaSchema):
     zindex : :class:`numberValue`
 
     """
-    _schema = {'$ref': '#/defs/encodeEntry'}
+    _schema = {'$ref': '#/definitions/encodeEntry'}
 
-    def __init__(self, align=Undefined, angle=Undefined, aspect=Undefined, baseline=Undefined,
-                 blend=Undefined, clip=Undefined, cornerRadius=Undefined,
-                 cornerRadiusBottomLeft=Undefined, cornerRadiusBottomRight=Undefined,
-                 cornerRadiusTopLeft=Undefined, cornerRadiusTopRight=Undefined, cursor=Undefined,
-                 defined=Undefined, dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined,
+    def __init__(self, align=Undefined, angle=Undefined, aria=Undefined, ariaRole=Undefined,
+                 ariaRoleDescription=Undefined, aspect=Undefined, baseline=Undefined, blend=Undefined,
+                 clip=Undefined, cornerRadius=Undefined, cornerRadiusBottomLeft=Undefined,
+                 cornerRadiusBottomRight=Undefined, cornerRadiusTopLeft=Undefined,
+                 cornerRadiusTopRight=Undefined, cursor=Undefined, defined=Undefined,
+                 description=Undefined, dir=Undefined, dx=Undefined, dy=Undefined, ellipsis=Undefined,
                  endAngle=Undefined, fill=Undefined, fillOpacity=Undefined, font=Undefined,
                  fontSize=Undefined, fontStyle=Undefined, fontWeight=Undefined, height=Undefined,
                  innerRadius=Undefined, interpolate=Undefined, limit=Undefined, lineBreak=Undefined,
@@ -479,21 +564,23 @@ class encodeEntry(VegaSchema):
                  strokeWidth=Undefined, tension=Undefined, text=Undefined, theta=Undefined,
                  tooltip=Undefined, url=Undefined, width=Undefined, x=Undefined, x2=Undefined,
                  xc=Undefined, y=Undefined, y2=Undefined, yc=Undefined, zindex=Undefined, **kwds):
-        super(encodeEntry, self).__init__(align=align, angle=angle, aspect=aspect, baseline=baseline,
-                                          blend=blend, clip=clip, cornerRadius=cornerRadius,
+        super(encodeEntry, self).__init__(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
+                                          ariaRoleDescription=ariaRoleDescription, aspect=aspect,
+                                          baseline=baseline, blend=blend, clip=clip,
+                                          cornerRadius=cornerRadius,
                                           cornerRadiusBottomLeft=cornerRadiusBottomLeft,
                                           cornerRadiusBottomRight=cornerRadiusBottomRight,
                                           cornerRadiusTopLeft=cornerRadiusTopLeft,
                                           cornerRadiusTopRight=cornerRadiusTopRight, cursor=cursor,
-                                          defined=defined, dir=dir, dx=dx, dy=dy, ellipsis=ellipsis,
-                                          endAngle=endAngle, fill=fill, fillOpacity=fillOpacity,
-                                          font=font, fontSize=fontSize, fontStyle=fontStyle,
-                                          fontWeight=fontWeight, height=height, innerRadius=innerRadius,
-                                          interpolate=interpolate, limit=limit, lineBreak=lineBreak,
-                                          lineHeight=lineHeight, opacity=opacity, orient=orient,
-                                          outerRadius=outerRadius, padAngle=padAngle, path=path,
-                                          radius=radius, scaleX=scaleX, scaleY=scaleY, shape=shape,
-                                          size=size, smooth=smooth, startAngle=startAngle,
+                                          defined=defined, description=description, dir=dir, dx=dx,
+                                          dy=dy, ellipsis=ellipsis, endAngle=endAngle, fill=fill,
+                                          fillOpacity=fillOpacity, font=font, fontSize=fontSize,
+                                          fontStyle=fontStyle, fontWeight=fontWeight, height=height,
+                                          innerRadius=innerRadius, interpolate=interpolate, limit=limit,
+                                          lineBreak=lineBreak, lineHeight=lineHeight, opacity=opacity,
+                                          orient=orient, outerRadius=outerRadius, padAngle=padAngle,
+                                          path=path, radius=radius, scaleX=scaleX, scaleY=scaleY,
+                                          shape=shape, size=size, smooth=smooth, startAngle=startAngle,
                                           stroke=stroke, strokeCap=strokeCap, strokeDash=strokeDash,
                                           strokeDashOffset=strokeDashOffset,
                                           strokeForeground=strokeForeground, strokeJoin=strokeJoin,
@@ -509,2170 +596,22 @@ class encode(VegaSchema):
 
     Mapping(required=[])
     """
-    _schema = {'$ref': '#/defs/encode'}
+    _schema = {'$ref': '#/definitions/encode'}
 
     def __init__(self, **kwds):
         super(encode, self).__init__(**kwds)
 
 
-class layout(VegaSchema):
-    """layout schema wrapper
-
-    oneOf(Mapping(required=[]), :class:`signal`)
-    """
-    _schema = {'$ref': '#/defs/layout'}
-
-    def __init__(self, *args, **kwds):
-        super(layout, self).__init__(*args, **kwds)
-
-
-class guideEncode(VegaSchema):
-    """guideEncode schema wrapper
-
-    Mapping(required=[])
-
-    Attributes
-    ----------
-
-    interactive : boolean
-
-    name : string
-
-    style : :class:`style`
-
-    """
-    _schema = {'$ref': '#/defs/guideEncode'}
-
-    def __init__(self, interactive=Undefined, name=Undefined, style=Undefined, **kwds):
-        super(guideEncode, self).__init__(interactive=interactive, name=name, style=style, **kwds)
-
-
-class legend(VegaSchema):
-    """legend schema wrapper
-
-    allOf(Mapping(required=[]), anyOf(Mapping(required=[size]), Mapping(required=[shape]),
-    Mapping(required=[fill]), Mapping(required=[stroke]), Mapping(required=[opacity]),
-    Mapping(required=[strokeDash]), Mapping(required=[strokeWidth])))
-    """
-    _schema = {'$ref': '#/defs/legend'}
-
-    def __init__(self, clipHeight=Undefined, columnPadding=Undefined, columns=Undefined,
-                 cornerRadius=Undefined, direction=Undefined, encode=Undefined, fill=Undefined,
-                 fillColor=Undefined, format=Undefined, formatType=Undefined, gradientLength=Undefined,
-                 gradientOpacity=Undefined, gradientStrokeColor=Undefined,
-                 gradientStrokeWidth=Undefined, gradientThickness=Undefined, gridAlign=Undefined,
-                 labelAlign=Undefined, labelBaseline=Undefined, labelColor=Undefined,
-                 labelFont=Undefined, labelFontSize=Undefined, labelFontStyle=Undefined,
-                 labelFontWeight=Undefined, labelLimit=Undefined, labelOffset=Undefined,
-                 labelOpacity=Undefined, labelOverlap=Undefined, labelSeparation=Undefined,
-                 legendX=Undefined, legendY=Undefined, offset=Undefined, opacity=Undefined,
-                 orient=Undefined, padding=Undefined, rowPadding=Undefined, shape=Undefined,
-                 size=Undefined, stroke=Undefined, strokeColor=Undefined, strokeDash=Undefined,
-                 strokeWidth=Undefined, symbolDash=Undefined, symbolDashOffset=Undefined,
-                 symbolFillColor=Undefined, symbolLimit=Undefined, symbolOffset=Undefined,
-                 symbolOpacity=Undefined, symbolSize=Undefined, symbolStrokeColor=Undefined,
-                 symbolStrokeWidth=Undefined, symbolType=Undefined, tickCount=Undefined,
-                 tickMinStep=Undefined, title=Undefined, titleAlign=Undefined, titleAnchor=Undefined,
-                 titleBaseline=Undefined, titleColor=Undefined, titleFont=Undefined,
-                 titleFontSize=Undefined, titleFontStyle=Undefined, titleFontWeight=Undefined,
-                 titleLimit=Undefined, titleLineHeight=Undefined, titleOpacity=Undefined,
-                 titleOrient=Undefined, titlePadding=Undefined, type=Undefined, values=Undefined,
-                 zindex=Undefined, **kwds):
-        super(legend, self).__init__(clipHeight=clipHeight, columnPadding=columnPadding,
-                                     columns=columns, cornerRadius=cornerRadius, direction=direction,
-                                     encode=encode, fill=fill, fillColor=fillColor, format=format,
-                                     formatType=formatType, gradientLength=gradientLength,
-                                     gradientOpacity=gradientOpacity,
-                                     gradientStrokeColor=gradientStrokeColor,
-                                     gradientStrokeWidth=gradientStrokeWidth,
-                                     gradientThickness=gradientThickness, gridAlign=gridAlign,
-                                     labelAlign=labelAlign, labelBaseline=labelBaseline,
-                                     labelColor=labelColor, labelFont=labelFont,
-                                     labelFontSize=labelFontSize, labelFontStyle=labelFontStyle,
-                                     labelFontWeight=labelFontWeight, labelLimit=labelLimit,
-                                     labelOffset=labelOffset, labelOpacity=labelOpacity,
-                                     labelOverlap=labelOverlap, labelSeparation=labelSeparation,
-                                     legendX=legendX, legendY=legendY, offset=offset, opacity=opacity,
-                                     orient=orient, padding=padding, rowPadding=rowPadding, shape=shape,
-                                     size=size, stroke=stroke, strokeColor=strokeColor,
-                                     strokeDash=strokeDash, strokeWidth=strokeWidth,
-                                     symbolDash=symbolDash, symbolDashOffset=symbolDashOffset,
-                                     symbolFillColor=symbolFillColor, symbolLimit=symbolLimit,
-                                     symbolOffset=symbolOffset, symbolOpacity=symbolOpacity,
-                                     symbolSize=symbolSize, symbolStrokeColor=symbolStrokeColor,
-                                     symbolStrokeWidth=symbolStrokeWidth, symbolType=symbolType,
-                                     tickCount=tickCount, tickMinStep=tickMinStep, title=title,
-                                     titleAlign=titleAlign, titleAnchor=titleAnchor,
-                                     titleBaseline=titleBaseline, titleColor=titleColor,
-                                     titleFont=titleFont, titleFontSize=titleFontSize,
-                                     titleFontStyle=titleFontStyle, titleFontWeight=titleFontWeight,
-                                     titleLimit=titleLimit, titleLineHeight=titleLineHeight,
-                                     titleOpacity=titleOpacity, titleOrient=titleOrient,
-                                     titlePadding=titlePadding, type=type, values=values, zindex=zindex,
-                                     **kwds)
-
-
-class mark(VegaSchema):
-    """mark schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : :class:`marktype`
-
-    clip : :class:`markclip`
-
-    encode : :class:`encode`
-
-    interactive : :class:`booleanOrSignal`
-
-    key : string
-
-    name : string
-
-    on : :class:`onMarkTrigger`
-
-    role : string
-
-    sort : :class:`compare`
-
-    style : :class:`style`
-
-    transform : List(:class:`transformMark`)
-
-    """
-    _schema = {'$ref': '#/defs/mark'}
-
-    def __init__(self, type=Undefined, clip=Undefined, encode=Undefined, interactive=Undefined,
-                 key=Undefined, name=Undefined, on=Undefined, role=Undefined, sort=Undefined,
-                 style=Undefined, transform=Undefined, **kwds):
-        super(mark, self).__init__(type=type, clip=clip, encode=encode, interactive=interactive,
-                                   key=key, name=name, on=on, role=role, sort=sort, style=style,
-                                   transform=transform, **kwds)
-
-
-class markGroup(VegaSchema):
-    """markGroup schema wrapper
-
-    allOf(Mapping(required=[type]), :class:`mark`, :class:`scope`)
-    """
-    _schema = {'$ref': '#/defs/markGroup'}
-
-    def __init__(self, type=Undefined, axes=Undefined, clip=Undefined, data=Undefined, encode=Undefined,
-                 interactive=Undefined, key=Undefined, layout=Undefined, legends=Undefined,
-                 marks=Undefined, name=Undefined, on=Undefined, projections=Undefined, role=Undefined,
-                 scales=Undefined, signals=Undefined, sort=Undefined, style=Undefined, title=Undefined,
-                 transform=Undefined, usermeta=Undefined, **kwds):
-        super(markGroup, self).__init__(type=type, axes=axes, clip=clip, data=data, encode=encode,
-                                        interactive=interactive, key=key, layout=layout,
-                                        legends=legends, marks=marks, name=name, on=on,
-                                        projections=projections, role=role, scales=scales,
-                                        signals=signals, sort=sort, style=style, title=title,
-                                        transform=transform, usermeta=usermeta, **kwds)
-
-
-class markVisual(VegaSchema):
-    """markVisual schema wrapper
-
-    allOf(Mapping(required=[]), :class:`mark`)
-    """
-    _schema = {'$ref': '#/defs/markVisual'}
-
-    def __init__(self, type=Undefined, clip=Undefined, encode=Undefined, interactive=Undefined,
-                 key=Undefined, name=Undefined, on=Undefined, role=Undefined, sort=Undefined,
-                 style=Undefined, transform=Undefined, **kwds):
-        super(markVisual, self).__init__(type=type, clip=clip, encode=encode, interactive=interactive,
-                                         key=key, name=name, on=on, role=role, sort=sort, style=style,
-                                         transform=transform, **kwds)
-
-
-class listener(VegaSchema):
-    """listener schema wrapper
-
-    oneOf(:class:`signal`, Mapping(required=[scale]), :class:`stream`)
-    """
-    _schema = {'$ref': '#/defs/listener'}
-
-    def __init__(self, *args, **kwds):
-        super(listener, self).__init__(*args, **kwds)
-
-
-class onEvents(VegaSchema):
-    """onEvents schema wrapper
-
-    List(allOf(Mapping(required=[events]), oneOf(Mapping(required=[encode]),
-    Mapping(required=[update]))))
-    """
-    _schema = {'$ref': '#/defs/onEvents'}
-
-    def __init__(self, *args):
-        super(onEvents, self).__init__(*args)
-
-
-class onTrigger(VegaSchema):
-    """onTrigger schema wrapper
-
-    List(Mapping(required=[trigger]))
-    """
-    _schema = {'$ref': '#/defs/onTrigger'}
-
-    def __init__(self, *args):
-        super(onTrigger, self).__init__(*args)
-
-
-class onMarkTrigger(VegaSchema):
-    """onMarkTrigger schema wrapper
-
-    List(Mapping(required=[trigger]))
-    """
-    _schema = {'$ref': '#/defs/onMarkTrigger'}
-
-    def __init__(self, *args):
-        super(onMarkTrigger, self).__init__(*args)
-
-
-class padding(VegaSchema):
-    """padding schema wrapper
-
-    oneOf(float, Mapping(required=[]), :class:`signal`)
-    """
-    _schema = {'$ref': '#/defs/padding'}
-
-    def __init__(self, *args, **kwds):
-        super(padding, self).__init__(*args, **kwds)
-
-
-class projection(VegaSchema):
-    """projection schema wrapper
-
-    Mapping(required=[name])
-
-    Attributes
-    ----------
-
-    name : string
-
-    center : oneOf(List(:class:`numberOrSignal`), :class:`signal`)
-
-    clipAngle : :class:`numberOrSignal`
-
-    clipExtent : oneOf(List(oneOf(List(:class:`numberOrSignal`), :class:`signal`)),
-    :class:`signal`)
-
-    extent : oneOf(List(oneOf(List(:class:`numberOrSignal`), :class:`signal`)), :class:`signal`)
-
-    fit : oneOf(Mapping(required=[]), List(Any))
-
-    parallels : oneOf(List(:class:`numberOrSignal`), :class:`signal`)
-
-    pointRadius : :class:`numberOrSignal`
-
-    precision : :class:`numberOrSignal`
-
-    rotate : oneOf(List(:class:`numberOrSignal`), :class:`signal`)
-
-    scale : :class:`numberOrSignal`
-
-    size : oneOf(List(:class:`numberOrSignal`), :class:`signal`)
-
-    translate : oneOf(List(:class:`numberOrSignal`), :class:`signal`)
-
-    type : :class:`stringOrSignal`
-
-    """
-    _schema = {'$ref': '#/defs/projection'}
-
-    def __init__(self, name=Undefined, center=Undefined, clipAngle=Undefined, clipExtent=Undefined,
-                 extent=Undefined, fit=Undefined, parallels=Undefined, pointRadius=Undefined,
-                 precision=Undefined, rotate=Undefined, scale=Undefined, size=Undefined,
-                 translate=Undefined, type=Undefined, **kwds):
-        super(projection, self).__init__(name=name, center=center, clipAngle=clipAngle,
-                                         clipExtent=clipExtent, extent=extent, fit=fit,
-                                         parallels=parallels, pointRadius=pointRadius,
-                                         precision=precision, rotate=rotate, scale=scale, size=size,
-                                         translate=translate, type=type, **kwds)
-
-
-class scale(VegaSchema):
-    """scale schema wrapper
-
-    oneOf(Mapping(required=[type, name]), Mapping(required=[type, name]),
-    Mapping(required=[type, name]), Mapping(required=[type, name]), Mapping(required=[type,
-    name]), Mapping(required=[type, name]), Mapping(required=[type, name]),
-    Mapping(required=[type, name]), Mapping(required=[name]), Mapping(required=[type, name]),
-    Mapping(required=[type, name]), Mapping(required=[type, name]))
-    """
-    _schema = {'$ref': '#/defs/scale'}
-
-    def __init__(self, *args, **kwds):
-        super(scale, self).__init__(*args, **kwds)
-
-
-class scope(VegaSchema):
-    """scope schema wrapper
-
-    Mapping(required=[])
-
-    Attributes
-    ----------
-
-    axes : List(:class:`axis`)
-
-    data : List(:class:`data`)
-
-    encode : :class:`encode`
-
-    layout : :class:`layout`
-
-    legends : List(:class:`legend`)
-
-    marks : List(oneOf(:class:`markGroup`, :class:`markVisual`))
-
-    projections : List(:class:`projection`)
-
-    scales : List(:class:`scale`)
-
-    signals : List(:class:`signal`)
-
-    title : :class:`title`
-
-    usermeta : Mapping(required=[])
-
-    """
-    _schema = {'$ref': '#/defs/scope'}
-
-    def __init__(self, axes=Undefined, data=Undefined, encode=Undefined, layout=Undefined,
-                 legends=Undefined, marks=Undefined, projections=Undefined, scales=Undefined,
-                 signals=Undefined, title=Undefined, usermeta=Undefined, **kwds):
-        super(scope, self).__init__(axes=axes, data=data, encode=encode, layout=layout, legends=legends,
-                                    marks=marks, projections=projections, scales=scales,
-                                    signals=signals, title=title, usermeta=usermeta, **kwds)
-
-
-class signalName(VegaSchema):
-    """signalName schema wrapper
-
-    not enum('parent', 'datum', 'event', 'item')
-    """
-    _schema = {'$ref': '#/defs/signalName'}
-
-    def __init__(self, *args):
-        super(signalName, self).__init__(*args)
-
-
-class signal(VegaSchema):
-    """signal schema wrapper
-
-    oneOf(Mapping(required=[name, push]), Mapping(required=[name]), Mapping(required=[name,
-    init]))
-    """
-    _schema = {'$ref': '#/defs/signal'}
-
-    def __init__(self, *args, **kwds):
-        super(signal, self).__init__(*args, **kwds)
-
-
-class stream(VegaSchema):
-    """stream schema wrapper
-
-    allOf(Mapping(required=[]), oneOf(Mapping(required=[type]), Mapping(required=[stream]),
-    Mapping(required=[merge])))
-    """
-    _schema = {'$ref': '#/defs/stream'}
-
-    def __init__(self, between=Undefined, consume=Undefined, debounce=Undefined, filter=Undefined,
-                 markname=Undefined, marktype=Undefined, throttle=Undefined, **kwds):
-        super(stream, self).__init__(between=between, consume=consume, debounce=debounce, filter=filter,
-                                     markname=markname, marktype=marktype, throttle=throttle, **kwds)
-
-
-class title(VegaSchema):
-    """title schema wrapper
-
-    oneOf(string, Mapping(required=[]))
-    """
-    _schema = {'$ref': '#/defs/title'}
-
-    def __init__(self, *args, **kwds):
-        super(title, self).__init__(*args, **kwds)
-
-
-class transform(VegaSchema):
-    """transform schema wrapper
-
-    oneOf(:class:`crossfilterTransform`, :class:`resolvefilterTransform`,
-    :class:`linkpathTransform`, :class:`pieTransform`, :class:`stackTransform`,
-    :class:`forceTransform`, :class:`contourTransform`, :class:`geojsonTransform`,
-    :class:`geopathTransform`, :class:`geopointTransform`, :class:`geoshapeTransform`,
-    :class:`graticuleTransform`, :class:`heatmapTransform`, :class:`isocontourTransform`,
-    :class:`kde2dTransform`, :class:`nestTransform`, :class:`packTransform`,
-    :class:`partitionTransform`, :class:`stratifyTransform`, :class:`treeTransform`,
-    :class:`treelinksTransform`, :class:`treemapTransform`, :class:`loessTransform`,
-    :class:`regressionTransform`, :class:`aggregateTransform`, :class:`binTransform`,
-    :class:`collectTransform`, :class:`countpatternTransform`, :class:`crossTransform`,
-    :class:`densityTransform`, :class:`dotbinTransform`, :class:`extentTransform`,
-    :class:`filterTransform`, :class:`flattenTransform`, :class:`foldTransform`,
-    :class:`formulaTransform`, :class:`imputeTransform`, :class:`joinaggregateTransform`,
-    :class:`kdeTransform`, :class:`lookupTransform`, :class:`pivotTransform`,
-    :class:`projectTransform`, :class:`quantileTransform`, :class:`sampleTransform`,
-    :class:`sequenceTransform`, :class:`timeunitTransform`, :class:`windowTransform`,
-    :class:`identifierTransform`, :class:`voronoiTransform`, :class:`wordcloudTransform`)
-    """
-    _schema = {'$ref': '#/defs/transform'}
-
-    def __init__(self, *args, **kwds):
-        super(transform, self).__init__(*args, **kwds)
-
-
-class transformMark(VegaSchema):
-    """transformMark schema wrapper
-
-    oneOf(:class:`crossfilterTransform`, :class:`resolvefilterTransform`,
-    :class:`linkpathTransform`, :class:`pieTransform`, :class:`stackTransform`,
-    :class:`forceTransform`, :class:`geojsonTransform`, :class:`geopathTransform`,
-    :class:`geopointTransform`, :class:`geoshapeTransform`, :class:`heatmapTransform`,
-    :class:`packTransform`, :class:`partitionTransform`, :class:`stratifyTransform`,
-    :class:`treeTransform`, :class:`treemapTransform`, :class:`binTransform`,
-    :class:`collectTransform`, :class:`dotbinTransform`, :class:`extentTransform`,
-    :class:`formulaTransform`, :class:`joinaggregateTransform`, :class:`lookupTransform`,
-    :class:`sampleTransform`, :class:`timeunitTransform`, :class:`windowTransform`,
-    :class:`identifierTransform`, :class:`voronoiTransform`, :class:`wordcloudTransform`)
-    """
-    _schema = {'$ref': '#/defs/transformMark'}
-
-    def __init__(self, *args, **kwds):
-        super(transformMark, self).__init__(*args, **kwds)
-
-
-class crossfilterTransform(VegaSchema):
-    """crossfilterTransform schema wrapper
-
-    Mapping(required=[type, fields, query])
-
-    Attributes
-    ----------
-
-    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    query : oneOf(List(Any), :class:`signal`)
-
-    type : enum('crossfilter')
-
-    signal : string
-
-    """
-    _schema = {'$ref': '#/defs/crossfilterTransform'}
-
-    def __init__(self, fields=Undefined, query=Undefined, type=Undefined, signal=Undefined, **kwds):
-        super(crossfilterTransform, self).__init__(fields=fields, query=query, type=type, signal=signal,
-                                                   **kwds)
-
-
-class resolvefilterTransform(VegaSchema):
-    """resolvefilterTransform schema wrapper
-
-    Mapping(required=[type, ignore, filter])
-
-    Attributes
-    ----------
-
-    filter : Any
-
-    ignore : anyOf(float, :class:`signal`)
-
-    type : enum('resolvefilter')
-
-    signal : string
-
-    """
-    _schema = {'$ref': '#/defs/resolvefilterTransform'}
-
-    def __init__(self, filter=Undefined, ignore=Undefined, type=Undefined, signal=Undefined, **kwds):
-        super(resolvefilterTransform, self).__init__(filter=filter, ignore=ignore, type=type,
-                                                     signal=signal, **kwds)
-
-
-class linkpathTransform(VegaSchema):
-    """linkpathTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('linkpath')
-
-    orient : anyOf(enum('horizontal', 'vertical', 'radial'), :class:`signal`)
-
-    require : :class:`signal`
-
-    shape : anyOf(enum('line', 'arc', 'curve', 'diagonal', 'orthogonal'), :class:`signal`)
-
-    signal : string
-
-    sourceX : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    sourceY : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    targetX : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    targetY : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    as : anyOf(string, :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/linkpathTransform'}
-
-    def __init__(self, type=Undefined, orient=Undefined, require=Undefined, shape=Undefined,
-                 signal=Undefined, sourceX=Undefined, sourceY=Undefined, targetX=Undefined,
-                 targetY=Undefined, **kwds):
-        super(linkpathTransform, self).__init__(type=type, orient=orient, require=require, shape=shape,
-                                                signal=signal, sourceX=sourceX, sourceY=sourceY,
-                                                targetX=targetX, targetY=targetY, **kwds)
-
-
-class pieTransform(VegaSchema):
-    """pieTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('pie')
-
-    endAngle : anyOf(float, :class:`signal`)
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    signal : string
-
-    sort : anyOf(boolean, :class:`signal`)
-
-    startAngle : anyOf(float, :class:`signal`)
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/pieTransform'}
-
-    def __init__(self, type=Undefined, endAngle=Undefined, field=Undefined, signal=Undefined,
-                 sort=Undefined, startAngle=Undefined, **kwds):
-        super(pieTransform, self).__init__(type=type, endAngle=endAngle, field=field, signal=signal,
-                                           sort=sort, startAngle=startAngle, **kwds)
-
-
-class stackTransform(VegaSchema):
-    """stackTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('stack')
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    offset : anyOf(enum('zero', 'center', 'normalize'), :class:`signal`)
-
-    signal : string
-
-    sort : :class:`compare`
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/stackTransform'}
-
-    def __init__(self, type=Undefined, field=Undefined, groupby=Undefined, offset=Undefined,
-                 signal=Undefined, sort=Undefined, **kwds):
-        super(stackTransform, self).__init__(type=type, field=field, groupby=groupby, offset=offset,
-                                             signal=signal, sort=sort, **kwds)
-
-
-class forceTransform(VegaSchema):
-    """forceTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('force')
-
-    alpha : anyOf(float, :class:`signal`)
-
-    alphaMin : anyOf(float, :class:`signal`)
-
-    alphaTarget : anyOf(float, :class:`signal`)
-
-    forces : List(oneOf(Mapping(required=[force]), Mapping(required=[force]),
-    Mapping(required=[force]), Mapping(required=[force]), Mapping(required=[force]),
-    Mapping(required=[force])))
-
-    iterations : anyOf(float, :class:`signal`)
-
-    restart : anyOf(boolean, :class:`signal`)
-
-    signal : string
-
-    static : anyOf(boolean, :class:`signal`)
-
-    velocityDecay : anyOf(float, :class:`signal`)
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/forceTransform'}
-
-    def __init__(self, type=Undefined, alpha=Undefined, alphaMin=Undefined, alphaTarget=Undefined,
-                 forces=Undefined, iterations=Undefined, restart=Undefined, signal=Undefined,
-                 static=Undefined, velocityDecay=Undefined, **kwds):
-        super(forceTransform, self).__init__(type=type, alpha=alpha, alphaMin=alphaMin,
-                                             alphaTarget=alphaTarget, forces=forces,
-                                             iterations=iterations, restart=restart, signal=signal,
-                                             static=static, velocityDecay=velocityDecay, **kwds)
-
-
-class contourTransform(VegaSchema):
-    """contourTransform schema wrapper
-
-    Mapping(required=[type, size])
-
-    Attributes
-    ----------
-
-    size : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    type : enum('contour')
-
-    bandwidth : anyOf(float, :class:`signal`)
-
-    cellSize : anyOf(float, :class:`signal`)
-
-    count : anyOf(float, :class:`signal`)
-
-    nice : anyOf(boolean, :class:`signal`)
-
-    signal : string
-
-    smooth : anyOf(boolean, :class:`signal`)
-
-    thresholds : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    values : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    weight : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    x : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    y : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    """
-    _schema = {'$ref': '#/defs/contourTransform'}
-
-    def __init__(self, size=Undefined, type=Undefined, bandwidth=Undefined, cellSize=Undefined,
-                 count=Undefined, nice=Undefined, signal=Undefined, smooth=Undefined,
-                 thresholds=Undefined, values=Undefined, weight=Undefined, x=Undefined, y=Undefined,
-                 **kwds):
-        super(contourTransform, self).__init__(size=size, type=type, bandwidth=bandwidth,
-                                               cellSize=cellSize, count=count, nice=nice, signal=signal,
-                                               smooth=smooth, thresholds=thresholds, values=values,
-                                               weight=weight, x=x, y=y, **kwds)
-
-
-class geojsonTransform(VegaSchema):
-    """geojsonTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('geojson')
-
-    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    geojson : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    signal : string
-
-    """
-    _schema = {'$ref': '#/defs/geojsonTransform'}
-
-    def __init__(self, type=Undefined, fields=Undefined, geojson=Undefined, signal=Undefined, **kwds):
-        super(geojsonTransform, self).__init__(type=type, fields=fields, geojson=geojson, signal=signal,
-                                               **kwds)
-
-
-class geopathTransform(VegaSchema):
-    """geopathTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('geopath')
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    pointRadius : anyOf(float, :class:`signal`, :class:`expr`, :class:`paramField`)
-
-    projection : string
-
-    signal : string
-
-    as : anyOf(string, :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/geopathTransform'}
-
-    def __init__(self, type=Undefined, field=Undefined, pointRadius=Undefined, projection=Undefined,
-                 signal=Undefined, **kwds):
-        super(geopathTransform, self).__init__(type=type, field=field, pointRadius=pointRadius,
-                                               projection=projection, signal=signal, **kwds)
-
-
-class geopointTransform(VegaSchema):
-    """geopointTransform schema wrapper
-
-    Mapping(required=[type, projection, fields])
-
-    Attributes
-    ----------
-
-    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    projection : string
-
-    type : enum('geopoint')
-
-    signal : string
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/geopointTransform'}
-
-    def __init__(self, fields=Undefined, projection=Undefined, type=Undefined, signal=Undefined, **kwds):
-        super(geopointTransform, self).__init__(fields=fields, projection=projection, type=type,
-                                                signal=signal, **kwds)
-
-
-class geoshapeTransform(VegaSchema):
-    """geoshapeTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('geoshape')
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    pointRadius : anyOf(float, :class:`signal`, :class:`expr`, :class:`paramField`)
-
-    projection : string
-
-    signal : string
-
-    as : anyOf(string, :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/geoshapeTransform'}
-
-    def __init__(self, type=Undefined, field=Undefined, pointRadius=Undefined, projection=Undefined,
-                 signal=Undefined, **kwds):
-        super(geoshapeTransform, self).__init__(type=type, field=field, pointRadius=pointRadius,
-                                                projection=projection, signal=signal, **kwds)
-
-
-class graticuleTransform(VegaSchema):
-    """graticuleTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('graticule')
-
-    extent : oneOf(List(Any), :class:`signal`)
-
-    extentMajor : oneOf(List(Any), :class:`signal`)
-
-    extentMinor : oneOf(List(Any), :class:`signal`)
-
-    precision : anyOf(float, :class:`signal`)
-
-    signal : string
-
-    step : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    stepMajor : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    stepMinor : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/graticuleTransform'}
-
-    def __init__(self, type=Undefined, extent=Undefined, extentMajor=Undefined, extentMinor=Undefined,
-                 precision=Undefined, signal=Undefined, step=Undefined, stepMajor=Undefined,
-                 stepMinor=Undefined, **kwds):
-        super(graticuleTransform, self).__init__(type=type, extent=extent, extentMajor=extentMajor,
-                                                 extentMinor=extentMinor, precision=precision,
-                                                 signal=signal, step=step, stepMajor=stepMajor,
-                                                 stepMinor=stepMinor, **kwds)
-
-
-class heatmapTransform(VegaSchema):
-    """heatmapTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('heatmap')
-
-    color : anyOf(string, :class:`signal`, :class:`expr`, :class:`paramField`)
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    opacity : anyOf(float, :class:`signal`, :class:`expr`, :class:`paramField`)
-
-    resolve : anyOf(enum('shared', 'independent'), :class:`signal`)
-
-    signal : string
-
-    as : anyOf(string, :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/heatmapTransform'}
-
-    def __init__(self, type=Undefined, color=Undefined, field=Undefined, opacity=Undefined,
-                 resolve=Undefined, signal=Undefined, **kwds):
-        super(heatmapTransform, self).__init__(type=type, color=color, field=field, opacity=opacity,
-                                               resolve=resolve, signal=signal, **kwds)
-
-
-class isocontourTransform(VegaSchema):
-    """isocontourTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('isocontour')
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    levels : anyOf(float, :class:`signal`)
-
-    nice : anyOf(boolean, :class:`signal`)
-
-    resolve : anyOf(enum('shared', 'independent'), :class:`signal`)
-
-    scale : anyOf(float, :class:`signal`, :class:`expr`, :class:`paramField`)
-
-    signal : string
-
-    smooth : anyOf(boolean, :class:`signal`)
-
-    thresholds : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    translate : oneOf(List(anyOf(float, :class:`signal`, :class:`expr`, :class:`paramField`)),
-    :class:`signal`)
-
-    zero : anyOf(boolean, :class:`signal`)
-
-    as : anyOf(string, :class:`signal`, None)
-
-    """
-    _schema = {'$ref': '#/defs/isocontourTransform'}
-
-    def __init__(self, type=Undefined, field=Undefined, levels=Undefined, nice=Undefined,
-                 resolve=Undefined, scale=Undefined, signal=Undefined, smooth=Undefined,
-                 thresholds=Undefined, translate=Undefined, zero=Undefined, **kwds):
-        super(isocontourTransform, self).__init__(type=type, field=field, levels=levels, nice=nice,
-                                                  resolve=resolve, scale=scale, signal=signal,
-                                                  smooth=smooth, thresholds=thresholds,
-                                                  translate=translate, zero=zero, **kwds)
-
-
-class kde2dTransform(VegaSchema):
-    """kde2dTransform schema wrapper
-
-    Mapping(required=[type, size, x, y])
-
-    Attributes
-    ----------
-
-    size : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    type : enum('kde2d')
-
-    x : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    y : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    bandwidth : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    cellSize : anyOf(float, :class:`signal`)
-
-    counts : anyOf(boolean, :class:`signal`)
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    signal : string
-
-    weight : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    as : anyOf(string, :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/kde2dTransform'}
-
-    def __init__(self, size=Undefined, type=Undefined, x=Undefined, y=Undefined, bandwidth=Undefined,
-                 cellSize=Undefined, counts=Undefined, groupby=Undefined, signal=Undefined,
-                 weight=Undefined, **kwds):
-        super(kde2dTransform, self).__init__(size=size, type=type, x=x, y=y, bandwidth=bandwidth,
-                                             cellSize=cellSize, counts=counts, groupby=groupby,
-                                             signal=signal, weight=weight, **kwds)
-
-
-class nestTransform(VegaSchema):
-    """nestTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('nest')
-
-    generate : anyOf(boolean, :class:`signal`)
-
-    keys : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    signal : string
-
-    """
-    _schema = {'$ref': '#/defs/nestTransform'}
-
-    def __init__(self, type=Undefined, generate=Undefined, keys=Undefined, signal=Undefined, **kwds):
-        super(nestTransform, self).__init__(type=type, generate=generate, keys=keys, signal=signal,
-                                            **kwds)
-
-
-class packTransform(VegaSchema):
-    """packTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('pack')
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    padding : anyOf(float, :class:`signal`)
-
-    radius : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    signal : string
-
-    size : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    sort : :class:`compare`
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/packTransform'}
-
-    def __init__(self, type=Undefined, field=Undefined, padding=Undefined, radius=Undefined,
-                 signal=Undefined, size=Undefined, sort=Undefined, **kwds):
-        super(packTransform, self).__init__(type=type, field=field, padding=padding, radius=radius,
-                                            signal=signal, size=size, sort=sort, **kwds)
-
-
-class partitionTransform(VegaSchema):
-    """partitionTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('partition')
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    padding : anyOf(float, :class:`signal`)
-
-    round : anyOf(boolean, :class:`signal`)
-
-    signal : string
-
-    size : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    sort : :class:`compare`
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/partitionTransform'}
-
-    def __init__(self, type=Undefined, field=Undefined, padding=Undefined, round=Undefined,
-                 signal=Undefined, size=Undefined, sort=Undefined, **kwds):
-        super(partitionTransform, self).__init__(type=type, field=field, padding=padding, round=round,
-                                                 signal=signal, size=size, sort=sort, **kwds)
-
-
-class stratifyTransform(VegaSchema):
-    """stratifyTransform schema wrapper
-
-    Mapping(required=[type, key, parentKey])
-
-    Attributes
-    ----------
-
-    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    parentKey : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    type : enum('stratify')
-
-    signal : string
-
-    """
-    _schema = {'$ref': '#/defs/stratifyTransform'}
-
-    def __init__(self, key=Undefined, parentKey=Undefined, type=Undefined, signal=Undefined, **kwds):
-        super(stratifyTransform, self).__init__(key=key, parentKey=parentKey, type=type, signal=signal,
-                                                **kwds)
-
-
-class treeTransform(VegaSchema):
-    """treeTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('tree')
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    method : anyOf(enum('tidy', 'cluster'), :class:`signal`)
-
-    nodeSize : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    separation : anyOf(boolean, :class:`signal`)
-
-    signal : string
-
-    size : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    sort : :class:`compare`
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/treeTransform'}
-
-    def __init__(self, type=Undefined, field=Undefined, method=Undefined, nodeSize=Undefined,
-                 separation=Undefined, signal=Undefined, size=Undefined, sort=Undefined, **kwds):
-        super(treeTransform, self).__init__(type=type, field=field, method=method, nodeSize=nodeSize,
-                                            separation=separation, signal=signal, size=size, sort=sort,
-                                            **kwds)
-
-
-class treelinksTransform(VegaSchema):
-    """treelinksTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('treelinks')
-
-    signal : string
-
-    """
-    _schema = {'$ref': '#/defs/treelinksTransform'}
-
-    def __init__(self, type=Undefined, signal=Undefined, **kwds):
-        super(treelinksTransform, self).__init__(type=type, signal=signal, **kwds)
-
-
-class treemapTransform(VegaSchema):
-    """treemapTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('treemap')
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    method : anyOf(enum('squarify', 'resquarify', 'binary', 'dice', 'slice', 'slicedice'),
-    :class:`signal`)
-
-    padding : anyOf(float, :class:`signal`)
-
-    paddingBottom : anyOf(float, :class:`signal`)
-
-    paddingInner : anyOf(float, :class:`signal`)
-
-    paddingLeft : anyOf(float, :class:`signal`)
-
-    paddingOuter : anyOf(float, :class:`signal`)
-
-    paddingRight : anyOf(float, :class:`signal`)
-
-    paddingTop : anyOf(float, :class:`signal`)
-
-    ratio : anyOf(float, :class:`signal`)
-
-    round : anyOf(boolean, :class:`signal`)
-
-    signal : string
-
-    size : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    sort : :class:`compare`
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/treemapTransform'}
-
-    def __init__(self, type=Undefined, field=Undefined, method=Undefined, padding=Undefined,
-                 paddingBottom=Undefined, paddingInner=Undefined, paddingLeft=Undefined,
-                 paddingOuter=Undefined, paddingRight=Undefined, paddingTop=Undefined, ratio=Undefined,
-                 round=Undefined, signal=Undefined, size=Undefined, sort=Undefined, **kwds):
-        super(treemapTransform, self).__init__(type=type, field=field, method=method, padding=padding,
-                                               paddingBottom=paddingBottom, paddingInner=paddingInner,
-                                               paddingLeft=paddingLeft, paddingOuter=paddingOuter,
-                                               paddingRight=paddingRight, paddingTop=paddingTop,
-                                               ratio=ratio, round=round, signal=signal, size=size,
-                                               sort=sort, **kwds)
-
-
-class loessTransform(VegaSchema):
-    """loessTransform schema wrapper
-
-    Mapping(required=[type, x, y])
-
-    Attributes
-    ----------
-
-    type : enum('loess')
-
-    x : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    y : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    bandwidth : anyOf(float, :class:`signal`)
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    signal : string
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/loessTransform'}
-
-    def __init__(self, type=Undefined, x=Undefined, y=Undefined, bandwidth=Undefined, groupby=Undefined,
-                 signal=Undefined, **kwds):
-        super(loessTransform, self).__init__(type=type, x=x, y=y, bandwidth=bandwidth, groupby=groupby,
-                                             signal=signal, **kwds)
-
-
-class regressionTransform(VegaSchema):
-    """regressionTransform schema wrapper
-
-    Mapping(required=[type, x, y])
-
-    Attributes
-    ----------
-
-    type : enum('regression')
-
-    x : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    y : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    extent : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    method : anyOf(string, :class:`signal`)
-
-    order : anyOf(float, :class:`signal`)
-
-    params : anyOf(boolean, :class:`signal`)
-
-    signal : string
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/regressionTransform'}
-
-    def __init__(self, type=Undefined, x=Undefined, y=Undefined, extent=Undefined, groupby=Undefined,
-                 method=Undefined, order=Undefined, params=Undefined, signal=Undefined, **kwds):
-        super(regressionTransform, self).__init__(type=type, x=x, y=y, extent=extent, groupby=groupby,
-                                                  method=method, order=order, params=params,
-                                                  signal=signal, **kwds)
-
-
-class aggregateTransform(VegaSchema):
-    """aggregateTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('aggregate')
-
-    cross : anyOf(boolean, :class:`signal`)
-
-    drop : anyOf(boolean, :class:`signal`)
-
-    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`, None)),
-    :class:`signal`)
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    ops : oneOf(List(anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum',
-    'product', 'mean', 'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr',
-    'distinct', 'ci0', 'ci1', 'median', 'q1', 'q3', 'argmin', 'argmax', 'min', 'max'),
-    :class:`signal`)), :class:`signal`)
-
-    signal : string
-
-    as : oneOf(List(anyOf(string, :class:`signal`, None)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/aggregateTransform'}
-
-    def __init__(self, type=Undefined, cross=Undefined, drop=Undefined, fields=Undefined,
-                 groupby=Undefined, key=Undefined, ops=Undefined, signal=Undefined, **kwds):
-        super(aggregateTransform, self).__init__(type=type, cross=cross, drop=drop, fields=fields,
-                                                 groupby=groupby, key=key, ops=ops, signal=signal,
-                                                 **kwds)
-
-
-class binTransform(VegaSchema):
-    """binTransform schema wrapper
-
-    Mapping(required=[type, field, extent])
-
-    Attributes
-    ----------
-
-    extent : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    type : enum('bin')
-
-    anchor : anyOf(float, :class:`signal`)
-
-    base : anyOf(float, :class:`signal`)
-
-    divide : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    interval : anyOf(boolean, :class:`signal`)
-
-    maxbins : anyOf(float, :class:`signal`)
-
-    minstep : anyOf(float, :class:`signal`)
-
-    name : anyOf(string, :class:`signal`)
-
-    nice : anyOf(boolean, :class:`signal`)
-
-    signal : string
-
-    span : anyOf(float, :class:`signal`)
-
-    step : anyOf(float, :class:`signal`)
-
-    steps : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/binTransform'}
-
-    def __init__(self, extent=Undefined, field=Undefined, type=Undefined, anchor=Undefined,
-                 base=Undefined, divide=Undefined, interval=Undefined, maxbins=Undefined,
-                 minstep=Undefined, name=Undefined, nice=Undefined, signal=Undefined, span=Undefined,
-                 step=Undefined, steps=Undefined, **kwds):
-        super(binTransform, self).__init__(extent=extent, field=field, type=type, anchor=anchor,
-                                           base=base, divide=divide, interval=interval, maxbins=maxbins,
-                                           minstep=minstep, name=name, nice=nice, signal=signal,
-                                           span=span, step=step, steps=steps, **kwds)
-
-
-class collectTransform(VegaSchema):
-    """collectTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('collect')
-
-    signal : string
-
-    sort : :class:`compare`
-
-    """
-    _schema = {'$ref': '#/defs/collectTransform'}
-
-    def __init__(self, type=Undefined, signal=Undefined, sort=Undefined, **kwds):
-        super(collectTransform, self).__init__(type=type, signal=signal, sort=sort, **kwds)
-
-
-class countpatternTransform(VegaSchema):
-    """countpatternTransform schema wrapper
-
-    Mapping(required=[type, field])
-
-    Attributes
-    ----------
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    type : enum('countpattern')
-
-    case : anyOf(enum('upper', 'lower', 'mixed'), :class:`signal`)
-
-    pattern : anyOf(string, :class:`signal`)
-
-    signal : string
-
-    stopwords : anyOf(string, :class:`signal`)
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/countpatternTransform'}
-
-    def __init__(self, field=Undefined, type=Undefined, case=Undefined, pattern=Undefined,
-                 signal=Undefined, stopwords=Undefined, **kwds):
-        super(countpatternTransform, self).__init__(field=field, type=type, case=case, pattern=pattern,
-                                                    signal=signal, stopwords=stopwords, **kwds)
-
-
-class crossTransform(VegaSchema):
-    """crossTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('cross')
-
-    filter : :class:`exprString`
-
-    signal : string
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/crossTransform'}
-
-    def __init__(self, type=Undefined, filter=Undefined, signal=Undefined, **kwds):
-        super(crossTransform, self).__init__(type=type, filter=filter, signal=signal, **kwds)
-
-
-class densityTransform(VegaSchema):
-    """densityTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('density')
-
-    distribution : oneOf(Mapping(required=[function]), Mapping(required=[function]),
-    Mapping(required=[function]), Mapping(required=[function, field]),
-    Mapping(required=[function]))
-
-    extent : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    maxsteps : anyOf(float, :class:`signal`)
-
-    method : anyOf(string, :class:`signal`)
-
-    minsteps : anyOf(float, :class:`signal`)
-
-    signal : string
-
-    steps : anyOf(float, :class:`signal`)
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/densityTransform'}
-
-    def __init__(self, type=Undefined, distribution=Undefined, extent=Undefined, maxsteps=Undefined,
-                 method=Undefined, minsteps=Undefined, signal=Undefined, steps=Undefined, **kwds):
-        super(densityTransform, self).__init__(type=type, distribution=distribution, extent=extent,
-                                               maxsteps=maxsteps, method=method, minsteps=minsteps,
-                                               signal=signal, steps=steps, **kwds)
-
-
-class dotbinTransform(VegaSchema):
-    """dotbinTransform schema wrapper
-
-    Mapping(required=[type, field])
-
-    Attributes
-    ----------
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    type : enum('dotbin')
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    signal : string
-
-    smooth : anyOf(boolean, :class:`signal`)
-
-    step : anyOf(float, :class:`signal`)
-
-    as : anyOf(string, :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/dotbinTransform'}
-
-    def __init__(self, field=Undefined, type=Undefined, groupby=Undefined, signal=Undefined,
-                 smooth=Undefined, step=Undefined, **kwds):
-        super(dotbinTransform, self).__init__(field=field, type=type, groupby=groupby, signal=signal,
-                                              smooth=smooth, step=step, **kwds)
-
-
-class extentTransform(VegaSchema):
-    """extentTransform schema wrapper
-
-    Mapping(required=[type, field])
-
-    Attributes
-    ----------
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    type : enum('extent')
-
-    signal : string
-
-    """
-    _schema = {'$ref': '#/defs/extentTransform'}
-
-    def __init__(self, field=Undefined, type=Undefined, signal=Undefined, **kwds):
-        super(extentTransform, self).__init__(field=field, type=type, signal=signal, **kwds)
-
-
-class filterTransform(VegaSchema):
-    """filterTransform schema wrapper
-
-    Mapping(required=[type, expr])
-
-    Attributes
-    ----------
-
-    expr : :class:`exprString`
-
-    type : enum('filter')
-
-    signal : string
-
-    """
-    _schema = {'$ref': '#/defs/filterTransform'}
-
-    def __init__(self, expr=Undefined, type=Undefined, signal=Undefined, **kwds):
-        super(filterTransform, self).__init__(expr=expr, type=type, signal=signal, **kwds)
-
-
-class flattenTransform(VegaSchema):
-    """flattenTransform schema wrapper
-
-    Mapping(required=[type, fields])
-
-    Attributes
-    ----------
-
-    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    type : enum('flatten')
-
-    index : anyOf(string, :class:`signal`)
-
-    signal : string
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/flattenTransform'}
-
-    def __init__(self, fields=Undefined, type=Undefined, index=Undefined, signal=Undefined, **kwds):
-        super(flattenTransform, self).__init__(fields=fields, type=type, index=index, signal=signal,
-                                               **kwds)
-
-
-class foldTransform(VegaSchema):
-    """foldTransform schema wrapper
-
-    Mapping(required=[type, fields])
-
-    Attributes
-    ----------
-
-    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    type : enum('fold')
-
-    signal : string
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/foldTransform'}
-
-    def __init__(self, fields=Undefined, type=Undefined, signal=Undefined, **kwds):
-        super(foldTransform, self).__init__(fields=fields, type=type, signal=signal, **kwds)
-
-
-class formulaTransform(VegaSchema):
-    """formulaTransform schema wrapper
-
-    Mapping(required=[type, expr, as])
-
-    Attributes
-    ----------
-
-    expr : :class:`exprString`
-
-    type : enum('formula')
-
-    initonly : anyOf(boolean, :class:`signal`)
-
-    signal : string
-
-    as : anyOf(string, :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/formulaTransform'}
-
-    def __init__(self, expr=Undefined, type=Undefined, initonly=Undefined, signal=Undefined, **kwds):
-        super(formulaTransform, self).__init__(expr=expr, type=type, initonly=initonly, signal=signal,
-                                               **kwds)
-
-
-class imputeTransform(VegaSchema):
-    """imputeTransform schema wrapper
-
-    Mapping(required=[type, field, key])
-
-    Attributes
-    ----------
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    type : enum('impute')
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    keyvals : oneOf(List(Any), :class:`signal`)
-
-    method : anyOf(enum('value', 'mean', 'median', 'max', 'min'), :class:`signal`)
-
-    signal : string
-
-    value : Any
-
-    """
-    _schema = {'$ref': '#/defs/imputeTransform'}
-
-    def __init__(self, field=Undefined, key=Undefined, type=Undefined, groupby=Undefined,
-                 keyvals=Undefined, method=Undefined, signal=Undefined, value=Undefined, **kwds):
-        super(imputeTransform, self).__init__(field=field, key=key, type=type, groupby=groupby,
-                                              keyvals=keyvals, method=method, signal=signal,
-                                              value=value, **kwds)
-
-
-class joinaggregateTransform(VegaSchema):
-    """joinaggregateTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('joinaggregate')
-
-    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`, None)),
-    :class:`signal`)
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    ops : oneOf(List(anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum',
-    'product', 'mean', 'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr',
-    'distinct', 'ci0', 'ci1', 'median', 'q1', 'q3', 'argmin', 'argmax', 'min', 'max'),
-    :class:`signal`)), :class:`signal`)
-
-    signal : string
-
-    as : oneOf(List(anyOf(string, :class:`signal`, None)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/joinaggregateTransform'}
-
-    def __init__(self, type=Undefined, fields=Undefined, groupby=Undefined, key=Undefined,
-                 ops=Undefined, signal=Undefined, **kwds):
-        super(joinaggregateTransform, self).__init__(type=type, fields=fields, groupby=groupby, key=key,
-                                                     ops=ops, signal=signal, **kwds)
-
-
-class kdeTransform(VegaSchema):
-    """kdeTransform schema wrapper
-
-    Mapping(required=[type, field])
-
-    Attributes
-    ----------
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    type : enum('kde')
-
-    bandwidth : anyOf(float, :class:`signal`)
-
-    counts : anyOf(boolean, :class:`signal`)
-
-    cumulative : anyOf(boolean, :class:`signal`)
-
-    extent : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    maxsteps : anyOf(float, :class:`signal`)
-
-    minsteps : anyOf(float, :class:`signal`)
-
-    resolve : anyOf(enum('shared', 'independent'), :class:`signal`)
-
-    signal : string
-
-    steps : anyOf(float, :class:`signal`)
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/kdeTransform'}
-
-    def __init__(self, field=Undefined, type=Undefined, bandwidth=Undefined, counts=Undefined,
-                 cumulative=Undefined, extent=Undefined, groupby=Undefined, maxsteps=Undefined,
-                 minsteps=Undefined, resolve=Undefined, signal=Undefined, steps=Undefined, **kwds):
-        super(kdeTransform, self).__init__(field=field, type=type, bandwidth=bandwidth, counts=counts,
-                                           cumulative=cumulative, extent=extent, groupby=groupby,
-                                           maxsteps=maxsteps, minsteps=minsteps, resolve=resolve,
-                                           signal=signal, steps=steps, **kwds)
-
-
-class lookupTransform(VegaSchema):
-    """lookupTransform schema wrapper
-
-    Mapping(required=[type, from, key, fields])
-
-    Attributes
-    ----------
-
-    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    type : enum('lookup')
-
-    default : Any
-
-    signal : string
-
-    values : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    from : string
-
-    """
-    _schema = {'$ref': '#/defs/lookupTransform'}
-
-    def __init__(self, fields=Undefined, key=Undefined, type=Undefined, default=Undefined,
-                 signal=Undefined, values=Undefined, **kwds):
-        super(lookupTransform, self).__init__(fields=fields, key=key, type=type, default=default,
-                                              signal=signal, values=values, **kwds)
-
-
-class pivotTransform(VegaSchema):
-    """pivotTransform schema wrapper
-
-    Mapping(required=[type, field, value])
-
-    Attributes
-    ----------
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    type : enum('pivot')
-
-    value : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    limit : anyOf(float, :class:`signal`)
-
-    op : anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum', 'product',
-    'mean', 'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr', 'distinct', 'ci0',
-    'ci1', 'median', 'q1', 'q3', 'argmin', 'argmax', 'min', 'max'), :class:`signal`)
-
-    signal : string
-
-    """
-    _schema = {'$ref': '#/defs/pivotTransform'}
-
-    def __init__(self, field=Undefined, type=Undefined, value=Undefined, groupby=Undefined,
-                 key=Undefined, limit=Undefined, op=Undefined, signal=Undefined, **kwds):
-        super(pivotTransform, self).__init__(field=field, type=type, value=value, groupby=groupby,
-                                             key=key, limit=limit, op=op, signal=signal, **kwds)
-
-
-class projectTransform(VegaSchema):
-    """projectTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('project')
-
-    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    signal : string
-
-    as : oneOf(List(anyOf(string, :class:`signal`, None)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/projectTransform'}
-
-    def __init__(self, type=Undefined, fields=Undefined, signal=Undefined, **kwds):
-        super(projectTransform, self).__init__(type=type, fields=fields, signal=signal, **kwds)
-
-
-class quantileTransform(VegaSchema):
-    """quantileTransform schema wrapper
-
-    Mapping(required=[type, field])
-
-    Attributes
-    ----------
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    type : enum('quantile')
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    probs : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    signal : string
-
-    step : anyOf(float, :class:`signal`)
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/quantileTransform'}
-
-    def __init__(self, field=Undefined, type=Undefined, groupby=Undefined, probs=Undefined,
-                 signal=Undefined, step=Undefined, **kwds):
-        super(quantileTransform, self).__init__(field=field, type=type, groupby=groupby, probs=probs,
-                                                signal=signal, step=step, **kwds)
-
-
-class sampleTransform(VegaSchema):
-    """sampleTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('sample')
-
-    signal : string
-
-    size : anyOf(float, :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/sampleTransform'}
-
-    def __init__(self, type=Undefined, signal=Undefined, size=Undefined, **kwds):
-        super(sampleTransform, self).__init__(type=type, signal=signal, size=size, **kwds)
-
-
-class sequenceTransform(VegaSchema):
-    """sequenceTransform schema wrapper
-
-    Mapping(required=[type, start, stop])
-
-    Attributes
-    ----------
-
-    start : anyOf(float, :class:`signal`)
-
-    stop : anyOf(float, :class:`signal`)
-
-    type : enum('sequence')
-
-    signal : string
-
-    step : anyOf(float, :class:`signal`)
-
-    as : anyOf(string, :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/sequenceTransform'}
-
-    def __init__(self, start=Undefined, stop=Undefined, type=Undefined, signal=Undefined,
-                 step=Undefined, **kwds):
-        super(sequenceTransform, self).__init__(start=start, stop=stop, type=type, signal=signal,
-                                                step=step, **kwds)
-
-
-class timeunitTransform(VegaSchema):
-    """timeunitTransform schema wrapper
-
-    Mapping(required=[type, field])
-
-    Attributes
-    ----------
-
-    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    type : enum('timeunit')
-
-    extent : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    interval : anyOf(boolean, :class:`signal`)
-
-    maxbins : anyOf(float, :class:`signal`)
-
-    signal : string
-
-    step : anyOf(float, :class:`signal`)
-
-    timezone : anyOf(enum('local', 'utc'), :class:`signal`)
-
-    units : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/timeunitTransform'}
-
-    def __init__(self, field=Undefined, type=Undefined, extent=Undefined, interval=Undefined,
-                 maxbins=Undefined, signal=Undefined, step=Undefined, timezone=Undefined,
-                 units=Undefined, **kwds):
-        super(timeunitTransform, self).__init__(field=field, type=type, extent=extent,
-                                                interval=interval, maxbins=maxbins, signal=signal,
-                                                step=step, timezone=timezone, units=units, **kwds)
-
-
-class windowTransform(VegaSchema):
-    """windowTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('window')
-
-    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`, None)),
-    :class:`signal`)
-
-    frame : oneOf(List(anyOf(float, :class:`signal`, None)), :class:`signal`)
-
-    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
-    :class:`signal`)
-
-    ignorePeers : anyOf(boolean, :class:`signal`)
-
-    ops : oneOf(List(anyOf(enum('row_number', 'rank', 'dense_rank', 'percent_rank', 'cume_dist',
-    'ntile', 'lag', 'lead', 'first_value', 'last_value', 'nth_value', 'prev_value',
-    'next_value', 'values', 'count', '__count__', 'missing', 'valid', 'sum', 'product', 'mean',
-    'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr', 'distinct', 'ci0', 'ci1',
-    'median', 'q1', 'q3', 'argmin', 'argmax', 'min', 'max'), :class:`signal`)), :class:`signal`)
-
-    params : oneOf(List(anyOf(float, :class:`signal`, None)), :class:`signal`)
-
-    signal : string
-
-    sort : :class:`compare`
-
-    as : oneOf(List(anyOf(string, :class:`signal`, None)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/windowTransform'}
-
-    def __init__(self, type=Undefined, fields=Undefined, frame=Undefined, groupby=Undefined,
-                 ignorePeers=Undefined, ops=Undefined, params=Undefined, signal=Undefined,
-                 sort=Undefined, **kwds):
-        super(windowTransform, self).__init__(type=type, fields=fields, frame=frame, groupby=groupby,
-                                              ignorePeers=ignorePeers, ops=ops, params=params,
-                                              signal=signal, sort=sort, **kwds)
-
-
-class identifierTransform(VegaSchema):
-    """identifierTransform schema wrapper
-
-    Mapping(required=[type, as])
-
-    Attributes
-    ----------
-
-    type : enum('identifier')
-
-    signal : string
-
-    as : anyOf(string, :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/identifierTransform'}
-
-    def __init__(self, type=Undefined, signal=Undefined, **kwds):
-        super(identifierTransform, self).__init__(type=type, signal=signal, **kwds)
-
-
-class voronoiTransform(VegaSchema):
-    """voronoiTransform schema wrapper
-
-    Mapping(required=[type, x, y])
-
-    Attributes
-    ----------
-
-    type : enum('voronoi')
-
-    x : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    y : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    extent : oneOf(List(Any), :class:`signal`)
-
-    signal : string
-
-    size : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    as : anyOf(string, :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/voronoiTransform'}
-
-    def __init__(self, type=Undefined, x=Undefined, y=Undefined, extent=Undefined, signal=Undefined,
-                 size=Undefined, **kwds):
-        super(voronoiTransform, self).__init__(type=type, x=x, y=y, extent=extent, signal=signal,
-                                               size=size, **kwds)
-
-
-class wordcloudTransform(VegaSchema):
-    """wordcloudTransform schema wrapper
-
-    Mapping(required=[type])
-
-    Attributes
-    ----------
-
-    type : enum('wordcloud')
-
-    font : anyOf(string, :class:`signal`, :class:`expr`, :class:`paramField`)
-
-    fontSize : anyOf(float, :class:`signal`, :class:`expr`, :class:`paramField`)
-
-    fontSizeRange : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`, None)
-
-    fontStyle : anyOf(string, :class:`signal`, :class:`expr`, :class:`paramField`)
-
-    fontWeight : anyOf(string, :class:`signal`, :class:`expr`, :class:`paramField`)
-
-    padding : anyOf(float, :class:`signal`, :class:`expr`, :class:`paramField`)
-
-    rotate : anyOf(float, :class:`signal`, :class:`expr`, :class:`paramField`)
-
-    signal : string
-
-    size : oneOf(List(anyOf(float, :class:`signal`)), :class:`signal`)
-
-    spiral : anyOf(string, :class:`signal`)
-
-    text : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
-
-    as : oneOf(List(anyOf(string, :class:`signal`)), :class:`signal`)
-
-    """
-    _schema = {'$ref': '#/defs/wordcloudTransform'}
-
-    def __init__(self, type=Undefined, font=Undefined, fontSize=Undefined, fontSizeRange=Undefined,
-                 fontStyle=Undefined, fontWeight=Undefined, padding=Undefined, rotate=Undefined,
-                 signal=Undefined, size=Undefined, spiral=Undefined, text=Undefined, **kwds):
-        super(wordcloudTransform, self).__init__(type=type, font=font, fontSize=fontSize,
-                                                 fontSizeRange=fontSizeRange, fontStyle=fontStyle,
-                                                 fontWeight=fontWeight, padding=padding, rotate=rotate,
-                                                 signal=signal, size=size, spiral=spiral, text=text,
-                                                 **kwds)
-
-
-class labelOverlap(VegaSchema):
-    """labelOverlap schema wrapper
-
-    oneOf(boolean, enum('parity', 'greedy'), :class:`signal`)
-    """
-    _schema = {'$ref': '#/refs/labelOverlap'}
-
-    def __init__(self, *args, **kwds):
-        super(labelOverlap, self).__init__(*args, **kwds)
-
-
-class tickBand(VegaSchema):
-    """tickBand schema wrapper
-
-    oneOf(enum('center', 'extent'), :class:`signal`)
-    """
-    _schema = {'$ref': '#/refs/tickBand'}
-
-    def __init__(self, *args, **kwds):
-        super(tickBand, self).__init__(*args, **kwds)
-
-
-class tickCount(VegaSchema):
-    """tickCount schema wrapper
-
-    oneOf(float, enum('millisecond', 'second', 'minute', 'hour', 'day', 'week', 'month',
-    'year'), Mapping(required=[interval]), :class:`signal`)
-    """
-    _schema = {'$ref': '#/refs/tickCount'}
-
-    def __init__(self, *args, **kwds):
-        super(tickCount, self).__init__(*args, **kwds)
-
-
-class element(VegaSchema):
-    """element schema wrapper
-
-    string
-    """
-    _schema = {'$ref': '#/refs/element'}
-
-    def __init__(self, *args):
-        super(element, self).__init__(*args)
-
-
-class paramField(VegaSchema):
-    """paramField schema wrapper
-
-    Mapping(required=[field])
-
-    Attributes
-    ----------
-
-    field : string
-
-    as : string
-
-    """
-    _schema = {'$ref': '#/refs/paramField'}
-
-    def __init__(self, field=Undefined, **kwds):
-        super(paramField, self).__init__(field=field, **kwds)
-
-
 class field(VegaSchema):
     """field schema wrapper
 
-    oneOf(string, :class:`signal`, Mapping(required=[datum]), Mapping(required=[group]),
+    oneOf(string, :class:`signalRef`, Mapping(required=[datum]), Mapping(required=[group]),
     Mapping(required=[parent]))
     """
-    _schema = {'$ref': '#/refs/field'}
+    _schema = {'$ref': '#/definitions/field'}
 
     def __init__(self, *args, **kwds):
         super(field, self).__init__(*args, **kwds)
-
-
-class scale(VegaSchema):
-    """scale schema wrapper
-
-    oneOf(string, :class:`signal`, Mapping(required=[datum]), Mapping(required=[group]),
-    Mapping(required=[parent]))
-    """
-    _schema = {'$ref': '#/refs/scale'}
-
-    def __init__(self, *args, **kwds):
-        super(scale, self).__init__(*args, **kwds)
 
 
 class stringModifiers(VegaSchema):
@@ -2683,10 +622,10 @@ class stringModifiers(VegaSchema):
     Attributes
     ----------
 
-    scale : :class:`scale`
+    scale : :class:`field`
 
     """
-    _schema = {'$ref': '#/refs/stringModifiers'}
+    _schema = {'$ref': '#/definitions/stringModifiers'}
 
     def __init__(self, scale=Undefined, **kwds):
         super(stringModifiers, self).__init__(scale=scale, **kwds)
@@ -2712,10 +651,10 @@ class numberModifiers(VegaSchema):
 
     round : boolean
 
-    scale : :class:`scale`
+    scale : :class:`field`
 
     """
-    _schema = {'$ref': '#/refs/numberModifiers'}
+    _schema = {'$ref': '#/definitions/numberModifiers'}
 
     def __init__(self, band=Undefined, exponent=Undefined, extra=Undefined, mult=Undefined,
                  offset=Undefined, round=Undefined, scale=Undefined, **kwds):
@@ -2726,15 +665,15 @@ class numberModifiers(VegaSchema):
 class anyValue(VegaSchema):
     """anyValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/anyValue'}
+    _schema = {'$ref': '#/definitions/anyValue'}
 
     def __init__(self, *args, **kwds):
         super(anyValue, self).__init__(*args, **kwds)
@@ -2743,15 +682,15 @@ class anyValue(VegaSchema):
 class blendValue(VegaSchema):
     """blendValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/blendValue'}
+    _schema = {'$ref': '#/definitions/blendValue'}
 
     def __init__(self, *args, **kwds):
         super(blendValue, self).__init__(*args, **kwds)
@@ -2760,15 +699,15 @@ class blendValue(VegaSchema):
 class numberValue(VegaSchema):
     """numberValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`numberModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`numberModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`numberModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`numberModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/numberValue'}
+    _schema = {'$ref': '#/definitions/numberValue'}
 
     def __init__(self, *args, **kwds):
         super(numberValue, self).__init__(*args, **kwds)
@@ -2777,15 +716,15 @@ class numberValue(VegaSchema):
 class stringValue(VegaSchema):
     """stringValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/stringValue'}
+    _schema = {'$ref': '#/definitions/stringValue'}
 
     def __init__(self, *args, **kwds):
         super(stringValue, self).__init__(*args, **kwds)
@@ -2794,15 +733,15 @@ class stringValue(VegaSchema):
 class textValue(VegaSchema):
     """textValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/textValue'}
+    _schema = {'$ref': '#/definitions/textValue'}
 
     def __init__(self, *args, **kwds):
         super(textValue, self).__init__(*args, **kwds)
@@ -2811,15 +750,15 @@ class textValue(VegaSchema):
 class booleanValue(VegaSchema):
     """booleanValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/booleanValue'}
+    _schema = {'$ref': '#/definitions/booleanValue'}
 
     def __init__(self, *args, **kwds):
         super(booleanValue, self).__init__(*args, **kwds)
@@ -2828,15 +767,15 @@ class booleanValue(VegaSchema):
 class arrayValue(VegaSchema):
     """arrayValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/arrayValue'}
+    _schema = {'$ref': '#/definitions/arrayValue'}
 
     def __init__(self, *args, **kwds):
         super(arrayValue, self).__init__(*args, **kwds)
@@ -2845,15 +784,15 @@ class arrayValue(VegaSchema):
 class fontWeightValue(VegaSchema):
     """fontWeightValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/fontWeightValue'}
+    _schema = {'$ref': '#/definitions/fontWeightValue'}
 
     def __init__(self, *args, **kwds):
         super(fontWeightValue, self).__init__(*args, **kwds)
@@ -2862,15 +801,15 @@ class fontWeightValue(VegaSchema):
 class anchorValue(VegaSchema):
     """anchorValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/anchorValue'}
+    _schema = {'$ref': '#/definitions/anchorValue'}
 
     def __init__(self, *args, **kwds):
         super(anchorValue, self).__init__(*args, **kwds)
@@ -2879,15 +818,15 @@ class anchorValue(VegaSchema):
 class alignValue(VegaSchema):
     """alignValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/alignValue'}
+    _schema = {'$ref': '#/definitions/alignValue'}
 
     def __init__(self, *args, **kwds):
         super(alignValue, self).__init__(*args, **kwds)
@@ -2896,15 +835,15 @@ class alignValue(VegaSchema):
 class baselineValue(VegaSchema):
     """baselineValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/baselineValue'}
+    _schema = {'$ref': '#/definitions/baselineValue'}
 
     def __init__(self, *args, **kwds):
         super(baselineValue, self).__init__(*args, **kwds)
@@ -2913,15 +852,15 @@ class baselineValue(VegaSchema):
 class directionValue(VegaSchema):
     """directionValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/directionValue'}
+    _schema = {'$ref': '#/definitions/directionValue'}
 
     def __init__(self, *args, **kwds):
         super(directionValue, self).__init__(*args, **kwds)
@@ -2930,15 +869,15 @@ class directionValue(VegaSchema):
 class orientValue(VegaSchema):
     """orientValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/orientValue'}
+    _schema = {'$ref': '#/definitions/orientValue'}
 
     def __init__(self, *args, **kwds):
         super(orientValue, self).__init__(*args, **kwds)
@@ -2947,15 +886,15 @@ class orientValue(VegaSchema):
 class strokeCapValue(VegaSchema):
     """strokeCapValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/strokeCapValue'}
+    _schema = {'$ref': '#/definitions/strokeCapValue'}
 
     def __init__(self, *args, **kwds):
         super(strokeCapValue, self).__init__(*args, **kwds)
@@ -2964,15 +903,15 @@ class strokeCapValue(VegaSchema):
 class strokeJoinValue(VegaSchema):
     """strokeJoinValue schema wrapper
 
-    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))), allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
-    Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
-    Mapping(required=[scale, value]), Mapping(required=[scale, band]),
-    Mapping(required=[offset]))))
+    oneOf(List(allOf(:class:`rule`, allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))), allOf(:class:`stringModifiers`,
+    anyOf(oneOf(:class:`signalRef`, Mapping(required=[value]), Mapping(required=[field]),
+    Mapping(required=[range])), Mapping(required=[scale, value]), Mapping(required=[scale,
+    band]), Mapping(required=[offset]))))
     """
-    _schema = {'$ref': '#/refs/strokeJoinValue'}
+    _schema = {'$ref': '#/definitions/strokeJoinValue'}
 
     def __init__(self, *args, **kwds):
         super(strokeJoinValue, self).__init__(*args, **kwds)
@@ -2981,13 +920,13 @@ class strokeJoinValue(VegaSchema):
 class baseColorValue(VegaSchema):
     """baseColorValue schema wrapper
 
-    oneOf(allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signal`,
+    oneOf(allOf(:class:`stringModifiers`, anyOf(oneOf(:class:`signalRef`,
     Mapping(required=[value]), Mapping(required=[field]), Mapping(required=[range])),
     Mapping(required=[scale, value]), Mapping(required=[scale, band]),
     Mapping(required=[offset]))), Mapping(required=[value]), Mapping(required=[value]),
     Mapping(required=[gradient]), Mapping(required=[color]))
     """
-    _schema = {'$ref': '#/refs/baseColorValue'}
+    _schema = {'$ref': '#/definitions/baseColorValue'}
 
     def __init__(self, *args, **kwds):
         super(baseColorValue, self).__init__(*args, **kwds)
@@ -3008,7 +947,7 @@ class colorRGB(VegaSchema):
     r : :class:`numberValue`
 
     """
-    _schema = {'$ref': '#/refs/colorRGB'}
+    _schema = {'$ref': '#/definitions/colorRGB'}
 
     def __init__(self, b=Undefined, g=Undefined, r=Undefined, **kwds):
         super(colorRGB, self).__init__(b=b, g=g, r=r, **kwds)
@@ -3029,7 +968,7 @@ class colorHSL(VegaSchema):
     s : :class:`numberValue`
 
     """
-    _schema = {'$ref': '#/refs/colorHSL'}
+    _schema = {'$ref': '#/definitions/colorHSL'}
 
     def __init__(self, h=Undefined, l=Undefined, s=Undefined, **kwds):
         super(colorHSL, self).__init__(h=h, l=l, s=s, **kwds)
@@ -3050,7 +989,7 @@ class colorLAB(VegaSchema):
     l : :class:`numberValue`
 
     """
-    _schema = {'$ref': '#/refs/colorLAB'}
+    _schema = {'$ref': '#/definitions/colorLAB'}
 
     def __init__(self, a=Undefined, b=Undefined, l=Undefined, **kwds):
         super(colorLAB, self).__init__(a=a, b=b, l=l, **kwds)
@@ -3071,7 +1010,7 @@ class colorHCL(VegaSchema):
     l : :class:`numberValue`
 
     """
-    _schema = {'$ref': '#/refs/colorHCL'}
+    _schema = {'$ref': '#/definitions/colorHCL'}
 
     def __init__(self, c=Undefined, h=Undefined, l=Undefined, **kwds):
         super(colorHCL, self).__init__(c=c, h=h, l=l, **kwds)
@@ -3082,7 +1021,7 @@ class colorValue(VegaSchema):
 
     oneOf(List(allOf(:class:`rule`, :class:`baseColorValue`)), :class:`baseColorValue`)
     """
-    _schema = {'$ref': '#/refs/colorValue'}
+    _schema = {'$ref': '#/definitions/colorValue'}
 
     def __init__(self, *args, **kwds):
         super(colorValue, self).__init__(*args, **kwds)
@@ -3093,7 +1032,7 @@ class gradientStops(VegaSchema):
 
     List(Mapping(required=[offset, color]))
     """
-    _schema = {'$ref': '#/refs/gradientStops'}
+    _schema = {'$ref': '#/definitions/gradientStops'}
 
     def __init__(self, *args):
         super(gradientStops, self).__init__(*args)
@@ -3122,7 +1061,7 @@ class linearGradient(VegaSchema):
     y2 : float
 
     """
-    _schema = {'$ref': '#/refs/linearGradient'}
+    _schema = {'$ref': '#/definitions/linearGradient'}
 
     def __init__(self, gradient=Undefined, stops=Undefined, id=Undefined, x1=Undefined, x2=Undefined,
                  y1=Undefined, y2=Undefined, **kwds):
@@ -3157,7 +1096,7 @@ class radialGradient(VegaSchema):
     y2 : float
 
     """
-    _schema = {'$ref': '#/refs/radialGradient'}
+    _schema = {'$ref': '#/definitions/radialGradient'}
 
     def __init__(self, gradient=Undefined, stops=Undefined, id=Undefined, r1=Undefined, r2=Undefined,
                  x1=Undefined, x2=Undefined, y1=Undefined, y2=Undefined, **kwds):
@@ -3178,7 +1117,7 @@ class expr(VegaSchema):
     as : string
 
     """
-    _schema = {'$ref': '#/refs/expr'}
+    _schema = {'$ref': '#/definitions/expr'}
 
     def __init__(self, expr=Undefined, **kwds):
         super(expr, self).__init__(expr=expr, **kwds)
@@ -3189,10 +1128,108 @@ class exprString(VegaSchema):
 
     string
     """
-    _schema = {'$ref': '#/refs/exprString'}
+    _schema = {'$ref': '#/definitions/exprString'}
 
     def __init__(self, *args):
         super(exprString, self).__init__(*args)
+
+
+class layout(VegaSchema):
+    """layout schema wrapper
+
+    oneOf(Mapping(required=[]), :class:`signalRef`)
+    """
+    _schema = {'$ref': '#/definitions/layout'}
+
+    def __init__(self, *args, **kwds):
+        super(layout, self).__init__(*args, **kwds)
+
+
+class guideEncode(VegaSchema):
+    """guideEncode schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    interactive : boolean
+
+    name : string
+
+    style : :class:`style`
+
+    """
+    _schema = {'$ref': '#/definitions/guideEncode'}
+
+    def __init__(self, interactive=Undefined, name=Undefined, style=Undefined, **kwds):
+        super(guideEncode, self).__init__(interactive=interactive, name=name, style=style, **kwds)
+
+
+class legend(VegaSchema):
+    """legend schema wrapper
+
+    allOf(Mapping(required=[]), anyOf(Mapping(required=[size]), Mapping(required=[shape]),
+    Mapping(required=[fill]), Mapping(required=[stroke]), Mapping(required=[opacity]),
+    Mapping(required=[strokeDash]), Mapping(required=[strokeWidth])))
+    """
+    _schema = {'$ref': '#/definitions/legend'}
+
+    def __init__(self, aria=Undefined, clipHeight=Undefined, columnPadding=Undefined, columns=Undefined,
+                 cornerRadius=Undefined, description=Undefined, direction=Undefined, encode=Undefined,
+                 fill=Undefined, fillColor=Undefined, format=Undefined, formatType=Undefined,
+                 gradientLength=Undefined, gradientOpacity=Undefined, gradientStrokeColor=Undefined,
+                 gradientStrokeWidth=Undefined, gradientThickness=Undefined, gridAlign=Undefined,
+                 labelAlign=Undefined, labelBaseline=Undefined, labelColor=Undefined,
+                 labelFont=Undefined, labelFontSize=Undefined, labelFontStyle=Undefined,
+                 labelFontWeight=Undefined, labelLimit=Undefined, labelOffset=Undefined,
+                 labelOpacity=Undefined, labelOverlap=Undefined, labelSeparation=Undefined,
+                 legendX=Undefined, legendY=Undefined, offset=Undefined, opacity=Undefined,
+                 orient=Undefined, padding=Undefined, rowPadding=Undefined, shape=Undefined,
+                 size=Undefined, stroke=Undefined, strokeColor=Undefined, strokeDash=Undefined,
+                 strokeWidth=Undefined, symbolDash=Undefined, symbolDashOffset=Undefined,
+                 symbolFillColor=Undefined, symbolLimit=Undefined, symbolOffset=Undefined,
+                 symbolOpacity=Undefined, symbolSize=Undefined, symbolStrokeColor=Undefined,
+                 symbolStrokeWidth=Undefined, symbolType=Undefined, tickCount=Undefined,
+                 tickMinStep=Undefined, title=Undefined, titleAlign=Undefined, titleAnchor=Undefined,
+                 titleBaseline=Undefined, titleColor=Undefined, titleFont=Undefined,
+                 titleFontSize=Undefined, titleFontStyle=Undefined, titleFontWeight=Undefined,
+                 titleLimit=Undefined, titleLineHeight=Undefined, titleOpacity=Undefined,
+                 titleOrient=Undefined, titlePadding=Undefined, type=Undefined, values=Undefined,
+                 zindex=Undefined, **kwds):
+        super(legend, self).__init__(aria=aria, clipHeight=clipHeight, columnPadding=columnPadding,
+                                     columns=columns, cornerRadius=cornerRadius,
+                                     description=description, direction=direction, encode=encode,
+                                     fill=fill, fillColor=fillColor, format=format,
+                                     formatType=formatType, gradientLength=gradientLength,
+                                     gradientOpacity=gradientOpacity,
+                                     gradientStrokeColor=gradientStrokeColor,
+                                     gradientStrokeWidth=gradientStrokeWidth,
+                                     gradientThickness=gradientThickness, gridAlign=gridAlign,
+                                     labelAlign=labelAlign, labelBaseline=labelBaseline,
+                                     labelColor=labelColor, labelFont=labelFont,
+                                     labelFontSize=labelFontSize, labelFontStyle=labelFontStyle,
+                                     labelFontWeight=labelFontWeight, labelLimit=labelLimit,
+                                     labelOffset=labelOffset, labelOpacity=labelOpacity,
+                                     labelOverlap=labelOverlap, labelSeparation=labelSeparation,
+                                     legendX=legendX, legendY=legendY, offset=offset, opacity=opacity,
+                                     orient=orient, padding=padding, rowPadding=rowPadding, shape=shape,
+                                     size=size, stroke=stroke, strokeColor=strokeColor,
+                                     strokeDash=strokeDash, strokeWidth=strokeWidth,
+                                     symbolDash=symbolDash, symbolDashOffset=symbolDashOffset,
+                                     symbolFillColor=symbolFillColor, symbolLimit=symbolLimit,
+                                     symbolOffset=symbolOffset, symbolOpacity=symbolOpacity,
+                                     symbolSize=symbolSize, symbolStrokeColor=symbolStrokeColor,
+                                     symbolStrokeWidth=symbolStrokeWidth, symbolType=symbolType,
+                                     tickCount=tickCount, tickMinStep=tickMinStep, title=title,
+                                     titleAlign=titleAlign, titleAnchor=titleAnchor,
+                                     titleBaseline=titleBaseline, titleColor=titleColor,
+                                     titleFont=titleFont, titleFontSize=titleFontSize,
+                                     titleFontStyle=titleFontStyle, titleFontWeight=titleFontWeight,
+                                     titleLimit=titleLimit, titleLineHeight=titleLineHeight,
+                                     titleOpacity=titleOpacity, titleOrient=titleOrient,
+                                     titlePadding=titlePadding, type=type, values=values, zindex=zindex,
+                                     **kwds)
 
 
 class compare(VegaSchema):
@@ -3200,7 +1237,7 @@ class compare(VegaSchema):
 
     oneOf(Mapping(required=[]), Mapping(required=[]))
     """
-    _schema = {'$ref': '#/refs/compare'}
+    _schema = {'$ref': '#/definitions/compare'}
 
     def __init__(self, *args, **kwds):
         super(compare, self).__init__(*args, **kwds)
@@ -3217,7 +1254,7 @@ class from_(VegaSchema):
     data : string
 
     """
-    _schema = {'$ref': '#/refs/from'}
+    _schema = {'$ref': '#/definitions/from'}
 
     def __init__(self, data=Undefined, **kwds):
         super(from_, self).__init__(data=data, **kwds)
@@ -3237,10 +1274,55 @@ class facet(VegaSchema):
     data : string
 
     """
-    _schema = {'$ref': '#/refs/facet'}
+    _schema = {'$ref': '#/definitions/facet'}
 
     def __init__(self, facet=Undefined, data=Undefined, **kwds):
         super(facet, self).__init__(facet=facet, data=data, **kwds)
+
+
+class mark(VegaSchema):
+    """mark schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : :class:`marktype`
+
+    aria : boolean
+
+    clip : :class:`markclip`
+
+    description : string
+
+    encode : :class:`encode`
+
+    interactive : :class:`booleanOrSignal`
+
+    key : string
+
+    name : string
+
+    on : :class:`onMarkTrigger`
+
+    role : string
+
+    sort : :class:`compare`
+
+    style : :class:`style`
+
+    transform : List(:class:`transformMark`)
+
+    """
+    _schema = {'$ref': '#/definitions/mark'}
+
+    def __init__(self, type=Undefined, aria=Undefined, clip=Undefined, description=Undefined,
+                 encode=Undefined, interactive=Undefined, key=Undefined, name=Undefined, on=Undefined,
+                 role=Undefined, sort=Undefined, style=Undefined, transform=Undefined, **kwds):
+        super(mark, self).__init__(type=type, aria=aria, clip=clip, description=description,
+                                   encode=encode, interactive=interactive, key=key, name=name, on=on,
+                                   role=role, sort=sort, style=style, transform=transform, **kwds)
 
 
 class markclip(VegaSchema):
@@ -3248,10 +1330,47 @@ class markclip(VegaSchema):
 
     oneOf(:class:`booleanOrSignal`, Mapping(required=[path]), Mapping(required=[sphere]))
     """
-    _schema = {'$ref': '#/refs/markclip'}
+    _schema = {'$ref': '#/definitions/markclip'}
 
     def __init__(self, *args, **kwds):
         super(markclip, self).__init__(*args, **kwds)
+
+
+class markGroup(VegaSchema):
+    """markGroup schema wrapper
+
+    allOf(Mapping(required=[type]), :class:`mark`, :class:`scope`)
+    """
+    _schema = {'$ref': '#/definitions/markGroup'}
+
+    def __init__(self, type=Undefined, aria=Undefined, axes=Undefined, clip=Undefined, data=Undefined,
+                 description=Undefined, encode=Undefined, interactive=Undefined, key=Undefined,
+                 layout=Undefined, legends=Undefined, marks=Undefined, name=Undefined, on=Undefined,
+                 projections=Undefined, role=Undefined, scales=Undefined, signals=Undefined,
+                 sort=Undefined, style=Undefined, title=Undefined, transform=Undefined,
+                 usermeta=Undefined, **kwds):
+        super(markGroup, self).__init__(type=type, aria=aria, axes=axes, clip=clip, data=data,
+                                        description=description, encode=encode, interactive=interactive,
+                                        key=key, layout=layout, legends=legends, marks=marks, name=name,
+                                        on=on, projections=projections, role=role, scales=scales,
+                                        signals=signals, sort=sort, style=style, title=title,
+                                        transform=transform, usermeta=usermeta, **kwds)
+
+
+class markVisual(VegaSchema):
+    """markVisual schema wrapper
+
+    allOf(Mapping(required=[]), :class:`mark`)
+    """
+    _schema = {'$ref': '#/definitions/markVisual'}
+
+    def __init__(self, type=Undefined, aria=Undefined, clip=Undefined, description=Undefined,
+                 encode=Undefined, interactive=Undefined, key=Undefined, name=Undefined, on=Undefined,
+                 role=Undefined, sort=Undefined, style=Undefined, transform=Undefined, **kwds):
+        super(markVisual, self).__init__(type=type, aria=aria, clip=clip, description=description,
+                                         encode=encode, interactive=interactive, key=key, name=name,
+                                         on=on, role=role, sort=sort, style=style, transform=transform,
+                                         **kwds)
 
 
 class style(VegaSchema):
@@ -3259,7 +1378,7 @@ class style(VegaSchema):
 
     oneOf(string, List(string))
     """
-    _schema = {'$ref': '#/refs/style'}
+    _schema = {'$ref': '#/definitions/style'}
 
     def __init__(self, *args, **kwds):
         super(style, self).__init__(*args, **kwds)
@@ -3270,18 +1389,141 @@ class marktype(VegaSchema):
 
     string
     """
-    _schema = {'$ref': '#/refs/marktype'}
+    _schema = {'$ref': '#/definitions/marktype'}
 
     def __init__(self, *args):
         super(marktype, self).__init__(*args)
 
 
+class listener(VegaSchema):
+    """listener schema wrapper
+
+    oneOf(:class:`signalRef`, Mapping(required=[scale]), :class:`stream`)
+    """
+    _schema = {'$ref': '#/definitions/listener'}
+
+    def __init__(self, *args, **kwds):
+        super(listener, self).__init__(*args, **kwds)
+
+
+class onEvents(VegaSchema):
+    """onEvents schema wrapper
+
+    List(allOf(Mapping(required=[events]), oneOf(Mapping(required=[encode]),
+    Mapping(required=[update]))))
+    """
+    _schema = {'$ref': '#/definitions/onEvents'}
+
+    def __init__(self, *args):
+        super(onEvents, self).__init__(*args)
+
+
+class onTrigger(VegaSchema):
+    """onTrigger schema wrapper
+
+    List(Mapping(required=[trigger]))
+    """
+    _schema = {'$ref': '#/definitions/onTrigger'}
+
+    def __init__(self, *args):
+        super(onTrigger, self).__init__(*args)
+
+
+class onMarkTrigger(VegaSchema):
+    """onMarkTrigger schema wrapper
+
+    List(Mapping(required=[trigger]))
+    """
+    _schema = {'$ref': '#/definitions/onMarkTrigger'}
+
+    def __init__(self, *args):
+        super(onMarkTrigger, self).__init__(*args)
+
+
+class padding(VegaSchema):
+    """padding schema wrapper
+
+    oneOf(float, Mapping(required=[]), :class:`signalRef`)
+    """
+    _schema = {'$ref': '#/definitions/padding'}
+
+    def __init__(self, *args, **kwds):
+        super(padding, self).__init__(*args, **kwds)
+
+
+class projection(VegaSchema):
+    """projection schema wrapper
+
+    Mapping(required=[name])
+
+    Attributes
+    ----------
+
+    name : string
+
+    center : oneOf(List(:class:`numberOrSignal`), :class:`signalRef`)
+
+    clipAngle : :class:`numberOrSignal`
+
+    clipExtent : oneOf(List(oneOf(List(:class:`numberOrSignal`), :class:`signalRef`)),
+    :class:`signalRef`)
+
+    extent : oneOf(List(oneOf(List(:class:`numberOrSignal`), :class:`signalRef`)),
+    :class:`signalRef`)
+
+    fit : oneOf(Mapping(required=[]), List(Any))
+
+    parallels : oneOf(List(:class:`numberOrSignal`), :class:`signalRef`)
+
+    pointRadius : :class:`numberOrSignal`
+
+    precision : :class:`numberOrSignal`
+
+    rotate : oneOf(List(:class:`numberOrSignal`), :class:`signalRef`)
+
+    scale : :class:`numberOrSignal`
+
+    size : oneOf(List(:class:`numberOrSignal`), :class:`signalRef`)
+
+    translate : oneOf(List(:class:`numberOrSignal`), :class:`signalRef`)
+
+    type : :class:`stringOrSignal`
+
+    """
+    _schema = {'$ref': '#/definitions/projection'}
+
+    def __init__(self, name=Undefined, center=Undefined, clipAngle=Undefined, clipExtent=Undefined,
+                 extent=Undefined, fit=Undefined, parallels=Undefined, pointRadius=Undefined,
+                 precision=Undefined, rotate=Undefined, scale=Undefined, size=Undefined,
+                 translate=Undefined, type=Undefined, **kwds):
+        super(projection, self).__init__(name=name, center=center, clipAngle=clipAngle,
+                                         clipExtent=clipExtent, extent=extent, fit=fit,
+                                         parallels=parallels, pointRadius=pointRadius,
+                                         precision=precision, rotate=rotate, scale=scale, size=size,
+                                         translate=translate, type=type, **kwds)
+
+
+class scale(VegaSchema):
+    """scale schema wrapper
+
+    oneOf(Mapping(required=[type, name]), Mapping(required=[type, name]),
+    Mapping(required=[type, name]), Mapping(required=[type, name]), Mapping(required=[type,
+    name]), Mapping(required=[type, name]), Mapping(required=[type, name]),
+    Mapping(required=[type, name]), Mapping(required=[name]), Mapping(required=[type, name]),
+    Mapping(required=[type, name]), Mapping(required=[type, name]))
+    """
+    _schema = {'$ref': '#/definitions/scale'}
+
+    def __init__(self, *args, **kwds):
+        super(scale, self).__init__(*args, **kwds)
+
+
 class scaleField(VegaSchema):
     """scaleField schema wrapper
 
-    oneOf(string, :class:`signal`)
+    oneOf(string, :class:`signalRef`)
     """
-    _schema = {'$ref': '#/refs/scaleField'}
+    _schema = {'$ref': '#/definitions/scaleField'}
 
     def __init__(self, *args, **kwds):
         super(scaleField, self).__init__(*args, **kwds)
@@ -3290,9 +1532,9 @@ class scaleField(VegaSchema):
 class sortOrder(VegaSchema):
     """sortOrder schema wrapper
 
-    oneOf(enum('ascending', 'descending'), :class:`signal`)
+    oneOf(enum('ascending', 'descending'), :class:`signalRef`)
     """
-    _schema = {'$ref': '#/refs/sortOrder'}
+    _schema = {'$ref': '#/definitions/sortOrder'}
 
     def __init__(self, *args, **kwds):
         super(sortOrder, self).__init__(*args, **kwds)
@@ -3301,9 +1543,9 @@ class sortOrder(VegaSchema):
 class scaleBins(VegaSchema):
     """scaleBins schema wrapper
 
-    oneOf(List(:class:`numberOrSignal`), Mapping(required=[step]), :class:`signal`)
+    oneOf(List(:class:`numberOrSignal`), Mapping(required=[step]), :class:`signalRef`)
     """
-    _schema = {'$ref': '#/refs/scaleBins'}
+    _schema = {'$ref': '#/definitions/scaleBins'}
 
     def __init__(self, *args, **kwds):
         super(scaleBins, self).__init__(*args, **kwds)
@@ -3312,9 +1554,9 @@ class scaleBins(VegaSchema):
 class scaleInterpolate(VegaSchema):
     """scaleInterpolate schema wrapper
 
-    oneOf(string, :class:`signal`, Mapping(required=[type]))
+    oneOf(string, :class:`signalRef`, Mapping(required=[type]))
     """
-    _schema = {'$ref': '#/refs/scaleInterpolate'}
+    _schema = {'$ref': '#/definitions/scaleInterpolate'}
 
     def __init__(self, *args, **kwds):
         super(scaleInterpolate, self).__init__(*args, **kwds)
@@ -3326,10 +1568,51 @@ class scaleData(VegaSchema):
     oneOf(Mapping(required=[data, field]), Mapping(required=[data, fields]),
     Mapping(required=[fields]))
     """
-    _schema = {'$ref': '#/refs/scaleData'}
+    _schema = {'$ref': '#/definitions/scaleData'}
 
     def __init__(self, *args, **kwds):
         super(scaleData, self).__init__(*args, **kwds)
+
+
+class scope(VegaSchema):
+    """scope schema wrapper
+
+    Mapping(required=[])
+
+    Attributes
+    ----------
+
+    axes : List(:class:`axis`)
+
+    data : List(:class:`data`)
+
+    encode : :class:`encode`
+
+    layout : :class:`layout`
+
+    legends : List(:class:`legend`)
+
+    marks : List(oneOf(:class:`markGroup`, :class:`markVisual`))
+
+    projections : List(:class:`projection`)
+
+    scales : List(:class:`scale`)
+
+    signals : List(:class:`signal`)
+
+    title : :class:`title`
+
+    usermeta : Mapping(required=[])
+
+    """
+    _schema = {'$ref': '#/definitions/scope'}
+
+    def __init__(self, axes=Undefined, data=Undefined, encode=Undefined, layout=Undefined,
+                 legends=Undefined, marks=Undefined, projections=Undefined, scales=Undefined,
+                 signals=Undefined, title=Undefined, usermeta=Undefined, **kwds):
+        super(scope, self).__init__(axes=axes, data=data, encode=encode, layout=layout, legends=legends,
+                                    marks=marks, projections=projections, scales=scales,
+                                    signals=signals, title=title, usermeta=usermeta, **kwds)
 
 
 class selector(VegaSchema):
@@ -3337,7 +1620,7 @@ class selector(VegaSchema):
 
     string
     """
-    _schema = {'$ref': '#/refs/selector'}
+    _schema = {'$ref': '#/definitions/selector'}
 
     def __init__(self, *args):
         super(selector, self).__init__(*args)
@@ -3345,6 +1628,29 @@ class selector(VegaSchema):
 
 class signal(VegaSchema):
     """signal schema wrapper
+
+    oneOf(Mapping(required=[name, push]), Mapping(required=[name]), Mapping(required=[name,
+    init]))
+    """
+    _schema = {'$ref': '#/definitions/signal'}
+
+    def __init__(self, *args, **kwds):
+        super(signal, self).__init__(*args, **kwds)
+
+
+class signalName(VegaSchema):
+    """signalName schema wrapper
+
+    not enum('parent', 'datum', 'event', 'item')
+    """
+    _schema = {'$ref': '#/definitions/signalName'}
+
+    def __init__(self, *args):
+        super(signalName, self).__init__(*args)
+
+
+class signalRef(VegaSchema):
+    """signalRef schema wrapper
 
     Mapping(required=[signal])
 
@@ -3354,18 +1660,18 @@ class signal(VegaSchema):
     signal : string
 
     """
-    _schema = {'$ref': '#/refs/signal'}
+    _schema = {'$ref': '#/definitions/signalRef'}
 
     def __init__(self, signal=Undefined, **kwds):
-        super(signal, self).__init__(signal=signal, **kwds)
+        super(signalRef, self).__init__(signal=signal, **kwds)
 
 
 class arrayOrSignal(VegaSchema):
     """arrayOrSignal schema wrapper
 
-    oneOf(List(Any), :class:`signal`)
+    oneOf(List(Any), :class:`signalRef`)
     """
-    _schema = {'$ref': '#/refs/arrayOrSignal'}
+    _schema = {'$ref': '#/definitions/arrayOrSignal'}
 
     def __init__(self, *args, **kwds):
         super(arrayOrSignal, self).__init__(*args, **kwds)
@@ -3374,9 +1680,9 @@ class arrayOrSignal(VegaSchema):
 class booleanOrSignal(VegaSchema):
     """booleanOrSignal schema wrapper
 
-    oneOf(boolean, :class:`signal`)
+    oneOf(boolean, :class:`signalRef`)
     """
-    _schema = {'$ref': '#/refs/booleanOrSignal'}
+    _schema = {'$ref': '#/definitions/booleanOrSignal'}
 
     def __init__(self, *args, **kwds):
         super(booleanOrSignal, self).__init__(*args, **kwds)
@@ -3385,9 +1691,9 @@ class booleanOrSignal(VegaSchema):
 class numberOrSignal(VegaSchema):
     """numberOrSignal schema wrapper
 
-    oneOf(float, :class:`signal`)
+    oneOf(float, :class:`signalRef`)
     """
-    _schema = {'$ref': '#/refs/numberOrSignal'}
+    _schema = {'$ref': '#/definitions/numberOrSignal'}
 
     def __init__(self, *args, **kwds):
         super(numberOrSignal, self).__init__(*args, **kwds)
@@ -3396,9 +1702,9 @@ class numberOrSignal(VegaSchema):
 class stringOrSignal(VegaSchema):
     """stringOrSignal schema wrapper
 
-    oneOf(string, :class:`signal`)
+    oneOf(string, :class:`signalRef`)
     """
-    _schema = {'$ref': '#/refs/stringOrSignal'}
+    _schema = {'$ref': '#/definitions/stringOrSignal'}
 
     def __init__(self, *args, **kwds):
         super(stringOrSignal, self).__init__(*args, **kwds)
@@ -3407,10 +1713,1775 @@ class stringOrSignal(VegaSchema):
 class textOrSignal(VegaSchema):
     """textOrSignal schema wrapper
 
-    oneOf(oneOf(string, List(string)), :class:`signal`)
+    oneOf(oneOf(string, List(string)), :class:`signalRef`)
     """
-    _schema = {'$ref': '#/refs/textOrSignal'}
+    _schema = {'$ref': '#/definitions/textOrSignal'}
 
     def __init__(self, *args, **kwds):
         super(textOrSignal, self).__init__(*args, **kwds)
+
+
+class stream(VegaSchema):
+    """stream schema wrapper
+
+    allOf(Mapping(required=[]), oneOf(Mapping(required=[type]), Mapping(required=[stream]),
+    Mapping(required=[merge])))
+    """
+    _schema = {'$ref': '#/definitions/stream'}
+
+    def __init__(self, between=Undefined, consume=Undefined, debounce=Undefined, filter=Undefined,
+                 markname=Undefined, marktype=Undefined, throttle=Undefined, **kwds):
+        super(stream, self).__init__(between=between, consume=consume, debounce=debounce, filter=filter,
+                                     markname=markname, marktype=marktype, throttle=throttle, **kwds)
+
+
+class title(VegaSchema):
+    """title schema wrapper
+
+    oneOf(string, Mapping(required=[]))
+    """
+    _schema = {'$ref': '#/definitions/title'}
+
+    def __init__(self, *args, **kwds):
+        super(title, self).__init__(*args, **kwds)
+
+
+class transform(VegaSchema):
+    """transform schema wrapper
+
+    oneOf(:class:`crossfilterTransform`, :class:`resolvefilterTransform`,
+    :class:`linkpathTransform`, :class:`pieTransform`, :class:`stackTransform`,
+    :class:`forceTransform`, :class:`contourTransform`, :class:`geojsonTransform`,
+    :class:`geopathTransform`, :class:`geopointTransform`, :class:`geoshapeTransform`,
+    :class:`graticuleTransform`, :class:`heatmapTransform`, :class:`isocontourTransform`,
+    :class:`kde2dTransform`, :class:`nestTransform`, :class:`packTransform`,
+    :class:`partitionTransform`, :class:`stratifyTransform`, :class:`treeTransform`,
+    :class:`treelinksTransform`, :class:`treemapTransform`, :class:`labelTransform`,
+    :class:`loessTransform`, :class:`regressionTransform`, :class:`aggregateTransform`,
+    :class:`binTransform`, :class:`collectTransform`, :class:`countpatternTransform`,
+    :class:`crossTransform`, :class:`densityTransform`, :class:`dotbinTransform`,
+    :class:`extentTransform`, :class:`filterTransform`, :class:`flattenTransform`,
+    :class:`foldTransform`, :class:`formulaTransform`, :class:`imputeTransform`,
+    :class:`joinaggregateTransform`, :class:`kdeTransform`, :class:`lookupTransform`,
+    :class:`pivotTransform`, :class:`projectTransform`, :class:`quantileTransform`,
+    :class:`sampleTransform`, :class:`sequenceTransform`, :class:`timeunitTransform`,
+    :class:`windowTransform`, :class:`identifierTransform`, :class:`voronoiTransform`,
+    :class:`wordcloudTransform`)
+    """
+    _schema = {'$ref': '#/definitions/transform'}
+
+    def __init__(self, *args, **kwds):
+        super(transform, self).__init__(*args, **kwds)
+
+
+class transformMark(VegaSchema):
+    """transformMark schema wrapper
+
+    oneOf(:class:`crossfilterTransform`, :class:`resolvefilterTransform`,
+    :class:`linkpathTransform`, :class:`pieTransform`, :class:`stackTransform`,
+    :class:`forceTransform`, :class:`geojsonTransform`, :class:`geopathTransform`,
+    :class:`geopointTransform`, :class:`geoshapeTransform`, :class:`heatmapTransform`,
+    :class:`packTransform`, :class:`partitionTransform`, :class:`stratifyTransform`,
+    :class:`treeTransform`, :class:`treemapTransform`, :class:`labelTransform`,
+    :class:`binTransform`, :class:`collectTransform`, :class:`dotbinTransform`,
+    :class:`extentTransform`, :class:`formulaTransform`, :class:`joinaggregateTransform`,
+    :class:`lookupTransform`, :class:`sampleTransform`, :class:`timeunitTransform`,
+    :class:`windowTransform`, :class:`identifierTransform`, :class:`voronoiTransform`,
+    :class:`wordcloudTransform`)
+    """
+    _schema = {'$ref': '#/definitions/transformMark'}
+
+    def __init__(self, *args, **kwds):
+        super(transformMark, self).__init__(*args, **kwds)
+
+
+class crossfilterTransform(VegaSchema):
+    """crossfilterTransform schema wrapper
+
+    Mapping(required=[type, fields, query])
+
+    Attributes
+    ----------
+
+    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    query : oneOf(List(Any), :class:`signalRef`)
+
+    type : enum('crossfilter')
+
+    signal : string
+
+    """
+    _schema = {'$ref': '#/definitions/crossfilterTransform'}
+
+    def __init__(self, fields=Undefined, query=Undefined, type=Undefined, signal=Undefined, **kwds):
+        super(crossfilterTransform, self).__init__(fields=fields, query=query, type=type, signal=signal,
+                                                   **kwds)
+
+
+class resolvefilterTransform(VegaSchema):
+    """resolvefilterTransform schema wrapper
+
+    Mapping(required=[type, ignore, filter])
+
+    Attributes
+    ----------
+
+    filter : Any
+
+    ignore : anyOf(float, :class:`signalRef`)
+
+    type : enum('resolvefilter')
+
+    signal : string
+
+    """
+    _schema = {'$ref': '#/definitions/resolvefilterTransform'}
+
+    def __init__(self, filter=Undefined, ignore=Undefined, type=Undefined, signal=Undefined, **kwds):
+        super(resolvefilterTransform, self).__init__(filter=filter, ignore=ignore, type=type,
+                                                     signal=signal, **kwds)
+
+
+class linkpathTransform(VegaSchema):
+    """linkpathTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('linkpath')
+
+    orient : anyOf(enum('horizontal', 'vertical', 'radial'), :class:`signalRef`)
+
+    require : :class:`signalRef`
+
+    shape : anyOf(enum('line', 'arc', 'curve', 'diagonal', 'orthogonal'), :class:`signalRef`)
+
+    signal : string
+
+    sourceX : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    sourceY : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    targetX : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    targetY : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    as : anyOf(string, :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/linkpathTransform'}
+
+    def __init__(self, type=Undefined, orient=Undefined, require=Undefined, shape=Undefined,
+                 signal=Undefined, sourceX=Undefined, sourceY=Undefined, targetX=Undefined,
+                 targetY=Undefined, **kwds):
+        super(linkpathTransform, self).__init__(type=type, orient=orient, require=require, shape=shape,
+                                                signal=signal, sourceX=sourceX, sourceY=sourceY,
+                                                targetX=targetX, targetY=targetY, **kwds)
+
+
+class pieTransform(VegaSchema):
+    """pieTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('pie')
+
+    endAngle : anyOf(float, :class:`signalRef`)
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    signal : string
+
+    sort : anyOf(boolean, :class:`signalRef`)
+
+    startAngle : anyOf(float, :class:`signalRef`)
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/pieTransform'}
+
+    def __init__(self, type=Undefined, endAngle=Undefined, field=Undefined, signal=Undefined,
+                 sort=Undefined, startAngle=Undefined, **kwds):
+        super(pieTransform, self).__init__(type=type, endAngle=endAngle, field=field, signal=signal,
+                                           sort=sort, startAngle=startAngle, **kwds)
+
+
+class stackTransform(VegaSchema):
+    """stackTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('stack')
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    offset : anyOf(enum('zero', 'center', 'normalize'), :class:`signalRef`)
+
+    signal : string
+
+    sort : :class:`compare`
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/stackTransform'}
+
+    def __init__(self, type=Undefined, field=Undefined, groupby=Undefined, offset=Undefined,
+                 signal=Undefined, sort=Undefined, **kwds):
+        super(stackTransform, self).__init__(type=type, field=field, groupby=groupby, offset=offset,
+                                             signal=signal, sort=sort, **kwds)
+
+
+class forceTransform(VegaSchema):
+    """forceTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('force')
+
+    alpha : anyOf(float, :class:`signalRef`)
+
+    alphaMin : anyOf(float, :class:`signalRef`)
+
+    alphaTarget : anyOf(float, :class:`signalRef`)
+
+    forces : List(oneOf(Mapping(required=[force]), Mapping(required=[force]),
+    Mapping(required=[force]), Mapping(required=[force]), Mapping(required=[force]),
+    Mapping(required=[force])))
+
+    iterations : anyOf(float, :class:`signalRef`)
+
+    restart : anyOf(boolean, :class:`signalRef`)
+
+    signal : string
+
+    static : anyOf(boolean, :class:`signalRef`)
+
+    velocityDecay : anyOf(float, :class:`signalRef`)
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/forceTransform'}
+
+    def __init__(self, type=Undefined, alpha=Undefined, alphaMin=Undefined, alphaTarget=Undefined,
+                 forces=Undefined, iterations=Undefined, restart=Undefined, signal=Undefined,
+                 static=Undefined, velocityDecay=Undefined, **kwds):
+        super(forceTransform, self).__init__(type=type, alpha=alpha, alphaMin=alphaMin,
+                                             alphaTarget=alphaTarget, forces=forces,
+                                             iterations=iterations, restart=restart, signal=signal,
+                                             static=static, velocityDecay=velocityDecay, **kwds)
+
+
+class contourTransform(VegaSchema):
+    """contourTransform schema wrapper
+
+    Mapping(required=[type, size])
+
+    Attributes
+    ----------
+
+    size : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    type : enum('contour')
+
+    bandwidth : anyOf(float, :class:`signalRef`)
+
+    cellSize : anyOf(float, :class:`signalRef`)
+
+    count : anyOf(float, :class:`signalRef`)
+
+    nice : anyOf(boolean, :class:`signalRef`)
+
+    signal : string
+
+    smooth : anyOf(boolean, :class:`signalRef`)
+
+    thresholds : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    values : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    weight : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    x : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    y : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    """
+    _schema = {'$ref': '#/definitions/contourTransform'}
+
+    def __init__(self, size=Undefined, type=Undefined, bandwidth=Undefined, cellSize=Undefined,
+                 count=Undefined, nice=Undefined, signal=Undefined, smooth=Undefined,
+                 thresholds=Undefined, values=Undefined, weight=Undefined, x=Undefined, y=Undefined,
+                 **kwds):
+        super(contourTransform, self).__init__(size=size, type=type, bandwidth=bandwidth,
+                                               cellSize=cellSize, count=count, nice=nice, signal=signal,
+                                               smooth=smooth, thresholds=thresholds, values=values,
+                                               weight=weight, x=x, y=y, **kwds)
+
+
+class geojsonTransform(VegaSchema):
+    """geojsonTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('geojson')
+
+    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    geojson : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    signal : string
+
+    """
+    _schema = {'$ref': '#/definitions/geojsonTransform'}
+
+    def __init__(self, type=Undefined, fields=Undefined, geojson=Undefined, signal=Undefined, **kwds):
+        super(geojsonTransform, self).__init__(type=type, fields=fields, geojson=geojson, signal=signal,
+                                               **kwds)
+
+
+class geopathTransform(VegaSchema):
+    """geopathTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('geopath')
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    pointRadius : anyOf(float, :class:`signalRef`, :class:`expr`, :class:`paramField`)
+
+    projection : string
+
+    signal : string
+
+    as : anyOf(string, :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/geopathTransform'}
+
+    def __init__(self, type=Undefined, field=Undefined, pointRadius=Undefined, projection=Undefined,
+                 signal=Undefined, **kwds):
+        super(geopathTransform, self).__init__(type=type, field=field, pointRadius=pointRadius,
+                                               projection=projection, signal=signal, **kwds)
+
+
+class geopointTransform(VegaSchema):
+    """geopointTransform schema wrapper
+
+    Mapping(required=[type, projection, fields])
+
+    Attributes
+    ----------
+
+    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    projection : string
+
+    type : enum('geopoint')
+
+    signal : string
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/geopointTransform'}
+
+    def __init__(self, fields=Undefined, projection=Undefined, type=Undefined, signal=Undefined, **kwds):
+        super(geopointTransform, self).__init__(fields=fields, projection=projection, type=type,
+                                                signal=signal, **kwds)
+
+
+class geoshapeTransform(VegaSchema):
+    """geoshapeTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('geoshape')
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    pointRadius : anyOf(float, :class:`signalRef`, :class:`expr`, :class:`paramField`)
+
+    projection : string
+
+    signal : string
+
+    as : anyOf(string, :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/geoshapeTransform'}
+
+    def __init__(self, type=Undefined, field=Undefined, pointRadius=Undefined, projection=Undefined,
+                 signal=Undefined, **kwds):
+        super(geoshapeTransform, self).__init__(type=type, field=field, pointRadius=pointRadius,
+                                                projection=projection, signal=signal, **kwds)
+
+
+class graticuleTransform(VegaSchema):
+    """graticuleTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('graticule')
+
+    extent : oneOf(List(Any), :class:`signalRef`)
+
+    extentMajor : oneOf(List(Any), :class:`signalRef`)
+
+    extentMinor : oneOf(List(Any), :class:`signalRef`)
+
+    precision : anyOf(float, :class:`signalRef`)
+
+    signal : string
+
+    step : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    stepMajor : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    stepMinor : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/graticuleTransform'}
+
+    def __init__(self, type=Undefined, extent=Undefined, extentMajor=Undefined, extentMinor=Undefined,
+                 precision=Undefined, signal=Undefined, step=Undefined, stepMajor=Undefined,
+                 stepMinor=Undefined, **kwds):
+        super(graticuleTransform, self).__init__(type=type, extent=extent, extentMajor=extentMajor,
+                                                 extentMinor=extentMinor, precision=precision,
+                                                 signal=signal, step=step, stepMajor=stepMajor,
+                                                 stepMinor=stepMinor, **kwds)
+
+
+class heatmapTransform(VegaSchema):
+    """heatmapTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('heatmap')
+
+    color : anyOf(string, :class:`signalRef`, :class:`expr`, :class:`paramField`)
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    opacity : anyOf(float, :class:`signalRef`, :class:`expr`, :class:`paramField`)
+
+    resolve : anyOf(enum('shared', 'independent'), :class:`signalRef`)
+
+    signal : string
+
+    as : anyOf(string, :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/heatmapTransform'}
+
+    def __init__(self, type=Undefined, color=Undefined, field=Undefined, opacity=Undefined,
+                 resolve=Undefined, signal=Undefined, **kwds):
+        super(heatmapTransform, self).__init__(type=type, color=color, field=field, opacity=opacity,
+                                               resolve=resolve, signal=signal, **kwds)
+
+
+class isocontourTransform(VegaSchema):
+    """isocontourTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('isocontour')
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    levels : anyOf(float, :class:`signalRef`)
+
+    nice : anyOf(boolean, :class:`signalRef`)
+
+    resolve : anyOf(enum('shared', 'independent'), :class:`signalRef`)
+
+    scale : anyOf(float, :class:`signalRef`, :class:`expr`, :class:`paramField`)
+
+    signal : string
+
+    smooth : anyOf(boolean, :class:`signalRef`)
+
+    thresholds : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    translate : oneOf(List(anyOf(float, :class:`signalRef`, :class:`expr`,
+    :class:`paramField`)), :class:`signalRef`)
+
+    zero : anyOf(boolean, :class:`signalRef`)
+
+    as : anyOf(string, :class:`signalRef`, None)
+
+    """
+    _schema = {'$ref': '#/definitions/isocontourTransform'}
+
+    def __init__(self, type=Undefined, field=Undefined, levels=Undefined, nice=Undefined,
+                 resolve=Undefined, scale=Undefined, signal=Undefined, smooth=Undefined,
+                 thresholds=Undefined, translate=Undefined, zero=Undefined, **kwds):
+        super(isocontourTransform, self).__init__(type=type, field=field, levels=levels, nice=nice,
+                                                  resolve=resolve, scale=scale, signal=signal,
+                                                  smooth=smooth, thresholds=thresholds,
+                                                  translate=translate, zero=zero, **kwds)
+
+
+class kde2dTransform(VegaSchema):
+    """kde2dTransform schema wrapper
+
+    Mapping(required=[type, size, x, y])
+
+    Attributes
+    ----------
+
+    size : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    type : enum('kde2d')
+
+    x : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    y : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    bandwidth : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    cellSize : anyOf(float, :class:`signalRef`)
+
+    counts : anyOf(boolean, :class:`signalRef`)
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    signal : string
+
+    weight : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    as : anyOf(string, :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/kde2dTransform'}
+
+    def __init__(self, size=Undefined, type=Undefined, x=Undefined, y=Undefined, bandwidth=Undefined,
+                 cellSize=Undefined, counts=Undefined, groupby=Undefined, signal=Undefined,
+                 weight=Undefined, **kwds):
+        super(kde2dTransform, self).__init__(size=size, type=type, x=x, y=y, bandwidth=bandwidth,
+                                             cellSize=cellSize, counts=counts, groupby=groupby,
+                                             signal=signal, weight=weight, **kwds)
+
+
+class nestTransform(VegaSchema):
+    """nestTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('nest')
+
+    generate : anyOf(boolean, :class:`signalRef`)
+
+    keys : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    signal : string
+
+    """
+    _schema = {'$ref': '#/definitions/nestTransform'}
+
+    def __init__(self, type=Undefined, generate=Undefined, keys=Undefined, signal=Undefined, **kwds):
+        super(nestTransform, self).__init__(type=type, generate=generate, keys=keys, signal=signal,
+                                            **kwds)
+
+
+class packTransform(VegaSchema):
+    """packTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('pack')
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    padding : anyOf(float, :class:`signalRef`)
+
+    radius : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    signal : string
+
+    size : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    sort : :class:`compare`
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/packTransform'}
+
+    def __init__(self, type=Undefined, field=Undefined, padding=Undefined, radius=Undefined,
+                 signal=Undefined, size=Undefined, sort=Undefined, **kwds):
+        super(packTransform, self).__init__(type=type, field=field, padding=padding, radius=radius,
+                                            signal=signal, size=size, sort=sort, **kwds)
+
+
+class partitionTransform(VegaSchema):
+    """partitionTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('partition')
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    padding : anyOf(float, :class:`signalRef`)
+
+    round : anyOf(boolean, :class:`signalRef`)
+
+    signal : string
+
+    size : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    sort : :class:`compare`
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/partitionTransform'}
+
+    def __init__(self, type=Undefined, field=Undefined, padding=Undefined, round=Undefined,
+                 signal=Undefined, size=Undefined, sort=Undefined, **kwds):
+        super(partitionTransform, self).__init__(type=type, field=field, padding=padding, round=round,
+                                                 signal=signal, size=size, sort=sort, **kwds)
+
+
+class stratifyTransform(VegaSchema):
+    """stratifyTransform schema wrapper
+
+    Mapping(required=[type, key, parentKey])
+
+    Attributes
+    ----------
+
+    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    parentKey : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    type : enum('stratify')
+
+    signal : string
+
+    """
+    _schema = {'$ref': '#/definitions/stratifyTransform'}
+
+    def __init__(self, key=Undefined, parentKey=Undefined, type=Undefined, signal=Undefined, **kwds):
+        super(stratifyTransform, self).__init__(key=key, parentKey=parentKey, type=type, signal=signal,
+                                                **kwds)
+
+
+class treeTransform(VegaSchema):
+    """treeTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('tree')
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    method : anyOf(enum('tidy', 'cluster'), :class:`signalRef`)
+
+    nodeSize : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    separation : anyOf(boolean, :class:`signalRef`)
+
+    signal : string
+
+    size : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    sort : :class:`compare`
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/treeTransform'}
+
+    def __init__(self, type=Undefined, field=Undefined, method=Undefined, nodeSize=Undefined,
+                 separation=Undefined, signal=Undefined, size=Undefined, sort=Undefined, **kwds):
+        super(treeTransform, self).__init__(type=type, field=field, method=method, nodeSize=nodeSize,
+                                            separation=separation, signal=signal, size=size, sort=sort,
+                                            **kwds)
+
+
+class treelinksTransform(VegaSchema):
+    """treelinksTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('treelinks')
+
+    signal : string
+
+    """
+    _schema = {'$ref': '#/definitions/treelinksTransform'}
+
+    def __init__(self, type=Undefined, signal=Undefined, **kwds):
+        super(treelinksTransform, self).__init__(type=type, signal=signal, **kwds)
+
+
+class treemapTransform(VegaSchema):
+    """treemapTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('treemap')
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    method : anyOf(enum('squarify', 'resquarify', 'binary', 'dice', 'slice', 'slicedice'),
+    :class:`signalRef`)
+
+    padding : anyOf(float, :class:`signalRef`)
+
+    paddingBottom : anyOf(float, :class:`signalRef`)
+
+    paddingInner : anyOf(float, :class:`signalRef`)
+
+    paddingLeft : anyOf(float, :class:`signalRef`)
+
+    paddingOuter : anyOf(float, :class:`signalRef`)
+
+    paddingRight : anyOf(float, :class:`signalRef`)
+
+    paddingTop : anyOf(float, :class:`signalRef`)
+
+    ratio : anyOf(float, :class:`signalRef`)
+
+    round : anyOf(boolean, :class:`signalRef`)
+
+    signal : string
+
+    size : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    sort : :class:`compare`
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/treemapTransform'}
+
+    def __init__(self, type=Undefined, field=Undefined, method=Undefined, padding=Undefined,
+                 paddingBottom=Undefined, paddingInner=Undefined, paddingLeft=Undefined,
+                 paddingOuter=Undefined, paddingRight=Undefined, paddingTop=Undefined, ratio=Undefined,
+                 round=Undefined, signal=Undefined, size=Undefined, sort=Undefined, **kwds):
+        super(treemapTransform, self).__init__(type=type, field=field, method=method, padding=padding,
+                                               paddingBottom=paddingBottom, paddingInner=paddingInner,
+                                               paddingLeft=paddingLeft, paddingOuter=paddingOuter,
+                                               paddingRight=paddingRight, paddingTop=paddingTop,
+                                               ratio=ratio, round=round, signal=signal, size=size,
+                                               sort=sort, **kwds)
+
+
+class labelTransform(VegaSchema):
+    """labelTransform schema wrapper
+
+    Mapping(required=[type, size])
+
+    Attributes
+    ----------
+
+    size : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    type : enum('label')
+
+    anchor : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    avoidBaseMark : anyOf(boolean, :class:`signalRef`)
+
+    avoidMarks : oneOf(List(string), :class:`signalRef`)
+
+    lineAnchor : anyOf(string, :class:`signalRef`)
+
+    markIndex : anyOf(float, :class:`signalRef`)
+
+    method : anyOf(string, :class:`signalRef`)
+
+    offset : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    padding : anyOf(float, :class:`signalRef`, None)
+
+    signal : string
+
+    sort : :class:`compare`
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/labelTransform'}
+
+    def __init__(self, size=Undefined, type=Undefined, anchor=Undefined, avoidBaseMark=Undefined,
+                 avoidMarks=Undefined, lineAnchor=Undefined, markIndex=Undefined, method=Undefined,
+                 offset=Undefined, padding=Undefined, signal=Undefined, sort=Undefined, **kwds):
+        super(labelTransform, self).__init__(size=size, type=type, anchor=anchor,
+                                             avoidBaseMark=avoidBaseMark, avoidMarks=avoidMarks,
+                                             lineAnchor=lineAnchor, markIndex=markIndex, method=method,
+                                             offset=offset, padding=padding, signal=signal, sort=sort,
+                                             **kwds)
+
+
+class loessTransform(VegaSchema):
+    """loessTransform schema wrapper
+
+    Mapping(required=[type, x, y])
+
+    Attributes
+    ----------
+
+    type : enum('loess')
+
+    x : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    y : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    bandwidth : anyOf(float, :class:`signalRef`)
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    signal : string
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/loessTransform'}
+
+    def __init__(self, type=Undefined, x=Undefined, y=Undefined, bandwidth=Undefined, groupby=Undefined,
+                 signal=Undefined, **kwds):
+        super(loessTransform, self).__init__(type=type, x=x, y=y, bandwidth=bandwidth, groupby=groupby,
+                                             signal=signal, **kwds)
+
+
+class regressionTransform(VegaSchema):
+    """regressionTransform schema wrapper
+
+    Mapping(required=[type, x, y])
+
+    Attributes
+    ----------
+
+    type : enum('regression')
+
+    x : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    y : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    extent : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    method : anyOf(string, :class:`signalRef`)
+
+    order : anyOf(float, :class:`signalRef`)
+
+    params : anyOf(boolean, :class:`signalRef`)
+
+    signal : string
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/regressionTransform'}
+
+    def __init__(self, type=Undefined, x=Undefined, y=Undefined, extent=Undefined, groupby=Undefined,
+                 method=Undefined, order=Undefined, params=Undefined, signal=Undefined, **kwds):
+        super(regressionTransform, self).__init__(type=type, x=x, y=y, extent=extent, groupby=groupby,
+                                                  method=method, order=order, params=params,
+                                                  signal=signal, **kwds)
+
+
+class aggregateTransform(VegaSchema):
+    """aggregateTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('aggregate')
+
+    cross : anyOf(boolean, :class:`signalRef`)
+
+    drop : anyOf(boolean, :class:`signalRef`)
+
+    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`, None)),
+    :class:`signalRef`)
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    ops : oneOf(List(anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum',
+    'product', 'mean', 'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr',
+    'distinct', 'ci0', 'ci1', 'median', 'q1', 'q3', 'min', 'max', 'argmin', 'argmax'),
+    :class:`signalRef`)), :class:`signalRef`)
+
+    signal : string
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`, None)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/aggregateTransform'}
+
+    def __init__(self, type=Undefined, cross=Undefined, drop=Undefined, fields=Undefined,
+                 groupby=Undefined, key=Undefined, ops=Undefined, signal=Undefined, **kwds):
+        super(aggregateTransform, self).__init__(type=type, cross=cross, drop=drop, fields=fields,
+                                                 groupby=groupby, key=key, ops=ops, signal=signal,
+                                                 **kwds)
+
+
+class binTransform(VegaSchema):
+    """binTransform schema wrapper
+
+    Mapping(required=[type, field, extent])
+
+    Attributes
+    ----------
+
+    extent : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    type : enum('bin')
+
+    anchor : anyOf(float, :class:`signalRef`)
+
+    base : anyOf(float, :class:`signalRef`)
+
+    divide : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    interval : anyOf(boolean, :class:`signalRef`)
+
+    maxbins : anyOf(float, :class:`signalRef`)
+
+    minstep : anyOf(float, :class:`signalRef`)
+
+    name : anyOf(string, :class:`signalRef`)
+
+    nice : anyOf(boolean, :class:`signalRef`)
+
+    signal : string
+
+    span : anyOf(float, :class:`signalRef`)
+
+    step : anyOf(float, :class:`signalRef`)
+
+    steps : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/binTransform'}
+
+    def __init__(self, extent=Undefined, field=Undefined, type=Undefined, anchor=Undefined,
+                 base=Undefined, divide=Undefined, interval=Undefined, maxbins=Undefined,
+                 minstep=Undefined, name=Undefined, nice=Undefined, signal=Undefined, span=Undefined,
+                 step=Undefined, steps=Undefined, **kwds):
+        super(binTransform, self).__init__(extent=extent, field=field, type=type, anchor=anchor,
+                                           base=base, divide=divide, interval=interval, maxbins=maxbins,
+                                           minstep=minstep, name=name, nice=nice, signal=signal,
+                                           span=span, step=step, steps=steps, **kwds)
+
+
+class collectTransform(VegaSchema):
+    """collectTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('collect')
+
+    signal : string
+
+    sort : :class:`compare`
+
+    """
+    _schema = {'$ref': '#/definitions/collectTransform'}
+
+    def __init__(self, type=Undefined, signal=Undefined, sort=Undefined, **kwds):
+        super(collectTransform, self).__init__(type=type, signal=signal, sort=sort, **kwds)
+
+
+class countpatternTransform(VegaSchema):
+    """countpatternTransform schema wrapper
+
+    Mapping(required=[type, field])
+
+    Attributes
+    ----------
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    type : enum('countpattern')
+
+    case : anyOf(enum('upper', 'lower', 'mixed'), :class:`signalRef`)
+
+    pattern : anyOf(string, :class:`signalRef`)
+
+    signal : string
+
+    stopwords : anyOf(string, :class:`signalRef`)
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/countpatternTransform'}
+
+    def __init__(self, field=Undefined, type=Undefined, case=Undefined, pattern=Undefined,
+                 signal=Undefined, stopwords=Undefined, **kwds):
+        super(countpatternTransform, self).__init__(field=field, type=type, case=case, pattern=pattern,
+                                                    signal=signal, stopwords=stopwords, **kwds)
+
+
+class crossTransform(VegaSchema):
+    """crossTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('cross')
+
+    filter : :class:`exprString`
+
+    signal : string
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/crossTransform'}
+
+    def __init__(self, type=Undefined, filter=Undefined, signal=Undefined, **kwds):
+        super(crossTransform, self).__init__(type=type, filter=filter, signal=signal, **kwds)
+
+
+class densityTransform(VegaSchema):
+    """densityTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('density')
+
+    distribution : oneOf(Mapping(required=[function]), Mapping(required=[function]),
+    Mapping(required=[function]), Mapping(required=[function, field]),
+    Mapping(required=[function]))
+
+    extent : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    maxsteps : anyOf(float, :class:`signalRef`)
+
+    method : anyOf(string, :class:`signalRef`)
+
+    minsteps : anyOf(float, :class:`signalRef`)
+
+    signal : string
+
+    steps : anyOf(float, :class:`signalRef`)
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/densityTransform'}
+
+    def __init__(self, type=Undefined, distribution=Undefined, extent=Undefined, maxsteps=Undefined,
+                 method=Undefined, minsteps=Undefined, signal=Undefined, steps=Undefined, **kwds):
+        super(densityTransform, self).__init__(type=type, distribution=distribution, extent=extent,
+                                               maxsteps=maxsteps, method=method, minsteps=minsteps,
+                                               signal=signal, steps=steps, **kwds)
+
+
+class dotbinTransform(VegaSchema):
+    """dotbinTransform schema wrapper
+
+    Mapping(required=[type, field])
+
+    Attributes
+    ----------
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    type : enum('dotbin')
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    signal : string
+
+    smooth : anyOf(boolean, :class:`signalRef`)
+
+    step : anyOf(float, :class:`signalRef`)
+
+    as : anyOf(string, :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/dotbinTransform'}
+
+    def __init__(self, field=Undefined, type=Undefined, groupby=Undefined, signal=Undefined,
+                 smooth=Undefined, step=Undefined, **kwds):
+        super(dotbinTransform, self).__init__(field=field, type=type, groupby=groupby, signal=signal,
+                                              smooth=smooth, step=step, **kwds)
+
+
+class extentTransform(VegaSchema):
+    """extentTransform schema wrapper
+
+    Mapping(required=[type, field])
+
+    Attributes
+    ----------
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    type : enum('extent')
+
+    signal : string
+
+    """
+    _schema = {'$ref': '#/definitions/extentTransform'}
+
+    def __init__(self, field=Undefined, type=Undefined, signal=Undefined, **kwds):
+        super(extentTransform, self).__init__(field=field, type=type, signal=signal, **kwds)
+
+
+class filterTransform(VegaSchema):
+    """filterTransform schema wrapper
+
+    Mapping(required=[type, expr])
+
+    Attributes
+    ----------
+
+    expr : :class:`exprString`
+
+    type : enum('filter')
+
+    signal : string
+
+    """
+    _schema = {'$ref': '#/definitions/filterTransform'}
+
+    def __init__(self, expr=Undefined, type=Undefined, signal=Undefined, **kwds):
+        super(filterTransform, self).__init__(expr=expr, type=type, signal=signal, **kwds)
+
+
+class flattenTransform(VegaSchema):
+    """flattenTransform schema wrapper
+
+    Mapping(required=[type, fields])
+
+    Attributes
+    ----------
+
+    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    type : enum('flatten')
+
+    index : anyOf(string, :class:`signalRef`)
+
+    signal : string
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/flattenTransform'}
+
+    def __init__(self, fields=Undefined, type=Undefined, index=Undefined, signal=Undefined, **kwds):
+        super(flattenTransform, self).__init__(fields=fields, type=type, index=index, signal=signal,
+                                               **kwds)
+
+
+class foldTransform(VegaSchema):
+    """foldTransform schema wrapper
+
+    Mapping(required=[type, fields])
+
+    Attributes
+    ----------
+
+    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    type : enum('fold')
+
+    signal : string
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/foldTransform'}
+
+    def __init__(self, fields=Undefined, type=Undefined, signal=Undefined, **kwds):
+        super(foldTransform, self).__init__(fields=fields, type=type, signal=signal, **kwds)
+
+
+class formulaTransform(VegaSchema):
+    """formulaTransform schema wrapper
+
+    Mapping(required=[type, expr, as])
+
+    Attributes
+    ----------
+
+    expr : :class:`exprString`
+
+    type : enum('formula')
+
+    initonly : anyOf(boolean, :class:`signalRef`)
+
+    signal : string
+
+    as : anyOf(string, :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/formulaTransform'}
+
+    def __init__(self, expr=Undefined, type=Undefined, initonly=Undefined, signal=Undefined, **kwds):
+        super(formulaTransform, self).__init__(expr=expr, type=type, initonly=initonly, signal=signal,
+                                               **kwds)
+
+
+class imputeTransform(VegaSchema):
+    """imputeTransform schema wrapper
+
+    Mapping(required=[type, field, key])
+
+    Attributes
+    ----------
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    type : enum('impute')
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    keyvals : oneOf(List(Any), :class:`signalRef`)
+
+    method : anyOf(enum('value', 'mean', 'median', 'max', 'min'), :class:`signalRef`)
+
+    signal : string
+
+    value : Any
+
+    """
+    _schema = {'$ref': '#/definitions/imputeTransform'}
+
+    def __init__(self, field=Undefined, key=Undefined, type=Undefined, groupby=Undefined,
+                 keyvals=Undefined, method=Undefined, signal=Undefined, value=Undefined, **kwds):
+        super(imputeTransform, self).__init__(field=field, key=key, type=type, groupby=groupby,
+                                              keyvals=keyvals, method=method, signal=signal,
+                                              value=value, **kwds)
+
+
+class joinaggregateTransform(VegaSchema):
+    """joinaggregateTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('joinaggregate')
+
+    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`, None)),
+    :class:`signalRef`)
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    ops : oneOf(List(anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum',
+    'product', 'mean', 'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr',
+    'distinct', 'ci0', 'ci1', 'median', 'q1', 'q3', 'min', 'max', 'argmin', 'argmax'),
+    :class:`signalRef`)), :class:`signalRef`)
+
+    signal : string
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`, None)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/joinaggregateTransform'}
+
+    def __init__(self, type=Undefined, fields=Undefined, groupby=Undefined, key=Undefined,
+                 ops=Undefined, signal=Undefined, **kwds):
+        super(joinaggregateTransform, self).__init__(type=type, fields=fields, groupby=groupby, key=key,
+                                                     ops=ops, signal=signal, **kwds)
+
+
+class kdeTransform(VegaSchema):
+    """kdeTransform schema wrapper
+
+    Mapping(required=[type, field])
+
+    Attributes
+    ----------
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    type : enum('kde')
+
+    bandwidth : anyOf(float, :class:`signalRef`)
+
+    counts : anyOf(boolean, :class:`signalRef`)
+
+    cumulative : anyOf(boolean, :class:`signalRef`)
+
+    extent : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    maxsteps : anyOf(float, :class:`signalRef`)
+
+    minsteps : anyOf(float, :class:`signalRef`)
+
+    resolve : anyOf(enum('shared', 'independent'), :class:`signalRef`)
+
+    signal : string
+
+    steps : anyOf(float, :class:`signalRef`)
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/kdeTransform'}
+
+    def __init__(self, field=Undefined, type=Undefined, bandwidth=Undefined, counts=Undefined,
+                 cumulative=Undefined, extent=Undefined, groupby=Undefined, maxsteps=Undefined,
+                 minsteps=Undefined, resolve=Undefined, signal=Undefined, steps=Undefined, **kwds):
+        super(kdeTransform, self).__init__(field=field, type=type, bandwidth=bandwidth, counts=counts,
+                                           cumulative=cumulative, extent=extent, groupby=groupby,
+                                           maxsteps=maxsteps, minsteps=minsteps, resolve=resolve,
+                                           signal=signal, steps=steps, **kwds)
+
+
+class lookupTransform(VegaSchema):
+    """lookupTransform schema wrapper
+
+    Mapping(required=[type, from, key, fields])
+
+    Attributes
+    ----------
+
+    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    type : enum('lookup')
+
+    default : Any
+
+    signal : string
+
+    values : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    from : string
+
+    """
+    _schema = {'$ref': '#/definitions/lookupTransform'}
+
+    def __init__(self, fields=Undefined, key=Undefined, type=Undefined, default=Undefined,
+                 signal=Undefined, values=Undefined, **kwds):
+        super(lookupTransform, self).__init__(fields=fields, key=key, type=type, default=default,
+                                              signal=signal, values=values, **kwds)
+
+
+class pivotTransform(VegaSchema):
+    """pivotTransform schema wrapper
+
+    Mapping(required=[type, field, value])
+
+    Attributes
+    ----------
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    type : enum('pivot')
+
+    value : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    key : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    limit : anyOf(float, :class:`signalRef`)
+
+    op : anyOf(enum('values', 'count', '__count__', 'missing', 'valid', 'sum', 'product',
+    'mean', 'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr', 'distinct', 'ci0',
+    'ci1', 'median', 'q1', 'q3', 'min', 'max', 'argmin', 'argmax'), :class:`signalRef`)
+
+    signal : string
+
+    """
+    _schema = {'$ref': '#/definitions/pivotTransform'}
+
+    def __init__(self, field=Undefined, type=Undefined, value=Undefined, groupby=Undefined,
+                 key=Undefined, limit=Undefined, op=Undefined, signal=Undefined, **kwds):
+        super(pivotTransform, self).__init__(field=field, type=type, value=value, groupby=groupby,
+                                             key=key, limit=limit, op=op, signal=signal, **kwds)
+
+
+class projectTransform(VegaSchema):
+    """projectTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('project')
+
+    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    signal : string
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`, None)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/projectTransform'}
+
+    def __init__(self, type=Undefined, fields=Undefined, signal=Undefined, **kwds):
+        super(projectTransform, self).__init__(type=type, fields=fields, signal=signal, **kwds)
+
+
+class quantileTransform(VegaSchema):
+    """quantileTransform schema wrapper
+
+    Mapping(required=[type, field])
+
+    Attributes
+    ----------
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    type : enum('quantile')
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    probs : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    signal : string
+
+    step : anyOf(float, :class:`signalRef`)
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/quantileTransform'}
+
+    def __init__(self, field=Undefined, type=Undefined, groupby=Undefined, probs=Undefined,
+                 signal=Undefined, step=Undefined, **kwds):
+        super(quantileTransform, self).__init__(field=field, type=type, groupby=groupby, probs=probs,
+                                                signal=signal, step=step, **kwds)
+
+
+class sampleTransform(VegaSchema):
+    """sampleTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('sample')
+
+    signal : string
+
+    size : anyOf(float, :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/sampleTransform'}
+
+    def __init__(self, type=Undefined, signal=Undefined, size=Undefined, **kwds):
+        super(sampleTransform, self).__init__(type=type, signal=signal, size=size, **kwds)
+
+
+class sequenceTransform(VegaSchema):
+    """sequenceTransform schema wrapper
+
+    Mapping(required=[type, start, stop])
+
+    Attributes
+    ----------
+
+    start : anyOf(float, :class:`signalRef`)
+
+    stop : anyOf(float, :class:`signalRef`)
+
+    type : enum('sequence')
+
+    signal : string
+
+    step : anyOf(float, :class:`signalRef`)
+
+    as : anyOf(string, :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/sequenceTransform'}
+
+    def __init__(self, start=Undefined, stop=Undefined, type=Undefined, signal=Undefined,
+                 step=Undefined, **kwds):
+        super(sequenceTransform, self).__init__(start=start, stop=stop, type=type, signal=signal,
+                                                step=step, **kwds)
+
+
+class timeunitTransform(VegaSchema):
+    """timeunitTransform schema wrapper
+
+    Mapping(required=[type, field])
+
+    Attributes
+    ----------
+
+    field : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    type : enum('timeunit')
+
+    extent : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    interval : anyOf(boolean, :class:`signalRef`)
+
+    maxbins : anyOf(float, :class:`signalRef`)
+
+    signal : string
+
+    step : anyOf(float, :class:`signalRef`)
+
+    timezone : anyOf(enum('local', 'utc'), :class:`signalRef`)
+
+    units : oneOf(List(anyOf(enum('year', 'quarter', 'month', 'week', 'date', 'day',
+    'dayofyear', 'hours', 'minutes', 'seconds', 'milliseconds'), :class:`signalRef`)),
+    :class:`signalRef`)
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/timeunitTransform'}
+
+    def __init__(self, field=Undefined, type=Undefined, extent=Undefined, interval=Undefined,
+                 maxbins=Undefined, signal=Undefined, step=Undefined, timezone=Undefined,
+                 units=Undefined, **kwds):
+        super(timeunitTransform, self).__init__(field=field, type=type, extent=extent,
+                                                interval=interval, maxbins=maxbins, signal=signal,
+                                                step=step, timezone=timezone, units=units, **kwds)
+
+
+class windowTransform(VegaSchema):
+    """windowTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('window')
+
+    fields : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`, None)),
+    :class:`signalRef`)
+
+    frame : oneOf(List(anyOf(float, :class:`signalRef`, None)), :class:`signalRef`)
+
+    groupby : oneOf(List(oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)),
+    :class:`signalRef`)
+
+    ignorePeers : anyOf(boolean, :class:`signalRef`)
+
+    ops : oneOf(List(anyOf(enum('row_number', 'rank', 'dense_rank', 'percent_rank', 'cume_dist',
+    'ntile', 'lag', 'lead', 'first_value', 'last_value', 'nth_value', 'prev_value',
+    'next_value', 'values', 'count', '__count__', 'missing', 'valid', 'sum', 'product', 'mean',
+    'average', 'variance', 'variancep', 'stdev', 'stdevp', 'stderr', 'distinct', 'ci0', 'ci1',
+    'median', 'q1', 'q3', 'min', 'max', 'argmin', 'argmax'), :class:`signalRef`)),
+    :class:`signalRef`)
+
+    params : oneOf(List(anyOf(float, :class:`signalRef`, None)), :class:`signalRef`)
+
+    signal : string
+
+    sort : :class:`compare`
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`, None)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/windowTransform'}
+
+    def __init__(self, type=Undefined, fields=Undefined, frame=Undefined, groupby=Undefined,
+                 ignorePeers=Undefined, ops=Undefined, params=Undefined, signal=Undefined,
+                 sort=Undefined, **kwds):
+        super(windowTransform, self).__init__(type=type, fields=fields, frame=frame, groupby=groupby,
+                                              ignorePeers=ignorePeers, ops=ops, params=params,
+                                              signal=signal, sort=sort, **kwds)
+
+
+class identifierTransform(VegaSchema):
+    """identifierTransform schema wrapper
+
+    Mapping(required=[type, as])
+
+    Attributes
+    ----------
+
+    type : enum('identifier')
+
+    signal : string
+
+    as : anyOf(string, :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/identifierTransform'}
+
+    def __init__(self, type=Undefined, signal=Undefined, **kwds):
+        super(identifierTransform, self).__init__(type=type, signal=signal, **kwds)
+
+
+class voronoiTransform(VegaSchema):
+    """voronoiTransform schema wrapper
+
+    Mapping(required=[type, x, y])
+
+    Attributes
+    ----------
+
+    type : enum('voronoi')
+
+    x : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    y : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    extent : oneOf(List(Any), :class:`signalRef`)
+
+    signal : string
+
+    size : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    as : anyOf(string, :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/voronoiTransform'}
+
+    def __init__(self, type=Undefined, x=Undefined, y=Undefined, extent=Undefined, signal=Undefined,
+                 size=Undefined, **kwds):
+        super(voronoiTransform, self).__init__(type=type, x=x, y=y, extent=extent, signal=signal,
+                                               size=size, **kwds)
+
+
+class wordcloudTransform(VegaSchema):
+    """wordcloudTransform schema wrapper
+
+    Mapping(required=[type])
+
+    Attributes
+    ----------
+
+    type : enum('wordcloud')
+
+    font : anyOf(string, :class:`signalRef`, :class:`expr`, :class:`paramField`)
+
+    fontSize : anyOf(float, :class:`signalRef`, :class:`expr`, :class:`paramField`)
+
+    fontSizeRange : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`, None)
+
+    fontStyle : anyOf(string, :class:`signalRef`, :class:`expr`, :class:`paramField`)
+
+    fontWeight : anyOf(string, :class:`signalRef`, :class:`expr`, :class:`paramField`)
+
+    padding : anyOf(float, :class:`signalRef`, :class:`expr`, :class:`paramField`)
+
+    rotate : anyOf(float, :class:`signalRef`, :class:`expr`, :class:`paramField`)
+
+    signal : string
+
+    size : oneOf(List(anyOf(float, :class:`signalRef`)), :class:`signalRef`)
+
+    spiral : anyOf(string, :class:`signalRef`)
+
+    text : oneOf(:class:`scaleField`, :class:`paramField`, :class:`expr`)
+
+    as : oneOf(List(anyOf(string, :class:`signalRef`)), :class:`signalRef`)
+
+    """
+    _schema = {'$ref': '#/definitions/wordcloudTransform'}
+
+    def __init__(self, type=Undefined, font=Undefined, fontSize=Undefined, fontSizeRange=Undefined,
+                 fontStyle=Undefined, fontWeight=Undefined, padding=Undefined, rotate=Undefined,
+                 signal=Undefined, size=Undefined, spiral=Undefined, text=Undefined, **kwds):
+        super(wordcloudTransform, self).__init__(type=type, font=font, fontSize=fontSize,
+                                                 fontSizeRange=fontSizeRange, fontStyle=fontStyle,
+                                                 fontWeight=fontWeight, padding=padding, rotate=rotate,
+                                                 signal=signal, size=size, spiral=spiral, text=text,
+                                                 **kwds)
 

--- a/altair/vega/v5/schema/vega-schema.json
+++ b/altair/vega/v5/schema/vega-schema.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Vega Visualization Specification Language",
-  "defs": {
+  "definitions": {
     "autosize": {
       "oneOf": [
         {
@@ -43,7 +43,7 @@
           "additionalProperties": false
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         }
       ]
     },
@@ -51,11 +51,18 @@
       "type": "object",
       "properties": {
         "orient": {
-          "enum": [
-            "top",
-            "bottom",
-            "left",
-            "right"
+          "oneOf": [
+            {
+              "enum": [
+                "top",
+                "bottom",
+                "left",
+                "right"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
           ]
         },
         "scale": {
@@ -103,7 +110,7 @@
               "additionalProperties": false
             },
             {
-              "$ref": "#/refs/signal"
+              "$ref": "#/definitions/signalRef"
             }
           ]
         },
@@ -117,7 +124,7 @@
               ]
             },
             {
-              "$ref": "#/refs/signal"
+              "$ref": "#/definitions/signalRef"
             }
           ]
         },
@@ -127,7 +134,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -137,7 +144,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -147,7 +154,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -157,7 +164,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -167,21 +174,34 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
         "translate": {
-          "type": "number"
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/numberValue"
+            }
+          ]
         },
         "values": {
-          "$ref": "#/refs/arrayOrSignal"
+          "$ref": "#/definitions/arrayOrSignal"
         },
         "zindex": {
           "type": "number"
         },
+        "aria": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
         "title": {
-          "$ref": "#/refs/textOrSignal"
+          "$ref": "#/definitions/textOrSignal"
         },
         "titlePadding": {
           "oneOf": [
@@ -189,7 +209,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -203,7 +223,7 @@
               ]
             },
             {
-              "$ref": "#/refs/alignValue"
+              "$ref": "#/definitions/alignValue"
             }
           ]
         },
@@ -218,7 +238,7 @@
               ]
             },
             {
-              "$ref": "#/refs/anchorValue"
+              "$ref": "#/definitions/anchorValue"
             }
           ]
         },
@@ -228,7 +248,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -238,7 +258,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -248,7 +268,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -265,7 +285,7 @@
               ]
             },
             {
-              "$ref": "#/refs/baselineValue"
+              "$ref": "#/definitions/baselineValue"
             }
           ]
         },
@@ -278,7 +298,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/refs/colorValue"
+              "$ref": "#/definitions/colorValue"
             }
           ]
         },
@@ -288,7 +308,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/refs/stringValue"
+              "$ref": "#/definitions/stringValue"
             }
           ]
         },
@@ -298,7 +318,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -308,7 +328,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/refs/stringValue"
+              "$ref": "#/definitions/stringValue"
             }
           ]
         },
@@ -342,7 +362,7 @@
               ]
             },
             {
-              "$ref": "#/refs/fontWeightValue"
+              "$ref": "#/definitions/fontWeightValue"
             }
           ]
         },
@@ -352,7 +372,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -362,7 +382,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -372,12 +392,22 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
         "domain": {
           "type": "boolean"
+        },
+        "domainCap": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/stringValue"
+            }
+          ]
         },
         "domainColor": {
           "oneOf": [
@@ -388,7 +418,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/refs/colorValue"
+              "$ref": "#/definitions/colorValue"
             }
           ]
         },
@@ -401,7 +431,7 @@
               }
             },
             {
-              "$ref": "#/refs/arrayValue"
+              "$ref": "#/definitions/arrayValue"
             }
           ]
         },
@@ -411,7 +441,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -421,7 +451,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -431,7 +461,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -439,7 +469,17 @@
           "type": "boolean"
         },
         "tickBand": {
-          "$ref": "#/refs/tickBand"
+          "$ref": "#/definitions/tickBand"
+        },
+        "tickCap": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/stringValue"
+            }
+          ]
         },
         "tickColor": {
           "oneOf": [
@@ -450,7 +490,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/refs/colorValue"
+              "$ref": "#/definitions/colorValue"
             }
           ]
         },
@@ -463,7 +503,7 @@
               }
             },
             {
-              "$ref": "#/refs/arrayValue"
+              "$ref": "#/definitions/arrayValue"
             }
           ]
         },
@@ -473,7 +513,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -483,7 +523,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -493,7 +533,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -503,7 +543,7 @@
               "type": "boolean"
             },
             {
-              "$ref": "#/refs/booleanValue"
+              "$ref": "#/definitions/booleanValue"
             }
           ]
         },
@@ -513,7 +553,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -523,24 +563,34 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
         "tickCount": {
-          "$ref": "#/refs/tickCount"
+          "$ref": "#/definitions/tickCount"
         },
         "tickExtra": {
-          "$ref": "#/refs/booleanOrSignal"
+          "$ref": "#/definitions/booleanOrSignal"
         },
         "tickMinStep": {
-          "$ref": "#/refs/numberOrSignal"
+          "$ref": "#/definitions/numberOrSignal"
         },
         "grid": {
           "type": "boolean"
         },
         "gridScale": {
           "type": "string"
+        },
+        "gridCap": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/stringValue"
+            }
+          ]
         },
         "gridColor": {
           "oneOf": [
@@ -551,7 +601,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/refs/colorValue"
+              "$ref": "#/definitions/colorValue"
             }
           ]
         },
@@ -564,7 +614,7 @@
               }
             },
             {
-              "$ref": "#/refs/arrayValue"
+              "$ref": "#/definitions/arrayValue"
             }
           ]
         },
@@ -574,7 +624,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -584,7 +634,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -594,7 +644,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -611,7 +661,7 @@
               ]
             },
             {
-              "$ref": "#/refs/alignValue"
+              "$ref": "#/definitions/alignValue"
             }
           ]
         },
@@ -628,7 +678,7 @@
               ]
             },
             {
-              "$ref": "#/refs/baselineValue"
+              "$ref": "#/definitions/baselineValue"
             }
           ]
         },
@@ -641,7 +691,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/signal"
+              "$ref": "#/definitions/signalRef"
             }
           ]
         },
@@ -654,15 +704,15 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/signal"
+              "$ref": "#/definitions/signalRef"
             }
           ]
         },
         "labelFlushOffset": {
-          "$ref": "#/refs/numberOrSignal"
+          "$ref": "#/definitions/numberOrSignal"
         },
         "labelOverlap": {
-          "$ref": "#/refs/labelOverlap"
+          "$ref": "#/definitions/labelOverlap"
         },
         "labelAngle": {
           "oneOf": [
@@ -670,7 +720,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -683,7 +733,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/refs/colorValue"
+              "$ref": "#/definitions/colorValue"
             }
           ]
         },
@@ -693,7 +743,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/refs/stringValue"
+              "$ref": "#/definitions/stringValue"
             }
           ]
         },
@@ -703,7 +753,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -737,7 +787,7 @@
               ]
             },
             {
-              "$ref": "#/refs/fontWeightValue"
+              "$ref": "#/definitions/fontWeightValue"
             }
           ]
         },
@@ -747,7 +797,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/refs/stringValue"
+              "$ref": "#/definitions/stringValue"
             }
           ]
         },
@@ -757,7 +807,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -767,7 +817,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -777,7 +827,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -787,7 +837,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -797,33 +847,33 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
         "labelSeparation": {
-          "$ref": "#/refs/numberOrSignal"
+          "$ref": "#/definitions/numberOrSignal"
         },
         "encode": {
           "type": "object",
           "properties": {
             "axis": {
-              "$ref": "#/defs/guideEncode"
+              "$ref": "#/definitions/guideEncode"
             },
             "ticks": {
-              "$ref": "#/defs/guideEncode"
+              "$ref": "#/definitions/guideEncode"
             },
             "labels": {
-              "$ref": "#/defs/guideEncode"
+              "$ref": "#/definitions/guideEncode"
             },
             "title": {
-              "$ref": "#/defs/guideEncode"
+              "$ref": "#/definitions/guideEncode"
             },
             "grid": {
-              "$ref": "#/defs/guideEncode"
+              "$ref": "#/definitions/guideEncode"
             },
             "domain": {
-              "$ref": "#/defs/guideEncode"
+              "$ref": "#/definitions/guideEncode"
             }
           },
           "additionalProperties": false
@@ -835,11251 +885,6 @@
       ],
       "additionalProperties": false
     },
-    "background": {
-      "$ref": "#/refs/stringOrSignal"
-    },
-    "bind": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "input": {
-              "enum": [
-                "checkbox"
-              ]
-            },
-            "element": {
-              "$ref": "#/refs/element"
-            },
-            "debounce": {
-              "type": "number"
-            },
-            "name": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "input"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "input": {
-              "enum": [
-                "radio",
-                "select"
-              ]
-            },
-            "element": {
-              "$ref": "#/refs/element"
-            },
-            "options": {
-              "type": "array"
-            },
-            "labels": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "debounce": {
-              "type": "number"
-            },
-            "name": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "input",
-            "options"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "input": {
-              "enum": [
-                "range"
-              ]
-            },
-            "element": {
-              "$ref": "#/refs/element"
-            },
-            "min": {
-              "type": "number"
-            },
-            "max": {
-              "type": "number"
-            },
-            "step": {
-              "type": "number"
-            },
-            "debounce": {
-              "type": "number"
-            },
-            "name": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "input"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "input": {
-              "not": {
-                "enum": [
-                  "checkbox",
-                  "radio",
-                  "range",
-                  "select"
-                ]
-              }
-            },
-            "element": {
-              "$ref": "#/refs/element"
-            },
-            "debounce": {
-              "type": "number"
-            },
-            "name": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "input"
-          ],
-          "additionalProperties": true
-        }
-      ]
-    },
-    "data": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "transform": {
-              "type": "array",
-              "items": {
-                "$ref": "#/defs/transform"
-              }
-            },
-            "on": {
-              "$ref": "#/defs/onTrigger"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "source": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "minItems": 1
-                }
-              ]
-            },
-            "name": {
-              "type": "string"
-            },
-            "transform": {
-              "type": "array",
-              "items": {
-                "$ref": "#/defs/transform"
-              }
-            },
-            "on": {
-              "$ref": "#/defs/onTrigger"
-            }
-          },
-          "required": [
-            "source",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "url": {
-              "$ref": "#/refs/stringOrSignal"
-            },
-            "format": {
-              "oneOf": [
-                {
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "$ref": "#/refs/stringOrSignal"
-                        },
-                        "parse": {
-                          "oneOf": [
-                            {
-                              "enum": [
-                                "auto"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {},
-                              "additionalProperties": {
-                                "oneOf": [
-                                  {
-                                    "enum": [
-                                      "boolean",
-                                      "number",
-                                      "date",
-                                      "string"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "pattern": "^(date|utc):.*$"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "$ref": "#/refs/signal"
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "enum": [
-                            "json"
-                          ]
-                        },
-                        "parse": {
-                          "oneOf": [
-                            {
-                              "enum": [
-                                "auto"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {},
-                              "additionalProperties": {
-                                "oneOf": [
-                                  {
-                                    "enum": [
-                                      "boolean",
-                                      "number",
-                                      "date",
-                                      "string"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "pattern": "^(date|utc):.*$"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "$ref": "#/refs/signal"
-                            }
-                          ]
-                        },
-                        "property": {
-                          "$ref": "#/refs/stringOrSignal"
-                        },
-                        "copy": {
-                          "$ref": "#/refs/booleanOrSignal"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "enum": [
-                            "csv",
-                            "tsv"
-                          ]
-                        },
-                        "header": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "parse": {
-                          "oneOf": [
-                            {
-                              "enum": [
-                                "auto"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {},
-                              "additionalProperties": {
-                                "oneOf": [
-                                  {
-                                    "enum": [
-                                      "boolean",
-                                      "number",
-                                      "date",
-                                      "string"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "pattern": "^(date|utc):.*$"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "$ref": "#/refs/signal"
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "type"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "enum": [
-                            "dsv"
-                          ]
-                        },
-                        "delimiter": {
-                          "type": "string"
-                        },
-                        "header": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "parse": {
-                          "oneOf": [
-                            {
-                              "enum": [
-                                "auto"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {},
-                              "additionalProperties": {
-                                "oneOf": [
-                                  {
-                                    "enum": [
-                                      "boolean",
-                                      "number",
-                                      "date",
-                                      "string"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "pattern": "^(date|utc):.*$"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "$ref": "#/refs/signal"
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "type",
-                        "delimiter"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "enum": [
-                                "topojson"
-                              ]
-                            },
-                            "feature": {
-                              "$ref": "#/refs/stringOrSignal"
-                            },
-                            "property": {
-                              "$ref": "#/refs/stringOrSignal"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "feature"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "enum": [
-                                "topojson"
-                              ]
-                            },
-                            "mesh": {
-                              "$ref": "#/refs/stringOrSignal"
-                            },
-                            "property": {
-                              "$ref": "#/refs/stringOrSignal"
-                            },
-                            "filter": {
-                              "enum": [
-                                "interior",
-                                "exterior",
-                                null
-                              ]
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "mesh"
-                          ],
-                          "additionalProperties": false
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "async": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "transform": {
-              "type": "array",
-              "items": {
-                "$ref": "#/defs/transform"
-              }
-            },
-            "on": {
-              "$ref": "#/defs/onTrigger"
-            }
-          },
-          "required": [
-            "url",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "values": {
-              "oneOf": [
-                {},
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "format": {
-              "oneOf": [
-                {
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "$ref": "#/refs/stringOrSignal"
-                        },
-                        "parse": {
-                          "oneOf": [
-                            {
-                              "enum": [
-                                "auto"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {},
-                              "additionalProperties": {
-                                "oneOf": [
-                                  {
-                                    "enum": [
-                                      "boolean",
-                                      "number",
-                                      "date",
-                                      "string"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "pattern": "^(date|utc):.*$"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "$ref": "#/refs/signal"
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "enum": [
-                            "json"
-                          ]
-                        },
-                        "parse": {
-                          "oneOf": [
-                            {
-                              "enum": [
-                                "auto"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {},
-                              "additionalProperties": {
-                                "oneOf": [
-                                  {
-                                    "enum": [
-                                      "boolean",
-                                      "number",
-                                      "date",
-                                      "string"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "pattern": "^(date|utc):.*$"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "$ref": "#/refs/signal"
-                            }
-                          ]
-                        },
-                        "property": {
-                          "$ref": "#/refs/stringOrSignal"
-                        },
-                        "copy": {
-                          "$ref": "#/refs/booleanOrSignal"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "enum": [
-                            "csv",
-                            "tsv"
-                          ]
-                        },
-                        "header": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "parse": {
-                          "oneOf": [
-                            {
-                              "enum": [
-                                "auto"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {},
-                              "additionalProperties": {
-                                "oneOf": [
-                                  {
-                                    "enum": [
-                                      "boolean",
-                                      "number",
-                                      "date",
-                                      "string"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "pattern": "^(date|utc):.*$"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "$ref": "#/refs/signal"
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "type"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "enum": [
-                            "dsv"
-                          ]
-                        },
-                        "delimiter": {
-                          "type": "string"
-                        },
-                        "header": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "parse": {
-                          "oneOf": [
-                            {
-                              "enum": [
-                                "auto"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {},
-                              "additionalProperties": {
-                                "oneOf": [
-                                  {
-                                    "enum": [
-                                      "boolean",
-                                      "number",
-                                      "date",
-                                      "string"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "pattern": "^(date|utc):.*$"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "$ref": "#/refs/signal"
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "type",
-                        "delimiter"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "enum": [
-                                "topojson"
-                              ]
-                            },
-                            "feature": {
-                              "$ref": "#/refs/stringOrSignal"
-                            },
-                            "property": {
-                              "$ref": "#/refs/stringOrSignal"
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "feature"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "enum": [
-                                "topojson"
-                              ]
-                            },
-                            "mesh": {
-                              "$ref": "#/refs/stringOrSignal"
-                            },
-                            "property": {
-                              "$ref": "#/refs/stringOrSignal"
-                            },
-                            "filter": {
-                              "enum": [
-                                "interior",
-                                "exterior",
-                                null
-                              ]
-                            }
-                          },
-                          "required": [
-                            "type",
-                            "mesh"
-                          ],
-                          "additionalProperties": false
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "async": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "transform": {
-              "type": "array",
-              "items": {
-                "$ref": "#/defs/transform"
-              }
-            },
-            "on": {
-              "$ref": "#/defs/onTrigger"
-            }
-          },
-          "required": [
-            "values",
-            "name"
-          ],
-          "additionalProperties": false
-        }
-      ]
-    },
-    "rule": {
-      "type": "object",
-      "properties": {
-        "test": {
-          "type": "string"
-        }
-      }
-    },
-    "encodeEntry": {
-      "type": "object",
-      "properties": {
-        "x": {
-          "$ref": "#/refs/numberValue"
-        },
-        "x2": {
-          "$ref": "#/refs/numberValue"
-        },
-        "xc": {
-          "$ref": "#/refs/numberValue"
-        },
-        "width": {
-          "$ref": "#/refs/numberValue"
-        },
-        "y": {
-          "$ref": "#/refs/numberValue"
-        },
-        "y2": {
-          "$ref": "#/refs/numberValue"
-        },
-        "yc": {
-          "$ref": "#/refs/numberValue"
-        },
-        "height": {
-          "$ref": "#/refs/numberValue"
-        },
-        "opacity": {
-          "$ref": "#/refs/numberValue"
-        },
-        "fill": {
-          "$ref": "#/refs/colorValue"
-        },
-        "fillOpacity": {
-          "$ref": "#/refs/numberValue"
-        },
-        "stroke": {
-          "$ref": "#/refs/colorValue"
-        },
-        "strokeOpacity": {
-          "$ref": "#/refs/numberValue"
-        },
-        "strokeWidth": {
-          "$ref": "#/refs/numberValue"
-        },
-        "strokeCap": {
-          "$ref": "#/refs/strokeCapValue"
-        },
-        "strokeDash": {
-          "$ref": "#/refs/arrayValue"
-        },
-        "strokeDashOffset": {
-          "$ref": "#/refs/numberValue"
-        },
-        "strokeJoin": {
-          "$ref": "#/refs/strokeJoinValue"
-        },
-        "strokeMiterLimit": {
-          "$ref": "#/refs/numberValue"
-        },
-        "blend": {
-          "$ref": "#/refs/blendValue"
-        },
-        "cursor": {
-          "$ref": "#/refs/stringValue"
-        },
-        "tooltip": {
-          "$ref": "#/refs/anyValue"
-        },
-        "zindex": {
-          "$ref": "#/refs/numberValue"
-        },
-        "clip": {
-          "$ref": "#/refs/booleanValue"
-        },
-        "strokeForeground": {
-          "$ref": "#/refs/booleanValue"
-        },
-        "strokeOffset": {
-          "$ref": "#/refs/numberValue"
-        },
-        "cornerRadius": {
-          "$ref": "#/refs/numberValue"
-        },
-        "cornerRadiusTopLeft": {
-          "$ref": "#/refs/numberValue"
-        },
-        "cornerRadiusTopRight": {
-          "$ref": "#/refs/numberValue"
-        },
-        "cornerRadiusBottomRight": {
-          "$ref": "#/refs/numberValue"
-        },
-        "cornerRadiusBottomLeft": {
-          "$ref": "#/refs/numberValue"
-        },
-        "angle": {
-          "$ref": "#/refs/numberValue"
-        },
-        "size": {
-          "$ref": "#/refs/numberValue"
-        },
-        "shape": {
-          "$ref": "#/refs/stringValue"
-        },
-        "path": {
-          "$ref": "#/refs/stringValue"
-        },
-        "scaleX": {
-          "$ref": "#/refs/numberValue"
-        },
-        "scaleY": {
-          "$ref": "#/refs/numberValue"
-        },
-        "innerRadius": {
-          "$ref": "#/refs/numberValue"
-        },
-        "outerRadius": {
-          "$ref": "#/refs/numberValue"
-        },
-        "startAngle": {
-          "$ref": "#/refs/numberValue"
-        },
-        "endAngle": {
-          "$ref": "#/refs/numberValue"
-        },
-        "padAngle": {
-          "$ref": "#/refs/numberValue"
-        },
-        "interpolate": {
-          "$ref": "#/refs/stringValue"
-        },
-        "tension": {
-          "$ref": "#/refs/numberValue"
-        },
-        "orient": {
-          "$ref": "#/refs/directionValue"
-        },
-        "defined": {
-          "$ref": "#/refs/booleanValue"
-        },
-        "url": {
-          "$ref": "#/refs/stringValue"
-        },
-        "align": {
-          "$ref": "#/refs/alignValue"
-        },
-        "baseline": {
-          "$ref": "#/refs/baselineValue"
-        },
-        "aspect": {
-          "$ref": "#/refs/booleanValue"
-        },
-        "smooth": {
-          "$ref": "#/refs/booleanValue"
-        },
-        "text": {
-          "$ref": "#/refs/textValue"
-        },
-        "dir": {
-          "$ref": "#/refs/stringValue"
-        },
-        "ellipsis": {
-          "$ref": "#/refs/stringValue"
-        },
-        "limit": {
-          "$ref": "#/refs/numberValue"
-        },
-        "lineBreak": {
-          "$ref": "#/refs/stringValue"
-        },
-        "lineHeight": {
-          "$ref": "#/refs/numberValue"
-        },
-        "dx": {
-          "$ref": "#/refs/numberValue"
-        },
-        "dy": {
-          "$ref": "#/refs/numberValue"
-        },
-        "radius": {
-          "$ref": "#/refs/numberValue"
-        },
-        "theta": {
-          "$ref": "#/refs/numberValue"
-        },
-        "font": {
-          "$ref": "#/refs/stringValue"
-        },
-        "fontSize": {
-          "$ref": "#/refs/numberValue"
-        },
-        "fontWeight": {
-          "$ref": "#/refs/fontWeightValue"
-        },
-        "fontStyle": {
-          "$ref": "#/refs/stringValue"
-        }
-      },
-      "additionalProperties": true
-    },
-    "encode": {
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^.+$": {
-          "$ref": "#/defs/encodeEntry"
-        }
-      }
-    },
-    "layout": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "align": {
-              "oneOf": [
-                {
-                  "oneOf": [
-                    {
-                      "enum": [
-                        "all",
-                        "each",
-                        "none"
-                      ]
-                    },
-                    {
-                      "$ref": "#/refs/signal"
-                    }
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "row": {
-                      "oneOf": [
-                        {
-                          "enum": [
-                            "all",
-                            "each",
-                            "none"
-                          ]
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "column": {
-                      "oneOf": [
-                        {
-                          "enum": [
-                            "all",
-                            "each",
-                            "none"
-                          ]
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "bounds": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "full",
-                    "flush"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "center": {
-              "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "row": {
-                      "$ref": "#/refs/booleanOrSignal"
-                    },
-                    "column": {
-                      "$ref": "#/refs/booleanOrSignal"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "columns": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "padding": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "row": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "column": {
-                      "$ref": "#/refs/numberOrSignal"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "offset": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "rowHeader": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "rowFooter": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "rowTitle": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "columnHeader": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "columnFooter": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "columnTitle": {
-                      "$ref": "#/refs/numberOrSignal"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "headerBand": {
-              "oneOf": [
-                {
-                  "$ref": "#/refs/numberOrSignal"
-                },
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "row": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "column": {
-                      "$ref": "#/refs/numberOrSignal"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "footerBand": {
-              "oneOf": [
-                {
-                  "$ref": "#/refs/numberOrSignal"
-                },
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "row": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "column": {
-                      "$ref": "#/refs/numberOrSignal"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "titleBand": {
-              "oneOf": [
-                {
-                  "$ref": "#/refs/numberOrSignal"
-                },
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "row": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "column": {
-                      "$ref": "#/refs/numberOrSignal"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "titleAnchor": {
-              "oneOf": [
-                {
-                  "oneOf": [
-                    {
-                      "enum": [
-                        "start",
-                        "end"
-                      ]
-                    },
-                    {
-                      "$ref": "#/refs/signal"
-                    }
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "row": {
-                      "oneOf": [
-                        {
-                          "enum": [
-                            "start",
-                            "end"
-                          ]
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "column": {
-                      "oneOf": [
-                        {
-                          "enum": [
-                            "start",
-                            "end"
-                          ]
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ]
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/refs/signal"
-        }
-      ]
-    },
-    "guideEncode": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "interactive": {
-          "type": "boolean",
-          "default": false
-        },
-        "style": {
-          "$ref": "#/refs/style"
-        }
-      },
-      "additionalProperties": false,
-      "patternProperties": {
-        "^(?!interactive|name|style).+$": {
-          "$ref": "#/defs/encodeEntry"
-        }
-      }
-    },
-    "legend": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "size": {
-              "type": "string"
-            },
-            "shape": {
-              "type": "string"
-            },
-            "fill": {
-              "type": "string"
-            },
-            "stroke": {
-              "type": "string"
-            },
-            "opacity": {
-              "type": "string"
-            },
-            "strokeDash": {
-              "type": "string"
-            },
-            "strokeWidth": {
-              "type": "string"
-            },
-            "type": {
-              "enum": [
-                "gradient",
-                "symbol"
-              ]
-            },
-            "direction": {
-              "enum": [
-                "vertical",
-                "horizontal"
-              ]
-            },
-            "orient": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "none",
-                    "left",
-                    "right",
-                    "top",
-                    "bottom",
-                    "top-left",
-                    "top-right",
-                    "bottom-left",
-                    "bottom-right"
-                  ],
-                  "default": "right"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "tickCount": {
-              "$ref": "#/refs/tickCount"
-            },
-            "tickMinStep": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "symbolLimit": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "values": {
-              "$ref": "#/refs/arrayOrSignal"
-            },
-            "zindex": {
-              "type": "number"
-            },
-            "cornerRadius": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "fillColor": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/colorValue"
-                }
-              ]
-            },
-            "offset": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "padding": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "strokeColor": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/colorValue"
-                }
-              ]
-            },
-            "legendX": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "legendY": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "title": {
-              "$ref": "#/refs/textOrSignal"
-            },
-            "titleAlign": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "left",
-                    "right",
-                    "center"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/alignValue"
-                }
-              ]
-            },
-            "titleAnchor": {
-              "oneOf": [
-                {
-                  "enum": [
-                    null,
-                    "start",
-                    "middle",
-                    "end"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/anchorValue"
-                }
-              ]
-            },
-            "titleBaseline": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "top",
-                    "middle",
-                    "bottom",
-                    "alphabetic",
-                    "line-top",
-                    "line-bottom"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/baselineValue"
-                }
-              ]
-            },
-            "titleColor": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/colorValue"
-                }
-              ]
-            },
-            "titleFont": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/stringValue"
-                }
-              ]
-            },
-            "titleFontSize": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "titleFontStyle": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/stringValue"
-                }
-              ]
-            },
-            "titleFontWeight": {
-              "oneOf": [
-                {
-                  "enum": [
-                    null,
-                    "normal",
-                    "bold",
-                    "lighter",
-                    "bolder",
-                    "100",
-                    "200",
-                    "300",
-                    "400",
-                    "500",
-                    "600",
-                    "700",
-                    "800",
-                    "900",
-                    100,
-                    200,
-                    300,
-                    400,
-                    500,
-                    600,
-                    700,
-                    800,
-                    900
-                  ]
-                },
-                {
-                  "$ref": "#/refs/fontWeightValue"
-                }
-              ]
-            },
-            "titleLimit": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "titleLineHeight": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "titleOpacity": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "titleOrient": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "left",
-                    "right",
-                    "top",
-                    "bottom"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/orientValue"
-                }
-              ]
-            },
-            "titlePadding": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "gradientLength": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "gradientOpacity": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "gradientStrokeColor": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/colorValue"
-                }
-              ]
-            },
-            "gradientStrokeWidth": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "gradientThickness": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "clipHeight": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "columns": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "columnPadding": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "rowPadding": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "gridAlign": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "all",
-                    "each",
-                    "none"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "symbolDash": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "number"
-                  }
-                },
-                {
-                  "$ref": "#/refs/arrayValue"
-                }
-              ]
-            },
-            "symbolDashOffset": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "symbolFillColor": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/colorValue"
-                }
-              ]
-            },
-            "symbolOffset": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "symbolOpacity": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "symbolSize": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "symbolStrokeColor": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/colorValue"
-                }
-              ]
-            },
-            "symbolStrokeWidth": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "symbolType": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/stringValue"
-                }
-              ]
-            },
-            "format": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "year": {
-                      "type": "string"
-                    },
-                    "quarter": {
-                      "type": "string"
-                    },
-                    "month": {
-                      "type": "string"
-                    },
-                    "date": {
-                      "type": "string"
-                    },
-                    "week": {
-                      "type": "string"
-                    },
-                    "day": {
-                      "type": "string"
-                    },
-                    "hours": {
-                      "type": "string"
-                    },
-                    "minutes": {
-                      "type": "string"
-                    },
-                    "seconds": {
-                      "type": "string"
-                    },
-                    "milliseconds": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "formatType": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "number",
-                    "time",
-                    "utc"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "labelAlign": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "left",
-                    "right",
-                    "center"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/alignValue"
-                }
-              ]
-            },
-            "labelBaseline": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "top",
-                    "middle",
-                    "bottom",
-                    "alphabetic",
-                    "line-top",
-                    "line-bottom"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/baselineValue"
-                }
-              ]
-            },
-            "labelColor": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/colorValue"
-                }
-              ]
-            },
-            "labelFont": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/stringValue"
-                }
-              ]
-            },
-            "labelFontSize": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "labelFontStyle": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/stringValue"
-                }
-              ]
-            },
-            "labelFontWeight": {
-              "oneOf": [
-                {
-                  "enum": [
-                    null,
-                    "normal",
-                    "bold",
-                    "lighter",
-                    "bolder",
-                    "100",
-                    "200",
-                    "300",
-                    "400",
-                    "500",
-                    "600",
-                    "700",
-                    "800",
-                    "900",
-                    100,
-                    200,
-                    300,
-                    400,
-                    500,
-                    600,
-                    700,
-                    800,
-                    900
-                  ]
-                },
-                {
-                  "$ref": "#/refs/fontWeightValue"
-                }
-              ]
-            },
-            "labelLimit": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "labelOffset": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "labelOpacity": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "labelOverlap": {
-              "$ref": "#/refs/labelOverlap"
-            },
-            "labelSeparation": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "encode": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "$ref": "#/defs/guideEncode"
-                },
-                "labels": {
-                  "$ref": "#/defs/guideEncode"
-                },
-                "legend": {
-                  "$ref": "#/defs/guideEncode"
-                },
-                "entries": {
-                  "$ref": "#/defs/guideEncode"
-                },
-                "symbols": {
-                  "$ref": "#/defs/guideEncode"
-                },
-                "gradient": {
-                  "$ref": "#/defs/guideEncode"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "anyOf": [
-            {
-              "type": "object",
-              "required": [
-                "size"
-              ]
-            },
-            {
-              "type": "object",
-              "required": [
-                "shape"
-              ]
-            },
-            {
-              "type": "object",
-              "required": [
-                "fill"
-              ]
-            },
-            {
-              "type": "object",
-              "required": [
-                "stroke"
-              ]
-            },
-            {
-              "type": "object",
-              "required": [
-                "opacity"
-              ]
-            },
-            {
-              "type": "object",
-              "required": [
-                "strokeDash"
-              ]
-            },
-            {
-              "type": "object",
-              "required": [
-                "strokeWidth"
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "mark": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "$ref": "#/refs/marktype"
-        },
-        "role": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "style": {
-          "$ref": "#/refs/style"
-        },
-        "key": {
-          "type": "string"
-        },
-        "clip": {
-          "$ref": "#/refs/markclip"
-        },
-        "sort": {
-          "$ref": "#/refs/compare"
-        },
-        "interactive": {
-          "$ref": "#/refs/booleanOrSignal"
-        },
-        "encode": {
-          "$ref": "#/defs/encode"
-        },
-        "transform": {
-          "type": "array",
-          "items": {
-            "$ref": "#/defs/transformMark"
-          }
-        },
-        "on": {
-          "$ref": "#/defs/onMarkTrigger"
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
-    "markGroup": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "group"
-              ]
-            },
-            "from": {
-              "oneOf": [
-                {
-                  "$ref": "#/refs/from"
-                },
-                {
-                  "$ref": "#/refs/facet"
-                }
-              ]
-            }
-          },
-          "required": [
-            "type"
-          ]
-        },
-        {
-          "$ref": "#/defs/mark"
-        },
-        {
-          "$ref": "#/defs/scope"
-        }
-      ]
-    },
-    "markVisual": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "not": {
-                "enum": [
-                  "group"
-                ]
-              }
-            },
-            "from": {
-              "$ref": "#/refs/from"
-            }
-          }
-        },
-        {
-          "$ref": "#/defs/mark"
-        }
-      ]
-    },
-    "listener": {
-      "oneOf": [
-        {
-          "$ref": "#/refs/signal"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "scale": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "scale"
-          ]
-        },
-        {
-          "$ref": "#/defs/stream"
-        }
-      ]
-    },
-    "onEvents": {
-      "type": "array",
-      "items": {
-        "allOf": [
-          {
-            "type": "object",
-            "properties": {
-              "events": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/selector"
-                  },
-                  {
-                    "$ref": "#/defs/listener"
-                  },
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/defs/listener"
-                    },
-                    "minItems": 1
-                  }
-                ]
-              },
-              "force": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "events"
-            ]
-          },
-          {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "encode": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "encode"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "update": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/refs/exprString"
-                      },
-                      {
-                        "$ref": "#/refs/expr"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "value": {}
-                        },
-                        "required": [
-                          "value"
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "update"
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "onTrigger": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "trigger": {
-            "$ref": "#/refs/exprString"
-          },
-          "insert": {
-            "$ref": "#/refs/exprString"
-          },
-          "remove": {
-            "oneOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "$ref": "#/refs/exprString"
-              }
-            ]
-          },
-          "toggle": {
-            "$ref": "#/refs/exprString"
-          },
-          "modify": {
-            "$ref": "#/refs/exprString"
-          },
-          "values": {
-            "$ref": "#/refs/exprString"
-          }
-        },
-        "required": [
-          "trigger"
-        ],
-        "additionalProperties": false
-      }
-    },
-    "onMarkTrigger": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "trigger": {
-            "$ref": "#/refs/exprString"
-          },
-          "modify": {
-            "$ref": "#/refs/exprString"
-          },
-          "values": {
-            "$ref": "#/refs/exprString"
-          }
-        },
-        "required": [
-          "trigger"
-        ],
-        "additionalProperties": false
-      }
-    },
-    "padding": {
-      "oneOf": [
-        {
-          "type": "number"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "top": {
-              "type": "number"
-            },
-            "bottom": {
-              "type": "number"
-            },
-            "left": {
-              "type": "number"
-            },
-            "right": {
-              "type": "number"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "$ref": "#/refs/signal"
-        }
-      ]
-    },
-    "projection": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "type": {
-          "$ref": "#/refs/stringOrSignal"
-        },
-        "clipAngle": {
-          "$ref": "#/refs/numberOrSignal"
-        },
-        "clipExtent": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "minItems": 2,
-                    "maxItems": 2
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "scale": {
-          "$ref": "#/refs/numberOrSignal"
-        },
-        "translate": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/refs/numberOrSignal"
-              },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "center": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/refs/numberOrSignal"
-              },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "rotate": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/refs/numberOrSignal"
-              },
-              "minItems": 2,
-              "maxItems": 3
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "parallels": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/refs/numberOrSignal"
-              },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "precision": {
-          "$ref": "#/refs/numberOrSignal"
-        },
-        "pointRadius": {
-          "$ref": "#/refs/numberOrSignal"
-        },
-        "fit": {
-          "oneOf": [
-            {
-              "type": "object"
-            },
-            {
-              "type": "array"
-            }
-          ]
-        },
-        "extent": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "minItems": 2,
-                    "maxItems": 2
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "size": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/refs/numberOrSignal"
-              },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        }
-      },
-      "required": [
-        "name"
-      ],
-      "additionalProperties": true
-    },
-    "scale": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "identity"
-              ]
-            },
-            "nice": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "ordinal"
-              ]
-            },
-            "range": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "width",
-                    "height",
-                    "symbol",
-                    "category",
-                    "ordinal",
-                    "ramp",
-                    "diverging",
-                    "heatmap"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "scheme": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "oneOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "$ref": "#/refs/signal"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "count": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "extent": {
-                      "oneOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/refs/numberOrSignal"
-                          },
-                          "numItems": 2
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "scheme"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "oneOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "string"
-                        },
-                        "field": {
-                          "$ref": "#/refs/stringOrSignal"
-                        },
-                        "sort": {
-                          "oneOf": [
-                            {
-                              "type": "boolean"
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "field": {
-                                  "$ref": "#/refs/stringOrSignal"
-                                },
-                                "op": {
-                                  "$ref": "#/refs/stringOrSignal"
-                                },
-                                "order": {
-                                  "$ref": "#/refs/sortOrder"
-                                }
-                              },
-                              "additionalProperties": false
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "data",
-                        "field"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "string"
-                        },
-                        "fields": {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/refs/stringOrSignal"
-                          },
-                          "minItems": 1
-                        },
-                        "sort": {
-                          "oneOf": [
-                            {
-                              "type": "boolean"
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "op": {
-                                  "enum": [
-                                    "count"
-                                  ]
-                                },
-                                "order": {
-                                  "$ref": "#/refs/sortOrder"
-                                }
-                              },
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "field": {
-                                  "$ref": "#/refs/stringOrSignal"
-                                },
-                                "op": {
-                                  "enum": [
-                                    "count",
-                                    "min",
-                                    "max"
-                                  ]
-                                },
-                                "order": {
-                                  "$ref": "#/refs/sortOrder"
-                                }
-                              },
-                              "required": [
-                                "field",
-                                "op"
-                              ],
-                              "additionalProperties": false
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "data",
-                        "fields"
-                      ],
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "fields": {
-                          "type": "array",
-                          "items": {
-                            "oneOf": [
-                              {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string"
-                                  },
-                                  "field": {
-                                    "$ref": "#/refs/stringOrSignal"
-                                  }
-                                },
-                                "required": [
-                                  "data",
-                                  "field"
-                                ],
-                                "additionalProperties": false
-                              },
-                              {
-                                "type": "array",
-                                "items": {
-                                  "oneOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "number"
-                                    },
-                                    {
-                                      "type": "boolean"
-                                    }
-                                  ]
-                                }
-                              },
-                              {
-                                "$ref": "#/refs/signal"
-                              }
-                            ]
-                          },
-                          "minItems": 1
-                        },
-                        "sort": {
-                          "oneOf": [
-                            {
-                              "type": "boolean"
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "op": {
-                                  "enum": [
-                                    "count"
-                                  ]
-                                },
-                                "order": {
-                                  "$ref": "#/refs/sortOrder"
-                                }
-                              },
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "field": {
-                                  "$ref": "#/refs/stringOrSignal"
-                                },
-                                "op": {
-                                  "enum": [
-                                    "count",
-                                    "min",
-                                    "max"
-                                  ]
-                                },
-                                "order": {
-                                  "$ref": "#/refs/sortOrder"
-                                }
-                              },
-                              "required": [
-                                "field",
-                                "op"
-                              ],
-                              "additionalProperties": false
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "fields"
-                      ],
-                      "additionalProperties": false
-                    }
-                  ]
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "interpolate": {
-              "$ref": "#/refs/scaleInterpolate"
-            },
-            "domainImplicit": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "band"
-              ]
-            },
-            "paddingInner": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "range": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "width",
-                    "height",
-                    "symbol",
-                    "category",
-                    "ordinal",
-                    "ramp",
-                    "diverging",
-                    "heatmap"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "step": {
-                      "$ref": "#/refs/numberOrSignal"
-                    }
-                  },
-                  "required": [
-                    "step"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "padding": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "paddingOuter": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "align": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "point"
-              ]
-            },
-            "range": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "width",
-                    "height",
-                    "symbol",
-                    "category",
-                    "ordinal",
-                    "ramp",
-                    "diverging",
-                    "heatmap"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "step": {
-                      "$ref": "#/refs/numberOrSignal"
-                    }
-                  },
-                  "required": [
-                    "step"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "padding": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "paddingOuter": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "align": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "quantize",
-                "threshold"
-              ]
-            },
-            "range": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "width",
-                    "height",
-                    "symbol",
-                    "category",
-                    "ordinal",
-                    "ramp",
-                    "diverging",
-                    "heatmap"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "scheme": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "oneOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "$ref": "#/refs/signal"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "count": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "extent": {
-                      "oneOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/refs/numberOrSignal"
-                          },
-                          "numItems": 2
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "scheme"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "interpolate": {
-              "$ref": "#/refs/scaleInterpolate"
-            },
-            "nice": {
-              "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "zero": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "quantile"
-              ]
-            },
-            "range": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "width",
-                    "height",
-                    "symbol",
-                    "category",
-                    "ordinal",
-                    "ramp",
-                    "diverging",
-                    "heatmap"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "scheme": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "oneOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "$ref": "#/refs/signal"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "count": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "extent": {
-                      "oneOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/refs/numberOrSignal"
-                          },
-                          "numItems": 2
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "scheme"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "interpolate": {
-              "$ref": "#/refs/scaleInterpolate"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "bin-ordinal"
-              ]
-            },
-            "bins": {
-              "$ref": "#/refs/scaleBins"
-            },
-            "range": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "width",
-                    "height",
-                    "symbol",
-                    "category",
-                    "ordinal",
-                    "ramp",
-                    "diverging",
-                    "heatmap"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "scheme": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "oneOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "$ref": "#/refs/signal"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "count": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "extent": {
-                      "oneOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/refs/numberOrSignal"
-                          },
-                          "numItems": 2
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "scheme"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "interpolate": {
-              "$ref": "#/refs/scaleInterpolate"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "time",
-                "utc"
-              ]
-            },
-            "nice": {
-              "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "enum": [
-                    "millisecond",
-                    "second",
-                    "minute",
-                    "hour",
-                    "day",
-                    "week",
-                    "month",
-                    "year"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "interval": {
-                      "oneOf": [
-                        {
-                          "enum": [
-                            "millisecond",
-                            "second",
-                            "minute",
-                            "hour",
-                            "day",
-                            "week",
-                            "month",
-                            "year"
-                          ]
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "step": {
-                      "$ref": "#/refs/numberOrSignal"
-                    }
-                  },
-                  "required": [
-                    "interval"
-                  ],
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "range": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "width",
-                    "height",
-                    "symbol",
-                    "category",
-                    "ordinal",
-                    "ramp",
-                    "diverging",
-                    "heatmap"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "scheme": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "oneOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "$ref": "#/refs/signal"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "count": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "extent": {
-                      "oneOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/refs/numberOrSignal"
-                          },
-                          "numItems": 2
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "scheme"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "bins": {
-              "$ref": "#/refs/scaleBins"
-            },
-            "interpolate": {
-              "$ref": "#/refs/scaleInterpolate"
-            },
-            "clamp": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "padding": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "linear",
-                "sqrt",
-                "sequential"
-              ]
-            },
-            "nice": {
-              "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "zero": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "range": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "width",
-                    "height",
-                    "symbol",
-                    "category",
-                    "ordinal",
-                    "ramp",
-                    "diverging",
-                    "heatmap"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "scheme": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "oneOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "$ref": "#/refs/signal"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "count": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "extent": {
-                      "oneOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/refs/numberOrSignal"
-                          },
-                          "numItems": 2
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "scheme"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "bins": {
-              "$ref": "#/refs/scaleBins"
-            },
-            "interpolate": {
-              "$ref": "#/refs/scaleInterpolate"
-            },
-            "clamp": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "padding": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "log"
-              ]
-            },
-            "base": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "nice": {
-              "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "zero": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "range": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "width",
-                    "height",
-                    "symbol",
-                    "category",
-                    "ordinal",
-                    "ramp",
-                    "diverging",
-                    "heatmap"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "scheme": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "oneOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "$ref": "#/refs/signal"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "count": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "extent": {
-                      "oneOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/refs/numberOrSignal"
-                          },
-                          "numItems": 2
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "scheme"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "bins": {
-              "$ref": "#/refs/scaleBins"
-            },
-            "interpolate": {
-              "$ref": "#/refs/scaleInterpolate"
-            },
-            "clamp": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "padding": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "pow"
-              ]
-            },
-            "exponent": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "nice": {
-              "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "zero": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "range": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "width",
-                    "height",
-                    "symbol",
-                    "category",
-                    "ordinal",
-                    "ramp",
-                    "diverging",
-                    "heatmap"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "scheme": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "oneOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "$ref": "#/refs/signal"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "count": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "extent": {
-                      "oneOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/refs/numberOrSignal"
-                          },
-                          "numItems": 2
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "scheme"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "bins": {
-              "$ref": "#/refs/scaleBins"
-            },
-            "interpolate": {
-              "$ref": "#/refs/scaleInterpolate"
-            },
-            "clamp": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "padding": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "symlog"
-              ]
-            },
-            "constant": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "nice": {
-              "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "zero": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "range": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "width",
-                    "height",
-                    "symbol",
-                    "category",
-                    "ordinal",
-                    "ramp",
-                    "diverging",
-                    "heatmap"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "scheme": {
-                      "oneOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "oneOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "$ref": "#/refs/signal"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    },
-                    "count": {
-                      "$ref": "#/refs/numberOrSignal"
-                    },
-                    "extent": {
-                      "oneOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/refs/numberOrSignal"
-                          },
-                          "numItems": 2
-                        },
-                        {
-                          "$ref": "#/refs/signal"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "scheme"
-                  ],
-                  "additionalProperties": false
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "bins": {
-              "$ref": "#/refs/scaleBins"
-            },
-            "interpolate": {
-              "$ref": "#/refs/scaleInterpolate"
-            },
-            "clamp": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "padding": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "name": {
-              "type": "string"
-            },
-            "domain": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "null"
-                      },
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/refs/numberOrSignal"
-                        }
-                      }
-                    ]
-                  }
-                },
-                {
-                  "$ref": "#/refs/scaleData"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "domainMin": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMax": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainMid": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "domainRaw": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "reverse": {
-              "$ref": "#/refs/booleanOrSignal"
-            },
-            "round": {
-              "$ref": "#/refs/booleanOrSignal"
-            }
-          },
-          "required": [
-            "type",
-            "name"
-          ],
-          "additionalProperties": false
-        }
-      ]
-    },
-    "scope": {
-      "type": "object",
-      "properties": {
-        "encode": {
-          "$ref": "#/defs/encode"
-        },
-        "layout": {
-          "$ref": "#/defs/layout"
-        },
-        "signals": {
-          "type": "array",
-          "items": {
-            "$ref": "#/defs/signal"
-          }
-        },
-        "data": {
-          "type": "array",
-          "items": {
-            "$ref": "#/defs/data"
-          }
-        },
-        "scales": {
-          "type": "array",
-          "items": {
-            "$ref": "#/defs/scale"
-          }
-        },
-        "projections": {
-          "type": "array",
-          "items": {
-            "$ref": "#/defs/projection"
-          }
-        },
-        "axes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/defs/axis"
-          }
-        },
-        "legends": {
-          "type": "array",
-          "items": {
-            "$ref": "#/defs/legend"
-          }
-        },
-        "title": {
-          "$ref": "#/defs/title"
-        },
-        "marks": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "#/defs/markGroup"
-              },
-              {
-                "$ref": "#/defs/markVisual"
-              }
-            ]
-          }
-        },
-        "usermeta": {
-          "type": "object"
-        }
-      }
-    },
-    "signalName": {
-      "type": "string",
-      "not": {
-        "enum": [
-          "parent",
-          "datum",
-          "event",
-          "item"
-        ]
-      }
-    },
-    "signal": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "name": {
-              "$ref": "#/defs/signalName"
-            },
-            "description": {
-              "type": "string"
-            },
-            "push": {
-              "enum": [
-                "outer"
-              ]
-            },
-            "on": {
-              "$ref": "#/defs/onEvents"
-            }
-          },
-          "required": [
-            "name",
-            "push"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "name": {
-              "$ref": "#/defs/signalName"
-            },
-            "description": {
-              "type": "string"
-            },
-            "value": {},
-            "react": {
-              "type": "boolean",
-              "default": true
-            },
-            "update": {
-              "$ref": "#/refs/exprString"
-            },
-            "on": {
-              "$ref": "#/defs/onEvents"
-            },
-            "bind": {
-              "$ref": "#/defs/bind"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "name": {
-              "$ref": "#/defs/signalName"
-            },
-            "description": {
-              "type": "string"
-            },
-            "value": {},
-            "init": {
-              "$ref": "#/refs/exprString"
-            },
-            "on": {
-              "$ref": "#/defs/onEvents"
-            },
-            "bind": {
-              "$ref": "#/defs/bind"
-            }
-          },
-          "required": [
-            "name",
-            "init"
-          ],
-          "additionalProperties": false
-        }
-      ]
-    },
-    "stream": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "between": {
-              "type": "array",
-              "items": {
-                "$ref": "#/defs/stream"
-              },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            "marktype": {
-              "type": "string"
-            },
-            "markname": {
-              "type": "string"
-            },
-            "filter": {
-              "oneOf": [
-                {
-                  "$ref": "#/refs/exprString"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/refs/exprString"
-                  },
-                  "minItems": 1
-                }
-              ]
-            },
-            "throttle": {
-              "type": "number"
-            },
-            "debounce": {
-              "type": "number"
-            },
-            "consume": {
-              "type": "boolean"
-            }
-          }
-        },
-        {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "type"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "stream": {
-                  "$ref": "#/defs/stream"
-                }
-              },
-              "required": [
-                "stream"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "merge": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/defs/stream"
-                  },
-                  "minItems": 1
-                }
-              },
-              "required": [
-                "merge"
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "title": {
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "orient": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "none",
-                    "left",
-                    "right",
-                    "top",
-                    "bottom"
-                  ],
-                  "default": "top"
-                },
-                {
-                  "$ref": "#/refs/signal"
-                }
-              ]
-            },
-            "anchor": {
-              "oneOf": [
-                {
-                  "enum": [
-                    null,
-                    "start",
-                    "middle",
-                    "end"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/anchorValue"
-                }
-              ]
-            },
-            "frame": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "group",
-                    "bounds"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/stringValue"
-                }
-              ]
-            },
-            "offset": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "limit": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "text": {
-              "$ref": "#/refs/textOrSignal"
-            },
-            "subtitle": {
-              "$ref": "#/refs/textOrSignal"
-            },
-            "zindex": {
-              "type": "number"
-            },
-            "align": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "left",
-                    "right",
-                    "center"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/alignValue"
-                }
-              ]
-            },
-            "angle": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "baseline": {
-              "oneOf": [
-                {
-                  "enum": [
-                    "top",
-                    "middle",
-                    "bottom",
-                    "alphabetic",
-                    "line-top",
-                    "line-bottom"
-                  ]
-                },
-                {
-                  "$ref": "#/refs/baselineValue"
-                }
-              ]
-            },
-            "dx": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "dy": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "color": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/colorValue"
-                }
-              ]
-            },
-            "font": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/stringValue"
-                }
-              ]
-            },
-            "fontSize": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "fontStyle": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/stringValue"
-                }
-              ]
-            },
-            "fontWeight": {
-              "oneOf": [
-                {
-                  "enum": [
-                    null,
-                    "normal",
-                    "bold",
-                    "lighter",
-                    "bolder",
-                    "100",
-                    "200",
-                    "300",
-                    "400",
-                    "500",
-                    "600",
-                    "700",
-                    "800",
-                    "900",
-                    100,
-                    200,
-                    300,
-                    400,
-                    500,
-                    600,
-                    700,
-                    800,
-                    900
-                  ]
-                },
-                {
-                  "$ref": "#/refs/fontWeightValue"
-                }
-              ]
-            },
-            "lineHeight": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "subtitleColor": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/colorValue"
-                }
-              ]
-            },
-            "subtitleFont": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/stringValue"
-                }
-              ]
-            },
-            "subtitleFontSize": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "subtitleFontStyle": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/refs/stringValue"
-                }
-              ]
-            },
-            "subtitleFontWeight": {
-              "oneOf": [
-                {
-                  "enum": [
-                    null,
-                    "normal",
-                    "bold",
-                    "lighter",
-                    "bolder",
-                    "100",
-                    "200",
-                    "300",
-                    "400",
-                    "500",
-                    "600",
-                    "700",
-                    "800",
-                    "900",
-                    100,
-                    200,
-                    300,
-                    400,
-                    500,
-                    600,
-                    700,
-                    800,
-                    900
-                  ]
-                },
-                {
-                  "$ref": "#/refs/fontWeightValue"
-                }
-              ]
-            },
-            "subtitleLineHeight": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "$ref": "#/refs/numberValue"
-                }
-              ]
-            },
-            "subtitlePadding": {
-              "$ref": "#/refs/numberOrSignal"
-            },
-            "encode": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "patternProperties": {
-                    "^(?!interactive|name|style).+$": {
-                      "$ref": "#/defs/encodeEntry"
-                    }
-                  }
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "group": {
-                      "$ref": "#/defs/guideEncode"
-                    },
-                    "title": {
-                      "$ref": "#/defs/guideEncode"
-                    },
-                    "subtitle": {
-                      "$ref": "#/defs/guideEncode"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ]
-            },
-            "name": {
-              "type": "string"
-            },
-            "interactive": {
-              "type": "boolean"
-            },
-            "style": {
-              "$ref": "#/refs/style"
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "transform": {
-      "oneOf": [
-        {
-          "$ref": "#/defs/crossfilterTransform"
-        },
-        {
-          "$ref": "#/defs/resolvefilterTransform"
-        },
-        {
-          "$ref": "#/defs/linkpathTransform"
-        },
-        {
-          "$ref": "#/defs/pieTransform"
-        },
-        {
-          "$ref": "#/defs/stackTransform"
-        },
-        {
-          "$ref": "#/defs/forceTransform"
-        },
-        {
-          "$ref": "#/defs/contourTransform"
-        },
-        {
-          "$ref": "#/defs/geojsonTransform"
-        },
-        {
-          "$ref": "#/defs/geopathTransform"
-        },
-        {
-          "$ref": "#/defs/geopointTransform"
-        },
-        {
-          "$ref": "#/defs/geoshapeTransform"
-        },
-        {
-          "$ref": "#/defs/graticuleTransform"
-        },
-        {
-          "$ref": "#/defs/heatmapTransform"
-        },
-        {
-          "$ref": "#/defs/isocontourTransform"
-        },
-        {
-          "$ref": "#/defs/kde2dTransform"
-        },
-        {
-          "$ref": "#/defs/nestTransform"
-        },
-        {
-          "$ref": "#/defs/packTransform"
-        },
-        {
-          "$ref": "#/defs/partitionTransform"
-        },
-        {
-          "$ref": "#/defs/stratifyTransform"
-        },
-        {
-          "$ref": "#/defs/treeTransform"
-        },
-        {
-          "$ref": "#/defs/treelinksTransform"
-        },
-        {
-          "$ref": "#/defs/treemapTransform"
-        },
-        {
-          "$ref": "#/defs/loessTransform"
-        },
-        {
-          "$ref": "#/defs/regressionTransform"
-        },
-        {
-          "$ref": "#/defs/aggregateTransform"
-        },
-        {
-          "$ref": "#/defs/binTransform"
-        },
-        {
-          "$ref": "#/defs/collectTransform"
-        },
-        {
-          "$ref": "#/defs/countpatternTransform"
-        },
-        {
-          "$ref": "#/defs/crossTransform"
-        },
-        {
-          "$ref": "#/defs/densityTransform"
-        },
-        {
-          "$ref": "#/defs/dotbinTransform"
-        },
-        {
-          "$ref": "#/defs/extentTransform"
-        },
-        {
-          "$ref": "#/defs/filterTransform"
-        },
-        {
-          "$ref": "#/defs/flattenTransform"
-        },
-        {
-          "$ref": "#/defs/foldTransform"
-        },
-        {
-          "$ref": "#/defs/formulaTransform"
-        },
-        {
-          "$ref": "#/defs/imputeTransform"
-        },
-        {
-          "$ref": "#/defs/joinaggregateTransform"
-        },
-        {
-          "$ref": "#/defs/kdeTransform"
-        },
-        {
-          "$ref": "#/defs/lookupTransform"
-        },
-        {
-          "$ref": "#/defs/pivotTransform"
-        },
-        {
-          "$ref": "#/defs/projectTransform"
-        },
-        {
-          "$ref": "#/defs/quantileTransform"
-        },
-        {
-          "$ref": "#/defs/sampleTransform"
-        },
-        {
-          "$ref": "#/defs/sequenceTransform"
-        },
-        {
-          "$ref": "#/defs/timeunitTransform"
-        },
-        {
-          "$ref": "#/defs/windowTransform"
-        },
-        {
-          "$ref": "#/defs/identifierTransform"
-        },
-        {
-          "$ref": "#/defs/voronoiTransform"
-        },
-        {
-          "$ref": "#/defs/wordcloudTransform"
-        }
-      ]
-    },
-    "transformMark": {
-      "oneOf": [
-        {
-          "$ref": "#/defs/crossfilterTransform"
-        },
-        {
-          "$ref": "#/defs/resolvefilterTransform"
-        },
-        {
-          "$ref": "#/defs/linkpathTransform"
-        },
-        {
-          "$ref": "#/defs/pieTransform"
-        },
-        {
-          "$ref": "#/defs/stackTransform"
-        },
-        {
-          "$ref": "#/defs/forceTransform"
-        },
-        {
-          "$ref": "#/defs/geojsonTransform"
-        },
-        {
-          "$ref": "#/defs/geopathTransform"
-        },
-        {
-          "$ref": "#/defs/geopointTransform"
-        },
-        {
-          "$ref": "#/defs/geoshapeTransform"
-        },
-        {
-          "$ref": "#/defs/heatmapTransform"
-        },
-        {
-          "$ref": "#/defs/packTransform"
-        },
-        {
-          "$ref": "#/defs/partitionTransform"
-        },
-        {
-          "$ref": "#/defs/stratifyTransform"
-        },
-        {
-          "$ref": "#/defs/treeTransform"
-        },
-        {
-          "$ref": "#/defs/treemapTransform"
-        },
-        {
-          "$ref": "#/defs/binTransform"
-        },
-        {
-          "$ref": "#/defs/collectTransform"
-        },
-        {
-          "$ref": "#/defs/dotbinTransform"
-        },
-        {
-          "$ref": "#/defs/extentTransform"
-        },
-        {
-          "$ref": "#/defs/formulaTransform"
-        },
-        {
-          "$ref": "#/defs/joinaggregateTransform"
-        },
-        {
-          "$ref": "#/defs/lookupTransform"
-        },
-        {
-          "$ref": "#/defs/sampleTransform"
-        },
-        {
-          "$ref": "#/defs/timeunitTransform"
-        },
-        {
-          "$ref": "#/defs/windowTransform"
-        },
-        {
-          "$ref": "#/defs/identifierTransform"
-        },
-        {
-          "$ref": "#/defs/voronoiTransform"
-        },
-        {
-          "$ref": "#/defs/wordcloudTransform"
-        }
-      ]
-    },
-    "crossfilterTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "crossfilter"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "fields": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "query": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {}
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "fields",
-        "query"
-      ],
-      "additionalProperties": false
-    },
-    "resolvefilterTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "resolvefilter"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "ignore": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "filter": {}
-      },
-      "required": [
-        "type",
-        "ignore",
-        "filter"
-      ],
-      "additionalProperties": false
-    },
-    "linkpathTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "linkpath"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "sourceX": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ],
-          "default": "source.x"
-        },
-        "sourceY": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ],
-          "default": "source.y"
-        },
-        "targetX": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ],
-          "default": "target.x"
-        },
-        "targetY": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ],
-          "default": "target.y"
-        },
-        "orient": {
-          "anyOf": [
-            {
-              "enum": [
-                "horizontal",
-                "vertical",
-                "radial"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "vertical"
-        },
-        "shape": {
-          "anyOf": [
-            {
-              "enum": [
-                "line",
-                "arc",
-                "curve",
-                "diagonal",
-                "orthogonal"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "line"
-        },
-        "require": {
-          "$ref": "#/refs/signal"
-        },
-        "as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "path"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "pieTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "pie"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "startAngle": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "endAngle": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 6.283185307179586
-        },
-        "sort": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            "startAngle",
-            "endAngle"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "stackTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "stack"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "sort": {
-          "$ref": "#/refs/compare"
-        },
-        "offset": {
-          "anyOf": [
-            {
-              "enum": [
-                "zero",
-                "center",
-                "normalize"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "zero"
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            "y0",
-            "y1"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "forceTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "force"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "static": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "restart": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "iterations": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 300
-        },
-        "alpha": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 1
-        },
-        "alphaMin": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 0.001
-        },
-        "alphaTarget": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "velocityDecay": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 0.4
-        },
-        "forces": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "force": {
-                    "enum": [
-                      "center"
-                    ]
-                  },
-                  "x": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      }
-                    ]
-                  },
-                  "y": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "force"
-                ],
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "force": {
-                    "enum": [
-                      "collide"
-                    ]
-                  },
-                  "radius": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "$ref": "#/refs/expr"
-                      },
-                      {
-                        "$ref": "#/refs/paramField"
-                      }
-                    ]
-                  },
-                  "strength": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      }
-                    ],
-                    "default": 0.7
-                  },
-                  "iterations": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      }
-                    ],
-                    "default": 1
-                  }
-                },
-                "required": [
-                  "force"
-                ],
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "force": {
-                    "enum": [
-                      "nbody"
-                    ]
-                  },
-                  "strength": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      }
-                    ],
-                    "default": -30
-                  },
-                  "theta": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      }
-                    ],
-                    "default": 0.9
-                  },
-                  "distanceMin": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      }
-                    ],
-                    "default": 1
-                  },
-                  "distanceMax": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "force"
-                ],
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "force": {
-                    "enum": [
-                      "link"
-                    ]
-                  },
-                  "links": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/refs/scaleField"
-                      },
-                      {
-                        "$ref": "#/refs/paramField"
-                      },
-                      {
-                        "$ref": "#/refs/expr"
-                      }
-                    ]
-                  },
-                  "distance": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "$ref": "#/refs/expr"
-                      },
-                      {
-                        "$ref": "#/refs/paramField"
-                      }
-                    ],
-                    "default": 30
-                  },
-                  "strength": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      },
-                      {
-                        "$ref": "#/refs/expr"
-                      },
-                      {
-                        "$ref": "#/refs/paramField"
-                      }
-                    ]
-                  },
-                  "iterations": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      }
-                    ],
-                    "default": 1
-                  }
-                },
-                "required": [
-                  "force"
-                ],
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "force": {
-                    "enum": [
-                      "x"
-                    ]
-                  },
-                  "strength": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      }
-                    ],
-                    "default": 0.1
-                  },
-                  "x": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/refs/scaleField"
-                      },
-                      {
-                        "$ref": "#/refs/paramField"
-                      },
-                      {
-                        "$ref": "#/refs/expr"
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "force"
-                ],
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "force": {
-                    "enum": [
-                      "y"
-                    ]
-                  },
-                  "strength": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "$ref": "#/refs/signal"
-                      }
-                    ],
-                    "default": 0.1
-                  },
-                  "y": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/refs/scaleField"
-                      },
-                      {
-                        "$ref": "#/refs/paramField"
-                      },
-                      {
-                        "$ref": "#/refs/expr"
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "force"
-                ],
-                "additionalProperties": false
-              }
-            ]
-          }
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": [
-            "x",
-            "y",
-            "vx",
-            "vy"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "contourTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "contour"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "size": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "values": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "x": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "y": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "weight": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "cellSize": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "bandwidth": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "count": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "nice": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "thresholds": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "smooth": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": true
-        }
-      },
-      "required": [
-        "type",
-        "size"
-      ],
-      "additionalProperties": false
-    },
-    "geojsonTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "geojson"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "fields": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "geojson": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "geopathTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "geopath"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "projection": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "pointRadius": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "$ref": "#/refs/expr"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            }
-          ]
-        },
-        "as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "path"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "geopointTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "geopoint"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "projection": {
-          "type": "string"
-        },
-        "fields": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            "x",
-            "y"
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "projection",
-        "fields"
-      ],
-      "additionalProperties": false
-    },
-    "geoshapeTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "geoshape"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "projection": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ],
-          "default": "datum"
-        },
-        "pointRadius": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "$ref": "#/refs/expr"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            }
-          ]
-        },
-        "as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "shape"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "graticuleTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "graticule"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "extent": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {}
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "extentMajor": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {}
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "extentMinor": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {}
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "step": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "stepMajor": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            90,
-            360
-          ]
-        },
-        "stepMinor": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            10,
-            10
-          ]
-        },
-        "precision": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 2.5
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "heatmapTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "heatmap"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "color": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "$ref": "#/refs/expr"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            }
-          ]
-        },
-        "opacity": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "$ref": "#/refs/expr"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            }
-          ]
-        },
-        "resolve": {
-          "anyOf": [
-            {
-              "enum": [
-                "shared",
-                "independent"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "independent"
-        },
-        "as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "image"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "isocontourTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "isocontour"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "thresholds": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "levels": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "nice": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "resolve": {
-          "anyOf": [
-            {
-              "enum": [
-                "shared",
-                "independent"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "independent"
-        },
-        "zero": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": true
-        },
-        "smooth": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": true
-        },
-        "scale": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "$ref": "#/refs/expr"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            }
-          ]
-        },
-        "translate": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": "contour"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "kde2dTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "kde2d"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "size": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "x": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "y": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "weight": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "cellSize": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "bandwidth": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "counts": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "grid"
-        }
-      },
-      "required": [
-        "type",
-        "size",
-        "x",
-        "y"
-      ],
-      "additionalProperties": false
-    },
-    "nestTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "nest"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "keys": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "generate": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "packTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "pack"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "sort": {
-          "$ref": "#/refs/compare"
-        },
-        "padding": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "radius": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "size": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 5,
-          "minItems": 5,
-          "default": [
-            "x",
-            "y",
-            "r",
-            "depth",
-            "children"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "partitionTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "partition"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "sort": {
-          "$ref": "#/refs/compare"
-        },
-        "padding": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "round": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "size": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 6,
-          "minItems": 6,
-          "default": [
-            "x0",
-            "y0",
-            "x1",
-            "y1",
-            "depth",
-            "children"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "stratifyTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "stratify"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "key": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "parentKey": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "key",
-        "parentKey"
-      ],
-      "additionalProperties": false
-    },
-    "treeTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "tree"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "sort": {
-          "$ref": "#/refs/compare"
-        },
-        "method": {
-          "anyOf": [
-            {
-              "enum": [
-                "tidy",
-                "cluster"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "tidy"
-        },
-        "size": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "nodeSize": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "separation": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": true
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 4,
-          "minItems": 4,
-          "default": [
-            "x",
-            "y",
-            "depth",
-            "children"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "treelinksTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "treelinks"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "treemapTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "treemap"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "sort": {
-          "$ref": "#/refs/compare"
-        },
-        "method": {
-          "anyOf": [
-            {
-              "enum": [
-                "squarify",
-                "resquarify",
-                "binary",
-                "dice",
-                "slice",
-                "slicedice"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "squarify"
-        },
-        "padding": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "paddingInner": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "paddingOuter": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "paddingTop": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "paddingRight": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "paddingBottom": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "paddingLeft": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "ratio": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 1.618033988749895
-        },
-        "round": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "size": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 6,
-          "minItems": 6,
-          "default": [
-            "x0",
-            "y0",
-            "x1",
-            "y1",
-            "depth",
-            "children"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "loessTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "loess"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "x": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "y": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "bandwidth": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 0.3
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "x",
-        "y"
-      ],
-      "additionalProperties": false
-    },
-    "regressionTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "regression"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "x": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "y": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "method": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "linear"
-        },
-        "order": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 3
-        },
-        "extent": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "params": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "x",
-        "y"
-      ],
-      "additionalProperties": false
-    },
-    "aggregateTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "aggregate"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "ops": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "enum": [
-                      "values",
-                      "count",
-                      "__count__",
-                      "missing",
-                      "valid",
-                      "sum",
-                      "product",
-                      "mean",
-                      "average",
-                      "variance",
-                      "variancep",
-                      "stdev",
-                      "stdevp",
-                      "stderr",
-                      "distinct",
-                      "ci0",
-                      "ci1",
-                      "median",
-                      "q1",
-                      "q3",
-                      "argmin",
-                      "argmax",
-                      "min",
-                      "max"
-                    ]
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "fields": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "drop": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": true
-        },
-        "cross": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "key": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "binTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "bin"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "interval": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": true
-        },
-        "anchor": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "maxbins": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 20
-        },
-        "base": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 10
-        },
-        "divide": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": [
-            5,
-            2
-          ]
-        },
-        "extent": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "span": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "step": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "steps": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "minstep": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "nice": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": true
-        },
-        "name": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            "bin0",
-            "bin1"
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "field",
-        "extent"
-      ],
-      "additionalProperties": false
-    },
-    "collectTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "collect"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "sort": {
-          "$ref": "#/refs/compare"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "countpatternTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "countpattern"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "case": {
-          "anyOf": [
-            {
-              "enum": [
-                "upper",
-                "lower",
-                "mixed"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "mixed"
-        },
-        "pattern": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "[\\w\"]+"
-        },
-        "stopwords": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            "text",
-            "count"
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "field"
-      ],
-      "additionalProperties": false
-    },
-    "crossTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "cross"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "filter": {
-          "$ref": "#/refs/exprString"
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            "a",
-            "b"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "densityTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "density"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "extent": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "steps": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "minsteps": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 25
-        },
-        "maxsteps": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 200
-        },
-        "method": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "pdf"
-        },
-        "distribution": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "function": {
-                  "enum": [
-                    "normal"
-                  ]
-                },
-                "mean": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "$ref": "#/refs/signal"
-                    }
-                  ]
-                },
-                "stdev": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "$ref": "#/refs/signal"
-                    }
-                  ],
-                  "default": 1
-                }
-              },
-              "required": [
-                "function"
-              ],
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "function": {
-                  "enum": [
-                    "lognormal"
-                  ]
-                },
-                "mean": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "$ref": "#/refs/signal"
-                    }
-                  ]
-                },
-                "stdev": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "$ref": "#/refs/signal"
-                    }
-                  ],
-                  "default": 1
-                }
-              },
-              "required": [
-                "function"
-              ],
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "function": {
-                  "enum": [
-                    "uniform"
-                  ]
-                },
-                "min": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "$ref": "#/refs/signal"
-                    }
-                  ]
-                },
-                "max": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "$ref": "#/refs/signal"
-                    }
-                  ],
-                  "default": 1
-                }
-              },
-              "required": [
-                "function"
-              ],
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "function": {
-                  "enum": [
-                    "kde"
-                  ]
-                },
-                "field": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/refs/scaleField"
-                    },
-                    {
-                      "$ref": "#/refs/paramField"
-                    },
-                    {
-                      "$ref": "#/refs/expr"
-                    }
-                  ]
-                },
-                "from": {
-                  "type": "string"
-                },
-                "bandwidth": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "$ref": "#/refs/signal"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "function",
-                "field"
-              ],
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "properties": {
-                "function": {
-                  "enum": [
-                    "mixture"
-                  ]
-                },
-                "distributions": {
-                  "oneOf": [
-                    {
-                      "type": "array",
-                      "items": {}
-                    },
-                    {
-                      "$ref": "#/refs/signal"
-                    }
-                  ]
-                },
-                "weights": {
-                  "oneOf": [
-                    {
-                      "type": "array",
-                      "items": {
-                        "anyOf": [
-                          {
-                            "type": "number"
-                          },
-                          {
-                            "$ref": "#/refs/signal"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "$ref": "#/refs/signal"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "function"
-              ],
-              "additionalProperties": false
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": [
-            "value",
-            "density"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "dotbinTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "dotbin"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "step": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "smooth": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "bin"
-        }
-      },
-      "required": [
-        "type",
-        "field"
-      ],
-      "additionalProperties": false
-    },
-    "extentTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "extent"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "field"
-      ],
-      "additionalProperties": false
-    },
-    "filterTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "filter"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "expr": {
-          "$ref": "#/refs/exprString"
-        }
-      },
-      "required": [
-        "type",
-        "expr"
-      ],
-      "additionalProperties": false
-    },
-    "flattenTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "flatten"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "fields": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "index": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "fields"
-      ],
-      "additionalProperties": false
-    },
-    "foldTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "fold"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "fields": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            "key",
-            "value"
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "fields"
-      ],
-      "additionalProperties": false
-    },
-    "formulaTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "formula"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "expr": {
-          "$ref": "#/refs/exprString"
-        },
-        "as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "initonly": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "expr",
-        "as"
-      ],
-      "additionalProperties": false
-    },
-    "imputeTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "impute"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "key": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "keyvals": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {}
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "method": {
-          "anyOf": [
-            {
-              "enum": [
-                "value",
-                "mean",
-                "median",
-                "max",
-                "min"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "value"
-        },
-        "value": {}
-      },
-      "required": [
-        "type",
-        "field",
-        "key"
-      ],
-      "additionalProperties": false
-    },
-    "joinaggregateTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "joinaggregate"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "fields": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "ops": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "enum": [
-                      "values",
-                      "count",
-                      "__count__",
-                      "missing",
-                      "valid",
-                      "sum",
-                      "product",
-                      "mean",
-                      "average",
-                      "variance",
-                      "variancep",
-                      "stdev",
-                      "stdevp",
-                      "stderr",
-                      "distinct",
-                      "ci0",
-                      "ci1",
-                      "median",
-                      "q1",
-                      "q3",
-                      "argmin",
-                      "argmax",
-                      "min",
-                      "max"
-                    ]
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "key": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "kdeTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "kde"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "cumulative": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "counts": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "bandwidth": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "extent": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "resolve": {
-          "anyOf": [
-            {
-              "enum": [
-                "shared",
-                "independent"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "independent"
-        },
-        "steps": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "minsteps": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 25
-        },
-        "maxsteps": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 200
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": [
-            "value",
-            "density"
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "field"
-      ],
-      "additionalProperties": false
-    },
-    "lookupTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "lookup"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "from": {
-          "type": "string"
-        },
-        "key": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "values": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "fields": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "default": {}
-      },
-      "required": [
-        "type",
-        "from",
-        "key",
-        "fields"
-      ],
-      "additionalProperties": false
-    },
-    "pivotTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "pivot"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "value": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "op": {
-          "anyOf": [
-            {
-              "enum": [
-                "values",
-                "count",
-                "__count__",
-                "missing",
-                "valid",
-                "sum",
-                "product",
-                "mean",
-                "average",
-                "variance",
-                "variancep",
-                "stdev",
-                "stdevp",
-                "stderr",
-                "distinct",
-                "ci0",
-                "ci1",
-                "median",
-                "q1",
-                "q3",
-                "argmin",
-                "argmax",
-                "min",
-                "max"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "sum"
-        },
-        "limit": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "key": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "field",
-        "value"
-      ],
-      "additionalProperties": false
-    },
-    "projectTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "project"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "fields": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "quantileTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "quantile"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "probs": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "step": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 0.01
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": [
-            "prob",
-            "value"
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "field"
-      ],
-      "additionalProperties": false
-    },
-    "sampleTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "sample"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "size": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 1000
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "sequenceTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "sequence"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "start": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "stop": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "step": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 1
-        },
-        "as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "data"
-        }
-      },
-      "required": [
-        "type",
-        "start",
-        "stop"
-      ],
-      "additionalProperties": false
-    },
-    "timeunitTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "timeunit"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "field": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "interval": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": true
-        },
-        "units": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "step": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 1
-        },
-        "maxbins": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": 40
-        },
-        "extent": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "timezone": {
-          "anyOf": [
-            {
-              "enum": [
-                "local",
-                "utc"
-              ]
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "local"
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            "unit0",
-            "unit1"
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "field"
-      ],
-      "additionalProperties": false
-    },
-    "windowTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "window"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "sort": {
-          "$ref": "#/refs/compare"
-        },
-        "groupby": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "ops": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "enum": [
-                      "row_number",
-                      "rank",
-                      "dense_rank",
-                      "percent_rank",
-                      "cume_dist",
-                      "ntile",
-                      "lag",
-                      "lead",
-                      "first_value",
-                      "last_value",
-                      "nth_value",
-                      "prev_value",
-                      "next_value",
-                      "values",
-                      "count",
-                      "__count__",
-                      "missing",
-                      "valid",
-                      "sum",
-                      "product",
-                      "mean",
-                      "average",
-                      "variance",
-                      "variancep",
-                      "stdev",
-                      "stdevp",
-                      "stderr",
-                      "distinct",
-                      "ci0",
-                      "ci1",
-                      "median",
-                      "q1",
-                      "q3",
-                      "argmin",
-                      "argmax",
-                      "min",
-                      "max"
-                    ]
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "params": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "fields": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/refs/scaleField"
-                  },
-                  {
-                    "$ref": "#/refs/paramField"
-                  },
-                  {
-                    "$ref": "#/refs/expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "frame": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            null,
-            0
-          ]
-        },
-        "ignorePeers": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    },
-    "identifierTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "identifier"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type",
-        "as"
-      ],
-      "additionalProperties": false
-    },
-    "voronoiTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "voronoi"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "x": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "y": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "size": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "extent": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {}
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2,
-          "default": [
-            [
-              -100000,
-              -100000
-            ],
-            [
-              100000,
-              100000
-            ]
-          ]
-        },
-        "as": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "default": "path"
-        }
-      },
-      "required": [
-        "type",
-        "x",
-        "y"
-      ],
-      "additionalProperties": false
-    },
-    "wordcloudTransform": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "enum": [
-            "wordcloud"
-          ]
-        },
-        "signal": {
-          "type": "string"
-        },
-        "size": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 2,
-          "minItems": 2
-        },
-        "font": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "$ref": "#/refs/expr"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            }
-          ],
-          "default": "sans-serif"
-        },
-        "fontStyle": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "$ref": "#/refs/expr"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            }
-          ],
-          "default": "normal"
-        },
-        "fontWeight": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "$ref": "#/refs/expr"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            }
-          ],
-          "default": "normal"
-        },
-        "fontSize": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "$ref": "#/refs/expr"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            }
-          ],
-          "default": 14
-        },
-        "fontSizeRange": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": [
-            10,
-            50
-          ]
-        },
-        "rotate": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "$ref": "#/refs/expr"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            }
-          ]
-        },
-        "text": {
-          "oneOf": [
-            {
-              "$ref": "#/refs/scaleField"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            },
-            {
-              "$ref": "#/refs/expr"
-            }
-          ]
-        },
-        "spiral": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ]
-        },
-        "padding": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/refs/signal"
-            },
-            {
-              "$ref": "#/refs/expr"
-            },
-            {
-              "$ref": "#/refs/paramField"
-            }
-          ]
-        },
-        "as": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "$ref": "#/refs/signal"
-                  }
-                ]
-              }
-            },
-            {
-              "$ref": "#/refs/signal"
-            }
-          ],
-          "maxItems": 7,
-          "minItems": 7,
-          "default": [
-            "x",
-            "y",
-            "font",
-            "fontSize",
-            "fontStyle",
-            "fontWeight",
-            "angle"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "additionalProperties": false
-    }
-  },
-  "refs": {
     "labelOverlap": {
       "oneOf": [
         {
@@ -12092,7 +897,7 @@
           ]
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         }
       ]
     },
@@ -12105,7 +910,7 @@
           ]
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         }
       ]
     },
@@ -12144,12 +949,12 @@
                   ]
                 },
                 {
-                  "$ref": "#/refs/signal"
+                  "$ref": "#/definitions/signalRef"
                 }
               ]
             },
             "step": {
-              "$ref": "#/refs/numberOrSignal"
+              "$ref": "#/definitions/numberOrSignal"
             }
           },
           "required": [
@@ -12158,12 +963,800 @@
           "additionalProperties": false
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
+        }
+      ]
+    },
+    "background": {
+      "$ref": "#/definitions/stringOrSignal"
+    },
+    "bind": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "input": {
+              "enum": [
+                "checkbox"
+              ]
+            },
+            "element": {
+              "$ref": "#/definitions/element"
+            },
+            "debounce": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "input"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "input": {
+              "enum": [
+                "radio",
+                "select"
+              ]
+            },
+            "element": {
+              "$ref": "#/definitions/element"
+            },
+            "options": {
+              "type": "array"
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "debounce": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "input",
+            "options"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "input": {
+              "enum": [
+                "range"
+              ]
+            },
+            "element": {
+              "$ref": "#/definitions/element"
+            },
+            "min": {
+              "type": "number"
+            },
+            "max": {
+              "type": "number"
+            },
+            "step": {
+              "type": "number"
+            },
+            "debounce": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "input"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "input": {
+              "not": {
+                "enum": [
+                  "checkbox",
+                  "radio",
+                  "range",
+                  "select"
+                ]
+              }
+            },
+            "element": {
+              "$ref": "#/definitions/element"
+            },
+            "debounce": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "input"
+          ],
+          "additionalProperties": true
+        },
+        {
+          "type": "object",
+          "properties": {
+            "element": {
+              "$ref": "#/definitions/element"
+            },
+            "event": {
+              "type": "string"
+            },
+            "debounce": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "element"
+          ],
+          "additionalProperties": false
         }
       ]
     },
     "element": {
       "type": "string"
+    },
+    "data": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "transform": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/transform"
+              }
+            },
+            "on": {
+              "$ref": "#/definitions/onTrigger"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "source": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1
+                }
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "transform": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/transform"
+              }
+            },
+            "on": {
+              "$ref": "#/definitions/onTrigger"
+            }
+          },
+          "required": [
+            "source",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "url": {
+              "$ref": "#/definitions/stringOrSignal"
+            },
+            "format": {
+              "oneOf": [
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "$ref": "#/definitions/stringOrSignal"
+                        },
+                        "parse": {
+                          "oneOf": [
+                            {
+                              "enum": [
+                                "auto"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {},
+                              "additionalProperties": {
+                                "oneOf": [
+                                  {
+                                    "enum": [
+                                      "boolean",
+                                      "number",
+                                      "date",
+                                      "string"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "pattern": "^(date|utc):.*$"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "$ref": "#/definitions/signalRef"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "json"
+                          ]
+                        },
+                        "parse": {
+                          "oneOf": [
+                            {
+                              "enum": [
+                                "auto"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {},
+                              "additionalProperties": {
+                                "oneOf": [
+                                  {
+                                    "enum": [
+                                      "boolean",
+                                      "number",
+                                      "date",
+                                      "string"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "pattern": "^(date|utc):.*$"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "$ref": "#/definitions/signalRef"
+                            }
+                          ]
+                        },
+                        "property": {
+                          "$ref": "#/definitions/stringOrSignal"
+                        },
+                        "copy": {
+                          "$ref": "#/definitions/booleanOrSignal"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "csv",
+                            "tsv"
+                          ]
+                        },
+                        "header": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "parse": {
+                          "oneOf": [
+                            {
+                              "enum": [
+                                "auto"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {},
+                              "additionalProperties": {
+                                "oneOf": [
+                                  {
+                                    "enum": [
+                                      "boolean",
+                                      "number",
+                                      "date",
+                                      "string"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "pattern": "^(date|utc):.*$"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "$ref": "#/definitions/signalRef"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "dsv"
+                          ]
+                        },
+                        "delimiter": {
+                          "type": "string"
+                        },
+                        "header": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "parse": {
+                          "oneOf": [
+                            {
+                              "enum": [
+                                "auto"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {},
+                              "additionalProperties": {
+                                "oneOf": [
+                                  {
+                                    "enum": [
+                                      "boolean",
+                                      "number",
+                                      "date",
+                                      "string"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "pattern": "^(date|utc):.*$"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "$ref": "#/definitions/signalRef"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "delimiter"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "enum": [
+                                "topojson"
+                              ]
+                            },
+                            "feature": {
+                              "$ref": "#/definitions/stringOrSignal"
+                            },
+                            "property": {
+                              "$ref": "#/definitions/stringOrSignal"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "feature"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "enum": [
+                                "topojson"
+                              ]
+                            },
+                            "mesh": {
+                              "$ref": "#/definitions/stringOrSignal"
+                            },
+                            "property": {
+                              "$ref": "#/definitions/stringOrSignal"
+                            },
+                            "filter": {
+                              "enum": [
+                                "interior",
+                                "exterior",
+                                null
+                              ]
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "mesh"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "async": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "transform": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/transform"
+              }
+            },
+            "on": {
+              "$ref": "#/definitions/onTrigger"
+            }
+          },
+          "required": [
+            "url",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "values": {
+              "oneOf": [
+                {},
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "format": {
+              "oneOf": [
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "$ref": "#/definitions/stringOrSignal"
+                        },
+                        "parse": {
+                          "oneOf": [
+                            {
+                              "enum": [
+                                "auto"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {},
+                              "additionalProperties": {
+                                "oneOf": [
+                                  {
+                                    "enum": [
+                                      "boolean",
+                                      "number",
+                                      "date",
+                                      "string"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "pattern": "^(date|utc):.*$"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "$ref": "#/definitions/signalRef"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "json"
+                          ]
+                        },
+                        "parse": {
+                          "oneOf": [
+                            {
+                              "enum": [
+                                "auto"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {},
+                              "additionalProperties": {
+                                "oneOf": [
+                                  {
+                                    "enum": [
+                                      "boolean",
+                                      "number",
+                                      "date",
+                                      "string"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "pattern": "^(date|utc):.*$"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "$ref": "#/definitions/signalRef"
+                            }
+                          ]
+                        },
+                        "property": {
+                          "$ref": "#/definitions/stringOrSignal"
+                        },
+                        "copy": {
+                          "$ref": "#/definitions/booleanOrSignal"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "csv",
+                            "tsv"
+                          ]
+                        },
+                        "header": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "parse": {
+                          "oneOf": [
+                            {
+                              "enum": [
+                                "auto"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {},
+                              "additionalProperties": {
+                                "oneOf": [
+                                  {
+                                    "enum": [
+                                      "boolean",
+                                      "number",
+                                      "date",
+                                      "string"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "pattern": "^(date|utc):.*$"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "$ref": "#/definitions/signalRef"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "enum": [
+                            "dsv"
+                          ]
+                        },
+                        "delimiter": {
+                          "type": "string"
+                        },
+                        "header": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "parse": {
+                          "oneOf": [
+                            {
+                              "enum": [
+                                "auto"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {},
+                              "additionalProperties": {
+                                "oneOf": [
+                                  {
+                                    "enum": [
+                                      "boolean",
+                                      "number",
+                                      "date",
+                                      "string"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "pattern": "^(date|utc):.*$"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "$ref": "#/definitions/signalRef"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "delimiter"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "enum": [
+                                "topojson"
+                              ]
+                            },
+                            "feature": {
+                              "$ref": "#/definitions/stringOrSignal"
+                            },
+                            "property": {
+                              "$ref": "#/definitions/stringOrSignal"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "feature"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "enum": [
+                                "topojson"
+                              ]
+                            },
+                            "mesh": {
+                              "$ref": "#/definitions/stringOrSignal"
+                            },
+                            "property": {
+                              "$ref": "#/definitions/stringOrSignal"
+                            },
+                            "filter": {
+                              "enum": [
+                                "interior",
+                                "exterior",
+                                null
+                              ]
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "mesh"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "async": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "transform": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/transform"
+              }
+            },
+            "on": {
+              "$ref": "#/definitions/onTrigger"
+            }
+          },
+          "required": [
+            "values",
+            "name"
+          ],
+          "additionalProperties": false
+        }
+      ]
     },
     "paramField": {
       "type": "object",
@@ -12180,19 +1773,249 @@
       ],
       "additionalProperties": false
     },
+    "rule": {
+      "type": "object",
+      "properties": {
+        "test": {
+          "type": "string"
+        }
+      }
+    },
+    "encodeEntry": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "x2": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "xc": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "width": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "y": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "y2": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "yc": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "height": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "opacity": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "fill": {
+          "$ref": "#/definitions/colorValue"
+        },
+        "fillOpacity": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "stroke": {
+          "$ref": "#/definitions/colorValue"
+        },
+        "strokeOpacity": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "strokeWidth": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "strokeCap": {
+          "$ref": "#/definitions/strokeCapValue"
+        },
+        "strokeDash": {
+          "$ref": "#/definitions/arrayValue"
+        },
+        "strokeDashOffset": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/strokeJoinValue"
+        },
+        "strokeMiterLimit": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "blend": {
+          "$ref": "#/definitions/blendValue"
+        },
+        "cursor": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "tooltip": {
+          "$ref": "#/definitions/anyValue"
+        },
+        "zindex": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "description": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "aria": {
+          "$ref": "#/definitions/booleanValue"
+        },
+        "ariaRole": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "ariaRoleDescription": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "clip": {
+          "$ref": "#/definitions/booleanValue"
+        },
+        "strokeForeground": {
+          "$ref": "#/definitions/booleanValue"
+        },
+        "strokeOffset": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "cornerRadius": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "cornerRadiusTopLeft": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "cornerRadiusTopRight": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "cornerRadiusBottomRight": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "cornerRadiusBottomLeft": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "angle": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "size": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "shape": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "path": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "scaleX": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "scaleY": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "innerRadius": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "outerRadius": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "startAngle": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "endAngle": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "padAngle": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "interpolate": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "tension": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "orient": {
+          "$ref": "#/definitions/directionValue"
+        },
+        "defined": {
+          "$ref": "#/definitions/booleanValue"
+        },
+        "url": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "align": {
+          "$ref": "#/definitions/alignValue"
+        },
+        "baseline": {
+          "$ref": "#/definitions/baselineValue"
+        },
+        "aspect": {
+          "$ref": "#/definitions/booleanValue"
+        },
+        "smooth": {
+          "$ref": "#/definitions/booleanValue"
+        },
+        "text": {
+          "$ref": "#/definitions/textValue"
+        },
+        "dir": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "ellipsis": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "limit": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "lineBreak": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "lineHeight": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "dx": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "dy": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "radius": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "theta": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "font": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "fontSize": {
+          "$ref": "#/definitions/numberValue"
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/fontWeightValue"
+        },
+        "fontStyle": {
+          "$ref": "#/definitions/stringValue"
+        }
+      },
+      "additionalProperties": true
+    },
+    "encode": {
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^.+$": {
+          "$ref": "#/definitions/encodeEntry"
+        }
+      }
+    },
     "field": {
       "oneOf": [
         {
           "type": "string"
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         },
         {
           "type": "object",
           "properties": {
             "datum": {
-              "$ref": "#/refs/field"
+              "$ref": "#/definitions/field"
             }
           },
           "required": [
@@ -12204,7 +2027,7 @@
           "type": "object",
           "properties": {
             "group": {
-              "$ref": "#/refs/field"
+              "$ref": "#/definitions/field"
             },
             "level": {
               "type": "number"
@@ -12219,7 +2042,7 @@
           "type": "object",
           "properties": {
             "parent": {
-              "$ref": "#/refs/field"
+              "$ref": "#/definitions/field"
             },
             "level": {
               "type": "number"
@@ -12232,14 +2055,11 @@
         }
       ]
     },
-    "scale": {
-      "$ref": "#/refs/field"
-    },
     "stringModifiers": {
       "type": "object",
       "properties": {
         "scale": {
-          "$ref": "#/refs/scale"
+          "$ref": "#/definitions/field"
         }
       }
     },
@@ -12252,7 +2072,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -12262,7 +2082,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -12272,7 +2092,7 @@
               "type": "number"
             },
             {
-              "$ref": "#/refs/numberValue"
+              "$ref": "#/definitions/numberValue"
             }
           ]
         },
@@ -12281,7 +2101,7 @@
           "default": false
         },
         "scale": {
-          "$ref": "#/refs/scale"
+          "$ref": "#/definitions/field"
         },
         "band": {
           "oneOf": [
@@ -12305,19 +2125,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -12332,7 +2152,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -12389,14 +2209,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -12411,7 +2231,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -12471,19 +2291,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -12517,7 +2337,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -12574,14 +2394,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -12615,7 +2435,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -12675,19 +2495,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/numberModifiers"
+                    "$ref": "#/definitions/numberModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -12704,7 +2524,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -12761,14 +2581,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/numberModifiers"
+              "$ref": "#/definitions/numberModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -12785,7 +2605,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -12845,19 +2665,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -12874,7 +2694,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -12931,14 +2751,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -12955,7 +2775,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -13015,19 +2835,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -13054,7 +2874,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -13111,14 +2931,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -13145,7 +2965,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -13205,19 +3025,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -13234,7 +3054,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -13291,14 +3111,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -13315,7 +3135,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -13375,19 +3195,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -13404,7 +3224,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -13461,14 +3281,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -13485,7 +3305,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -13545,19 +3365,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -13598,7 +3418,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -13655,14 +3475,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -13703,7 +3523,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -13763,19 +3583,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -13796,7 +3616,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -13853,14 +3673,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -13881,7 +3701,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -13941,19 +3761,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -13974,7 +3794,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -14031,14 +3851,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -14059,7 +3879,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -14119,19 +3939,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -14153,7 +3973,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -14210,14 +4030,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -14239,7 +4059,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -14299,19 +4119,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -14331,7 +4151,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -14388,14 +4208,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -14415,7 +4235,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -14475,19 +4295,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -14509,7 +4329,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -14566,14 +4386,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -14595,7 +4415,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -14655,19 +4475,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -14688,7 +4508,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -14745,14 +4565,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -14773,7 +4593,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -14833,19 +4653,19 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
                 "allOf": [
                   {
-                    "$ref": "#/refs/stringModifiers"
+                    "$ref": "#/definitions/stringModifiers"
                   },
                   {
                     "anyOf": [
                       {
                         "oneOf": [
                           {
-                            "$ref": "#/refs/signal"
+                            "$ref": "#/definitions/signalRef"
                           },
                           {
                             "type": "object",
@@ -14866,7 +4686,7 @@
                             "type": "object",
                             "properties": {
                               "field": {
-                                "$ref": "#/refs/field"
+                                "$ref": "#/definitions/field"
                               }
                             },
                             "required": [
@@ -14923,14 +4743,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -14951,7 +4771,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -15009,14 +4829,14 @@
         {
           "allOf": [
             {
-              "$ref": "#/refs/stringModifiers"
+              "$ref": "#/definitions/stringModifiers"
             },
             {
               "anyOf": [
                 {
                   "oneOf": [
                     {
-                      "$ref": "#/refs/signal"
+                      "$ref": "#/definitions/signalRef"
                     },
                     {
                       "type": "object",
@@ -15040,7 +4860,7 @@
                       "type": "object",
                       "properties": {
                         "field": {
-                          "$ref": "#/refs/field"
+                          "$ref": "#/definitions/field"
                         }
                       },
                       "required": [
@@ -15095,7 +4915,7 @@
           "type": "object",
           "properties": {
             "value": {
-              "$ref": "#/refs/linearGradient"
+              "$ref": "#/definitions/linearGradient"
             }
           },
           "required": [
@@ -15107,7 +4927,7 @@
           "type": "object",
           "properties": {
             "value": {
-              "$ref": "#/refs/radialGradient"
+              "$ref": "#/definitions/radialGradient"
             }
           },
           "required": [
@@ -15119,7 +4939,7 @@
           "type": "object",
           "properties": {
             "gradient": {
-              "$ref": "#/refs/scale"
+              "$ref": "#/definitions/field"
             },
             "start": {
               "type": "array",
@@ -15152,16 +4972,16 @@
             "color": {
               "oneOf": [
                 {
-                  "$ref": "#/refs/colorRGB"
+                  "$ref": "#/definitions/colorRGB"
                 },
                 {
-                  "$ref": "#/refs/colorHSL"
+                  "$ref": "#/definitions/colorHSL"
                 },
                 {
-                  "$ref": "#/refs/colorLAB"
+                  "$ref": "#/definitions/colorLAB"
                 },
                 {
-                  "$ref": "#/refs/colorHCL"
+                  "$ref": "#/definitions/colorHCL"
                 }
               ]
             }
@@ -15177,13 +4997,13 @@
       "type": "object",
       "properties": {
         "r": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         },
         "g": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         },
         "b": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         }
       },
       "required": [
@@ -15196,13 +5016,13 @@
       "type": "object",
       "properties": {
         "h": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         },
         "s": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         },
         "l": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         }
       },
       "required": [
@@ -15215,13 +5035,13 @@
       "type": "object",
       "properties": {
         "l": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         },
         "a": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         },
         "b": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         }
       },
       "required": [
@@ -15234,13 +5054,13 @@
       "type": "object",
       "properties": {
         "h": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         },
         "c": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         },
         "l": {
-          "$ref": "#/refs/numberValue"
+          "$ref": "#/definitions/numberValue"
         }
       },
       "required": [
@@ -15256,16 +5076,16 @@
           "items": {
             "allOf": [
               {
-                "$ref": "#/defs/rule"
+                "$ref": "#/definitions/rule"
               },
               {
-                "$ref": "#/refs/baseColorValue"
+                "$ref": "#/definitions/baseColorValue"
               }
             ]
           }
         },
         {
-          "$ref": "#/refs/baseColorValue"
+          "$ref": "#/definitions/baseColorValue"
         }
       ]
     },
@@ -15312,7 +5132,7 @@
           "type": "number"
         },
         "stops": {
-          "$ref": "#/refs/gradientStops"
+          "$ref": "#/definitions/gradientStops"
         }
       },
       "required": [
@@ -15351,7 +5171,7 @@
           "type": "number"
         },
         "stops": {
-          "$ref": "#/refs/gradientStops"
+          "$ref": "#/definitions/gradientStops"
         }
       },
       "required": [
@@ -15377,6 +5197,1081 @@
     "exprString": {
       "type": "string"
     },
+    "layout": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "align": {
+              "oneOf": [
+                {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "all",
+                        "each",
+                        "none"
+                      ]
+                    },
+                    {
+                      "$ref": "#/definitions/signalRef"
+                    }
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "row": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "all",
+                            "each",
+                            "none"
+                          ]
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "column": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "all",
+                            "each",
+                            "none"
+                          ]
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "bounds": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "full",
+                    "flush"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "center": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "row": {
+                      "$ref": "#/definitions/booleanOrSignal"
+                    },
+                    "column": {
+                      "$ref": "#/definitions/booleanOrSignal"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "columns": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "padding": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "row": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "column": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "offset": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "rowHeader": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "rowFooter": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "rowTitle": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "columnHeader": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "columnFooter": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "columnTitle": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "headerBand": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/numberOrSignal"
+                },
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "row": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "column": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "footerBand": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/numberOrSignal"
+                },
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "row": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "column": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "titleBand": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/numberOrSignal"
+                },
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "row": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "column": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "titleAnchor": {
+              "oneOf": [
+                {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "start",
+                        "end"
+                      ]
+                    },
+                    {
+                      "$ref": "#/definitions/signalRef"
+                    }
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "row": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "start",
+                            "end"
+                          ]
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "column": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "start",
+                            "end"
+                          ]
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/definitions/signalRef"
+        }
+      ]
+    },
+    "guideEncode": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "interactive": {
+          "type": "boolean",
+          "default": false
+        },
+        "style": {
+          "$ref": "#/definitions/style"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!interactive|name|style).+$": {
+          "$ref": "#/definitions/encodeEntry"
+        }
+      }
+    },
+    "legend": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "string"
+            },
+            "shape": {
+              "type": "string"
+            },
+            "fill": {
+              "type": "string"
+            },
+            "stroke": {
+              "type": "string"
+            },
+            "opacity": {
+              "type": "string"
+            },
+            "strokeDash": {
+              "type": "string"
+            },
+            "strokeWidth": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "gradient",
+                "symbol"
+              ]
+            },
+            "direction": {
+              "enum": [
+                "vertical",
+                "horizontal"
+              ]
+            },
+            "orient": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "none",
+                    "left",
+                    "right",
+                    "top",
+                    "bottom",
+                    "top-left",
+                    "top-right",
+                    "bottom-left",
+                    "bottom-right"
+                  ],
+                  "default": "right"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "tickCount": {
+              "$ref": "#/definitions/tickCount"
+            },
+            "tickMinStep": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "symbolLimit": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "values": {
+              "$ref": "#/definitions/arrayOrSignal"
+            },
+            "zindex": {
+              "type": "number"
+            },
+            "aria": {
+              "type": "boolean"
+            },
+            "description": {
+              "type": "string"
+            },
+            "cornerRadius": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "fillColor": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/colorValue"
+                }
+              ]
+            },
+            "offset": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "padding": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "strokeColor": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/colorValue"
+                }
+              ]
+            },
+            "legendX": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "legendY": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "title": {
+              "$ref": "#/definitions/textOrSignal"
+            },
+            "titleAlign": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "left",
+                    "right",
+                    "center"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/alignValue"
+                }
+              ]
+            },
+            "titleAnchor": {
+              "oneOf": [
+                {
+                  "enum": [
+                    null,
+                    "start",
+                    "middle",
+                    "end"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/anchorValue"
+                }
+              ]
+            },
+            "titleBaseline": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "top",
+                    "middle",
+                    "bottom",
+                    "alphabetic",
+                    "line-top",
+                    "line-bottom"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/baselineValue"
+                }
+              ]
+            },
+            "titleColor": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/colorValue"
+                }
+              ]
+            },
+            "titleFont": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/stringValue"
+                }
+              ]
+            },
+            "titleFontSize": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "titleFontStyle": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/stringValue"
+                }
+              ]
+            },
+            "titleFontWeight": {
+              "oneOf": [
+                {
+                  "enum": [
+                    null,
+                    "normal",
+                    "bold",
+                    "lighter",
+                    "bolder",
+                    "100",
+                    "200",
+                    "300",
+                    "400",
+                    "500",
+                    "600",
+                    "700",
+                    "800",
+                    "900",
+                    100,
+                    200,
+                    300,
+                    400,
+                    500,
+                    600,
+                    700,
+                    800,
+                    900
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/fontWeightValue"
+                }
+              ]
+            },
+            "titleLimit": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "titleLineHeight": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "titleOpacity": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "titleOrient": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "left",
+                    "right",
+                    "top",
+                    "bottom"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/orientValue"
+                }
+              ]
+            },
+            "titlePadding": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "gradientLength": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "gradientOpacity": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "gradientStrokeColor": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/colorValue"
+                }
+              ]
+            },
+            "gradientStrokeWidth": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "gradientThickness": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "clipHeight": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "columns": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "columnPadding": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "rowPadding": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "gridAlign": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "all",
+                    "each",
+                    "none"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "symbolDash": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                },
+                {
+                  "$ref": "#/definitions/arrayValue"
+                }
+              ]
+            },
+            "symbolDashOffset": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "symbolFillColor": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/colorValue"
+                }
+              ]
+            },
+            "symbolOffset": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "symbolOpacity": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "symbolSize": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "symbolStrokeColor": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/colorValue"
+                }
+              ]
+            },
+            "symbolStrokeWidth": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "symbolType": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/stringValue"
+                }
+              ]
+            },
+            "format": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "year": {
+                      "type": "string"
+                    },
+                    "quarter": {
+                      "type": "string"
+                    },
+                    "month": {
+                      "type": "string"
+                    },
+                    "date": {
+                      "type": "string"
+                    },
+                    "week": {
+                      "type": "string"
+                    },
+                    "day": {
+                      "type": "string"
+                    },
+                    "hours": {
+                      "type": "string"
+                    },
+                    "minutes": {
+                      "type": "string"
+                    },
+                    "seconds": {
+                      "type": "string"
+                    },
+                    "milliseconds": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "formatType": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "number",
+                    "time",
+                    "utc"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "labelAlign": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "left",
+                    "right",
+                    "center"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/alignValue"
+                }
+              ]
+            },
+            "labelBaseline": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "top",
+                    "middle",
+                    "bottom",
+                    "alphabetic",
+                    "line-top",
+                    "line-bottom"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/baselineValue"
+                }
+              ]
+            },
+            "labelColor": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/colorValue"
+                }
+              ]
+            },
+            "labelFont": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/stringValue"
+                }
+              ]
+            },
+            "labelFontSize": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "labelFontStyle": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/stringValue"
+                }
+              ]
+            },
+            "labelFontWeight": {
+              "oneOf": [
+                {
+                  "enum": [
+                    null,
+                    "normal",
+                    "bold",
+                    "lighter",
+                    "bolder",
+                    "100",
+                    "200",
+                    "300",
+                    "400",
+                    "500",
+                    "600",
+                    "700",
+                    "800",
+                    "900",
+                    100,
+                    200,
+                    300,
+                    400,
+                    500,
+                    600,
+                    700,
+                    800,
+                    900
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/fontWeightValue"
+                }
+              ]
+            },
+            "labelLimit": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "labelOffset": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "labelOpacity": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "labelOverlap": {
+              "$ref": "#/definitions/labelOverlap"
+            },
+            "labelSeparation": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "encode": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "$ref": "#/definitions/guideEncode"
+                },
+                "labels": {
+                  "$ref": "#/definitions/guideEncode"
+                },
+                "legend": {
+                  "$ref": "#/definitions/guideEncode"
+                },
+                "entries": {
+                  "$ref": "#/definitions/guideEncode"
+                },
+                "symbols": {
+                  "$ref": "#/definitions/guideEncode"
+                },
+                "gradient": {
+                  "$ref": "#/definitions/guideEncode"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "anyOf": [
+            {
+              "type": "object",
+              "required": [
+                "size"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "shape"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "fill"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "stroke"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "opacity"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "strokeDash"
+              ]
+            },
+            {
+              "type": "object",
+              "required": [
+                "strokeWidth"
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "compare": {
       "oneOf": [
         {
@@ -15385,15 +6280,15 @@
             "field": {
               "oneOf": [
                 {
-                  "$ref": "#/refs/scaleField"
+                  "$ref": "#/definitions/scaleField"
                 },
                 {
-                  "$ref": "#/refs/expr"
+                  "$ref": "#/definitions/expr"
                 }
               ]
             },
             "order": {
-              "$ref": "#/refs/sortOrder"
+              "$ref": "#/definitions/sortOrder"
             }
           },
           "additionalProperties": false
@@ -15406,10 +6301,10 @@
               "items": {
                 "oneOf": [
                   {
-                    "$ref": "#/refs/scaleField"
+                    "$ref": "#/definitions/scaleField"
                   },
                   {
-                    "$ref": "#/refs/expr"
+                    "$ref": "#/definitions/expr"
                   }
                 ]
               }
@@ -15417,7 +6312,7 @@
             "order": {
               "type": "array",
               "items": {
-                "$ref": "#/refs/sortOrder"
+                "$ref": "#/definitions/sortOrder"
               }
             }
           },
@@ -15527,16 +6422,66 @@
       ],
       "additionalProperties": false
     },
+    "mark": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/marktype"
+        },
+        "role": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "aria": {
+          "type": "boolean"
+        },
+        "style": {
+          "$ref": "#/definitions/style"
+        },
+        "key": {
+          "type": "string"
+        },
+        "clip": {
+          "$ref": "#/definitions/markclip"
+        },
+        "sort": {
+          "$ref": "#/definitions/compare"
+        },
+        "interactive": {
+          "$ref": "#/definitions/booleanOrSignal"
+        },
+        "encode": {
+          "$ref": "#/definitions/encode"
+        },
+        "transform": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/transformMark"
+          }
+        },
+        "on": {
+          "$ref": "#/definitions/onMarkTrigger"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
     "markclip": {
       "oneOf": [
         {
-          "$ref": "#/refs/booleanOrSignal"
+          "$ref": "#/definitions/booleanOrSignal"
         },
         {
           "type": "object",
           "properties": {
             "path": {
-              "$ref": "#/refs/stringOrSignal"
+              "$ref": "#/definitions/stringOrSignal"
             }
           },
           "required": [
@@ -15548,13 +6493,68 @@
           "type": "object",
           "properties": {
             "sphere": {
-              "$ref": "#/refs/stringOrSignal"
+              "$ref": "#/definitions/stringOrSignal"
             }
           },
           "required": [
             "sphere"
           ],
           "additionalProperties": false
+        }
+      ]
+    },
+    "markGroup": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "group"
+              ]
+            },
+            "from": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/from"
+                },
+                {
+                  "$ref": "#/definitions/facet"
+                }
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        {
+          "$ref": "#/definitions/mark"
+        },
+        {
+          "$ref": "#/definitions/scope"
+        }
+      ]
+    },
+    "markVisual": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "not": {
+                "enum": [
+                  "group"
+                ]
+              }
+            },
+            "from": {
+              "$ref": "#/definitions/from"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/mark"
         }
       ]
     },
@@ -15574,8 +6574,2810 @@
     "marktype": {
       "type": "string"
     },
+    "listener": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/signalRef"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "scale": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "scale"
+          ]
+        },
+        {
+          "$ref": "#/definitions/stream"
+        }
+      ]
+    },
+    "onEvents": {
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "events": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/selector"
+                  },
+                  {
+                    "$ref": "#/definitions/listener"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/listener"
+                    },
+                    "minItems": 1
+                  }
+                ]
+              },
+              "force": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "events"
+            ]
+          },
+          {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "encode": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "encode"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "update": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/exprString"
+                      },
+                      {
+                        "$ref": "#/definitions/expr"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {}
+                        },
+                        "required": [
+                          "value"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "update"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "onTrigger": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "trigger": {
+            "$ref": "#/definitions/exprString"
+          },
+          "insert": {
+            "$ref": "#/definitions/exprString"
+          },
+          "remove": {
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "$ref": "#/definitions/exprString"
+              }
+            ]
+          },
+          "toggle": {
+            "$ref": "#/definitions/exprString"
+          },
+          "modify": {
+            "$ref": "#/definitions/exprString"
+          },
+          "values": {
+            "$ref": "#/definitions/exprString"
+          }
+        },
+        "required": [
+          "trigger"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "onMarkTrigger": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "trigger": {
+            "$ref": "#/definitions/exprString"
+          },
+          "modify": {
+            "$ref": "#/definitions/exprString"
+          },
+          "values": {
+            "$ref": "#/definitions/exprString"
+          }
+        },
+        "required": [
+          "trigger"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "padding": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "top": {
+              "type": "number"
+            },
+            "bottom": {
+              "type": "number"
+            },
+            "left": {
+              "type": "number"
+            },
+            "right": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/definitions/signalRef"
+        }
+      ]
+    },
+    "projection": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/stringOrSignal"
+        },
+        "clipAngle": {
+          "$ref": "#/definitions/numberOrSignal"
+        },
+        "clipExtent": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "scale": {
+          "$ref": "#/definitions/numberOrSignal"
+        },
+        "translate": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/numberOrSignal"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "center": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/numberOrSignal"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "rotate": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/numberOrSignal"
+              },
+              "minItems": 2,
+              "maxItems": 3
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "parallels": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/numberOrSignal"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "precision": {
+          "$ref": "#/definitions/numberOrSignal"
+        },
+        "pointRadius": {
+          "$ref": "#/definitions/numberOrSignal"
+        },
+        "fit": {
+          "oneOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "extent": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "minItems": 2,
+                    "maxItems": 2
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "size": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/numberOrSignal"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": true
+    },
+    "scale": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "identity"
+              ]
+            },
+            "nice": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "ordinal"
+              ]
+            },
+            "range": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "width",
+                    "height",
+                    "symbol",
+                    "category",
+                    "ordinal",
+                    "ramp",
+                    "diverging",
+                    "heatmap"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "scheme": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/signalRef"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "extent": {
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/numberOrSignal"
+                          },
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "scheme"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string"
+                        },
+                        "field": {
+                          "$ref": "#/definitions/stringOrSignal"
+                        },
+                        "sort": {
+                          "oneOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "field": {
+                                  "$ref": "#/definitions/stringOrSignal"
+                                },
+                                "op": {
+                                  "$ref": "#/definitions/stringOrSignal"
+                                },
+                                "order": {
+                                  "$ref": "#/definitions/sortOrder"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "data",
+                        "field"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string"
+                        },
+                        "fields": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/stringOrSignal"
+                          },
+                          "minItems": 1
+                        },
+                        "sort": {
+                          "oneOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "op": {
+                                  "enum": [
+                                    "count"
+                                  ]
+                                },
+                                "order": {
+                                  "$ref": "#/definitions/sortOrder"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "field": {
+                                  "$ref": "#/definitions/stringOrSignal"
+                                },
+                                "op": {
+                                  "enum": [
+                                    "count",
+                                    "min",
+                                    "max"
+                                  ]
+                                },
+                                "order": {
+                                  "$ref": "#/definitions/sortOrder"
+                                }
+                              },
+                              "required": [
+                                "field",
+                                "op"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "data",
+                        "fields"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "fields": {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "data": {
+                                    "type": "string"
+                                  },
+                                  "field": {
+                                    "$ref": "#/definitions/stringOrSignal"
+                                  }
+                                },
+                                "required": [
+                                  "data",
+                                  "field"
+                                ],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "$ref": "#/definitions/signalRef"
+                              }
+                            ]
+                          },
+                          "minItems": 1
+                        },
+                        "sort": {
+                          "oneOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "op": {
+                                  "enum": [
+                                    "count"
+                                  ]
+                                },
+                                "order": {
+                                  "$ref": "#/definitions/sortOrder"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "field": {
+                                  "$ref": "#/definitions/stringOrSignal"
+                                },
+                                "op": {
+                                  "enum": [
+                                    "count",
+                                    "min",
+                                    "max"
+                                  ]
+                                },
+                                "order": {
+                                  "$ref": "#/definitions/sortOrder"
+                                }
+                              },
+                              "required": [
+                                "field",
+                                "op"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "fields"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "interpolate": {
+              "$ref": "#/definitions/scaleInterpolate"
+            },
+            "domainImplicit": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "band"
+              ]
+            },
+            "paddingInner": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "range": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "width",
+                    "height",
+                    "symbol",
+                    "category",
+                    "ordinal",
+                    "ramp",
+                    "diverging",
+                    "heatmap"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "step": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    }
+                  },
+                  "required": [
+                    "step"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "padding": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "paddingOuter": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "align": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "point"
+              ]
+            },
+            "range": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "width",
+                    "height",
+                    "symbol",
+                    "category",
+                    "ordinal",
+                    "ramp",
+                    "diverging",
+                    "heatmap"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "step": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    }
+                  },
+                  "required": [
+                    "step"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "padding": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "paddingOuter": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "align": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "quantize",
+                "threshold"
+              ]
+            },
+            "range": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "width",
+                    "height",
+                    "symbol",
+                    "category",
+                    "ordinal",
+                    "ramp",
+                    "diverging",
+                    "heatmap"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "scheme": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/signalRef"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "extent": {
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/numberOrSignal"
+                          },
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "scheme"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "interpolate": {
+              "$ref": "#/definitions/scaleInterpolate"
+            },
+            "nice": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "zero": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "quantile"
+              ]
+            },
+            "range": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "width",
+                    "height",
+                    "symbol",
+                    "category",
+                    "ordinal",
+                    "ramp",
+                    "diverging",
+                    "heatmap"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "scheme": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/signalRef"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "extent": {
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/numberOrSignal"
+                          },
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "scheme"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "interpolate": {
+              "$ref": "#/definitions/scaleInterpolate"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "bin-ordinal"
+              ]
+            },
+            "bins": {
+              "$ref": "#/definitions/scaleBins"
+            },
+            "range": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "width",
+                    "height",
+                    "symbol",
+                    "category",
+                    "ordinal",
+                    "ramp",
+                    "diverging",
+                    "heatmap"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "scheme": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/signalRef"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "extent": {
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/numberOrSignal"
+                          },
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "scheme"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "interpolate": {
+              "$ref": "#/definitions/scaleInterpolate"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "time",
+                "utc"
+              ]
+            },
+            "nice": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "enum": [
+                    "millisecond",
+                    "second",
+                    "minute",
+                    "hour",
+                    "day",
+                    "week",
+                    "month",
+                    "year"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "interval": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "millisecond",
+                            "second",
+                            "minute",
+                            "hour",
+                            "day",
+                            "week",
+                            "month",
+                            "year"
+                          ]
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "step": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    }
+                  },
+                  "required": [
+                    "interval"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "range": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "width",
+                    "height",
+                    "symbol",
+                    "category",
+                    "ordinal",
+                    "ramp",
+                    "diverging",
+                    "heatmap"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "scheme": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/signalRef"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "extent": {
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/numberOrSignal"
+                          },
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "scheme"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "bins": {
+              "$ref": "#/definitions/scaleBins"
+            },
+            "interpolate": {
+              "$ref": "#/definitions/scaleInterpolate"
+            },
+            "clamp": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "padding": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "linear",
+                "sqrt",
+                "sequential"
+              ]
+            },
+            "nice": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "zero": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "range": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "width",
+                    "height",
+                    "symbol",
+                    "category",
+                    "ordinal",
+                    "ramp",
+                    "diverging",
+                    "heatmap"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "scheme": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/signalRef"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "extent": {
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/numberOrSignal"
+                          },
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "scheme"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "bins": {
+              "$ref": "#/definitions/scaleBins"
+            },
+            "interpolate": {
+              "$ref": "#/definitions/scaleInterpolate"
+            },
+            "clamp": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "padding": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "log"
+              ]
+            },
+            "base": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "nice": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "zero": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "range": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "width",
+                    "height",
+                    "symbol",
+                    "category",
+                    "ordinal",
+                    "ramp",
+                    "diverging",
+                    "heatmap"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "scheme": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/signalRef"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "extent": {
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/numberOrSignal"
+                          },
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "scheme"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "bins": {
+              "$ref": "#/definitions/scaleBins"
+            },
+            "interpolate": {
+              "$ref": "#/definitions/scaleInterpolate"
+            },
+            "clamp": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "padding": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "pow"
+              ]
+            },
+            "exponent": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "nice": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "zero": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "range": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "width",
+                    "height",
+                    "symbol",
+                    "category",
+                    "ordinal",
+                    "ramp",
+                    "diverging",
+                    "heatmap"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "scheme": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/signalRef"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "extent": {
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/numberOrSignal"
+                          },
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "scheme"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "bins": {
+              "$ref": "#/definitions/scaleBins"
+            },
+            "interpolate": {
+              "$ref": "#/definitions/scaleInterpolate"
+            },
+            "clamp": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "padding": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "symlog"
+              ]
+            },
+            "constant": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "nice": {
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "zero": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "range": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "width",
+                    "height",
+                    "symbol",
+                    "category",
+                    "ordinal",
+                    "ramp",
+                    "diverging",
+                    "heatmap"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "scheme": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "$ref": "#/definitions/signalRef"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "$ref": "#/definitions/numberOrSignal"
+                    },
+                    "extent": {
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/numberOrSignal"
+                          },
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "$ref": "#/definitions/signalRef"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "scheme"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "bins": {
+              "$ref": "#/definitions/scaleBins"
+            },
+            "interpolate": {
+              "$ref": "#/definitions/scaleInterpolate"
+            },
+            "clamp": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "padding": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "name": {
+              "type": "string"
+            },
+            "domain": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/numberOrSignal"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "$ref": "#/definitions/scaleData"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "domainMin": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMax": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainMid": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "domainRaw": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "reverse": {
+              "$ref": "#/definitions/booleanOrSignal"
+            },
+            "round": {
+              "$ref": "#/definitions/booleanOrSignal"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
     "scaleField": {
-      "$ref": "#/refs/stringOrSignal"
+      "$ref": "#/definitions/stringOrSignal"
     },
     "sortOrder": {
       "oneOf": [
@@ -15586,7 +9388,7 @@
           ]
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         }
       ]
     },
@@ -15595,20 +9397,20 @@
         {
           "type": "array",
           "items": {
-            "$ref": "#/refs/numberOrSignal"
+            "$ref": "#/definitions/numberOrSignal"
           }
         },
         {
           "type": "object",
           "properties": {
             "step": {
-              "$ref": "#/refs/numberOrSignal"
+              "$ref": "#/definitions/numberOrSignal"
             },
             "start": {
-              "$ref": "#/refs/numberOrSignal"
+              "$ref": "#/definitions/numberOrSignal"
             },
             "stop": {
-              "$ref": "#/refs/numberOrSignal"
+              "$ref": "#/definitions/numberOrSignal"
             }
           },
           "required": [
@@ -15617,7 +9419,7 @@
           "additionalProperties": false
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         }
       ]
     },
@@ -15627,16 +9429,16 @@
           "type": "string"
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         },
         {
           "type": "object",
           "properties": {
             "type": {
-              "$ref": "#/refs/stringOrSignal"
+              "$ref": "#/definitions/stringOrSignal"
             },
             "gamma": {
-              "$ref": "#/refs/numberOrSignal"
+              "$ref": "#/definitions/numberOrSignal"
             }
           },
           "required": [
@@ -15655,7 +9457,7 @@
               "type": "string"
             },
             "field": {
-              "$ref": "#/refs/stringOrSignal"
+              "$ref": "#/definitions/stringOrSignal"
             },
             "sort": {
               "oneOf": [
@@ -15666,13 +9468,13 @@
                   "type": "object",
                   "properties": {
                     "field": {
-                      "$ref": "#/refs/stringOrSignal"
+                      "$ref": "#/definitions/stringOrSignal"
                     },
                     "op": {
-                      "$ref": "#/refs/stringOrSignal"
+                      "$ref": "#/definitions/stringOrSignal"
                     },
                     "order": {
-                      "$ref": "#/refs/sortOrder"
+                      "$ref": "#/definitions/sortOrder"
                     }
                   },
                   "additionalProperties": false
@@ -15695,7 +9497,7 @@
             "fields": {
               "type": "array",
               "items": {
-                "$ref": "#/refs/stringOrSignal"
+                "$ref": "#/definitions/stringOrSignal"
               },
               "minItems": 1
             },
@@ -15713,7 +9515,7 @@
                       ]
                     },
                     "order": {
-                      "$ref": "#/refs/sortOrder"
+                      "$ref": "#/definitions/sortOrder"
                     }
                   },
                   "additionalProperties": false
@@ -15722,7 +9524,7 @@
                   "type": "object",
                   "properties": {
                     "field": {
-                      "$ref": "#/refs/stringOrSignal"
+                      "$ref": "#/definitions/stringOrSignal"
                     },
                     "op": {
                       "enum": [
@@ -15732,7 +9534,7 @@
                       ]
                     },
                     "order": {
-                      "$ref": "#/refs/sortOrder"
+                      "$ref": "#/definitions/sortOrder"
                     }
                   },
                   "required": [
@@ -15764,7 +9566,7 @@
                         "type": "string"
                       },
                       "field": {
-                        "$ref": "#/refs/stringOrSignal"
+                        "$ref": "#/definitions/stringOrSignal"
                       }
                     },
                     "required": [
@@ -15790,7 +9592,7 @@
                     }
                   },
                   {
-                    "$ref": "#/refs/signal"
+                    "$ref": "#/definitions/signalRef"
                   }
                 ]
               },
@@ -15810,7 +9612,7 @@
                       ]
                     },
                     "order": {
-                      "$ref": "#/refs/sortOrder"
+                      "$ref": "#/definitions/sortOrder"
                     }
                   },
                   "additionalProperties": false
@@ -15819,7 +9621,7 @@
                   "type": "object",
                   "properties": {
                     "field": {
-                      "$ref": "#/refs/stringOrSignal"
+                      "$ref": "#/definitions/stringOrSignal"
                     },
                     "op": {
                       "enum": [
@@ -15829,7 +9631,7 @@
                       ]
                     },
                     "order": {
-                      "$ref": "#/refs/sortOrder"
+                      "$ref": "#/definitions/sortOrder"
                     }
                   },
                   "required": [
@@ -15848,10 +9650,170 @@
         }
       ]
     },
+    "scope": {
+      "type": "object",
+      "properties": {
+        "encode": {
+          "$ref": "#/definitions/encode"
+        },
+        "layout": {
+          "$ref": "#/definitions/layout"
+        },
+        "signals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/signal"
+          }
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/data"
+          }
+        },
+        "scales": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/scale"
+          }
+        },
+        "projections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/projection"
+          }
+        },
+        "axes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/axis"
+          }
+        },
+        "legends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/legend"
+          }
+        },
+        "title": {
+          "$ref": "#/definitions/title"
+        },
+        "marks": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/markGroup"
+              },
+              {
+                "$ref": "#/definitions/markVisual"
+              }
+            ]
+          }
+        },
+        "usermeta": {
+          "type": "object"
+        }
+      }
+    },
     "selector": {
       "type": "string"
     },
     "signal": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/signalName"
+            },
+            "description": {
+              "type": "string"
+            },
+            "push": {
+              "enum": [
+                "outer"
+              ]
+            },
+            "on": {
+              "$ref": "#/definitions/onEvents"
+            }
+          },
+          "required": [
+            "name",
+            "push"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/signalName"
+            },
+            "description": {
+              "type": "string"
+            },
+            "value": {},
+            "react": {
+              "type": "boolean",
+              "default": true
+            },
+            "update": {
+              "$ref": "#/definitions/exprString"
+            },
+            "on": {
+              "$ref": "#/definitions/onEvents"
+            },
+            "bind": {
+              "$ref": "#/definitions/bind"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/signalName"
+            },
+            "description": {
+              "type": "string"
+            },
+            "value": {},
+            "init": {
+              "$ref": "#/definitions/exprString"
+            },
+            "on": {
+              "$ref": "#/definitions/onEvents"
+            },
+            "bind": {
+              "$ref": "#/definitions/bind"
+            }
+          },
+          "required": [
+            "name",
+            "init"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "signalName": {
+      "type": "string",
+      "not": {
+        "enum": [
+          "parent",
+          "datum",
+          "event",
+          "item"
+        ]
+      }
+    },
+    "signalRef": {
       "type": "object",
       "properties": {
         "signal": {
@@ -15868,7 +9830,7 @@
           "type": "array"
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         }
       ]
     },
@@ -15878,7 +9840,7 @@
           "type": "boolean"
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         }
       ]
     },
@@ -15888,7 +9850,7 @@
           "type": "number"
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         }
       ]
     },
@@ -15898,7 +9860,7 @@
           "type": "string"
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         }
       ]
     },
@@ -15918,15 +9880,6364 @@
           ]
         },
         {
-          "$ref": "#/refs/signal"
+          "$ref": "#/definitions/signalRef"
         }
       ]
+    },
+    "stream": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "between": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/stream"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            },
+            "marktype": {
+              "type": "string"
+            },
+            "markname": {
+              "type": "string"
+            },
+            "filter": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/exprString"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/exprString"
+                  },
+                  "minItems": 1
+                }
+              ]
+            },
+            "throttle": {
+              "type": "number"
+            },
+            "debounce": {
+              "type": "number"
+            },
+            "consume": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "stream": {
+                  "$ref": "#/definitions/stream"
+                }
+              },
+              "required": [
+                "stream"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "merge": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/stream"
+                  },
+                  "minItems": 1
+                }
+              },
+              "required": [
+                "merge"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "title": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "orient": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "none",
+                    "left",
+                    "right",
+                    "top",
+                    "bottom"
+                  ],
+                  "default": "top"
+                },
+                {
+                  "$ref": "#/definitions/signalRef"
+                }
+              ]
+            },
+            "anchor": {
+              "oneOf": [
+                {
+                  "enum": [
+                    null,
+                    "start",
+                    "middle",
+                    "end"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/anchorValue"
+                }
+              ]
+            },
+            "frame": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "group",
+                    "bounds"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/stringValue"
+                }
+              ]
+            },
+            "offset": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "aria": {
+              "type": "boolean"
+            },
+            "limit": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "zindex": {
+              "type": "number"
+            },
+            "align": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "left",
+                    "right",
+                    "center"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/alignValue"
+                }
+              ]
+            },
+            "angle": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "baseline": {
+              "oneOf": [
+                {
+                  "enum": [
+                    "top",
+                    "middle",
+                    "bottom",
+                    "alphabetic",
+                    "line-top",
+                    "line-bottom"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/baselineValue"
+                }
+              ]
+            },
+            "dx": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "dy": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "text": {
+              "$ref": "#/definitions/textOrSignal"
+            },
+            "color": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/colorValue"
+                }
+              ]
+            },
+            "font": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/stringValue"
+                }
+              ]
+            },
+            "fontSize": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "fontStyle": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/stringValue"
+                }
+              ]
+            },
+            "fontWeight": {
+              "oneOf": [
+                {
+                  "enum": [
+                    null,
+                    "normal",
+                    "bold",
+                    "lighter",
+                    "bolder",
+                    "100",
+                    "200",
+                    "300",
+                    "400",
+                    "500",
+                    "600",
+                    "700",
+                    "800",
+                    "900",
+                    100,
+                    200,
+                    300,
+                    400,
+                    500,
+                    600,
+                    700,
+                    800,
+                    900
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/fontWeightValue"
+                }
+              ]
+            },
+            "lineHeight": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "subtitle": {
+              "$ref": "#/definitions/textOrSignal"
+            },
+            "subtitleColor": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/colorValue"
+                }
+              ]
+            },
+            "subtitleFont": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/stringValue"
+                }
+              ]
+            },
+            "subtitleFontSize": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "subtitleFontStyle": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/stringValue"
+                }
+              ]
+            },
+            "subtitleFontWeight": {
+              "oneOf": [
+                {
+                  "enum": [
+                    null,
+                    "normal",
+                    "bold",
+                    "lighter",
+                    "bolder",
+                    "100",
+                    "200",
+                    "300",
+                    "400",
+                    "500",
+                    "600",
+                    "700",
+                    "800",
+                    "900",
+                    100,
+                    200,
+                    300,
+                    400,
+                    500,
+                    600,
+                    700,
+                    800,
+                    900
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/fontWeightValue"
+                }
+              ]
+            },
+            "subtitleLineHeight": {
+              "oneOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "$ref": "#/definitions/numberValue"
+                }
+              ]
+            },
+            "subtitlePadding": {
+              "$ref": "#/definitions/numberOrSignal"
+            },
+            "encode": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^(?!interactive|name|style).+$": {
+                      "$ref": "#/definitions/encodeEntry"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "group": {
+                      "$ref": "#/definitions/guideEncode"
+                    },
+                    "title": {
+                      "$ref": "#/definitions/guideEncode"
+                    },
+                    "subtitle": {
+                      "$ref": "#/definitions/guideEncode"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "interactive": {
+              "type": "boolean"
+            },
+            "style": {
+              "$ref": "#/definitions/style"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "transform": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/crossfilterTransform"
+        },
+        {
+          "$ref": "#/definitions/resolvefilterTransform"
+        },
+        {
+          "$ref": "#/definitions/linkpathTransform"
+        },
+        {
+          "$ref": "#/definitions/pieTransform"
+        },
+        {
+          "$ref": "#/definitions/stackTransform"
+        },
+        {
+          "$ref": "#/definitions/forceTransform"
+        },
+        {
+          "$ref": "#/definitions/contourTransform"
+        },
+        {
+          "$ref": "#/definitions/geojsonTransform"
+        },
+        {
+          "$ref": "#/definitions/geopathTransform"
+        },
+        {
+          "$ref": "#/definitions/geopointTransform"
+        },
+        {
+          "$ref": "#/definitions/geoshapeTransform"
+        },
+        {
+          "$ref": "#/definitions/graticuleTransform"
+        },
+        {
+          "$ref": "#/definitions/heatmapTransform"
+        },
+        {
+          "$ref": "#/definitions/isocontourTransform"
+        },
+        {
+          "$ref": "#/definitions/kde2dTransform"
+        },
+        {
+          "$ref": "#/definitions/nestTransform"
+        },
+        {
+          "$ref": "#/definitions/packTransform"
+        },
+        {
+          "$ref": "#/definitions/partitionTransform"
+        },
+        {
+          "$ref": "#/definitions/stratifyTransform"
+        },
+        {
+          "$ref": "#/definitions/treeTransform"
+        },
+        {
+          "$ref": "#/definitions/treelinksTransform"
+        },
+        {
+          "$ref": "#/definitions/treemapTransform"
+        },
+        {
+          "$ref": "#/definitions/labelTransform"
+        },
+        {
+          "$ref": "#/definitions/loessTransform"
+        },
+        {
+          "$ref": "#/definitions/regressionTransform"
+        },
+        {
+          "$ref": "#/definitions/aggregateTransform"
+        },
+        {
+          "$ref": "#/definitions/binTransform"
+        },
+        {
+          "$ref": "#/definitions/collectTransform"
+        },
+        {
+          "$ref": "#/definitions/countpatternTransform"
+        },
+        {
+          "$ref": "#/definitions/crossTransform"
+        },
+        {
+          "$ref": "#/definitions/densityTransform"
+        },
+        {
+          "$ref": "#/definitions/dotbinTransform"
+        },
+        {
+          "$ref": "#/definitions/extentTransform"
+        },
+        {
+          "$ref": "#/definitions/filterTransform"
+        },
+        {
+          "$ref": "#/definitions/flattenTransform"
+        },
+        {
+          "$ref": "#/definitions/foldTransform"
+        },
+        {
+          "$ref": "#/definitions/formulaTransform"
+        },
+        {
+          "$ref": "#/definitions/imputeTransform"
+        },
+        {
+          "$ref": "#/definitions/joinaggregateTransform"
+        },
+        {
+          "$ref": "#/definitions/kdeTransform"
+        },
+        {
+          "$ref": "#/definitions/lookupTransform"
+        },
+        {
+          "$ref": "#/definitions/pivotTransform"
+        },
+        {
+          "$ref": "#/definitions/projectTransform"
+        },
+        {
+          "$ref": "#/definitions/quantileTransform"
+        },
+        {
+          "$ref": "#/definitions/sampleTransform"
+        },
+        {
+          "$ref": "#/definitions/sequenceTransform"
+        },
+        {
+          "$ref": "#/definitions/timeunitTransform"
+        },
+        {
+          "$ref": "#/definitions/windowTransform"
+        },
+        {
+          "$ref": "#/definitions/identifierTransform"
+        },
+        {
+          "$ref": "#/definitions/voronoiTransform"
+        },
+        {
+          "$ref": "#/definitions/wordcloudTransform"
+        }
+      ]
+    },
+    "transformMark": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/crossfilterTransform"
+        },
+        {
+          "$ref": "#/definitions/resolvefilterTransform"
+        },
+        {
+          "$ref": "#/definitions/linkpathTransform"
+        },
+        {
+          "$ref": "#/definitions/pieTransform"
+        },
+        {
+          "$ref": "#/definitions/stackTransform"
+        },
+        {
+          "$ref": "#/definitions/forceTransform"
+        },
+        {
+          "$ref": "#/definitions/geojsonTransform"
+        },
+        {
+          "$ref": "#/definitions/geopathTransform"
+        },
+        {
+          "$ref": "#/definitions/geopointTransform"
+        },
+        {
+          "$ref": "#/definitions/geoshapeTransform"
+        },
+        {
+          "$ref": "#/definitions/heatmapTransform"
+        },
+        {
+          "$ref": "#/definitions/packTransform"
+        },
+        {
+          "$ref": "#/definitions/partitionTransform"
+        },
+        {
+          "$ref": "#/definitions/stratifyTransform"
+        },
+        {
+          "$ref": "#/definitions/treeTransform"
+        },
+        {
+          "$ref": "#/definitions/treemapTransform"
+        },
+        {
+          "$ref": "#/definitions/labelTransform"
+        },
+        {
+          "$ref": "#/definitions/binTransform"
+        },
+        {
+          "$ref": "#/definitions/collectTransform"
+        },
+        {
+          "$ref": "#/definitions/dotbinTransform"
+        },
+        {
+          "$ref": "#/definitions/extentTransform"
+        },
+        {
+          "$ref": "#/definitions/formulaTransform"
+        },
+        {
+          "$ref": "#/definitions/joinaggregateTransform"
+        },
+        {
+          "$ref": "#/definitions/lookupTransform"
+        },
+        {
+          "$ref": "#/definitions/sampleTransform"
+        },
+        {
+          "$ref": "#/definitions/timeunitTransform"
+        },
+        {
+          "$ref": "#/definitions/windowTransform"
+        },
+        {
+          "$ref": "#/definitions/identifierTransform"
+        },
+        {
+          "$ref": "#/definitions/voronoiTransform"
+        },
+        {
+          "$ref": "#/definitions/wordcloudTransform"
+        }
+      ]
+    },
+    "crossfilterTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "crossfilter"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "fields": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "query": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {}
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "fields",
+        "query"
+      ],
+      "additionalProperties": false
+    },
+    "resolvefilterTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "resolvefilter"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "filter": {}
+      },
+      "required": [
+        "type",
+        "ignore",
+        "filter"
+      ],
+      "additionalProperties": false
+    },
+    "linkpathTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "linkpath"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "sourceX": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ],
+          "default": "source.x"
+        },
+        "sourceY": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ],
+          "default": "source.y"
+        },
+        "targetX": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ],
+          "default": "target.x"
+        },
+        "targetY": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ],
+          "default": "target.y"
+        },
+        "orient": {
+          "anyOf": [
+            {
+              "enum": [
+                "horizontal",
+                "vertical",
+                "radial"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "vertical"
+        },
+        "shape": {
+          "anyOf": [
+            {
+              "enum": [
+                "line",
+                "arc",
+                "curve",
+                "diagonal",
+                "orthogonal"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "line"
+        },
+        "require": {
+          "$ref": "#/definitions/signalRef"
+        },
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "path"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "pieTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "pie"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "startAngle": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "endAngle": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 6.283185307179586
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "startAngle",
+            "endAngle"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "stackTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "stack"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "sort": {
+          "$ref": "#/definitions/compare"
+        },
+        "offset": {
+          "anyOf": [
+            {
+              "enum": [
+                "zero",
+                "center",
+                "normalize"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "zero"
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "y0",
+            "y1"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "forceTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "force"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "static": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "restart": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "iterations": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 300
+        },
+        "alpha": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 1
+        },
+        "alphaMin": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 0.001
+        },
+        "alphaTarget": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "velocityDecay": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 0.4
+        },
+        "forces": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "enum": [
+                      "center"
+                    ]
+                  },
+                  "x": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      }
+                    ]
+                  },
+                  "y": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "force"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "enum": [
+                      "collide"
+                    ]
+                  },
+                  "radius": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "$ref": "#/definitions/expr"
+                      },
+                      {
+                        "$ref": "#/definitions/paramField"
+                      }
+                    ]
+                  },
+                  "strength": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      }
+                    ],
+                    "default": 0.7
+                  },
+                  "iterations": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      }
+                    ],
+                    "default": 1
+                  }
+                },
+                "required": [
+                  "force"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "enum": [
+                      "nbody"
+                    ]
+                  },
+                  "strength": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      }
+                    ],
+                    "default": -30
+                  },
+                  "theta": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      }
+                    ],
+                    "default": 0.9
+                  },
+                  "distanceMin": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      }
+                    ],
+                    "default": 1
+                  },
+                  "distanceMax": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "force"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "enum": [
+                      "link"
+                    ]
+                  },
+                  "links": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/scaleField"
+                      },
+                      {
+                        "$ref": "#/definitions/paramField"
+                      },
+                      {
+                        "$ref": "#/definitions/expr"
+                      }
+                    ]
+                  },
+                  "distance": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "$ref": "#/definitions/expr"
+                      },
+                      {
+                        "$ref": "#/definitions/paramField"
+                      }
+                    ],
+                    "default": 30
+                  },
+                  "strength": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      },
+                      {
+                        "$ref": "#/definitions/expr"
+                      },
+                      {
+                        "$ref": "#/definitions/paramField"
+                      }
+                    ]
+                  },
+                  "iterations": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      }
+                    ],
+                    "default": 1
+                  }
+                },
+                "required": [
+                  "force"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "enum": [
+                      "x"
+                    ]
+                  },
+                  "strength": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      }
+                    ],
+                    "default": 0.1
+                  },
+                  "x": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/scaleField"
+                      },
+                      {
+                        "$ref": "#/definitions/paramField"
+                      },
+                      {
+                        "$ref": "#/definitions/expr"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "force"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "enum": [
+                      "y"
+                    ]
+                  },
+                  "strength": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "$ref": "#/definitions/signalRef"
+                      }
+                    ],
+                    "default": 0.1
+                  },
+                  "y": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/scaleField"
+                      },
+                      {
+                        "$ref": "#/definitions/paramField"
+                      },
+                      {
+                        "$ref": "#/definitions/expr"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "force"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "x",
+            "y",
+            "vx",
+            "vy"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "contourTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "contour"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "size": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "values": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "x": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "y": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "weight": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "cellSize": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "bandwidth": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "count": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "nice": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "thresholds": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "smooth": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": true
+        }
+      },
+      "required": [
+        "type",
+        "size"
+      ],
+      "additionalProperties": false
+    },
+    "geojsonTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "geojson"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "fields": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "geojson": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "geopathTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "geopath"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "projection": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "pointRadius": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            }
+          ]
+        },
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "path"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "geopointTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "geopoint"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "projection": {
+          "type": "string"
+        },
+        "fields": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "x",
+            "y"
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "projection",
+        "fields"
+      ],
+      "additionalProperties": false
+    },
+    "geoshapeTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "geoshape"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "projection": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ],
+          "default": "datum"
+        },
+        "pointRadius": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            }
+          ]
+        },
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "shape"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "graticuleTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "graticule"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "extent": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {},
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "extentMajor": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {},
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "extentMinor": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {},
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "step": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "stepMajor": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            90,
+            360
+          ]
+        },
+        "stepMinor": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            10,
+            10
+          ]
+        },
+        "precision": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 2.5
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "heatmapTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "heatmap"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "color": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            }
+          ]
+        },
+        "opacity": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            }
+          ]
+        },
+        "resolve": {
+          "anyOf": [
+            {
+              "enum": [
+                "shared",
+                "independent"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "independent"
+        },
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "image"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "isocontourTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "isocontour"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "thresholds": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "levels": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "nice": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "resolve": {
+          "anyOf": [
+            {
+              "enum": [
+                "shared",
+                "independent"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "independent"
+        },
+        "zero": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": true
+        },
+        "smooth": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": true
+        },
+        "scale": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            }
+          ]
+        },
+        "translate": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "contour"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "kde2dTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "kde2d"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "size": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "x": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "y": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "weight": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "cellSize": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "bandwidth": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "counts": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "grid"
+        }
+      },
+      "required": [
+        "type",
+        "size",
+        "x",
+        "y"
+      ],
+      "additionalProperties": false
+    },
+    "nestTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "nest"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "keys": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "generate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "packTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "pack"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "sort": {
+          "$ref": "#/definitions/compare"
+        },
+        "padding": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "radius": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "size": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 5,
+              "minItems": 5
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "x",
+            "y",
+            "r",
+            "depth",
+            "children"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "partitionTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "partition"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "sort": {
+          "$ref": "#/definitions/compare"
+        },
+        "padding": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "round": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "size": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 6,
+              "minItems": 6
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "x0",
+            "y0",
+            "x1",
+            "y1",
+            "depth",
+            "children"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "stratifyTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "stratify"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "key": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "parentKey": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "parentKey"
+      ],
+      "additionalProperties": false
+    },
+    "treeTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "tree"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "sort": {
+          "$ref": "#/definitions/compare"
+        },
+        "method": {
+          "anyOf": [
+            {
+              "enum": [
+                "tidy",
+                "cluster"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "tidy"
+        },
+        "size": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "nodeSize": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "separation": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": true
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 4,
+              "minItems": 4
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "x",
+            "y",
+            "depth",
+            "children"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "treelinksTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "treelinks"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "treemapTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "treemap"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "sort": {
+          "$ref": "#/definitions/compare"
+        },
+        "method": {
+          "anyOf": [
+            {
+              "enum": [
+                "squarify",
+                "resquarify",
+                "binary",
+                "dice",
+                "slice",
+                "slicedice"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "squarify"
+        },
+        "padding": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "paddingInner": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "paddingOuter": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "paddingTop": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "paddingRight": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "paddingBottom": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "paddingLeft": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "ratio": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 1.618033988749895
+        },
+        "round": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "size": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 6,
+              "minItems": 6
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "x0",
+            "y0",
+            "x1",
+            "y1",
+            "depth",
+            "children"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "labelTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "label"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "size": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "sort": {
+          "$ref": "#/definitions/compare"
+        },
+        "anchor": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "top-left",
+            "left",
+            "bottom-left",
+            "top",
+            "bottom",
+            "top-right",
+            "right",
+            "bottom-right"
+          ]
+        },
+        "offset": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            1
+          ]
+        },
+        "padding": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "lineAnchor": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "end"
+        },
+        "markIndex": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "avoidBaseMark": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": true
+        },
+        "avoidMarks": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "naive"
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 5,
+              "minItems": 5
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "x",
+            "y",
+            "opacity",
+            "align",
+            "baseline"
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "size"
+      ],
+      "additionalProperties": false
+    },
+    "loessTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "loess"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "x": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "y": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "bandwidth": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 0.3
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "x",
+        "y"
+      ],
+      "additionalProperties": false
+    },
+    "regressionTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "regression"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "x": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "y": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "linear"
+        },
+        "order": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 3
+        },
+        "extent": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "params": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "x",
+        "y"
+      ],
+      "additionalProperties": false
+    },
+    "aggregateTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "aggregate"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "ops": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "values",
+                      "count",
+                      "__count__",
+                      "missing",
+                      "valid",
+                      "sum",
+                      "product",
+                      "mean",
+                      "average",
+                      "variance",
+                      "variancep",
+                      "stdev",
+                      "stdevp",
+                      "stderr",
+                      "distinct",
+                      "ci0",
+                      "ci1",
+                      "median",
+                      "q1",
+                      "q3",
+                      "min",
+                      "max",
+                      "argmin",
+                      "argmax"
+                    ]
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "fields": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "drop": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": true
+        },
+        "cross": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "key": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "binTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "bin"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "interval": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": true
+        },
+        "anchor": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "maxbins": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 20
+        },
+        "base": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 10
+        },
+        "divide": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            5,
+            2
+          ]
+        },
+        "extent": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "span": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "step": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "steps": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "minstep": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "nice": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": true
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "bin0",
+            "bin1"
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "field",
+        "extent"
+      ],
+      "additionalProperties": false
+    },
+    "collectTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "collect"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "sort": {
+          "$ref": "#/definitions/compare"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "countpatternTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "countpattern"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "case": {
+          "anyOf": [
+            {
+              "enum": [
+                "upper",
+                "lower",
+                "mixed"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "mixed"
+        },
+        "pattern": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "[\\w\"]+"
+        },
+        "stopwords": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "text",
+            "count"
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "field"
+      ],
+      "additionalProperties": false
+    },
+    "crossTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "cross"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "filter": {
+          "$ref": "#/definitions/exprString"
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "densityTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "density"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "extent": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "steps": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "minsteps": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 25
+        },
+        "maxsteps": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 200
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "pdf"
+        },
+        "distribution": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "function": {
+                  "enum": [
+                    "normal"
+                  ]
+                },
+                "mean": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/definitions/signalRef"
+                    }
+                  ]
+                },
+                "stdev": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/definitions/signalRef"
+                    }
+                  ],
+                  "default": 1
+                }
+              },
+              "required": [
+                "function"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "function": {
+                  "enum": [
+                    "lognormal"
+                  ]
+                },
+                "mean": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/definitions/signalRef"
+                    }
+                  ]
+                },
+                "stdev": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/definitions/signalRef"
+                    }
+                  ],
+                  "default": 1
+                }
+              },
+              "required": [
+                "function"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "function": {
+                  "enum": [
+                    "uniform"
+                  ]
+                },
+                "min": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/definitions/signalRef"
+                    }
+                  ]
+                },
+                "max": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/definitions/signalRef"
+                    }
+                  ],
+                  "default": 1
+                }
+              },
+              "required": [
+                "function"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "function": {
+                  "enum": [
+                    "kde"
+                  ]
+                },
+                "field": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/scaleField"
+                    },
+                    {
+                      "$ref": "#/definitions/paramField"
+                    },
+                    {
+                      "$ref": "#/definitions/expr"
+                    }
+                  ]
+                },
+                "from": {
+                  "type": "string"
+                },
+                "bandwidth": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/definitions/signalRef"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "function",
+                "field"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "function": {
+                  "enum": [
+                    "mixture"
+                  ]
+                },
+                "distributions": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {}
+                    },
+                    {
+                      "$ref": "#/definitions/signalRef"
+                    }
+                  ]
+                },
+                "weights": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "$ref": "#/definitions/signalRef"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "$ref": "#/definitions/signalRef"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "function"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "value",
+            "density"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "dotbinTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "dotbin"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "step": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "smooth": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "bin"
+        }
+      },
+      "required": [
+        "type",
+        "field"
+      ],
+      "additionalProperties": false
+    },
+    "extentTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "extent"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "field"
+      ],
+      "additionalProperties": false
+    },
+    "filterTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "filter"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "expr": {
+          "$ref": "#/definitions/exprString"
+        }
+      },
+      "required": [
+        "type",
+        "expr"
+      ],
+      "additionalProperties": false
+    },
+    "flattenTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "flatten"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "fields": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "index": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "fields"
+      ],
+      "additionalProperties": false
+    },
+    "foldTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "fold"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "fields": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "key",
+            "value"
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "fields"
+      ],
+      "additionalProperties": false
+    },
+    "formulaTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "formula"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "expr": {
+          "$ref": "#/definitions/exprString"
+        },
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "initonly": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "expr",
+        "as"
+      ],
+      "additionalProperties": false
+    },
+    "imputeTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "impute"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "key": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "keyvals": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {}
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "enum": [
+                "value",
+                "mean",
+                "median",
+                "max",
+                "min"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "value"
+        },
+        "value": {}
+      },
+      "required": [
+        "type",
+        "field",
+        "key"
+      ],
+      "additionalProperties": false
+    },
+    "joinaggregateTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "joinaggregate"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "fields": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "ops": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "values",
+                      "count",
+                      "__count__",
+                      "missing",
+                      "valid",
+                      "sum",
+                      "product",
+                      "mean",
+                      "average",
+                      "variance",
+                      "variancep",
+                      "stdev",
+                      "stdevp",
+                      "stderr",
+                      "distinct",
+                      "ci0",
+                      "ci1",
+                      "median",
+                      "q1",
+                      "q3",
+                      "min",
+                      "max",
+                      "argmin",
+                      "argmax"
+                    ]
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "key": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "kdeTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "kde"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "cumulative": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "counts": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "bandwidth": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "extent": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "resolve": {
+          "anyOf": [
+            {
+              "enum": [
+                "shared",
+                "independent"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "independent"
+        },
+        "steps": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "minsteps": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 25
+        },
+        "maxsteps": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 200
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "value",
+            "density"
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "field"
+      ],
+      "additionalProperties": false
+    },
+    "lookupTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "lookup"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "from": {
+          "type": "string"
+        },
+        "key": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "values": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "fields": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "default": {}
+      },
+      "required": [
+        "type",
+        "from",
+        "key",
+        "fields"
+      ],
+      "additionalProperties": false
+    },
+    "pivotTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "pivot"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "op": {
+          "anyOf": [
+            {
+              "enum": [
+                "values",
+                "count",
+                "__count__",
+                "missing",
+                "valid",
+                "sum",
+                "product",
+                "mean",
+                "average",
+                "variance",
+                "variancep",
+                "stdev",
+                "stdevp",
+                "stderr",
+                "distinct",
+                "ci0",
+                "ci1",
+                "median",
+                "q1",
+                "q3",
+                "min",
+                "max",
+                "argmin",
+                "argmax"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "sum"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "key": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "field",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "projectTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "project"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "fields": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "quantileTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "quantile"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "probs": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "step": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 0.01
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "prob",
+            "value"
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "field"
+      ],
+      "additionalProperties": false
+    },
+    "sampleTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "sample"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 1000
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "sequenceTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "sequence"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "start": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "stop": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "step": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 1
+        },
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "data"
+        }
+      },
+      "required": [
+        "type",
+        "start",
+        "stop"
+      ],
+      "additionalProperties": false
+    },
+    "timeunitTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "timeunit"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "field": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "interval": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": true
+        },
+        "units": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "year",
+                      "quarter",
+                      "month",
+                      "week",
+                      "date",
+                      "day",
+                      "dayofyear",
+                      "hours",
+                      "minutes",
+                      "seconds",
+                      "milliseconds"
+                    ]
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "step": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 1
+        },
+        "maxbins": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": 40
+        },
+        "extent": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "timezone": {
+          "anyOf": [
+            {
+              "enum": [
+                "local",
+                "utc"
+              ]
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "local"
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "unit0",
+            "unit1"
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "field"
+      ],
+      "additionalProperties": false
+    },
+    "windowTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "window"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "sort": {
+          "$ref": "#/definitions/compare"
+        },
+        "groupby": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "ops": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "row_number",
+                      "rank",
+                      "dense_rank",
+                      "percent_rank",
+                      "cume_dist",
+                      "ntile",
+                      "lag",
+                      "lead",
+                      "first_value",
+                      "last_value",
+                      "nth_value",
+                      "prev_value",
+                      "next_value",
+                      "values",
+                      "count",
+                      "__count__",
+                      "missing",
+                      "valid",
+                      "sum",
+                      "product",
+                      "mean",
+                      "average",
+                      "variance",
+                      "variancep",
+                      "stdev",
+                      "stdevp",
+                      "stderr",
+                      "distinct",
+                      "ci0",
+                      "ci1",
+                      "median",
+                      "q1",
+                      "q3",
+                      "min",
+                      "max",
+                      "argmin",
+                      "argmax"
+                    ]
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "params": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "fields": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/scaleField"
+                  },
+                  {
+                    "$ref": "#/definitions/paramField"
+                  },
+                  {
+                    "$ref": "#/definitions/expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "frame": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            null,
+            0
+          ]
+        },
+        "ignorePeers": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "identifierTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "identifier"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "as"
+      ],
+      "additionalProperties": false
+    },
+    "voronoiTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "voronoi"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "x": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "y": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "size": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "extent": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {},
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            [
+              -100000,
+              -100000
+            ],
+            [
+              100000,
+              100000
+            ]
+          ]
+        },
+        "as": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": "path"
+        }
+      },
+      "required": [
+        "type",
+        "x",
+        "y"
+      ],
+      "additionalProperties": false
+    },
+    "wordcloudTransform": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "wordcloud"
+          ]
+        },
+        "signal": {
+          "type": "string"
+        },
+        "size": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 2,
+              "minItems": 2
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "font": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            }
+          ],
+          "default": "sans-serif"
+        },
+        "fontStyle": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            }
+          ],
+          "default": "normal"
+        },
+        "fontWeight": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            }
+          ],
+          "default": "normal"
+        },
+        "fontSize": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            }
+          ],
+          "default": 14
+        },
+        "fontSizeRange": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              }
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [
+            10,
+            50
+          ]
+        },
+        "rotate": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            }
+          ]
+        },
+        "text": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/scaleField"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            }
+          ]
+        },
+        "spiral": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
+        "padding": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            },
+            {
+              "$ref": "#/definitions/expr"
+            },
+            {
+              "$ref": "#/definitions/paramField"
+            }
+          ]
+        },
+        "as": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/signalRef"
+                  }
+                ]
+              },
+              "maxItems": 7,
+              "minItems": 7
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ],
+          "default": [
+            "x",
+            "y",
+            "font",
+            "fontSize",
+            "fontStyle",
+            "fontWeight",
+            "angle"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
     }
   },
   "type": "object",
   "allOf": [
     {
-      "$ref": "#/defs/scope"
+      "$ref": "#/definitions/scope"
     },
     {
       "properties": {
@@ -15941,22 +16252,22 @@
           "type": "string"
         },
         "width": {
-          "$ref": "#/refs/numberOrSignal"
+          "$ref": "#/definitions/numberOrSignal"
         },
         "height": {
-          "$ref": "#/refs/numberOrSignal"
+          "$ref": "#/definitions/numberOrSignal"
         },
         "padding": {
-          "$ref": "#/defs/padding"
+          "$ref": "#/definitions/padding"
         },
         "autosize": {
-          "$ref": "#/defs/autosize"
+          "$ref": "#/definitions/autosize"
         },
         "background": {
-          "$ref": "#/defs/background"
+          "$ref": "#/definitions/background"
         },
         "style": {
-          "$ref": "#/refs/style"
+          "$ref": "#/definitions/style"
         }
       }
     }

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2441,14 +2441,10 @@ class ConcatChart(TopLevelMixin, core.TopLevelConcatSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params:
+        if not params or not self.concat:
             return self
-        copy = self.copy(deep=["params"])
-        if copy.params is Undefined:
-            copy.params = []
-
-        for s in params:
-            copy.params.append(s.param)
+        copy = self.copy()
+        copy.concat = [chart.add_params(*params) for chart in copy.concat]
         return copy
 
     @utils.deprecation.deprecated(
@@ -2489,14 +2485,10 @@ class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params:
+        if not params or not self.hconcat:
             return self
-        copy = self.copy(deep=["params"])
-        if copy.params is Undefined:
-            copy.params = []
-
-        for s in params:
-            copy.params.append(s.param)
+        copy = self.copy()
+        copy.hconcat = [chart.add_params(*params) for chart in copy.hconcat]
         return copy
 
     @utils.deprecation.deprecated(
@@ -2537,14 +2529,10 @@ class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params:
+        if not params or not self.vconcat:
             return self
-        copy = self.copy(deep=["params"])
-        if copy.params is Undefined:
-            copy.params = []
-
-        for s in params:
-            copy.params.append(s.param)
+        copy = self.copy()
+        copy.vconcat = [chart.add_params(*params) for chart in copy.vconcat]
         return copy
 
     @utils.deprecation.deprecated(

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2803,16 +2803,12 @@ def _combine_subchart_params(params, subcharts):
             )
         )
 
-    subcharts_with_params = []
-    other_charts = []
+    subcharts = [subchart.copy() for subchart in subcharts]
 
     for subchart in subcharts:
-        if subchart.params is not Undefined:
-            subcharts_with_params.append(subchart.copy())
-        else:
-            other_charts.append(subchart.copy())
+        if subchart.params is Undefined:
+            continue
 
-    for subchart in subcharts_with_params:
         if _needs_name(subchart):
             subchart.name = subchart._get_name()
 
@@ -2854,7 +2850,7 @@ def _combine_subchart_params(params, subcharts):
     if len(subparams) == 0:
         subparams = Undefined
 
-    return subparams, subcharts_with_params + other_charts
+    return subparams, subcharts
 
 
 def _remove_layer_props(chart, subcharts, layer_props):

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2327,6 +2327,10 @@ class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
         **kwds,
     ):
         _check_if_valid_subspec(spec, "RepeatChart")
+        _spec_as_list = [spec]
+        params, _spec_as_list = _combine_subchart_params(params, _spec_as_list)
+        assert len(_spec_as_list) == 1
+        spec = _spec_as_list[0]
         super(RepeatChart, self).__init__(
             repeat=repeat,
             spec=spec,
@@ -2380,7 +2384,7 @@ class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
             return self
         copy = self.copy()
         copy.spec = copy.spec.add_params(*params)
-        return copy
+        return copy.copy()
 
     @utils.deprecation.deprecated(
         message="'add_selection' is deprecated. Use 'add_params' instead."
@@ -2618,7 +2622,7 @@ class LayerChart(TopLevelMixin, _EncodingMixin, core.TopLevelLayerSpec):
             return self
         copy = self.copy()
         copy.layer[0] = copy.layer[0].add_params(*params)
-        return copy
+        return copy.copy()
 
     @utils.deprecation.deprecated(
         message="'add_selection' is deprecated. Use 'add_params' instead."
@@ -2782,7 +2786,7 @@ def _combine_subchart_params(params, subcharts):
     subcharts = [subchart.copy() for subchart in subcharts]
 
     for subchart in subcharts:
-        if subchart.params is Undefined:
+        if (not hasattr(subchart, "params")) or (subchart.params is Undefined):
             continue
 
         if _needs_name(subchart):

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2438,6 +2438,32 @@ class ConcatChart(TopLevelMixin, core.TopLevelConcatSpec):
         copy |= other
         return copy
 
+    def interactive(self, name=None, bind_x=True, bind_y=True):
+        """Make chart axes scales interactive
+
+        Parameters
+        ----------
+        name : string
+            The parameter name to use for the axes scales. This name should be
+            unique among all parameters within the chart.
+        bind_x : boolean, default True
+            If true, then bind the interactive scales to the x-axis
+        bind_y : boolean, default True
+            If true, then bind the interactive scales to the y-axis
+
+        Returns
+        -------
+        chart :
+            copy of self, with interactive axes added
+
+        """
+        encodings = []
+        if bind_x:
+            encodings.append("x")
+        if bind_y:
+            encodings.append("y")
+        return self.add_params(selection_interval(bind="scales", encodings=encodings))
+
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
         if not params or not self.concat:
@@ -2482,6 +2508,32 @@ class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):
         copy |= other
         return copy
 
+    def interactive(self, name=None, bind_x=True, bind_y=True):
+        """Make chart axes scales interactive
+
+        Parameters
+        ----------
+        name : string
+            The parameter name to use for the axes scales. This name should be
+            unique among all parameters within the chart.
+        bind_x : boolean, default True
+            If true, then bind the interactive scales to the x-axis
+        bind_y : boolean, default True
+            If true, then bind the interactive scales to the y-axis
+
+        Returns
+        -------
+        chart :
+            copy of self, with interactive axes added
+
+        """
+        encodings = []
+        if bind_x:
+            encodings.append("x")
+        if bind_y:
+            encodings.append("y")
+        return self.add_params(selection_interval(bind="scales", encodings=encodings))
+
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
         if not params or not self.hconcat:
@@ -2525,6 +2577,32 @@ class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
         copy = self.copy(deep=["vconcat"])
         copy &= other
         return copy
+
+    def interactive(self, name=None, bind_x=True, bind_y=True):
+        """Make chart axes scales interactive
+
+        Parameters
+        ----------
+        name : string
+            The parameter name to use for the axes scales. This name should be
+            unique among all parameters within the chart.
+        bind_x : boolean, default True
+            If true, then bind the interactive scales to the x-axis
+        bind_y : boolean, default True
+            If true, then bind the interactive scales to the y-axis
+
+        Returns
+        -------
+        chart :
+            copy of self, with interactive axes added
+
+        """
+        encodings = []
+        if bind_x:
+            encodings.append("x")
+        if bind_y:
+            encodings.append("y")
+        return self.add_params(selection_interval(bind="scales", encodings=encodings))
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -162,7 +162,7 @@ class Parameter(expr.core.OperatorMixin, object):
     @classmethod
     def _get_name(cls):
         cls._counter += 1
-        return "parameter{:03d}".format(cls._counter)
+        return f"param_{cls._counter}"
 
     def __init__(self, name):
         if name is None:
@@ -332,6 +332,11 @@ def param(name=None, select=None, **kwds):
     if select is None:
         parameter.param = core.VariableParameter(name=parameter.name, **kwds)
         parameter.param_type = "variable"
+    elif "views" in kwds:
+        parameter.param = core.TopLevelSelectionParameter(
+            name=parameter.name, select=select, **kwds
+        )
+        parameter.param_type = "selection"
     else:
         parameter.param = core.SelectionParameter(
             name=parameter.name, select=select, **kwds
@@ -361,7 +366,7 @@ def selection(type=Undefined, **kwds):
     # We separate out the parameter keywords from the selection keywords
     param_kwds = {}
 
-    for kwd in {"name", "value", "bind", "empty", "init"}:
+    for kwd in {"name", "value", "bind", "empty", "init", "views"}:
         if kwd in kwds:
             param_kwds[kwd] = kwds.pop(kwd)
 
@@ -2141,6 +2146,13 @@ class Chart(
             **kwargs,
         )
 
+    _counter = 0
+
+    @classmethod
+    def _get_name(cls):
+        cls._counter += 1
+        return f"view_{cls._counter}"
+
     @classmethod
     def from_dict(cls, dct, validate=True):
         """Construct class from a dictionary representation
@@ -2364,10 +2376,14 @@ class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params or self.spec is Undefined:
+        if not params:
             return self
-        copy = self.copy()
-        copy.spec = copy.spec.add_params(*params)
+        copy = self.copy(deep=["params"])
+        if copy.params is Undefined:
+            copy.params = []
+
+        for s in params:
+            copy.params.append(s.param)
         return copy
 
     @utils.deprecation.deprecated(
@@ -2409,11 +2425,13 @@ class ConcatChart(TopLevelMixin, core.TopLevelConcatSpec):
             data=data, concat=list(concat), columns=columns, **kwargs
         )
         self.data, self.concat = _combine_subchart_data(self.data, self.concat)
+        self.params, self.concat = _combine_subchart_params(self.params, self.concat)
 
     def __ior__(self, other):
         _check_if_valid_subspec(other, "ConcatChart")
         self.concat.append(other)
         self.data, self.concat = _combine_subchart_data(self.data, self.concat)
+        self.params, self.concat = _combine_subchart_params(self.params, self.concat)
         return self
 
     def __or__(self, other):
@@ -2423,10 +2441,14 @@ class ConcatChart(TopLevelMixin, core.TopLevelConcatSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params or not self.concat:
+        if not params:
             return self
-        copy = self.copy()
-        copy.concat = [chart.add_params(*params) for chart in copy.concat]
+        copy = self.copy(deep=["params"])
+        if copy.params is Undefined:
+            copy.params = []
+
+        for s in params:
+            copy.params.append(s.param)
         return copy
 
     @utils.deprecation.deprecated(
@@ -2451,11 +2473,13 @@ class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):
             _check_if_valid_subspec(spec, "HConcatChart")
         super(HConcatChart, self).__init__(data=data, hconcat=list(hconcat), **kwargs)
         self.data, self.hconcat = _combine_subchart_data(self.data, self.hconcat)
+        self.params, self.hconcat = _combine_subchart_params(self.params, self.hconcat)
 
     def __ior__(self, other):
         _check_if_valid_subspec(other, "HConcatChart")
         self.hconcat.append(other)
         self.data, self.hconcat = _combine_subchart_data(self.data, self.hconcat)
+        self.params, self.hconcat = _combine_subchart_params(self.params, self.hconcat)
         return self
 
     def __or__(self, other):
@@ -2465,10 +2489,14 @@ class HConcatChart(TopLevelMixin, core.TopLevelHConcatSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params or not self.hconcat:
+        if not params:
             return self
-        copy = self.copy()
-        copy.hconcat = [chart.add_params(*params) for chart in copy.hconcat]
+        copy = self.copy(deep=["params"])
+        if copy.params is Undefined:
+            copy.params = []
+
+        for s in params:
+            copy.params.append(s.param)
         return copy
 
     @utils.deprecation.deprecated(
@@ -2493,11 +2521,13 @@ class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
             _check_if_valid_subspec(spec, "VConcatChart")
         super(VConcatChart, self).__init__(data=data, vconcat=list(vconcat), **kwargs)
         self.data, self.vconcat = _combine_subchart_data(self.data, self.vconcat)
+        self.params, self.vconcat = _combine_subchart_params(self.params, self.vconcat)
 
     def __iand__(self, other):
         _check_if_valid_subspec(other, "VConcatChart")
         self.vconcat.append(other)
         self.data, self.vconcat = _combine_subchart_data(self.data, self.vconcat)
+        self.params, self.vconcat = _combine_subchart_params(self.params, self.vconcat)
         return self
 
     def __and__(self, other):
@@ -2507,10 +2537,14 @@ class VConcatChart(TopLevelMixin, core.TopLevelVConcatSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params or not self.vconcat:
+        if not params:
             return self
-        copy = self.copy()
-        copy.vconcat = [chart.add_params(*params) for chart in copy.vconcat]
+        copy = self.copy(deep=["params"])
+        if copy.params is Undefined:
+            copy.params = []
+
+        for s in params:
+            copy.params.append(s.param)
         return copy
 
     @utils.deprecation.deprecated(
@@ -2537,6 +2571,7 @@ class LayerChart(TopLevelMixin, _EncodingMixin, core.TopLevelLayerSpec):
             _check_if_can_be_layered(spec)
         super(LayerChart, self).__init__(data=data, layer=list(layer), **kwargs)
         self.data, self.layer = _combine_subchart_data(self.data, self.layer)
+        self.params, self.layer = _combine_subchart_params(self.params, self.layer)
 
         # Some properties are not allowed within layer; we'll move to parent.
         layer_props = ("height", "width", "view")
@@ -2550,6 +2585,7 @@ class LayerChart(TopLevelMixin, _EncodingMixin, core.TopLevelLayerSpec):
         _check_if_can_be_layered(other)
         self.layer.append(other)
         self.data, self.layer = _combine_subchart_data(self.data, self.layer)
+        self.params, self.layer = _combine_subchart_params(self.params, self.layer)
         return self
 
     def __add__(self, other):
@@ -2594,10 +2630,14 @@ class LayerChart(TopLevelMixin, _EncodingMixin, core.TopLevelLayerSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params or not self.layer:
+        if not params:
             return self
-        copy = self.copy()
-        copy.layer[0] = copy.layer[0].add_params(*params)
+        copy = self.copy(deep=["params"])
+        if copy.params is Undefined:
+            copy.params = []
+
+        for s in params:
+            copy.params.append(s.param)
         return copy
 
     @utils.deprecation.deprecated(
@@ -2645,10 +2685,14 @@ class FacetChart(TopLevelMixin, core.TopLevelFacetSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params or self.spec is Undefined:
+        if not params:
             return self
-        copy = self.copy()
-        copy.spec = copy.spec.add_params(*params)
+        copy = self.copy(deep=["params"])
+        if copy.params is Undefined:
+            copy.params = []
+
+        for s in params:
+            copy.params.append(s.param)
         return copy
 
     @utils.deprecation.deprecated(
@@ -2704,6 +2748,11 @@ def _combine_subchart_data(data, subcharts):
             subcharts = [remove_data(c) for c in subcharts]
 
     return data, subcharts
+
+
+# Yet to be defined
+def _combine_subchart_params(params, subcharts):
+    return params, subcharts
 
 
 def _remove_layer_props(chart, subcharts, layer_props):

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2376,14 +2376,10 @@ class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params:
+        if not params or self.spec is Undefined:
             return self
-        copy = self.copy(deep=["params"])
-        if copy.params is Undefined:
-            copy.params = []
-
-        for s in params:
-            copy.params.append(s.param)
+        copy = self.copy()
+        copy.spec = copy.spec.add_params(*params)
         return copy
 
     @utils.deprecation.deprecated(
@@ -2618,14 +2614,10 @@ class LayerChart(TopLevelMixin, _EncodingMixin, core.TopLevelLayerSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params:
+        if not params or not self.layer:
             return self
-        copy = self.copy(deep=["params"])
-        if copy.params is Undefined:
-            copy.params = []
-
-        for s in params:
-            copy.params.append(s.param)
+        copy = self.copy()
+        copy.layer[0] = copy.layer[0].add_params(*params)
         return copy
 
     @utils.deprecation.deprecated(
@@ -2673,14 +2665,10 @@ class FacetChart(TopLevelMixin, core.TopLevelFacetSpec):
 
     def add_params(self, *params):
         """Add one or more parameters to the chart."""
-        if not params:
+        if not params or self.spec is Undefined:
             return self
-        copy = self.copy(deep=["params"])
-        if copy.params is Undefined:
-            copy.params = []
-
-        for s in params:
-            copy.params.append(s.param)
+        copy = self.copy()
+        copy.spec = copy.spec.add_params(*params)
         return copy
 
     @utils.deprecation.deprecated(

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2641,9 +2641,21 @@ def layer(*charts, **kwargs):
 class FacetChart(TopLevelMixin, core.TopLevelFacetSpec):
     """A Chart with layers within a single panel"""
 
-    def __init__(self, data=Undefined, spec=Undefined, facet=Undefined, **kwargs):
+    def __init__(
+        self,
+        data=Undefined,
+        spec=Undefined,
+        facet=Undefined,
+        params=Undefined,
+        **kwargs,
+    ):
         _check_if_valid_subspec(spec, "FacetChart")
-        super(FacetChart, self).__init__(data=data, spec=spec, facet=facet, **kwargs)
+        _spec_as_list = [spec]
+        params, _spec_as_list = _combine_subchart_params(params, _spec_as_list)
+        spec = _spec_as_list[0]
+        super(FacetChart, self).__init__(
+            data=data, spec=spec, facet=facet, params=params, **kwargs
+        )
 
     def interactive(self, name=None, bind_x=True, bind_y=True):
         """Make chart axes scales interactive
@@ -2674,7 +2686,7 @@ class FacetChart(TopLevelMixin, core.TopLevelFacetSpec):
             return self
         copy = self.copy()
         copy.spec = copy.spec.add_params(*params)
-        return copy
+        return copy.copy()
 
     @utils.deprecation.deprecated(
         message="'add_selection' is deprecated. Use 'add_params' instead."

--- a/altair/vegalite/v5/schema/__init__.py
+++ b/altair/vegalite/v5/schema/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 from .core import *
 from .channels import *
-SCHEMA_VERSION = 'v5.2.0'
-SCHEMA_URL = 'https://vega.github.io/schema/vega-lite/v5.2.0.json'
+SCHEMA_VERSION = 'v5.5.0'
+SCHEMA_URL = 'https://vega.github.io/schema/vega-lite/v5.5.0.json'

--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -117,13 +117,13 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -502,13 +502,13 @@ class Color(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -900,13 +900,13 @@ class Column(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -1111,13 +1111,13 @@ class Description(FieldChannelMixin, core.StringFieldDefWithCondition):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -1347,13 +1347,13 @@ class Detail(FieldChannelMixin, core.FieldDefWithoutScale):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -1531,13 +1531,13 @@ class Facet(FieldChannelMixin, core.FacetEncodingFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -1777,13 +1777,13 @@ class Fill(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefG
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -2163,13 +2163,13 @@ class FillOpacity(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFi
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -2548,13 +2548,13 @@ class Href(FieldChannelMixin, core.StringFieldDefWithCondition):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -2784,13 +2784,13 @@ class Key(FieldChannelMixin, core.FieldDefWithoutScale):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -2951,13 +2951,13 @@ class Latitude(FieldChannelMixin, core.LatLongFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -3232,13 +3232,13 @@ class Latitude2(FieldChannelMixin, core.SecondaryFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -3464,13 +3464,13 @@ class Longitude(FieldChannelMixin, core.LatLongFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -3745,13 +3745,13 @@ class Longitude2(FieldChannelMixin, core.SecondaryFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -3979,13 +3979,13 @@ class Opacity(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldD
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -4362,13 +4362,13 @@ class Order(FieldChannelMixin, core.OrderFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -4560,13 +4560,13 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -4660,8 +4660,9 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -4829,8 +4830,9 @@ class RadiusDatum(DatumChannelMixin, core.PositionDatumDefBase):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -4990,13 +4992,13 @@ class Radius2(FieldChannelMixin, core.SecondaryFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -5236,13 +5238,13 @@ class Row(FieldChannelMixin, core.RowColumnEncodingFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -5447,13 +5449,13 @@ class Shape(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -5833,13 +5835,13 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -6218,13 +6220,13 @@ class Stroke(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDe
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -6604,13 +6606,13 @@ class StrokeDash(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFie
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -6990,13 +6992,13 @@ class StrokeOpacity(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkProp
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -7375,13 +7377,13 @@ class StrokeWidth(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFi
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -7760,13 +7762,13 @@ class Text(FieldChannelMixin, core.FieldOrDatumDefWithConditionStringFieldDefTex
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -8152,13 +8154,13 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -8252,8 +8254,9 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -8420,8 +8423,9 @@ class ThetaDatum(DatumChannelMixin, core.PositionDatumDefBase):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -8581,13 +8585,13 @@ class Theta2(FieldChannelMixin, core.SecondaryFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -8815,13 +8819,13 @@ class Tooltip(FieldChannelMixin, core.StringFieldDefWithCondition):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -9052,13 +9056,13 @@ class Url(FieldChannelMixin, core.StringFieldDefWithCondition):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -9296,13 +9300,13 @@ class X(FieldChannelMixin, core.PositionFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -9404,8 +9408,9 @@ class X(FieldChannelMixin, core.PositionFieldDef):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -9590,8 +9595,9 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -9751,13 +9757,13 @@ class X2(FieldChannelMixin, core.SecondaryFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -9984,13 +9990,13 @@ class XError(FieldChannelMixin, core.SecondaryFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -10106,13 +10112,13 @@ class XError2(FieldChannelMixin, core.SecondaryFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -10226,13 +10232,13 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -10602,13 +10608,13 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -10710,8 +10716,9 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -10896,8 +10903,9 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -11057,13 +11065,13 @@ class Y2(FieldChannelMixin, core.SecondaryFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -11290,13 +11298,13 @@ class YError(FieldChannelMixin, core.SecondaryFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -11412,13 +11420,13 @@ class YError2(FieldChannelMixin, core.SecondaryFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -11532,13 +11540,13 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -2636,13 +2636,13 @@ class ConditionalParameterStringFieldDef(ConditionalStringFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -2843,13 +2843,13 @@ class ConditionalPredicateStringFieldDef(ConditionalStringFieldDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -3597,9 +3597,43 @@ class Config(VegaLiteSchema):
         option.
     mark : :class:`MarkConfig`
         Mark Config
+    normalizedNumberFormat : string
+        If normalizedNumberFormatType is not specified, D3 number format for axis labels,
+        text marks, and tooltips of normalized stacked fields (fields with ``stack:
+        "normalize"`` ). For example ``"s"`` for SI units. Use `D3's number format pattern
+        <https://github.com/d3/d3-format#locale_format>`__.
+
+        If ``config.normalizedNumberFormatType`` is specified and
+        ``config.customFormatTypes`` is ``true``, this value will be passed as ``format``
+        alongside ``datum.value`` to the ``config.numberFormatType`` function. **Default
+        value:** ``%``
+    normalizedNumberFormatType : string
+        `Custom format type
+        <https://vega.github.io/vega-lite/docs/config.html#custom-format-type>`__ for
+        ``config.normalizedNumberFormat``.
+
+        **Default value:** ``undefined`` -- This is equilvalent to call D3-format, which is
+        exposed as `format in Vega-Expression
+        <https://vega.github.io/vega/docs/expressions/#format>`__. **Note:** You must also
+        set ``customFormatTypes`` to ``true`` to use this feature.
     numberFormat : string
-        D3 Number format for guide labels and text marks. For example ``"s"`` for SI units.
-        Use `D3's number format pattern <https://github.com/d3/d3-format#locale_format>`__.
+        If numberFormatType is not specified, D3 number format for guide labels, text marks,
+        and tooltips of non-normalized fields (fields *without* ``stack: "normalize"`` ).
+        For example ``"s"`` for SI units. Use `D3's number format pattern
+        <https://github.com/d3/d3-format#locale_format>`__.
+
+        If ``config.numberFormatType`` is specified and ``config.customFormatTypes`` is
+        ``true``, this value will be passed as ``format`` alongside ``datum.value`` to the
+        ``config.numberFormatType`` function.
+    numberFormatType : string
+        `Custom format type
+        <https://vega.github.io/vega-lite/docs/config.html#custom-format-type>`__ for
+        ``config.numberFormat``.
+
+        **Default value:** ``undefined`` -- This is equilvalent to call D3-format, which is
+        exposed as `format in Vega-Expression
+        <https://vega.github.io/vega/docs/expressions/#format>`__. **Note:** You must also
+        set ``customFormatTypes`` to ``true`` to use this feature.
     padding : anyOf(:class:`Padding`, :class:`ExprRef`)
         The default visualization padding, in pixels, from the edge of the visualization
         canvas to the data rectangle. If a number, specifies padding for all sides. If an
@@ -3607,7 +3641,7 @@ class Config(VegaLiteSchema):
         "bottom": 5}`` to specify padding for each side of the visualization.
 
         **Default value** : ``5``
-    params : List(anyOf(:class:`VariableParameter`, :class:`TopLevelSelectionParameter`))
+    params : List(:class:`TopLevelParameter`)
         Dynamic variables or selections that parameterize a visualization.
     point : :class:`MarkConfig`
         Point-Specific Config
@@ -3651,6 +3685,16 @@ class Config(VegaLiteSchema):
 
         **Default value:** ``"%b %d, %Y"`` **Note:** Axes automatically determine the format
         for each label automatically so this config does not affect axes.
+    timeFormatType : string
+        `Custom format type
+        <https://vega.github.io/vega-lite/docs/config.html#custom-format-type>`__ for
+        ``config.timeFormat``.
+
+        **Default value:** ``undefined`` -- This is equilvalent to call D3-time-format,
+        which is exposed as `timeFormat in Vega-Expression
+        <https://vega.github.io/vega/docs/expressions/#timeFormat>`__. **Note:** You must
+        also set ``customFormatTypes`` to ``true`` and there must *not* be a ``timeUnit``
+        defined to use this feature.
     title : :class:`TitleConfig`
         Title configuration, which determines default properties for all `titles
         <https://vega.github.io/vega-lite/docs/title.html>`__. For a full list of title
@@ -3677,11 +3721,13 @@ class Config(VegaLiteSchema):
                  errorbar=Undefined, facet=Undefined, fieldTitle=Undefined, font=Undefined,
                  geoshape=Undefined, header=Undefined, headerColumn=Undefined, headerFacet=Undefined,
                  headerRow=Undefined, image=Undefined, legend=Undefined, line=Undefined,
-                 lineBreak=Undefined, locale=Undefined, mark=Undefined, numberFormat=Undefined,
-                 padding=Undefined, params=Undefined, point=Undefined, projection=Undefined,
-                 range=Undefined, rect=Undefined, rule=Undefined, scale=Undefined, selection=Undefined,
-                 square=Undefined, style=Undefined, text=Undefined, tick=Undefined,
-                 timeFormat=Undefined, title=Undefined, trail=Undefined, view=Undefined, **kwds):
+                 lineBreak=Undefined, locale=Undefined, mark=Undefined,
+                 normalizedNumberFormat=Undefined, normalizedNumberFormatType=Undefined,
+                 numberFormat=Undefined, numberFormatType=Undefined, padding=Undefined,
+                 params=Undefined, point=Undefined, projection=Undefined, range=Undefined,
+                 rect=Undefined, rule=Undefined, scale=Undefined, selection=Undefined, square=Undefined,
+                 style=Undefined, text=Undefined, tick=Undefined, timeFormat=Undefined,
+                 timeFormatType=Undefined, title=Undefined, trail=Undefined, view=Undefined, **kwds):
         super(Config, self).__init__(arc=arc, area=area, aria=aria, autosize=autosize, axis=axis,
                                      axisBand=axisBand, axisBottom=axisBottom,
                                      axisDiscrete=axisDiscrete, axisLeft=axisLeft, axisPoint=axisPoint,
@@ -3699,11 +3745,14 @@ class Config(VegaLiteSchema):
                                      geoshape=geoshape, header=header, headerColumn=headerColumn,
                                      headerFacet=headerFacet, headerRow=headerRow, image=image,
                                      legend=legend, line=line, lineBreak=lineBreak, locale=locale,
-                                     mark=mark, numberFormat=numberFormat, padding=padding,
-                                     params=params, point=point, projection=projection, range=range,
-                                     rect=rect, rule=rule, scale=scale, selection=selection,
-                                     square=square, style=style, text=text, tick=tick,
-                                     timeFormat=timeFormat, title=title, trail=trail, view=view, **kwds)
+                                     mark=mark, normalizedNumberFormat=normalizedNumberFormat,
+                                     normalizedNumberFormatType=normalizedNumberFormatType,
+                                     numberFormat=numberFormat, numberFormatType=numberFormatType,
+                                     padding=padding, params=params, point=point, projection=projection,
+                                     range=range, rect=rect, rule=rule, scale=scale,
+                                     selection=selection, square=square, style=style, text=text,
+                                     tick=tick, timeFormat=timeFormat, timeFormatType=timeFormatType,
+                                     title=title, trail=trail, view=view, **kwds)
 
 
 class Cursor(VegaLiteSchema):
@@ -4535,13 +4584,13 @@ class FacetEncodingFieldDef(VegaLiteSchema):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -4777,13 +4826,13 @@ class FacetFieldDef(VegaLiteSchema):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -5236,13 +5285,13 @@ class FieldDefWithoutScale(VegaLiteSchema):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -5413,13 +5462,13 @@ class FieldOrDatumDefWithConditionStringFieldDefstring(VegaLiteSchema):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -5690,7 +5739,7 @@ class GenericUnitSpecEncodingAnyMark(VegaLiteSchema):
         A key-value mapping between encoding channels and definition of fields.
     name : string
         Name of the visualization for later reference.
-    params : List(anyOf(:class:`VariableParameter`, :class:`SelectionParameter`))
+    params : List(:class:`SelectionParameter`)
         An array of parameters that may either be simple variables, or more complex
         selections that map user input to data queries.
     projection : :class:`Projection`
@@ -6635,13 +6684,13 @@ class LatLongFieldDef(LatLongDef):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -8780,13 +8829,13 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull(ColorDef, M
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -9072,6 +9121,11 @@ class NamedData(DataSource):
 
     name : string
         Provide a placeholder name and bind data at runtime.
+
+        New data may change the layout but Vega does not always resize the chart. To update
+        the layout when the data updates, set `autosize
+        <https://vega.github.io/vega-lite/docs/size.html#autosize>`__ or explicitly use
+        `view.resize <https://vega.github.io/vega/docs/api/view/#view_resize>`__.
     format : :class:`DataFormat`
         An object that specifies the format for parsing the data.
     """
@@ -9305,13 +9359,13 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray(MarkPropDefnumberA
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -9686,13 +9740,13 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumber(MarkPropDefnumber, Nume
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -9937,13 +9991,13 @@ class OrderFieldDef(VegaLiteSchema):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -10934,8 +10988,9 @@ class PositionDatumDefBase(PolarDef):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -11118,8 +11173,9 @@ class PositionDatumDef(PositionDef):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -11263,13 +11319,13 @@ class PositionFieldDef(PositionDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -11371,8 +11427,9 @@ class PositionFieldDef(PositionDef):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -11518,13 +11575,13 @@ class PositionFieldDefBase(PolarDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -11618,8 +11675,9 @@ class PositionFieldDefBase(PolarDef):
           <https://vega.github.io/vega-lite/docs/stack.html#area>`__ chart).
         * ``"normalize"`` - stacking with normalized domain (for creating `normalized
           stacked bar and area charts
-          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__.
-          :raw-html:`<br/>`
+          <https://vega.github.io/vega-lite/docs/stack.html#normalized>`__ and pie charts
+          `with percentage tooltip
+          <https://vega.github.io/vega-lite/docs/arc.html#tooltip>`__ ). :raw-html:`<br/>`
         - ``"center"`` - stacking with center baseline (for `streamgraph
         <https://vega.github.io/vega-lite/docs/stack.html#streamgraph>`__ ).
         * ``null`` or ``false`` - No-stacking. This will produce layered `bar
@@ -12864,13 +12922,13 @@ class RowColumnEncodingFieldDef(VegaLiteSchema):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -13676,13 +13734,13 @@ class ScaleFieldDef(OffsetDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -14021,13 +14079,13 @@ class SecondaryFieldDef(Position2Def):
         and at the middle of the band if set to ``0.5``.
     bin : None
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -14575,13 +14633,13 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull(MarkPro
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -15386,7 +15444,7 @@ class FacetedUnitSpec(Spec, NonNormalizedSpec):
         documentation.
     name : string
         Name of the visualization for later reference.
-    params : List(anyOf(:class:`VariableParameter`, :class:`SelectionParameter`))
+    params : List(:class:`SelectionParameter`)
         An array of parameters that may either be simple variables, or more complex
         selections that map user input to data queries.
     projection : :class:`Projection`
@@ -16007,13 +16065,13 @@ class StringFieldDef(VegaLiteSchema):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -16208,13 +16266,13 @@ class StringFieldDefWithCondition(VegaLiteSchema):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -16742,13 +16800,13 @@ class FieldOrDatumDefWithConditionStringFieldDefText(TextDef):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -17678,7 +17736,18 @@ class TooltipContent(VegaLiteSchema):
         super(TooltipContent, self).__init__(content=content, **kwds)
 
 
-class TopLevelSelectionParameter(VegaLiteSchema):
+class TopLevelParameter(VegaLiteSchema):
+    """TopLevelParameter schema wrapper
+
+    anyOf(:class:`VariableParameter`, :class:`TopLevelSelectionParameter`)
+    """
+    _schema = {'$ref': '#/definitions/TopLevelParameter'}
+
+    def __init__(self, *args, **kwds):
+        super(TopLevelParameter, self).__init__(*args, **kwds)
+
+
+class TopLevelSelectionParameter(TopLevelParameter):
     """TopLevelSelectionParameter schema wrapper
 
     Mapping(required=[name, select])
@@ -17848,7 +17917,7 @@ class TopLevelConcatSpec(TopLevelSpec):
         "bottom": 5}`` to specify padding for each side of the visualization.
 
         **Default value** : ``5``
-    params : List(anyOf(:class:`VariableParameter`, :class:`TopLevelSelectionParameter`))
+    params : List(:class:`TopLevelParameter`)
         Dynamic variables or selections that parameterize a visualization.
     resolve : :class:`Resolve`
         Scale, axis, and legend resolutions for view composition specifications.
@@ -17992,7 +18061,7 @@ class TopLevelFacetSpec(TopLevelSpec):
         "bottom": 5}`` to specify padding for each side of the visualization.
 
         **Default value** : ``5``
-    params : List(anyOf(:class:`VariableParameter`, :class:`TopLevelSelectionParameter`))
+    params : List(:class:`TopLevelParameter`)
         Dynamic variables or selections that parameterize a visualization.
     resolve : :class:`Resolve`
         Scale, axis, and legend resolutions for view composition specifications.
@@ -18092,7 +18161,7 @@ class TopLevelHConcatSpec(TopLevelSpec):
         "bottom": 5}`` to specify padding for each side of the visualization.
 
         **Default value** : ``5``
-    params : List(anyOf(:class:`VariableParameter`, :class:`TopLevelSelectionParameter`))
+    params : List(:class:`TopLevelParameter`)
         Dynamic variables or selections that parameterize a visualization.
     resolve : :class:`Resolve`
         Scale, axis, and legend resolutions for view composition specifications.
@@ -18199,7 +18268,7 @@ class TopLevelLayerSpec(TopLevelSpec):
         "bottom": 5}`` to specify padding for each side of the visualization.
 
         **Default value** : ``5``
-    params : List(anyOf(:class:`VariableParameter`, :class:`TopLevelSelectionParameter`))
+    params : List(:class:`TopLevelParameter`)
         Dynamic variables or selections that parameterize a visualization.
     projection : :class:`Projection`
         An object defining properties of the geographic projection shared by underlying
@@ -18374,7 +18443,7 @@ class TopLevelUnitSpec(TopLevelSpec):
         "bottom": 5}`` to specify padding for each side of the visualization.
 
         **Default value** : ``5``
-    params : List(anyOf(:class:`VariableParameter`, :class:`SelectionParameter`))
+    params : List(:class:`TopLevelParameter`)
         An array of parameters that may either be simple variables, or more complex
         selections that map user input to data queries.
     projection : :class:`Projection`
@@ -18505,7 +18574,7 @@ class TopLevelVConcatSpec(TopLevelSpec):
         "bottom": 5}`` to specify padding for each side of the visualization.
 
         **Default value** : ``5``
-    params : List(anyOf(:class:`VariableParameter`, :class:`TopLevelSelectionParameter`))
+    params : List(:class:`TopLevelParameter`)
         Dynamic variables or selections that parameterize a visualization.
     resolve : :class:`Resolve`
         Scale, axis, and legend resolutions for view composition specifications.
@@ -19194,13 +19263,13 @@ class TypedFieldDef(VegaLiteSchema):
         and at the middle of the band if set to ``0.5``.
     bin : anyOf(boolean, :class:`BinParams`, string, None)
         A flag for binning a ``quantitative`` field, `an object defining binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html#params>`__, or indicating that the
-        data for ``x`` or ``y`` channel are binned before they are imported into Vega-Lite (
-        ``"binned"`` ).
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__, or indicating
+        that the data for ``x`` or ``y`` channel are binned before they are imported into
+        Vega-Lite ( ``"binned"`` ).
 
 
         If ``true``, default `binning parameters
-        <https://vega.github.io/vega-lite/docs/bin.html>`__ will be applied.
+        <https://vega.github.io/vega-lite/docs/bin.html#bin-parameters>`__ will be applied.
 
         If ``"binned"``, this indicates that the data for the ``x`` (or ``y`` ) channel are
         already binned. You can map the bin-start field to ``x`` (or ``y`` ) and the bin-end
@@ -19370,7 +19439,7 @@ class UnitSpec(VegaLiteSchema):
         A key-value mapping between encoding channels and definition of fields.
     name : string
         Name of the visualization for later reference.
-    params : List(anyOf(:class:`VariableParameter`, :class:`SelectionParameter`))
+    params : List(:class:`SelectionParameter`)
         An array of parameters that may either be simple variables, or more complex
         selections that map user input to data queries.
     projection : :class:`Projection`
@@ -19434,7 +19503,7 @@ class UnitSpecWithFrame(VegaLiteSchema):
         documentation.
     name : string
         Name of the visualization for later reference.
-    params : List(anyOf(:class:`VariableParameter`, :class:`SelectionParameter`))
+    params : List(:class:`SelectionParameter`)
         An array of parameters that may either be simple variables, or more complex
         selections that map user input to data queries.
     projection : :class:`Projection`
@@ -19778,7 +19847,7 @@ class ValueDefnumberwidthheightExprRef(VegaLiteSchema):
         super(ValueDefnumberwidthheightExprRef, self).__init__(value=value, **kwds)
 
 
-class VariableParameter(VegaLiteSchema):
+class VariableParameter(TopLevelParameter):
     """VariableParameter schema wrapper
 
     Mapping(required=[name])

--- a/altair/vegalite/v5/schema/vega-lite-schema.json
+++ b/altair/vegalite/v5/schema/vega-lite-schema.json
@@ -5814,7 +5814,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "empty": {
               "description": "For selection parameters, the predicate of empty selections returns true by default. Override this behavior, by setting this property `empty: false`.",
@@ -5992,7 +5992,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "empty": {
               "description": "For selection parameters, the predicate of empty selections returns true by default. Override this behavior, by setting this property `empty: false`.",
@@ -6172,7 +6172,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "empty": {
           "description": "For selection parameters, the predicate of empty selections returns true by default. Override this behavior, by setting this property `empty: false`.",
@@ -6839,7 +6839,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "field": {
               "$ref": "#/definitions/Field",
@@ -7009,7 +7009,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "field": {
               "$ref": "#/definitions/Field",
@@ -7181,7 +7181,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -7643,8 +7643,20 @@
           "$ref": "#/definitions/MarkConfig",
           "description": "Mark Config"
         },
+        "normalizedNumberFormat": {
+          "description": "If normalizedNumberFormatType is not specified, D3 number format for axis labels, text marks, and tooltips of normalized stacked fields (fields with `stack: \"normalize\"`). For example `\"s\"` for SI units. Use [D3's number format pattern](https://github.com/d3/d3-format#locale_format).\n\nIf `config.normalizedNumberFormatType` is specified and `config.customFormatTypes` is `true`, this value will be passed as `format` alongside `datum.value` to the `config.numberFormatType` function. __Default value:__ `%`",
+          "type": "string"
+        },
+        "normalizedNumberFormatType": {
+          "description": "[Custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type) for `config.normalizedNumberFormat`.\n\n__Default value:__ `undefined` -- This is equilvalent to call D3-format, which is exposed as [`format` in Vega-Expression](https://vega.github.io/vega/docs/expressions/#format). __Note:__ You must also set `customFormatTypes` to `true` to use this feature.",
+          "type": "string"
+        },
         "numberFormat": {
-          "description": "D3 Number format for guide labels and text marks. For example `\"s\"` for SI units. Use [D3's number format pattern](https://github.com/d3/d3-format#locale_format).",
+          "description": "If numberFormatType is not specified, D3 number format for guide labels, text marks, and tooltips of non-normalized fields (fields *without* `stack: \"normalize\"`). For example `\"s\"` for SI units. Use [D3's number format pattern](https://github.com/d3/d3-format#locale_format).\n\nIf `config.numberFormatType` is specified and `config.customFormatTypes` is `true`, this value will be passed as `format` alongside `datum.value` to the `config.numberFormatType` function.",
+          "type": "string"
+        },
+        "numberFormatType": {
+          "description": "[Custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type) for `config.numberFormat`.\n\n__Default value:__ `undefined` -- This is equilvalent to call D3-format, which is exposed as [`format` in Vega-Expression](https://vega.github.io/vega/docs/expressions/#format). __Note:__ You must also set `customFormatTypes` to `true` to use this feature.",
           "type": "string"
         },
         "padding": {
@@ -7661,14 +7673,7 @@
         "params": {
           "description": "Dynamic variables or selections that parameterize a visualization.",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/VariableParameter"
-              },
-              {
-                "$ref": "#/definitions/TopLevelSelectionParameter"
-              }
-            ]
+            "$ref": "#/definitions/TopLevelParameter"
           },
           "type": "array"
         },
@@ -7718,6 +7723,10 @@
         },
         "timeFormat": {
           "description": "Default time format for raw time values (without time units) in text marks, legend labels and header labels.\n\n__Default value:__ `\"%b %d, %Y\"` __Note:__ Axes automatically determine the format for each label automatically so this config does not affect axes.",
+          "type": "string"
+        },
+        "timeFormatType": {
+          "description": "[Custom format type](https://vega.github.io/vega-lite/docs/config.html#custom-format-type) for `config.timeFormat`.\n\n__Default value:__ `undefined` -- This is equilvalent to call D3-time-format, which is exposed as [`timeFormat` in Vega-Expression](https://vega.github.io/vega/docs/expressions/#timeFormat). __Note:__ You must also set `customFormatTypes` to `true` and there must *not* be a `timeUnit` defined to use this feature.",
           "type": "string"
         },
         "title": {
@@ -8732,7 +8741,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "bounds": {
           "description": "The bounds calculation method to use for determining the extent of a sub-plot. One of `full` (the default) or `flush`.\n\n- If set to `full`, the entire calculated bounds (including axes, title, and legend) will be used.\n- If set to `flush`, only the specified width and height values for the sub-view will be used. The `flush` setting can be useful when attempting to place sub-plots without axes or legends into a uniform grid structure.\n\n__Default value:__ `\"full\"`",
@@ -8854,7 +8863,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -9264,14 +9273,7 @@
         "params": {
           "description": "An array of parameters that may either be simple variables, or more complex selections that map user input to data queries.",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/VariableParameter"
-              },
-              {
-                "$ref": "#/definitions/SelectionParameter"
-              }
-            ]
+            "$ref": "#/definitions/SelectionParameter"
           },
           "type": "array"
         },
@@ -9883,7 +9885,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
           "anyOf": [
@@ -9984,7 +9986,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
           "anyOf": [
@@ -10085,7 +10087,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
           "anyOf": [
@@ -10186,7 +10188,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
           "anyOf": [
@@ -10365,7 +10367,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
           "anyOf": [
@@ -10459,7 +10461,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
           "anyOf": [
@@ -11088,14 +11090,7 @@
         "params": {
           "description": "An array of parameters that may either be simple variables, or more complex selections that map user input to data queries.",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/VariableParameter"
-              },
-              {
-                "$ref": "#/definitions/SelectionParameter"
-              }
-            ]
+            "$ref": "#/definitions/SelectionParameter"
           },
           "type": "array"
         },
@@ -12313,7 +12308,7 @@
           "type": "number"
         },
         "bin": {
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
           "type": "null"
         },
         "field": {
@@ -17346,7 +17341,7 @@
           "description": "An object that specifies the format for parsing the data."
         },
         "name": {
-          "description": "Provide a placeholder name and bind data at runtime.",
+          "description": "Provide a placeholder name and bind data at runtime.\n\nNew data may change the layout but Vega does not always resize the chart. To update the layout when the data updates, set [autosize](https://vega.github.io/vega-lite/docs/size.html#autosize) or explicitly use [view.resize](https://vega.github.io/vega/docs/api/view/#view_resize).",
           "type": "string"
         }
       },
@@ -17595,7 +17590,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -18967,7 +18962,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
+          "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized) and pie charts [with percentage tooltip](https://vega.github.io/vega-lite/docs/arc.html#tooltip)). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
         },
         "title": {
           "anyOf": [
@@ -19036,7 +19031,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
+          "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized) and pie charts [with percentage tooltip](https://vega.github.io/vega-lite/docs/arc.html#tooltip)). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
         },
         "title": {
           "anyOf": [
@@ -19109,7 +19104,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -19153,7 +19148,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
+          "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized) and pie charts [with percentage tooltip](https://vega.github.io/vega-lite/docs/arc.html#tooltip)). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
         },
         "timeUnit": {
           "anyOf": [
@@ -19213,7 +19208,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -19246,7 +19241,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
+          "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized) and pie charts [with percentage tooltip](https://vega.github.io/vega-lite/docs/arc.html#tooltip)). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
         },
         "timeUnit": {
           "anyOf": [
@@ -20938,7 +20933,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "center": {
           "description": "Boolean flag indicating if facet's subviews should be centered relative to their respective rows or columns.\n\n__Default value:__ `false`",
@@ -21697,7 +21692,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -21897,7 +21892,7 @@
           "type": "number"
         },
         "bin": {
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
           "type": "null"
         },
         "field": {
@@ -22356,7 +22351,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -22515,7 +22510,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -22684,7 +22679,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -22823,7 +22818,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -22988,7 +22983,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -23151,7 +23146,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -23280,7 +23275,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "field": {
               "$ref": "#/definitions/Field",
@@ -23329,7 +23324,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "datum": {
@@ -23406,7 +23401,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "datum": {
@@ -23492,7 +23487,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "datum": {
@@ -23569,7 +23564,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "datum": {
@@ -23666,7 +23661,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -23846,7 +23841,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "datum": {
               "anyOf": [
@@ -23896,7 +23891,7 @@
                   "type": "boolean"
                 }
               ],
-              "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
+              "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized) and pie charts [with percentage tooltip](https://vega.github.io/vega-lite/docs/arc.html#tooltip)). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
             },
             "timeUnit": {
               "anyOf": [
@@ -23969,7 +23964,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "datum": {
@@ -24066,7 +24061,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -24228,7 +24223,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -24387,7 +24382,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -24552,7 +24547,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -24714,7 +24709,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -24873,7 +24868,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -25036,7 +25031,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -25188,7 +25183,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "datum": {
               "anyOf": [
@@ -25238,7 +25233,7 @@
                   "type": "boolean"
                 }
               ],
-              "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
+              "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized) and pie charts [with percentage tooltip](https://vega.github.io/vega-lite/docs/arc.html#tooltip)). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
             },
             "timeUnit": {
               "anyOf": [
@@ -25311,7 +25306,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "datum": {
@@ -25432,7 +25427,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "condition": {
               "anyOf": [
@@ -25572,7 +25567,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "datum": {
               "anyOf": [
@@ -25633,7 +25628,7 @@
                   "type": "boolean"
                 }
               ],
-              "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
+              "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized) and pie charts [with percentage tooltip](https://vega.github.io/vega-lite/docs/arc.html#tooltip)). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
             },
             "timeUnit": {
               "anyOf": [
@@ -25706,7 +25701,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "datum": {
@@ -25792,7 +25787,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "field": {
@@ -25842,7 +25837,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "field": {
@@ -25903,7 +25898,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "datum": {
               "anyOf": [
@@ -26023,7 +26018,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "datum": {
               "anyOf": [
@@ -26084,7 +26079,7 @@
                   "type": "boolean"
                 }
               ],
-              "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
+              "description": "Type of stacking offset if the field should be stacked. `stack` is only applicable for `x`, `y`, `theta`, and `radius` channels with continuous domains. For example, `stack` of `y` can be used to customize stacking for a vertical bar chart.\n\n`stack` can be one of the following values:\n- `\"zero\"` or `true`: stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](https://vega.github.io/vega-lite/docs/stack.html#bar) and [area](https://vega.github.io/vega-lite/docs/stack.html#area) chart).\n- `\"normalize\"` - stacking with normalized domain (for creating [normalized stacked bar and area charts](https://vega.github.io/vega-lite/docs/stack.html#normalized) and pie charts [with percentage tooltip](https://vega.github.io/vega-lite/docs/arc.html#tooltip)). <br/>\n-`\"center\"` - stacking with center baseline (for [streamgraph](https://vega.github.io/vega-lite/docs/stack.html#streamgraph)).\n- `null` or `false` - No-stacking. This will produce layered [bar](https://vega.github.io/vega-lite/docs/stack.html#layered-bar-chart) and area chart.\n\n__Default value:__ `zero` for plots with all of the following conditions are true: (1) the mark is `bar`, `area`, or `arc`; (2) the stacked measure channel (x or y) has a linear scale; (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y. Otherwise, `null` by default.\n\n__See also:__ [`stack`](https://vega.github.io/vega-lite/docs/stack.html) documentation."
             },
             "timeUnit": {
               "anyOf": [
@@ -26157,7 +26152,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "datum": {
@@ -26243,7 +26238,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "field": {
@@ -26293,7 +26288,7 @@
               "type": "number"
             },
             "bin": {
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation.",
               "type": "null"
             },
             "field": {
@@ -26354,7 +26349,7 @@
                   "type": "null"
                 }
               ],
-              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+              "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
             },
             "datum": {
               "anyOf": [
@@ -26782,7 +26777,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -28436,14 +28431,7 @@
         "params": {
           "description": "Dynamic variables or selections that parameterize a visualization.",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/VariableParameter"
-              },
-              {
-                "$ref": "#/definitions/TopLevelSelectionParameter"
-              }
-            ]
+            "$ref": "#/definitions/TopLevelParameter"
           },
           "type": "array"
         },
@@ -28580,14 +28568,7 @@
         "params": {
           "description": "Dynamic variables or selections that parameterize a visualization.",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/VariableParameter"
-              },
-              {
-                "$ref": "#/definitions/TopLevelSelectionParameter"
-              }
-            ]
+            "$ref": "#/definitions/TopLevelParameter"
           },
           "type": "array"
         },
@@ -28710,14 +28691,7 @@
         "params": {
           "description": "Dynamic variables or selections that parameterize a visualization.",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/VariableParameter"
-              },
-              {
-                "$ref": "#/definitions/TopLevelSelectionParameter"
-              }
-            ]
+            "$ref": "#/definitions/TopLevelParameter"
           },
           "type": "array"
         },
@@ -28868,14 +28842,7 @@
         "params": {
           "description": "Dynamic variables or selections that parameterize a visualization.",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/VariableParameter"
-              },
-              {
-                "$ref": "#/definitions/TopLevelSelectionParameter"
-              }
-            ]
+            "$ref": "#/definitions/TopLevelParameter"
           },
           "type": "array"
         },
@@ -29041,14 +29008,7 @@
             "params": {
               "description": "Dynamic variables or selections that parameterize a visualization.",
               "items": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/VariableParameter"
-                  },
-                  {
-                    "$ref": "#/definitions/TopLevelSelectionParameter"
-                  }
-                ]
+                "$ref": "#/definitions/TopLevelParameter"
               },
               "type": "array"
             },
@@ -29219,14 +29179,7 @@
             "params": {
               "description": "Dynamic variables or selections that parameterize a visualization.",
               "items": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/VariableParameter"
-                  },
-                  {
-                    "$ref": "#/definitions/TopLevelSelectionParameter"
-                  }
-                ]
+                "$ref": "#/definitions/TopLevelParameter"
               },
               "type": "array"
             },
@@ -29407,14 +29360,7 @@
         "params": {
           "description": "Dynamic variables or selections that parameterize a visualization.",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/VariableParameter"
-              },
-              {
-                "$ref": "#/definitions/TopLevelSelectionParameter"
-              }
-            ]
+            "$ref": "#/definitions/TopLevelParameter"
           },
           "type": "array"
         },
@@ -29473,6 +29419,16 @@
         "spec"
       ],
       "type": "object"
+    },
+    "TopLevelParameter": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/VariableParameter"
+        },
+        {
+          "$ref": "#/definitions/TopLevelSelectionParameter"
+        }
+      ]
     },
     "TopLevelSelectionParameter": {
       "additionalProperties": false,
@@ -29707,14 +29663,7 @@
         "params": {
           "description": "An array of parameters that may either be simple variables, or more complex selections that map user input to data queries.",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/VariableParameter"
-              },
-              {
-                "$ref": "#/definitions/SelectionParameter"
-              }
-            ]
+            "$ref": "#/definitions/TopLevelParameter"
           },
           "type": "array"
         },
@@ -29922,7 +29871,7 @@
               "type": "null"
             }
           ],
-          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html#bin-parameters) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -30013,14 +29962,7 @@
         "params": {
           "description": "An array of parameters that may either be simple variables, or more complex selections that map user input to data queries.",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/VariableParameter"
-              },
-              {
-                "$ref": "#/definitions/SelectionParameter"
-              }
-            ]
+            "$ref": "#/definitions/SelectionParameter"
           },
           "type": "array"
         },

--- a/altair/vegalite/v5/tests/test_api.py
+++ b/altair/vegalite/v5/tests/test_api.py
@@ -606,7 +606,9 @@ def test_add_selection():
 def test_repeat_add_selections():
     base = alt.Chart("data.csv").mark_point()
     selection = alt.selection_point()
+    alt.Chart._counter = 0
     chart1 = base.add_params(selection).repeat(list("ABC"))
+    alt.Chart._counter = 0
     chart2 = base.repeat(list("ABC")).add_params(selection)
     assert chart1.to_dict() == chart2.to_dict()
 

--- a/altair/vegalite/v5/tests/test_api.py
+++ b/altair/vegalite/v5/tests/test_api.py
@@ -622,7 +622,9 @@ def test_facet_add_selections():
 def test_layer_add_selection():
     base = alt.Chart("data.csv").mark_point()
     selection = alt.selection_point()
+    alt.Chart._counter = 0
     chart1 = alt.layer(base.add_params(selection), base)
+    alt.Chart._counter = 0
     chart2 = alt.layer(base, base).add_params(selection)
     assert chart1.to_dict() == chart2.to_dict()
 

--- a/altair/vegalite/v5/tests/test_api.py
+++ b/altair/vegalite/v5/tests/test_api.py
@@ -616,7 +616,9 @@ def test_repeat_add_selections():
 def test_facet_add_selections():
     base = alt.Chart("data.csv").mark_point()
     selection = alt.selection_point()
+    alt.Chart._counter = 0
     chart1 = base.add_params(selection).facet("val:Q")
+    alt.Chart._counter = 0
     chart2 = base.facet("val:Q").add_params(selection)
     assert chart1.to_dict() == chart2.to_dict()
 

--- a/altair/vegalite/v5/tests/test_api.py
+++ b/altair/vegalite/v5/tests/test_api.py
@@ -631,7 +631,9 @@ def test_layer_add_selection():
 def test_compound_add_selections(charttype):
     base = alt.Chart("data.csv").mark_point()
     selection = alt.selection_point()
+    alt.Chart._counter = 0
     chart1 = charttype(base.add_params(selection), base.add_params(selection))
+    alt.Chart._counter = 0
     chart2 = charttype(base, base).add_params(selection)
     assert chart1.to_dict() == chart2.to_dict()
 

--- a/doc/user_guide/API.rst
+++ b/doc/user_guide/API.rst
@@ -15,7 +15,6 @@ Top-Level Objects
 
 .. autosummary::
    :toctree: generated/toplevel/
-   :caption: Top-Level Objects
    :nosignatures:
 
    Chart
@@ -33,7 +32,6 @@ Encoding Channels
 
 .. autosummary::
    :toctree: generated/channels/
-   :caption: Encoding Channels
    :nosignatures:
 
    Angle
@@ -142,7 +140,6 @@ API Functions
 
 .. autosummary::
    :toctree: generated/api/
-   :caption: API Functions
    :nosignatures:
 
    binding
@@ -150,16 +147,18 @@ API Functions
    binding_radio
    binding_range
    binding_select
+   check_fields_and_encodings
    concat
    condition
    graticule
    hconcat
    layer
-   parameter
+   param
    repeat
    selection
    selection_interval
    selection_multi
+   selection_point
    selection_single
    sequence
    sphere
@@ -173,7 +172,6 @@ Low-Level Schema Wrappers
 
 .. autosummary::
    :toctree: generated/core/
-   :caption: Low-Level Schema Wrappers
    :nosignatures:
 
    Aggregate
@@ -286,6 +284,7 @@ Low-Level Schema Wrappers
    Day
    DensityTransform
    DerivedStream
+   Dict
    DictInlineDataset
    DictSelectionInit
    DictSelectionInitInterval
@@ -332,6 +331,7 @@ Low-Level Schema Wrappers
    FieldOrDatumDefWithConditionStringDatumDefText
    FieldOrDatumDefWithConditionStringFieldDefText
    FieldOrDatumDefWithConditionStringFieldDefstring
+   FieldRange
    FieldRangePredicate
    FieldValidPredicate
    FilterTransform
@@ -414,7 +414,6 @@ Low-Level Schema Wrappers
    Orientation
    OverlayMarkDef
    Padding
-   Parameter
    ParameterExtent
    ParameterName
    ParameterPredicate

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -26,8 +26,8 @@ import generate_api_docs  # noqa: E402
 
 # Map of version name to github branch name.
 SCHEMA_VERSION = {
-    "vega": {"v5": "v5.10.0"},
-    "vega-lite": {"v3": "v3.4.0", "v4": "v4.17.0", "v5": "v5.2.0"},
+    "vega": {"v5": "v5.22.1"},
+    "vega-lite": {"v3": "v3.4.0", "v4": "v4.17.0", "v5": "v5.5.0"},
 }
 
 reLink = re.compile(r"(?<=\[)([^\]]+)(?=\]\([^\)]+\))", re.M)
@@ -402,20 +402,19 @@ def generate_vega_schema_wrapper(schema_file):
             schemarepr=CodeSnippet("{}._rootschema".format(basename)),
         )
     )
-    for deflist in ["defs", "refs"]:
-        for name in rootschema[deflist]:
-            defschema = {"$ref": "#/{}/{}".format(deflist, name)}
-            defschema_repr = {"$ref": "#/{}/{}".format(deflist, name)}
-            contents.append(
-                schema_class(
-                    get_valid_identifier(name),
-                    schema=defschema,
-                    schemarepr=defschema_repr,
-                    rootschema=rootschema,
-                    basename=basename,
-                    rootschemarepr=CodeSnippet("Root._schema"),
-                )
+    for name in rootschema["definitions"]:
+        defschema = {"$ref": f"#/definitions/{name}"}
+        defschema_repr = {"$ref": f"#/definitions/{name}"}
+        contents.append(
+            schema_class(
+                get_valid_identifier(name),
+                schema=defschema,
+                schemarepr=defschema_repr,
+                rootschema=rootschema,
+                basename=basename,
+                rootschemarepr=CodeSnippet("Root._schema"),
             )
+        )
     contents.append("")  # end with newline
     return "\n".join(contents)
 


### PR DESCRIPTION
Updated version of https://github.com/altair-viz/altair/pull/2671.  I believe the functionality is the same, but the code is a little cleaner.  @mattijn As always I am happy for any comments!

Here was the description of https://github.com/altair-viz/altair/pull/2671:

This is a draft version (some tests are currently failing) of the strategy suggested by @arvind and @mattijn [here](https://github.com/vega/vega-lite/issues/8230#issuecomment-1179607053) for dealing with parameters in multi-view Altair charts. We lift all parameters to the top level. In the case of selection parameters, we give the parameter a "views" property to indicate where the selections should be happening.