### PR TITLE
Fix docs for mobile devices

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -30,8 +30,19 @@ table td.vl-type-def {
   overflow-x: clip;
 }
 
+/* Default for the pydata theme is 25% */
 .bd-sidebar-primary {
   max-width: 20%
+}
+
+/* By providing max-width above for .bd-sidebar-primary, we also overwrite
+the setting from the template for small screens, e.g. mobile phones. The values below
+are copied out of pydata-sphinx-theme.css so that the sidebar is again
+properly displayed on mobile devices and not restricted to 20% */
+@media (max-width: 959.98px) {
+  .bd-sidebar-primary {
+      max-width: 350px;
+  }
 }
 
 .properties-example .vega-bind-name {

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -30,6 +30,13 @@ table td.vl-type-def {
   overflow-x: clip;
 }
 
+/* Hide this empty container as it leads to a vertical scrollbar in 
+the primary sidebar even if there is no need for such a scrollbar as all content
+would fit onto the screen */
+#rtd-footer-container {
+  display: none;
+}
+
 /* Default for the pydata theme is 25% */
 .bd-sidebar-primary {
   max-width: 20%

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -138,6 +138,7 @@ html_theme_options = {
     "navbar_start": ["navbar-logo", "navbar-project"],
     "navbar_center": ["navbar-nav"],
     "navbar_end": ["theme-switcher", "navbar-icon-links"],
+    "primary_sidebar_end": [],
     "footer_items": [],
     "icon_links": [
         {
@@ -210,7 +211,7 @@ def setup(app):
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
     "index": [],
-    "**": ["sidebar-nav-bs", "sidebar-ethical-ads"],
+    "**": ["sidebar-nav-bs"],
 }
 
 # Redirection of old page locations via the rediraffe sphinx-extension


### PR DESCRIPTION
Fix for #2775.

![image](https://user-images.githubusercontent.com/23366411/209839542-ee758194-2e66-4126-b140-ef9837522455.png)

Unrelated to this but I also hid the `rtd-footer-container` element which created a vertical scrollbar in the primary sidebar on the left side even if it's not needed, i.e. on larger screens.

Before:
![image](https://user-images.githubusercontent.com/23366411/209839761-eff5004c-dbc8-4298-af36-655db6af1b9a.png)


After:
![image](https://user-images.githubusercontent.com/23366411/209839670-5e7e9da1-b5e6-4ec9-bd02-77576865b049.png)
