### PR TITLE
Add inline argument to chart.save() for html export

### DIFF
--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -33,7 +33,7 @@ def save(
 ):
     """Save a chart to file in a variety of formats
 
-    Supported formats are [json, html, png, svg]
+    Supported formats are [json, html, png, svg, pdf]
 
     Parameters
     ----------

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -114,6 +114,8 @@ def save(
         json_spec = json.dumps(spec, **json_kwds)
         write_file_or_filename(fp, json_spec, mode="w")
     elif format == "html":
+        if inline:
+            kwargs["template"] = "inline"
         mimebundle = spec_to_mimebundle(
             spec=spec,
             format=format,
@@ -122,7 +124,6 @@ def save(
             vegalite_version=vegalite_version,
             vegaembed_version=vegaembed_version,
             embed_options=embed_options,
-            template="inline" if inline else "standard",
             json_kwds=json_kwds,
             **kwargs,
         )

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import warnings
 
 from .mimebundle import spec_to_mimebundle
 
@@ -27,6 +28,7 @@ def save(
     webdriver=None,
     scale_factor=1,
     engine=None,
+    inline=False,
     **kwargs,
 ):
     """Save a chart to file in a variety of formats
@@ -64,6 +66,12 @@ def save(
         scale_factor to use to change size/resolution of png or svg output
     engine: string {'vl-convert', 'altair_saver'}
         the conversion engine to use for 'png', 'svg', and 'pdf' formats
+    inline: bool (optional)
+        If False (default), the required JavaScript libraries are loaded
+        from a CDN location in the resulting html file.
+        If True, the required JavaScript libraries are inlined into the resulting
+        html file so that it will work without an internet connection.
+        The altair_viewer package is required if True.
     **kwargs :
         additional kwargs passed to spec_to_mimebundle.
     """
@@ -99,6 +107,9 @@ def save(
     if mode == "vega-lite" and vegalite_version is None:
         raise ValueError("must specify vega-lite version")
 
+    if format != "html" and inline:
+        warnings.warn("inline argument ignored for non HTML formats.")
+
     if format == "json":
         json_spec = json.dumps(spec, **json_kwds)
         write_file_or_filename(fp, json_spec, mode="w")
@@ -111,6 +122,7 @@ def save(
             vegalite_version=vegalite_version,
             vegaembed_version=vegaembed_version,
             embed_options=embed_options,
+            template="inline" if inline else "standard",
             json_kwds=json_kwds,
             **kwargs,
         )

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -42,7 +42,7 @@ def save(
     fp : string filename, pathlib.Path or file-like object
         file to which to write the chart.
     format : string (optional)
-        the format to write: one of ['json', 'html', 'png', 'svg'].
+        the format to write: one of ['json', 'html', 'png', 'svg', 'pdf'].
         If not specified, the format will be determined from the filename.
     mode : string (optional)
         Either 'vega' or 'vegalite'. If not specified, then infer the mode from

--- a/tests/vegalite/v5/tests/test_api.py
+++ b/tests/vegalite/v5/tests/test_api.py
@@ -347,9 +347,9 @@ def test_save_html(basic_chart, inline):
     if inline:
         assert '<script type="text/javascript">' in content
     else:
-        assert 'src="https://cdn.jsdelivr.net/npm/vega@5"' in content
-        assert 'src="https://cdn.jsdelivr.net/npm/vega-lite@5"' in content
-        assert 'src="https://cdn.jsdelivr.net/npm/vega-embed@6"' in content
+        assert 'src="https://cdn.jsdelivr.net/npm/vega@5' in content
+        assert 'src="https://cdn.jsdelivr.net/npm/vega-lite@5' in content
+        assert 'src="https://cdn.jsdelivr.net/npm/vega-embed@6' in content
 
 
 def test_facet_basic():

--- a/tests/vegalite/v5/tests/test_api.py
+++ b/tests/vegalite/v5/tests/test_api.py
@@ -335,6 +335,23 @@ def test_save(format, engine, basic_chart):
             os.remove(fp)
 
 
+@pytest.mark.parametrize("inline", [False, True])
+def test_save_html(basic_chart, inline):
+    out = io.StringIO()
+    basic_chart.save(out, format="html", inline=inline)
+    out.seek(0)
+    content = out.read()
+
+    assert content.startswith("<!DOCTYPE html>")
+
+    if inline:
+        assert '<script type="text/javascript">' in content
+    else:
+        assert 'src="https://cdn.jsdelivr.net/npm/vega@5"' in content
+        assert 'src="https://cdn.jsdelivr.net/npm/vega-lite@5.2.0"' in content
+        assert 'src="https://cdn.jsdelivr.net/npm/vega-embed@6"' in content
+
+
 def test_facet_basic():
     # wrapped facet
     chart1 = (

--- a/tests/vegalite/v5/tests/test_api.py
+++ b/tests/vegalite/v5/tests/test_api.py
@@ -348,7 +348,7 @@ def test_save_html(basic_chart, inline):
         assert '<script type="text/javascript">' in content
     else:
         assert 'src="https://cdn.jsdelivr.net/npm/vega@5"' in content
-        assert 'src="https://cdn.jsdelivr.net/npm/vega-lite@5.2.0"' in content
+        assert 'src="https://cdn.jsdelivr.net/npm/vega-lite@5"' in content
         assert 'src="https://cdn.jsdelivr.net/npm/vega-embed@6"' in content
 
 


### PR DESCRIPTION
This includes the Vega/Vega-Lite/Vega-Embed JavaScript source in the exported html file so that it works offline.  The logic is ported from altair_saver.

See https://github.com/altair-viz/altair/issues/2765

**Note:** Like altair_saver, this pulls the JavaScript source from the `altair_viewer` package. In the future we could talk about whether to include the JavaScript bundles in Altair itself to avoid this dependency.