### PR TITLE
Remove altair_viewer from GitHub build workflow as not needed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
         pip install .[dev]
         pip install "selenium<4.3.0"
         pip install altair_saver vl-convert-python
-        pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Test with pytest
       run: |
         pytest --doctest-modules altair


### PR DESCRIPTION
I don't see a need to install the package in the workflows. Maybe previously there was a test which used it?