### PR TITLE
Integrate vl-convert for saving to svg and png

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
         pip install "selenium<4.3.0"
-        pip install altair_saver
+        pip install altair_saver vl-convert-python
         pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Test with pytest
       run: |

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -20,7 +20,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
         pip install "selenium<4.3.0"
-        pip install altair_saver vl-convert-python
+        pip install altair_saver
         pip install -r doc/requirements.txt
         pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Run docbuild

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -20,7 +20,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
         pip install "selenium<4.3.0"
-        pip install altair_saver
+        pip install altair_saver vl-convert-python
         pip install -r doc/requirements.txt
         pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Run docbuild

--- a/altair/examples/tests/test_examples.py
+++ b/altair/examples/tests/test_examples.py
@@ -6,39 +6,47 @@ import pytest
 from altair.utils.execeval import eval_block
 from altair import examples
 
+try:
+    import altair_saver  # noqa: F401
+except ImportError:
+    altair_saver = None
 
-@pytest.fixture
-def require_altair_saver_png():
-    try:
-        import altair_saver  # noqa: F401
-    except ImportError:
-        pytest.skip("altair_saver not importable; cannot run saver tests")
-    if "png" not in altair_saver.available_formats('vega-lite'):
-        pytest.skip("altair_saver not configured to save to png")
+try:
+    import vl_convert as vlc  # noqa: F401
+except ImportError:
+    vlc = None
 
 
 def iter_example_filenames():
     for importer, modname, ispkg in pkgutil.iter_modules(examples.__path__):
-        if ispkg or modname.startswith('_'):
+        if ispkg or modname.startswith("_"):
             continue
-        yield modname + '.py'
+        yield modname + ".py"
 
 
-@pytest.mark.parametrize('filename', iter_example_filenames())
+@pytest.mark.parametrize("filename", iter_example_filenames())
 def test_examples(filename: str):
     source = pkgutil.get_data(examples.__name__, filename)
     chart = eval_block(source)
 
     if chart is None:
-        raise ValueError("Example file should define chart in its final "
-                         "statement.")
+        raise ValueError("Example file should define chart in its final " "statement.")
     chart.to_dict()
 
 
-@pytest.mark.parametrize('filename', iter_example_filenames())
-def test_render_examples_to_png(require_altair_saver_png, filename):
+@pytest.mark.parametrize("engine", ["vl-convert", "altair_saver"])
+@pytest.mark.parametrize("filename", iter_example_filenames())
+def test_render_examples_to_png(engine, filename):
+    if engine == "vl-convert" and vlc is None:
+        pytest.skip("vl_convert not importable; cannot run mimebundle tests")
+    elif engine == "altair_saver":
+        if altair_saver is None:
+            pytest.skip("altair_saver not importable; cannot run png tests")
+        if "png" not in altair_saver.available_formats("vega-lite"):
+            pytest.skip("altair_saver not configured to save to png")
+
     source = pkgutil.get_data(examples.__name__, filename)
     chart = eval_block(source)
     out = io.BytesIO()
