### PR TITLE
Various smaller updates to documentation (harmonizing title cases, vega version numbers, browser compatibility, ...)

### DIFF
--- a/doc/user_guide/customization.rst
+++ b/doc/user_guide/customization.rst
@@ -461,7 +461,7 @@ you can set ``scale=None`` to use those colors directly:
       color=alt.Color('color', scale=None)
   )
 
-Adjusting the width of Bar Marks
+Adjusting the Width of Bar Marks
 --------------------------------
 The width of the bars in a bar plot are controlled through the ``size`` property in the :meth:`~Chart.mark_bar()`:
 

--- a/doc/user_guide/data.rst
+++ b/doc/user_guide/data.rst
@@ -408,7 +408,7 @@ without applying a projection.
 
 .. _data-winding-order:
 
-Winding order
+Winding Order
 ~~~~~~~~~~~~~
 LineString, Polygon and MultiPolygon geometries contain coordinates in an order: lines
 go in a certain direction, and polygon rings do too. The GeoJSON-like structure of the

--- a/doc/user_guide/data_transformers.rst
+++ b/doc/user_guide/data_transformers.rst
@@ -1,6 +1,6 @@
 .. _data-transformers:
 
-Data transformers
+Data Transformers
 =================
 
 Before a Vega-Lite or Vega specification can be passed to a renderer, it typically
@@ -95,7 +95,7 @@ individual layer. This duplication of data is the reason that dataset
 consolidation is set to ``True`` by default.
 
 
-Built-in data transformers
+Built-in Data Transformers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Altair includes a default set of data transformers with the following signatures.
@@ -129,7 +129,7 @@ Multiple data transformers can be piped together using ``pipe``::
     from toolz.curried import pipe
     pipe(data, limit_rows(10000), to_values)
 
-Managing data transformers
+Managing Data Transformers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Altair maintains a registry of data transformers, which includes a default
@@ -174,7 +174,7 @@ be registered and enabled as::
     alt.data_transformers.enable('s3')
 
 
-Storing JSON data in a separate directory
+Storing JSON Data in a Separate Directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When creating many charts with ``alt.data_transformers.enable('json')`` the

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -28,7 +28,7 @@ Some of the built-in renderers are:
 
 ``alt.renderers.enable('html')``
   *(the default)* Output an HTML representation of the chart. The HTML renderer works
-  in JupyterLab_, `Jupyter Notebook`_, `Zeppelin`_, and many related notebook frontends,
+  in JupyterLab_, `Jupyter Notebook`_, `Zeppelin`_, `VSCode-Python`_ and many related notebook frontends,
   as well as Jupyter ecosystem tools like nbviewer_ and nbconvert_ HTML output.
   It requires a web connection in order to load relevant Javascript libraries.
 
@@ -116,11 +116,12 @@ mimetype, and use::
 
 Displaying in VSCode
 --------------------
-`VSCode-Python`_ includes a vega-lite renderer to display charts in-app via the
-vega-lite mimetype output. You can enable it by running::
+`VSCode-Python`_ works with Altair's default renderer with a live web connection: no render enable step is required.
 
+Optionally, for offline rendering, you can use the mimetype renderer::
+
+    # Optional in VS Code
     alt.renderers.enable('mimetype')
-
 
 .. _display-general:
 
@@ -187,12 +188,8 @@ the chart is closed.
 
 Manual ``save()`` and display
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you would prefer, you can manually save your chart as html and open it with
-a web browser. Once you have created your chart, run::
-
-    chart.save('filename.html')
-
-and use a web browser to open this file.
+If you would prefer, you can save your chart to a file (html, png, etc.) first and then display it.
+See :ref:`user-guide-saving` for more information.
 
 .. _renderer-api:
 

--- a/doc/user_guide/encoding.rst
+++ b/doc/user_guide/encoding.rst
@@ -475,7 +475,7 @@ Shorthand            Equivalent long-form
 
 .. _ordering-channels:
 
-Ordering marks
+Ordering Marks
 ~~~~~~~~~~~~~~
 
 The `order` option and :class:`Order` channel can sort how marks are drawn on the chart.

--- a/doc/user_guide/importing.rst
+++ b/doc/user_guide/importing.rst
@@ -3,27 +3,24 @@
 Importing Vega & Vega-Lite Versions
 ===================================
 
