### PR TITLE
Add gallery example for empirical cumulative distribution function

### DIFF
--- a/altair/examples/empirical_cumulative_distribution_function.py
+++ b/altair/examples/empirical_cumulative_distribution_function.py
@@ -1,0 +1,15 @@
+"""
+Empirical Cumulative Distribution Function
+------------------------------------------
+This example shows an empirical cumulative distribution function.
+"""
+# category: line charts
+import altair as alt
+from vega_datasets import data
+
+source = data.movies.url
+
+alt.Chart(source).transform_window(
+    ecdf="cume_dist()",
+    sort=[{"field": "IMDB_Rating"}],
+).mark_line(interpolate="step-after").encode(x="IMDB_Rating:Q", y="ecdf:Q")

--- a/altair/examples/empirical_cumulative_distribution_function.py
+++ b/altair/examples/empirical_cumulative_distribution_function.py
@@ -12,4 +12,9 @@ source = data.movies.url
 alt.Chart(source).transform_window(
     ecdf="cume_dist()",
     sort=[{"field": "IMDB_Rating"}],
-).mark_line(interpolate="step-after").encode(x="IMDB_Rating:Q", y="ecdf:Q")
+).mark_line(
+    interpolate="step-after"
+).encode(
+    x="IMDB_Rating:Q",
+    y="ecdf:Q"
+)


### PR DESCRIPTION
I added a simple example for an eCDF plot as I agree with #2661 that it is helpful to show some simple statistical visualisations that users might know from other libraries such as seaborn (.[ecdfplot](https://seaborn.pydata.org/generated/seaborn.ecdfplot.html))

![image](https://user-images.githubusercontent.com/23366411/195993570-68220d14-767c-40e3-9aa3-7f61396b1c84.png)

