### PR TITLE
docs: Use SVG thumbnail for emoji example and use VlConvert to build docs on CI

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -20,9 +20,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
         pip install "selenium<4.3.0"
-        pip install altair_saver
         pip install -r doc/requirements.txt
-        pip uninstall vl-convert-python --yes
         pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Run docbuild
       run: |

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -19,7 +19,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
-        pip install "selenium<4.3.0"
         pip install -r doc/requirements.txt
         pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Run docbuild

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,9 @@ Some additional notes:
   included then it should be referenced by URL, such as `source =
   data.movies.url`. This is to ensure that Altair's automated test suite does
   not depend on availability of external HTTP resources.
+- If VlConvert does not support PNG export of the chart (e.g. in the case of emoji),
+  then add the name of the example to the `SVG_EXAMPLES` set in 
+  `tests/examples_arguments_syntax/__init__.py` and `tests/examples_methods_syntax/__init__.py`
 
 ### Building the Documentation Locally
 In addition to the development dependencies mentioned further above,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,12 +164,6 @@ for details.
 pip install -r doc/requirements.txt
 ```
 
-If you want to build the documentation so it can be published on the [official Altair website](https://altair-viz.github.io), you need to
-additionally install [altair_saver](https://github.com/altair-viz/altair_saver/) and uninstall [vl-convert-python](https://github.com/vega/vl-convert/tree/main/vl-convert-python).
-These packages are used to generate PNG thumbnails for the example gallery. If both are installed, `vl-convert-python` is used by default.
-The reason for this is that `vl-convert-python` cannot create a thumbnail for the `isotype_emoji.py` example,
-which is fine for normal contributions but not when creating a new version of the official documentation.
-
 Once you have all the dependencies, you can build the documentation 
 using various commands defined in the Makefile. 
 From the `doc` folder, you can use `make help` to see all of the available commands

--- a/sphinxext/altairgallery.py
+++ b/sphinxext/altairgallery.py
@@ -96,7 +96,7 @@ MINIGALLERY_TEMPLATE = jinja2.Template(
     <div id="showcase">
       <div class="examples">
       {% for example in examples %}
-      <a 
+      <a
         class="preview" href="{{ gallery_dir }}/{{ example.name }}.html"
 {% if example['use_svg'] %}
         style="background-image: url(.{{ image_dir }}/{{ example.name }}-thumb.svg)"

--- a/tests/examples_arguments_syntax/__init__.py
+++ b/tests/examples_arguments_syntax/__init__.py
@@ -1,5 +1,9 @@
 import os
 
+# Set of the names of examples that should have SVG static images.
+# This is for examples that VlConvert's PNG export does not support.
+SVG_EXAMPLES = {"isotype_emoji"}
+
 
 def iter_examples_arguments_syntax():
     """Iterate over the examples in this directory.
@@ -7,6 +11,8 @@ def iter_examples_arguments_syntax():
     Each item is a dict with the following keys:
     - "name" : the unique name of the example
     - "filename" : the full file path to the example
+    - "use_svg": Flag indicating whether the static image for the
+        example should be an SVG instead of a PNG
     """
     examples_arguments_syntax_dir = os.path.abspath(os.path.dirname(__file__))
     for filename in os.listdir(examples_arguments_syntax_dir):
@@ -16,6 +22,5 @@ def iter_examples_arguments_syntax():
         yield {
             "name": name,
             "filename": os.path.join(examples_arguments_syntax_dir, filename),
-            # Use SVG image previews for charts not supported by vl-convert's PNG export
-            "use_svg": name in ["isotype_emoji"]
+            "use_svg": name in SVG_EXAMPLES
         }

--- a/tests/examples_arguments_syntax/__init__.py
+++ b/tests/examples_arguments_syntax/__init__.py
@@ -16,4 +16,6 @@ def iter_examples_arguments_syntax():
         yield {
             "name": name,
             "filename": os.path.join(examples_arguments_syntax_dir, filename),
+            # Use SVG image previews for charts not supported by vl-convert's PNG export
+            "use_svg": name in ["isotype_emoji"]
         }

--- a/tests/examples_methods_syntax/__init__.py
+++ b/tests/examples_methods_syntax/__init__.py
@@ -1,5 +1,9 @@
 import os
 
+# Set of the names of examples that should have SVG static images.
+# This is for examples that VlConvert's PNG export does not support.
+SVG_EXAMPLES = {"isotype_emoji"}
+
 
 def iter_examples_methods_syntax():
     """Iterate over the examples in this directory.
@@ -16,4 +20,5 @@ def iter_examples_methods_syntax():
         yield {
             "name": name,
             "filename": os.path.join(examples_methods_syntax_dir, filename),
+            "use_svg": name in SVG_EXAMPLES
         }


### PR DESCRIPTION
## Background
VlConvert PNG export does not support the [Isotype Emoji](https://altair-viz.github.io/gallery/isotype_emoji.html), so it wasn't suitable as a full drop-in replacement for altair_saver when building docs on CI.

## Overview
This PR is trying out an idea I had this morning. Interested to hear what folks think.

This PR updates the docs pipeline slightly to support using SVG image thumbnails for select examples (only the isotype_emoji example for now).  Since VlConvert's SVG export of the isotype_emoji example works fine, this makes it possible to use VlConvert to build all of the images in the docs.

I also updated the docs CI job to use VlConvert.