### PR TITLE
Run tests for both save engines altair_saver and vl-convert-python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,15 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --doctest-modules altair
+    - name: Selected tests without vl-convert-python
+      run: |
+        pip uninstall vl-convert-python --yes
+        pytest -m save_engine --doctest-modules altair
+    - name: Selected tests without vl-convert-python and altair_saver
+      run: |
+        pip uninstall altair_saver --yes
+        pytest -m save_engine --doctest-modules altair
+    - name: Selected tests with vl-convert-python and without altair_saver
+      run: |
+        pip install vl-convert-python
+        pytest -m save_engine --doctest-modules altair

--- a/altair/examples/tests/test_examples.py
+++ b/altair/examples/tests/test_examples.py
@@ -34,6 +34,11 @@ def test_examples(filename: str):
     chart.to_dict()
 
 
+# We do not apply the save_engine mark to this test. This mark is used in 
+# the build GitHub Action workflow to select the tests which should be rerun
+# with some of the saving engines uninstalled. This would not make sense for this test
+# as here it is only interesting to run it with all saving engines installed. 
+# Furthermore, the runtime of this test is rather long.
 @pytest.mark.parametrize("engine", ["vl-convert", "altair_saver"])
 @pytest.mark.parametrize("filename", iter_example_filenames())
 def test_render_examples_to_png(engine, filename):

--- a/altair/utils/tests/test_mimebundle.py
+++ b/altair/utils/tests/test_mimebundle.py
@@ -174,6 +174,11 @@ def test_vegalite_to_vega_mimebundle(engine, vegalite_spec, vega_spec):
         pytest.skip("vl_convert not importable; cannot run mimebundle tests")
     elif engine == "altair_saver" and altair_saver is None:
         pytest.skip("altair_saver not importable; cannot run mimebundle tests")
+    elif vlc is None and altair_saver is None:
+        pytest.skip(
+            "Neither altair_saver nor vl_convert are importable;"
+            + " cannot run mimebundle tests"
+        )
 
     # temporary fix for https://github.com/vega/vega-lite/issues/7776
     def delete_none(axes):

--- a/altair/utils/tests/test_mimebundle.py
+++ b/altair/utils/tests/test_mimebundle.py
@@ -167,6 +167,7 @@ def vega_spec():
     }
 
 
+@pytest.mark.save_engine
 @pytest.mark.parametrize("engine", ["vl-convert", "altair_saver", None])
 def test_vegalite_to_vega_mimebundle(engine, vegalite_spec, vega_spec):
     if engine == "vl-convert" and vlc is None:

--- a/altair/vegalite/v3/tests/test_api.py
+++ b/altair/vegalite/v3/tests/test_api.py
@@ -253,6 +253,7 @@ def test_selection_expression():
         selection.__magic__
 
 
+@pytest.mark.save_engine
 @pytest.mark.parametrize("format", ["html", "json", "png", "svg", "pdf"])
 def test_save(format, basic_chart):
     if format in ["pdf", "png"]:

--- a/altair/vegalite/v4/tests/test_api.py
+++ b/altair/vegalite/v4/tests/test_api.py
@@ -253,6 +253,7 @@ def test_selection_expression():
         selection.__magic__
 
 
+@pytest.mark.save_engine
 @pytest.mark.parametrize("format", ["html", "json", "png", "svg", "pdf"])
 def test_save(format, basic_chart):
     if format in ["pdf", "png"]:

--- a/altair/vegalite/v5/tests/test_api.py
+++ b/altair/vegalite/v5/tests/test_api.py
@@ -290,7 +290,7 @@ def test_save(format, engine, basic_chart):
                 return
 
         elif engine == "vl-convert":
-            if vlc is None:
+            if vlc is None and format != "bogus":
                 with pytest.raises(ValueError) as err:
                     basic_chart.save(out, format=format, engine=engine)
                 assert "vl-convert-python" in str(err.value)

--- a/altair/vegalite/v5/tests/test_api.py
+++ b/altair/vegalite/v5/tests/test_api.py
@@ -258,6 +258,7 @@ def test_selection_expression():
         selection.__magic__
 
 
+@pytest.mark.save_engine
 @pytest.mark.parametrize("format", ["html", "json", "png", "svg", "pdf", "bogus"])
 @pytest.mark.parametrize("engine", ["altair_saver", "vl-convert"])
 def test_save(format, engine, basic_chart):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,8 @@ exclude = '''
 # https://github.com/altair-viz/altair/pull/2758#issuecomment-1358091909
 requires = ["setuptools >= 40.6.0, <64", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+markers = [
+    "save_engine: marks some of the tests which are using an external package to save a chart to e.g. a png file. This mark is used to run those tests selectively in the build GitHub Action.",
+]


### PR DESCRIPTION
Extended the build workflow as suggested by @mattijn here https://github.com/altair-viz/altair/pull/2786#issuecomment-1368090897. Fixed another bug in the process when vl-convert-python was not installed.

I did not mark the rendering of the gallery examples to png for rerunning as that test takes quite some time and I don't think it is necessary to rerun it as this is about converting the examples, not about the behaviour of Altair if one of the engines is not installed.