### PR TITLE
Modify generator to move autogenerated test to tests folder

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -621,13 +621,12 @@ class _PropertySetter(object):
                         f"\n\n    {altair_prop.__doc__[attribute_index:]}"
                     )
                 )
-            # For short docsstrings such as Aggregate, Stack, et
+            # For short docstrings such as Aggregate, Stack, et
             else:
                 self.__doc__ = (
                     altair_prop.__doc__.replace("    ", "") + "\n" + self.__doc__
                 )
             # Add signatures and tab completion for the method and parameter names
-            # Currently works for `alt.X.bin` but not alt.X().bin`
             self.__signature__ = inspect.signature(altair_prop)
             self.__wrapped__ = inspect.getfullargspec(altair_prop)
             self.__name__ = altair_prop.__name__
@@ -645,7 +644,9 @@ class _PropertySetter(object):
 
 
 def with_property_setters(cls):
-    """Decorator to add property setters to a Schema class."""
+    """
+    Decorator to add property setters to a Schema class.
+    """
     schema = cls.resolve_references()
     for prop, propschema in schema.get("properties", {}).items():
         setattr(cls, prop, _PropertySetter(prop, propschema))

--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -91,6 +91,7 @@ class DatumChannelMixin(object):
                                                       ignore=ignore,
                                                       context=context)
 
+
 @with_property_setters
 class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefnumber):
     """Angle schema wrapper

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -248,7 +248,7 @@ def download_schemafile(library, version, schemapath, skip_download=False):
 
 def copy_schemapi_util():
     """
-    Copy the schemapi utility and its test file into altair/utils/
+    Copy the schemapi utility into altair/utils/ and its test file to tests/utils/
     """
     # copy the schemapi utility file
     source_path = abspath(join(dirname(__file__), "schemapi", "schemapi.py"))
@@ -267,7 +267,7 @@ def copy_schemapi_util():
         join(dirname(__file__), "schemapi", "tests", "test_schemapi.py")
     )
     destination_path = abspath(
-        join(dirname(__file__), "..", "altair", "utils", "tests", "test_schemapi.py")
+        join(dirname(__file__), "..", "tests", "utils", "tests", "test_schemapi.py")
     )
 
     print("Copying\n {}\n  -> {}".format(source_path, destination_path))

--- a/tools/schemapi/tests/test_schemapi.py
+++ b/tools/schemapi/tests/test_schemapi.py
@@ -7,7 +7,7 @@ import pytest
 
 import numpy as np
 
-from ..schemapi import (
+from altair.utils.schemapi import (
     UndefinedType,
     SchemaBase,
     Undefined,


### PR DESCRIPTION
Fix https://github.com/altair-viz/altair/issues/2802.

This PR modifies the `generate_schema_wrapper.py` so the generated test file is placed in the `tests/utils/` folder. 
I had to change the test file to use absolute imports instead of relative imports as it is moved.
I also ran the `generate_schema_wrapper.py` and `generate_api_docs.py` thad leads to the update of two auto-generated files (utils/schemapi.py and channels.py)