### PR TITLE
Include marks in sidebar/TOC

### DIFF
--- a/doc/user_guide/data.rst
+++ b/doc/user_guide/data.rst
@@ -442,7 +442,7 @@ data before usage in Altair using GeoPandas for example as such:
 
    self
    encoding
-   marks
+   marks/index
    transform/index
    interactions
    compound_charts

--- a/doc/user_guide/marks/index.rst
+++ b/doc/user_guide/marks/index.rst
@@ -19,29 +19,29 @@ Mark                                       Method                               
 =========================================  =========================================  ================================================================================
 :ref:`user-guide-arc-marks`                :meth:`~Chart.mark_arc`                    A pie chart.  
 :ref:`user-guide-area-marks`               :meth:`~Chart.mark_area`                   A filled area plot.                                  
-bar                                        :meth:`~Chart.mark_bar`                    A bar plot.                                          
-circle                                     :meth:`~Chart.mark_circle`                 A scatter plot with filled circles.                  
-geoshape                                   :meth:`~Chart.mark_geoshape`               Visualization containing spatial data
-image                                      :meth:`~Chart.mark_image`                  A scatter plot with image markers.  
-line                                       :meth:`~Chart.mark_line`                   A line plot.
-point                                      :meth:`~Chart.mark_point`                  A scatter plot with configurable point shapes.
-rect                                       :meth:`~Chart.mark_rect`                   A filled rectangle, used for heatmaps                
-rule                                       :meth:`~Chart.mark_rule`                   A vertical or horizontal line spanning the axis.     
-square                                     :meth:`~Chart.mark_square`                 A scatter plot with filled squares.                  
-text                                       :meth:`~Chart.mark_text`                   A scatter plot with points represented by text.      
-tick                                       :meth:`~Chart.mark_tick`                   A vertical or horizontal tick mark.                  
-trail                                      :meth:`~Chart.mark_trail`                  A line with variable widths.
+:ref:`user-guide-bar-marks`                :meth:`~Chart.mark_bar`                    A bar plot.                                          
+:ref:`user-guide-circle-marks`             :meth:`~Chart.mark_circle`                 A scatter plot with filled circles.                  
+:ref:`user-guide-geoshape-marks`           :meth:`~Chart.mark_geoshape`               Visualization containing spatial data
+:ref:`user-guide-image-marks`              :meth:`~Chart.mark_image`                  A scatter plot with image markers.  
+:ref:`user-guide-line-marks`               :meth:`~Chart.mark_line`                   A line plot.
+:ref:`user-guide-point-marks`              :meth:`~Chart.mark_point`                  A scatter plot with configurable point shapes.
+:ref:`user-guide-rect-marks`               :meth:`~Chart.mark_rect`                   A filled rectangle, used for heatmaps                
+:ref:`user-guide-rule-marks`               :meth:`~Chart.mark_rule`                   A vertical or horizontal line spanning the axis.     
+:ref:`user-guide-square-marks`             :meth:`~Chart.mark_square`                 A scatter plot with filled squares.                  
+:ref:`user-guide-text-marks`               :meth:`~Chart.mark_text`                   A scatter plot with points represented by text.      
+:ref:`user-guide-tick-marks`               :meth:`~Chart.mark_tick`                   A vertical or horizontal tick mark.                  
+:ref:`user-guide-trail-marks`              :meth:`~Chart.mark_trail`                  A line with variable widths.
 =========================================  =========================================  ================================================================================
 
 In addition, Altair provides the following compound marks:
 
-==========  ==============================  ================================  ==================================
-Mark Name   Method                          Description                       Example
-==========  ==============================  ================================  ==================================
-box plot    :meth:`~Chart.mark_boxplot`     A box plot.                       :ref:`gallery_boxplot`
-error band  :meth:`~Chart.mark_errorband`   A continuous band around a line.  :ref:`gallery_line_with_ci`
-error bar   :meth:`~Chart.mark_errorbar`    An errorbar around a point.       :ref:`gallery_errorbars_with_ci`
-==========  ==============================  ================================  ==================================
+=========================================  ==============================  ================================  ==================================
+Mark Name                                  Method                          Description                       Example
+=========================================  ==============================  ================================  ==================================
+:ref:`user-guide-boxplot-marks`            :meth:`~Chart.mark_boxplot`     A box plot.                       :ref:`gallery_boxplot`
+:ref:`user-guide-errorband-marks`          :meth:`~Chart.mark_errorband`   A continuous band around a line.  :ref:`gallery_line_with_ci`
+:ref:`user-guide-errorbar-marks`           :meth:`~Chart.mark_errorbar`    An errorbar around a point.       :ref:`gallery_errorbars_with_ci`
+=========================================  ==============================  ================================  ==================================
 
 In Altair, marks can be most conveniently specified by the ``mark_*`` methods
 of the Chart object, which take optional keyword arguments that are passed to
@@ -60,4 +60,17 @@ associated :class:`MarkDef` instance, which supports the following attributes:
 
    arc
    area
-
+   bar
+   boxplot
+   circle
+   errorband
+   errorbar
+   image
+   line
+   point
+   rect
+   rule
+   square
+   text
+   tick
+   trail


### PR DESCRIPTION
This PR is linked to this merged PR https://github.com/altair-viz/altair/pull/2607. 
Few changes in the index structure, so the marks also appear in the sidebar.
