### PR TITLE
Fix altair test save if vl-convert-python is installed and altair_saver is not

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 	python setup.py install
 
 test :
-	black .
+	black . --check
 	flake8 . --statistics
 	python -m pytest --pyargs --doctest-modules altair
 

--- a/altair/vegalite/v3/tests/test_api.py
+++ b/altair/vegalite/v3/tests/test_api.py
@@ -265,12 +265,12 @@ def test_save(format, basic_chart):
     if format in ["svg", "png", "pdf"]:
         if not altair_saver:
             with pytest.raises(ValueError) as err:
-                basic_chart.save(out, format=format)
-            assert "github.com/altair-viz/altair_saver" in str(err.value)
+                basic_chart.save(out, format=format, engine="altair_saver")
+            assert "altair_saver" in str(err.value)
             return
         elif format not in altair_saver.available_formats():
             with pytest.raises(ValueError) as err:
-                basic_chart.save(out, format=format)
+                basic_chart.save(out, format=format, engine="altair_saver")
             assert f"No enabled saver found that supports format='{format}'" in str(
                 err.value
             )

--- a/altair/vegalite/v4/tests/test_api.py
+++ b/altair/vegalite/v4/tests/test_api.py
@@ -265,12 +265,12 @@ def test_save(format, basic_chart):
     if format in ["svg", "png", "pdf"]:
         if not altair_saver:
             with pytest.raises(ValueError) as err:
-                basic_chart.save(out, format=format)
-            assert "github.com/altair-viz/altair_saver" in str(err.value)
+                basic_chart.save(out, format=format, engine="altair_saver")
+            assert "altair_saver" in str(err.value)
             return
         elif format not in altair_saver.available_formats():
             with pytest.raises(ValueError) as err:
-                basic_chart.save(out, format=format)
+                basic_chart.save(out, format=format, engine="altair_saver")
             assert f"No enabled saver found that supports format='{format}'" in str(
                 err.value
             )

--- a/altair/vegalite/v5/tests/test_api.py
+++ b/altair/vegalite/v5/tests/test_api.py
@@ -270,15 +270,15 @@ def test_save(format, engine, basic_chart):
 
     if format in ["svg", "png", "pdf", "bogus"]:
         if engine == "altair_saver":
-            if altair_saver is None:
-                with pytest.raises(ValueError) as err:
-                    basic_chart.save(out, format=format, engine=engine)
-                assert "altair_saver" in str(err.value)
-                return
-            elif format == "bogus":
+            if format == "bogus":
                 with pytest.raises(ValueError) as err:
                     basic_chart.save(out, format=format, engine=engine)
                 assert f"Unsupported format: '{format}'" in str(err.value)
+                return
+            elif altair_saver is None:
+                with pytest.raises(ValueError) as err:
+                    basic_chart.save(out, format=format, engine=engine)
+                assert "altair_saver" in str(err.value)
                 return
             elif format not in altair_saver.available_formats():
                 with pytest.raises(ValueError) as err:


### PR DESCRIPTION
If vl-convert-python is installed and altair_saver is not, `test_save` failed. For v3 and v4 this was probably introduced with the addition of vl-convert-python, for v5 it is related to #2784. Probably didn't pop up previously as all contributors had altair_saver installed anyway.