### PR TITLE
Improve documentation titles

### DIFF
--- a/doc/user_guide/data.rst
+++ b/doc/user_guide/data.rst
@@ -1,7 +1,7 @@
 .. _user-guide-data:
 
-Specifying Data in Altair
--------------------------
+Specifying Data
+---------------
 
 .. currentmodule:: altair
 

--- a/doc/user_guide/interactions.rst
+++ b/doc/user_guide/interactions.rst
@@ -55,7 +55,7 @@ Here is a simple scatter-plot created from the ``cars`` dataset:
         color='Origin:N'
     )
 
-We can create a variable parameter using :func:`alt.param`, and assign that parameter a default value of 0.1 using the ``value`` property, as follows:
+We can create a variable parameter using :func:`param`, and assign that parameter a default value of 0.1 using the ``value`` property, as follows:
 
 .. altair-plot::
     :output: none
@@ -81,7 +81,7 @@ In order to use this variable in the chart specification, we explicitly add it t
         op_var
     )
 
-It's reasonable to ask whether all this effort is necessary.  Here is a more natural way to accomplish the same thing.  We avoid the use of both :func:`alt.param` and ``add_params``.
+It's reasonable to ask whether all this effort is necessary.  Here is a more natural way to accomplish the same thing.  We avoid the use of both :func:`param` and ``add_params``.
 
 .. altair-plot::
 
@@ -98,7 +98,7 @@ It's reasonable to ask whether all this effort is necessary.  Here is a more nat
         color='Origin:N'
     )
 
-The benefit of using :func:`alt.param` doesn't become apparent until we incorporate an additional component, such as in the following, where we use the ``bind`` property of the parameter, so that the parameter becomes bound to an input element.  In this example, that input element is a slider widget.
+The benefit of using :func:`param` doesn't become apparent until we incorporate an additional component, such as in the following, where we use the ``bind`` property of the parameter, so that the parameter becomes bound to an input element.  In this example, that input element is a slider widget.
 
 .. altair-plot::
 
@@ -122,7 +122,7 @@ Now we can dynamically change the opacity of the points in our chart using the s
 
 The above example includes some aspects which occur frequently when creating interactive charts in Altair:
 
-1. Creating a variable parameter using :func:`parameter`.
+1. Creating a variable parameter using :func:`param`.
 2. Attaching the parameter to a chart using the :meth:`Chart.add_params` method.
 3. Binding the parameter to an input widget (such as the slider above) using the parameter's ``bind`` property.
 

--- a/doc/user_guide/interactions.rst
+++ b/doc/user_guide/interactions.rst
@@ -564,7 +564,7 @@ For instance, using our example from above a dropdown can be used to highlight c
 
 
 
-The above example shows all three elements at work. The :input_dropdown: is :bind: to the :selection: which is called from the :condition: encoded through the data.
+The above example shows all three elements at work. The ``input_dropdown`` is ``bind`` to the ``selection`` which is called from the ``condition`` encoded through the data.
 
 The following are the input elements supported in vega-lite:
 

--- a/doc/user_guide/interactions.rst
+++ b/doc/user_guide/interactions.rst
@@ -20,7 +20,7 @@ There are three core concepts of this grammar:
   between the selection and an input element of your chart,
   such as a drop-down, radio button or slider.
 
-Interactive charts can use one or more of these elements to create rich interactivity between the viewer and the data. 
+Interactive charts can use one or more of these elements to create rich interactivity between the viewer and the data.
 
 
 Parameters: Building Blocks of Interaction
@@ -55,7 +55,7 @@ Here is a simple scatter-plot created from the ``cars`` dataset:
         color='Origin:N'
     )
 
-We can create a variable parameter using :func:`parameter`, and assign that parameter a default value of 0.1 using the ``value`` property, as follows:
+We can create a variable parameter using :func:`alt.param`, and assign that parameter a default value of 0.1 using the ``value`` property, as follows:
 
 .. altair-plot::
     :output: none
