### PR TITLE
Run tests with Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
     name: Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -81,5 +81,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )


### PR DESCRIPTION
Altair works without issues for me under 3.11 so I added 3.11 in the build GH workflow and the classifier for then Python package.