### PR TITLE
Clarify that not all channels accept additional options

### DIFF
--- a/doc/user_guide/encodings/channel_options.rst
+++ b/doc/user_guide/encodings/channel_options.rst
@@ -5,7 +5,7 @@
 Channel Options
 ---------------
 
-Each encoding channel allows for a number of additional options to be expressed.
+Some encoding channels allow for additional options to be expressed.
 These can control things like axis properties, scale properties, headers and
 titles, binning parameters, aggregation, sorting, and many more.
 


### PR DESCRIPTION
Addressing https://github.com/altair-viz/altair/issues/2604#issuecomment-1366163307

Good catch @mattijn! I just checked and x and y offset channels do not accept any additional arguments, see https://github.com/altair-viz/altair/blob/fbd4f7bac5392b76e439fc3c58dd1b1476343c3e/altair/vegalite/v5/schema/core.py#L9883

I clarified in the introduction that only some channels take additional options.