@@ -463,7 +463,7 @@ clickable legend that will select points by both Origin and number of
 cylinders:
 
 .. altair-plot::
-   
+
     selection = alt.selection_point(fields=['Origin', 'Cylinders'])
     color = alt.condition(selection,
                           alt.Color('Origin:N', legend=None),
@@ -562,11 +562,11 @@ For instance, using our example from above a dropdown can be used to highlight c
     )
 
 
-    
 
-The above example shows all three elements at work. The :input_dropdown: is :bind: to the :selection: which is called from the :condition: encoded through the data. 
 
-The following are the input elements supported in vega-lite: 
+The above example shows all three elements at work. The :input_dropdown: is :bind: to the :selection: which is called from the :condition: encoded through the data.
+
+The following are the input elements supported in vega-lite:
 
 
 ========================= ===========================================================================  ===============================================
@@ -585,7 +585,7 @@ Bindings and input elements can also be used to filter data on the client side. 
 
     input_dropdown = alt.binding_select(options=['Europe','Japan','USA'], name='Region ')
     selection = alt.selection_point(fields=['Origin'], bind=input_dropdown)
-    
+
     alt.Chart(cars).mark_point().encode(
         x='Horsepower:Q',
         y='Miles_per_Gallon:Q',

--- a/doc/user_guide/times_and_dates.rst
+++ b/doc/user_guide/times_and_dates.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-time:
 
-Times and Dates in Altair
-=========================
+Times and Dates
+===============
 Working with dates, times, and timezones is often one of the more challenging
 aspects of data analysis. In Altair, the difficulties are compounded by the
 fact that users are writing Python code, which outputs JSON-serialized

--- a/doc/user_guide/transform/aggregate.rst
+++ b/doc/user_guide/transform/aggregate.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-aggregate-transform:
 
-Aggregate Transforms
-~~~~~~~~~~~~~~~~~~~~
+Aggregate
+~~~~~~~~~
 There are two ways to aggregate data within Altair: within the encoding itself,
 or using a top level aggregate transform.
 

--- a/doc/user_guide/transform/bin.rst
+++ b/doc/user_guide/transform/bin.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-bin-transform:
 
-Bin transforms
-~~~~~~~~~~~~~~
+Bin
+~~~
 As with :ref:`user-guide-aggregate-transform`, there are two ways to apply
 a bin transform in Altair: within the encoding itself, or using a top-level
 bin transform.

--- a/doc/user_guide/transform/calculate.rst
+++ b/doc/user_guide/transform/calculate.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-calculate-transform:
 
-Calculate Transform
-~~~~~~~~~~~~~~~~~~~
+Calculate
+~~~~~~~~~
 The calculate transform allows the user to define new fields in the dataset
 which are calculated from other fields using an expression syntax.
 

--- a/doc/user_guide/transform/density.rst
+++ b/doc/user_guide/transform/density.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-density-transform:
 
-Density Transform
-~~~~~~~~~~~~~~~~~
+Density
+~~~~~~~
 The density transform performs one-dimensional
 `kernel density estimation <https://en.wikipedia.org/wiki/Kernel_density_estimation>`_
 over input data and generates a new column of samples of the estimated densities.
@@ -12,10 +12,10 @@ Here is a simple example, showing the distribution of IMDB ratings from the movi
 dataset:
 
 .. altair-plot::
-   
+
    import altair as alt
    from vega_datasets import data
-   
+
    alt.Chart(data.movies.url).transform_density(
        'IMDB_Rating',
        as_=['IMDB_Rating', 'density'],
@@ -31,7 +31,7 @@ argument. Here we split the above density computation across movie genres:
 
    import altair as alt
    from vega_datasets import data
-   
+
    alt.Chart(
        data.movies.url,
        width=120,

--- a/doc/user_guide/transform/filter.rst
+++ b/doc/user_guide/transform/filter.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-filter-transform:
 
-Filter Transform
-~~~~~~~~~~~~~~~~
+Filter
+~~~~~~
 The filter transform removes objects from a data stream based on a provided
 filter expression, selection, or other filter predicate. A filter can be
 added at the top level of a chart using the :meth:`Chart.transform_filter`

--- a/doc/user_guide/transform/flatten.rst
+++ b/doc/user_guide/transform/flatten.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-flatten-transform:
 
-Flatten Transform
-~~~~~~~~~~~~~~~~~
+Flatten
+~~~~~~~
 The flatten transform can be used to extract the contents of arrays from data entries.
 This will not generally be useful for well-structured data within pandas dataframes,
 but it can be useful for working with data from other sources.

--- a/doc/user_guide/transform/fold.rst
+++ b/doc/user_guide/transform/fold.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-fold-transform:
 
-Fold Transform
-~~~~~~~~~~~~~~
+Fold
+~~~~
 The fold transform is, in short, a way to convert wide-form data to long-form
 data directly without any preprocessing (see :ref:`data-long-vs-wide` for more
 information). Fold transforms are the opposite of the :ref:`user-guide-pivot-transform`.

--- a/doc/user_guide/transform/impute.rst
+++ b/doc/user_guide/transform/impute.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-impute-transform:
 
-Impute Transform
-~~~~~~~~~~~~~~~~
+Impute
+~~~~~~
 The impute transform allows you to fill-in missing entries in a dataset.
 As an example, consider the following data, which includes missing values
 that we filter-out of the long-form representation (see :ref:`data-long-vs-wide`

--- a/doc/user_guide/transform/joinaggregate.rst
+++ b/doc/user_guide/transform/joinaggregate.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-joinaggregate-transform:
 
-Join Aggregate Transform
-~~~~~~~~~~~~~~~~~~~~~~~~
+Join Aggregate
+~~~~~~~~~~~~~~
 The Join Aggregate transform acts in almost every way the same as an Aggregate
 transform, but the resulting aggregate is joined to the original dataset.
 To make this more clear, consider the following dataset:

--- a/doc/user_guide/transform/loess.rst
+++ b/doc/user_guide/transform/loess.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-loess-transform:
 
-LOESS Transform
-~~~~~~~~~~~~~~~
+LOESS
+~~~~~
 The LOESS transform (LOcally Estimated Scatterplot Smoothing) uses a
 locally-estimated regression  to produce a trend line.
 LOESS performs a sequence of local weighted regressions over a sliding
@@ -17,19 +17,19 @@ Here is an example of using LOESS to smooth samples from a Gaussian random walk:
    import altair as alt
    import pandas as pd
    import numpy as np
-   
+
    np.random.seed(42)
-   
+
    df = pd.DataFrame({
        'x': range(100),
        'y': np.random.randn(100).cumsum()
    })
-   
+
    chart = alt.Chart(df).mark_point().encode(
        x='x',
        y='y'
    )
-   
+
    chart + chart.transform_loess('x', 'y').mark_line()
 
 

--- a/doc/user_guide/transform/lookup.rst
+++ b/doc/user_guide/transform/lookup.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-lookup-transform:
 
-Lookup Transform
-~~~~~~~~~~~~~~~~
+Lookup
+~~~~~~
 The Lookup transform extends a primary data source by looking up values from
 another data source; it is similar to a one-sided join. A lookup can be added
 at the top level of a chart using the :meth:`Chart.transform_lookup` method.

--- a/doc/user_guide/transform/pivot.rst
+++ b/doc/user_guide/transform/pivot.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-pivot-transform:
 
-Pivot Transform
-~~~~~~~~~~~~~~~
+Pivot
+~~~~~
 The pivot transform is, in short, a way to convert long-form data to wide-form
 data directly without any preprocessing (see :ref:`data-long-vs-wide` for more
 information). Pivot transforms are useful for creating matrix or cross-tabulation
@@ -45,24 +45,24 @@ values on multiple lines:
 
    import altair as alt
    from vega_datasets import data
-   
+
    source = data.stocks()
    base = alt.Chart(source).encode(x='date:T')
    columns = sorted(source.symbol.unique())
    selection = alt.selection_point(
        fields=['date'], nearest=True, on='mouseover', empty='none', clear='mouseout'
    )
-   
+
    lines = base.mark_line().encode(y='price:Q', color='symbol:N')
    points = lines.mark_point().transform_filter(selection)
-   
+
    rule = base.transform_pivot(
        'symbol', value='price', groupby=['date']
    ).mark_rule().encode(
        opacity=alt.condition(selection, alt.value(0.3), alt.value(0)),
        tooltip=[alt.Tooltip(c, type='quantitative') for c in columns]
    ).add_params(selection)
-   
+
    lines + points + rule
 
 

--- a/doc/user_guide/transform/quantile.rst
+++ b/doc/user_guide/transform/quantile.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-quantile-transform:
 
-Quantile Transform
-~~~~~~~~~~~~~~~~~~
+Quantile
+~~~~~~~~
 The quantile transform calculates empirical `quantile <https://en.wikipedia.org/wiki/Quantile>`_
 values for input data. If a groupby parameter is provided, quantiles are estimated
 separately per group. Among other uses, the quantile transform is useful for creating

--- a/doc/user_guide/transform/regression.rst
+++ b/doc/user_guide/transform/regression.rst
@@ -2,11 +2,11 @@
 
 .. _user-guide-regression-transform:
 
-Regression Transform
-~~~~~~~~~~~~~~~~~~~~
+Regression
+~~~~~~~~~~
 
 The regression transform fits two-dimensional regression models to smooth and
-predict data. This transform can fit multiple models for input data (one per group) 
+predict data. This transform can fit multiple models for input data (one per group)
 and generates new data objects that represent points for summary trend lines.
 Alternatively, this transform can be used to generate a set of objects containing
 regression model parameters, one per group.

--- a/doc/user_guide/transform/sample.rst
+++ b/doc/user_guide/transform/sample.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-sample-transform:
 
-Sample Transform
-~~~~~~~~~~~~~~~~
+Sample
+~~~~~~
 The sample transform is one of the simpler of all Altair's data transforms;
 it takes a single parameter ``sample`` which specified a number of rows to
 randomly choose from the dataset. The resulting chart will be created using

--- a/doc/user_guide/transform/stack.rst
+++ b/doc/user_guide/transform/stack.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-stack-transform:
 
-Stack Transform
-~~~~~~~~~~~~~~~
+Stack
+~~~~~
 The stack transform allows you to compute values associated with stacked versions
 of encodings. For example, consider this stacked bar chart:
 

--- a/doc/user_guide/transform/timeunit.rst
+++ b/doc/user_guide/transform/timeunit.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-timeunit-transform:
 
-TimeUnit Transform
-~~~~~~~~~~~~~~~~~~
+TimeUnit
+~~~~~~~~
 TimeUnit transforms are used to discretize dates and times within Altair.
 As with the :ref:`user-guide-aggregate-transform` and :ref:`user-guide-bin-transform`
 discussed above, they can be defined either as part of the encoding, or as a

--- a/doc/user_guide/transform/window.rst
+++ b/doc/user_guide/transform/window.rst
@@ -2,8 +2,8 @@
 
 .. _user-guide-window-transform:
 
-Window Transform
-~~~~~~~~~~~~~~~~
+Window
+~~~~~~
 The window transform performs calculations over sorted groups of data objects.
 These calculations include ranking, lead/lag analysis, and aggregates such as cumulative sums and averages.
 Calculated values are written back to the input data stream, where they can be referenced by encodings.


### PR DESCRIPTION
I'd suggest to remove 'Transform' from the titles of the transform pages. The navigation bar looks much cleaner this way, especially now that we also have a page for every mark. This is also in line with the vega-lite docs. There are also two other smaller commits in this PR.


![Screenshot 2022-11-18 at 23 26 35](https://user-images.githubusercontent.com/23366411/202813760-14a61889-fc9c-4b42-bd48-c72f1e769bcb.png)