-The main Altair API is based on version 2.X of `Vega-Lite`_. The core of the API,
-found in the ``altair.vegalite.v2.schema`` module, is programmatically generated
+The main Altair API is based on version 5.X of `Vega-Lite`_. The core of the API,
+found in the ``altair.vegalite.v5.schema`` module, is programmatically generated
 from the Vega-Lite schema.
 
-Altair additionally provides wrappers for several other schemas:
-
-- Vega-Lite 1.X in ``altair.vegalite.v1``
-- Vega 2.X in ``altair.vega.v2``
-- Vega 3.X in ``altair.vega.v3``
+Altair additionally provides wrappers for some of the previous `Vega-Lite`_ schemas
+and the current `Vega`_ schema (``altair.vega.v5``).
 
 So, for example, if you would like to create Altair plots targeting Vega-Lite
-version 1, you can use::
+version 3, you can use::
 
-    import altair.vegalite.v1 as alt
+    import altair.vegalite.v3 as alt
 
-and then proceed to use the Altair version 1 API.
+and then proceed to use the Altair version 3 API.
 
 .. note::
 
-  We strongly recommend all users transition to Vega-Lite 4.x and Vega 5.x.
-  These versions support many new features, are more stable, and Altair 4
+  We strongly recommend all users transition to Vega-Lite 5.x and Vega 5.x.
+  These versions support many new features, are more stable, and Altair 5
   works best with them.
 
 Because Altair has focused primarily on the vega-lite API, the vega wrappers are

--- a/doc/user_guide/internals.rst
+++ b/doc/user_guide/internals.rst
@@ -18,7 +18,7 @@ That's it. In order to take those specifications and turn them into actual
 visualizations requires a frontend that is correctly set up, but strictly
 speaking that rendering is generally not controlled by the Altair package.
 
-Altair chart to Vega-Lite Spec
+Altair Chart to Vega-Lite Spec
 ------------------------------
 Since Altair is fundamentally about constructing chart specifications, the central
 functionality of any chart object are the :meth:`~Chart.to_dict` and

--- a/doc/user_guide/times_and_dates.rst
+++ b/doc/user_guide/times_and_dates.rst
@@ -13,68 +13,6 @@ Altair and Vega-Lite do their best to ensure that dates are interpreted and
 visualized in a consistent way.
 
 
-.. _note-browser-compliance:
-
-Note on Browser Compliance
---------------------------
-
-.. note:: Warning about non-ES6 Browsers
-
-   The discussion below applies to modern browsers which support `ECMAScript 6`_,
-   in which time strings like ``"2018-01-01T12:00:00"`` without a trailing ``"Z"``
-   are treated as local time rather than `Coordinated Universal Time (UTC)`_.
-   For example, recent versions of Chrome and Firefox are ES6-compliant,
-   while Safari 11 is not.
-   If you are using a non-ES6 browser, this means that times displayed in Altair
-   charts may be rendered with a timezone offset, unless you explicitly use
-   UTC time (see :ref:`explicit-utc-time`).
-
-The following chart will help you determine if your browser parses dates in the
-way that Altair expects:
-
-.. altair-plot::
-    :links: none
-
-    import altair as alt
-    import pandas as pd
-
-    df = pd.DataFrame({'local': ['2018-01-01T00:00:00'],
-                       'utc': ['2018-01-01T00:00:00Z']})
-
-    alt.Chart(df).transform_calculate(
-        compliant="hours(datum.local) != hours(datum.utc) ? true : false",
-    ).mark_text(size=20, baseline='middle').encode(
-        text=alt.condition('datum.compliant', alt.value('OK'), alt.value('not OK')),
-        color=alt.condition('datum.compliant', alt.value('green'), alt.value('red'))
-    ).properties(width=80, height=50)
-
-If the above output contains a red "not OK":
-
-.. altair-plot::
-   :hide-code:
-   :links: none
-
-   alt.Chart(df).mark_text(size=10, baseline='middle').encode(
-       alt.TextValue('not OK'),
-       alt.ColorValue('red')
-   ).properties(width=40, height=25)
-
-it means that your browser's date parsing is not ES6-compliant.
-If it contains a green "OK":
-
-.. altair-plot::
-   :hide-code:
-   :links: none
-
-   alt.Chart(df).mark_text(size=10, baseline='middle').encode(
-       alt.TextValue('OK'),
-       alt.ColorValue('green')
-   ).properties(width=40, height=25)
-
-then it means that your browser parses dates as Altair expects, either because
-it is ES6-compliant or because your computer locale happens to be set to
-the UTC+0 (GMT) timezone.
-
 Altair and Pandas Datetimes
 ---------------------------
 
