### PR TITLE
Revert undefinedlike

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -142,10 +142,7 @@ class UndefinedType(object):
 # But for now, we'll add an annotation to indicate that the type checker
 # should permit any value passed to a function argument whose default
 # value is Undefined.
-UndefinedLike = Any
-
-
-Undefined: UndefinedLike = UndefinedType()
+Undefined: Any = UndefinedType()
 
 
 class SchemaBase(object):

--- a/doc/user_guide/API.rst
+++ b/doc/user_guide/API.rst
@@ -530,7 +530,6 @@ Low-Level Schema Wrappers
    TopLevelFacetSpec
    TopLevelHConcatSpec
    TopLevelLayerSpec
-   TopLevelParameter
    TopLevelRepeatSpec
    TopLevelSelectionParameter
    TopLevelSpec

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -140,10 +140,7 @@ class UndefinedType(object):
 # But for now, we'll add an annotation to indicate that the type checker
 # should permit any value passed to a function argument whose default
 # value is Undefined.
-UndefinedLike = Any
-
-
-Undefined: UndefinedLike = UndefinedType()
+Undefined: Any = UndefinedType()
 
 
 class SchemaBase(object):


### PR DESCRIPTION
Fix #2714.
Change from:
```python
UndefinedLike = Any
Undefined: UndefinedLike = UndefinedType()
```

to:
```python
Undefined: Any = UndefinedType()
```