-    chart.save(out, format="png")
-    assert out.getvalue().startswith(b'\x89PNG')
+    chart.save(out, format="png", engine=engine)
+    assert out.getvalue().startswith(b"\x89PNG")

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -69,7 +69,7 @@ def spec_to_mimebundle(
                     png = vlc.vegalite_to_png(
                         spec,
                         vl_version=vl_version,
-                        scale=kwargs.get("scale_factor", 1.0)
+                        scale=kwargs.get("scale_factor", 1.0),
                     )
                     return {"image/png": png}
             except ImportError:

--- a/altair/utils/mimebundle.py
+++ b/altair/utils/mimebundle.py
@@ -50,8 +50,7 @@ def spec_to_mimebundle(
             raise ValueError("Must specify vega_version")
         return {"application/vnd.vega.v{}+json".format(vega_version[0]): spec}
     if format in ["png", "svg", "pdf", "vega"]:
-        engine = kwargs.get("engine", None)
-        return _spec_to_mimebundle_with_engine(spec, format, mode, engine, **kwargs)
+        return _spec_to_mimebundle_with_engine(spec, format, mode, **kwargs)
     if format == "html":
         html = spec_to_html(
             spec,
@@ -77,7 +76,7 @@ def spec_to_mimebundle(
     )
 
 
-def _spec_to_mimebundle_with_engine(spec, format, mode, engine, **kwargs):
+def _spec_to_mimebundle_with_engine(spec, format, mode, **kwargs):
     """Helper for Vega-Lite to mimebundle conversions that require an engine
 
     Parameters
@@ -107,6 +106,7 @@ def _spec_to_mimebundle_with_engine(spec, format, mode, engine, **kwargs):
 
     # Normalize the engine string (if any) by lower casing
     # and removing underscores and hyphens
+    engine = kwargs.pop("engine", None)
     normalized_engine = (
         None if engine is None else engine.lower().replace("-", "").replace("_", "")
     )

--- a/altair/utils/tests/test_mimebundle.py
+++ b/altair/utils/tests/test_mimebundle.py
@@ -3,13 +3,15 @@ import pytest
 import altair as alt
 from ..mimebundle import spec_to_mimebundle
 
+try:
+    import altair_saver  # noqa: F401
+except ImportError:
+    altair_saver = None
 
-@pytest.fixture
-def require_altair_saver():
-    try:
-        import altair_saver  # noqa: F401
-    except ImportError:
-        pytest.skip("altair_saver not importable; cannot run saver tests")
+try:
+    import vl_convert as vlc  # noqa: F401
+except ImportError:
+    vlc = None
 
 
 @pytest.fixture
@@ -165,7 +167,13 @@ def vega_spec():
     }
 
 
-def test_vegalite_to_vega_mimebundle(require_altair_saver, vegalite_spec, vega_spec):
+@pytest.mark.parametrize("engine", ["vl-convert", "altair_saver", None])
+def test_vegalite_to_vega_mimebundle(engine, vegalite_spec, vega_spec):
+    if engine == "vl-convert" and vlc is None:
+        pytest.skip("vl_convert not importable; cannot run mimebundle tests")
+    elif engine == "altair_saver" and altair_saver is None:
+        pytest.skip("altair_saver not importable; cannot run mimebundle tests")
+
     # temporary fix for https://github.com/vega/vega-lite/issues/7776
     def delete_none(axes):
         for axis in axes:

--- a/altair/utils/tests/test_mimebundle.py
+++ b/altair/utils/tests/test_mimebundle.py
@@ -189,6 +189,7 @@ def test_vegalite_to_vega_mimebundle(engine, vegalite_spec, vega_spec):
         vega_version=alt.VEGA_VERSION,
         vegalite_version=alt.VEGALITE_VERSION,
         vegaembed_version=alt.VEGAEMBED_VERSION,
+        engine=engine,
     )
 
     bundle["application/vnd.vega.v5+json"]["axes"] = delete_none(

--- a/doc/user_guide/saving_charts.rst
+++ b/doc/user_guide/saving_charts.rst
@@ -158,9 +158,23 @@ To save an Altair chart object as a PNG, SVG, or PDF image, you can use
 
 However, saving these images requires some additional extensions to run the
 javascript code necessary to interpret the Vega-Lite specification and output
-it in the form of an image.
+it in the form of an image. There are two packages that can be used to enable
+image export: vl-convert-python_ or altair_saver_.
 
-Altair can do this via the altair_saver_ package, which can be installed with::
+vl-convert
+^^^^^^^^^^
+The vl-convert_ package can be installed with::
+
+    $ pip install vl-convert-python
+
+Unlike altair_saver_, vl-convert_ does not require any external dependencies.
+However, it only supports saving charts to PNG and SVG formats. To save directly to
+PDF, altair_saver_ is still required. See the vl-convert documentation for information
+on other `limitations <https://github.com/vega/vl-convert#limitations>`_.
+
+altair_saver
+^^^^^^^^^^^^
+The altair_saver_ package can be installed with::
 
     $ conda install altair_saver
 
@@ -170,6 +184,18 @@ or::
 
 See the altair_saver_ documentation for information about additional installation
 requirements.
+
+Engine Argument
+^^^^^^^^^^^^^^^
+If both vl-convert and altair_saver are installed, vl-convert will take precedence.
+The engine argument to :meth:`Chart.save` can be used to override this default
+behavior. For example, to use altair_saver for PNG export when vl-convert is also
+installed you can use::
+
+.. code-block:: python
+
+    chart.save('chart.png', engine="altair_saver")
+
 
 Figure Size/Resolution
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -183,5 +209,6 @@ This can be done with the ``scale_factor`` argument, which defaults to 1.0::
     chart.save('chart.png', scale_factor=2.0)
 
 
+.. _vl-convert: https://github.com/vega/vl-convert
 .. _altair_saver: http://github.com/altair-viz/altair_saver/
 .. _vegaEmbed: https://github.com/vega/vega-embed


### PR DESCRIPTION
This PR adds support for saving Altair charts to SVG and PNG static images using the [VlConvert](https://github.com/vega/vl-convert) Python package.

See https://github.com/altair-viz/altair/issues/2662 (opened by @mcp292) for some background on the need for a simpler method for exporting charts as static images.

See https://medium.com/@jonmmease/introducing-vlconvert-c763f0076e89 for background on how VlConvert works, and how it is able to avoid the need for external dependencies like selenium or Node.js.

Example:
```
$ pip install vl-convert-python
```
```python
import altair as alt
from vega_datasets import data

chart = alt.Chart(data.cars.url).mark_point().encode(
    x='Horsepower:Q',
    y='Miles_per_Gallon:Q',
    color='Origin:N'
)

chart.save('chart.svg')
chart.save('chart.png', scale_factor=2)
```

Questions:
 - Should this integration be added directly in Altair like this, or in [Altair saver](https://github.com/altair-viz/altair_saver)?
 - Should VlConvert take precedence over Altair Saver if they are both installed?

cc @joelostblom @mattijn @daylinmorgan
