### PR TITLE
Fix missing 's' from filename in quick start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ $ python -m pip install -e .
 
 You can now install the development requirements using
 ```
-$ python -m pip install -r requirement_dev.txt
+$ python -m pip install -r requirements_dev.txt
 ```
 
 


### PR DESCRIPTION
Previously, contributing md asked to install "requirement_dev.txt"
<img width="608" alt="image" src="https://user-images.githubusercontent.com/30129761/202308844-16247bb0-eb8c-4dd2-a189-554389d4aaf7.png">
but the repo actually contains a requirements_dev.txt file:
![image](https://user-images.githubusercontent.com/30129761/202308957-d531cf6d-11e9-4e8f-bef4-e7d8de92f5a0.png)
