### PR TITLE
Add toggle to hidden code snippets

### DIFF
--- a/altair/sphinxext/altairplot.py
+++ b/altair/sphinxext/altairplot.py
@@ -205,7 +205,7 @@ class AltairPlotDirective(Directive):
             result += [plot_node]
 
         if hide_code:
-            html = "<details><summary><a>Show code</a></summary>"
+            html = "<details><summary><a>Click to show code</a></summary>"
             raw_html = nodes.raw("", html, format="html")
             result += [raw_html]
 

--- a/altair/sphinxext/altairplot.py
+++ b/altair/sphinxext/altairplot.py
@@ -150,7 +150,7 @@ class AltairPlotDirective(Directive):
         env = self.state.document.settings.env
         app = env.app
 
-        show_code = "hide-code" not in self.options
+        hide_code = "hide-code" in self.options
         code_below = "code-below" in self.options
         strict = "strict" in self.options
 
@@ -163,9 +163,9 @@ class AltairPlotDirective(Directive):
 
         code = "\n".join(self.content)
 
-        if show_code:
-            source_literal = nodes.literal_block(code, code)
-            source_literal["language"] = "python"
+        # Show code
+        source_literal = nodes.literal_block(code, code)
+        source_literal["language"] = "python"
 
         # get the name of the source file we are currently processing
         rst_source = self.state_machine.document["source"]
@@ -203,8 +203,19 @@ class AltairPlotDirective(Directive):
 
         if code_below:
             result += [plot_node]
-        if show_code:
-            result += [source_literal]
+
+        if hide_code:
+            html = "<details><summary><a>Show code</a></summary>"
+            raw_html = nodes.raw("", html, format="html")
+            result += [raw_html]
+
+        result += [source_literal]
+
+        if hide_code:
+            html = "</details>"
+            raw_html = nodes.raw("", html, format="html")
+            result += [raw_html]
+
         if not code_below:
             result += [plot_node]
 


### PR DESCRIPTION
This adds a toggle to hidden code snippets as discussed in #2720. The main reason we want this is to be able to hide the verbose parameter code by default but show it on demand for interested readers. Live docs here https://joelostblom.github.io/altair-docs/user_guide/times_and_dates.html

 There are currently only two other pages that use the `:hide-code:` tag and neither of them suffer from having the toggle added in my opinion:

![image](https://user-images.githubusercontent.com/4560057/204113328-1519553f-64d7-4ca9-9e6a-bf27c8e14f34.png)


![image](https://user-images.githubusercontent.com/4560057/204113340-d1b77db9-4b99-479b-b00b-2b1e28a3e522.png)