@@ -140,7 +78,7 @@ local time.
 Specifying Time Zones
 ---------------------
 If you are viewing the above visualizations in a supported browser (see
-:ref:`note-browser-compliance` above), the times are both serialized and
+:ref:`note-browser-compliance`), the times are both serialized and
 rendered in local time, so that the ``January 1st 00:00:00`` row renders in
 the chart as ``00:00`` on ``January 1st``.
 
@@ -219,6 +157,67 @@ dates, in which both Pandas and Vega-Lite assume times are local
 but it gets around browser incompatibilities by explicitly working in UTC, which
 gives similar results even in older browsers.
 
+.. _note-browser-compliance:
+
+Note on Browser Compliance
+--------------------------
+
+.. note:: Warning about non-ES6 Browsers
+
+   The discussion below applies to modern browsers which support `ECMAScript 6`_,
+   in which time strings like ``"2018-01-01T12:00:00"`` without a trailing ``"Z"``
+   are treated as local time rather than `Coordinated Universal Time (UTC)`_.
+   For example, recent versions of Chrome and Firefox are ES6-compliant,
+   while Safari 11 is not.
+   If you are using a non-ES6 browser, this means that times displayed in Altair
+   charts may be rendered with a timezone offset, unless you explicitly use
+   UTC time (see :ref:`explicit-utc-time`).
+
+The following chart will help you determine if your browser parses dates in the
+way that Altair expects:
+
+.. altair-plot::
+    :links: none
+
+    import altair as alt
+    import pandas as pd
+
+    df = pd.DataFrame({'local': ['2018-01-01T00:00:00'],
+                       'utc': ['2018-01-01T00:00:00Z']})
+
+    alt.Chart(df).transform_calculate(
+        compliant="hours(datum.local) != hours(datum.utc) ? true : false",
+    ).mark_text(size=20, baseline='middle').encode(
+        text=alt.condition('datum.compliant', alt.value('OK'), alt.value('not OK')),
+        color=alt.condition('datum.compliant', alt.value('green'), alt.value('red'))
+    ).properties(width=80, height=50)
+
+If the above output contains a red "not OK":
+
+.. altair-plot::
+   :hide-code:
+   :links: none
+
+   alt.Chart(df).mark_text(size=10, baseline='middle').encode(
+       alt.TextValue('not OK'),
+       alt.ColorValue('red')
+   ).properties(width=40, height=25)
+
+it means that your browser's date parsing is not ES6-compliant.
+If it contains a green "OK":
+
+.. altair-plot::
+   :hide-code:
+   :links: none
+
+   alt.Chart(df).mark_text(size=10, baseline='middle').encode(
+       alt.TextValue('OK'),
+       alt.ColorValue('green')
+   ).properties(width=40, height=25)
+
+then it means that your browser parses dates as Altair expects, either because
+it is ES6-compliant or because your computer locale happens to be set to
+the UTC+0 (GMT) timezone.
 
 .. _Coordinated Universal Time (UTC): https://en.wikipedia.org/wiki/Coordinated_Universal_Time
 .. _Pandas timeseries: https://pandas.pydata.org/pandas-docs/stable/timeseries.html

--- a/doc/user_guide/times_and_dates.rst
+++ b/doc/user_guide/times_and_dates.rst
@@ -220,5 +220,5 @@ it is ES6-compliant or because your computer locale happens to be set to
 the UTC+0 (GMT) timezone.
 
 .. _Coordinated Universal Time (UTC): https://en.wikipedia.org/wiki/Coordinated_Universal_Time
-.. _Pandas timeseries: https://pandas.pydata.org/pandas-docs/stable/timeseries.html
+.. _Pandas timeseries: https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html
 .. _ECMAScript 6: http://www.ecma-international.org/ecma-262/6.0/


### PR DESCRIPTION
Most of the changes are smaller updates. Most noteworthy is the move of the "Note on browser compatibility" section in "Times and Dates" to the bottom of that page. I still think it's great that its documented but for most users this is not relevant anymore as all modern browsers are now es6 compatible for quite a while, see [https://caniuse.com/\?search\=es6](https://caniuse.com/%5C?search%5C=es6)