### PR TITLE
Add test for layer properties

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -3042,14 +3042,14 @@ def _remove_layer_props(chart, subcharts, layer_props):
                     pass
             if len(values) == 0:
                 pass
-            elif all(v is values[0] for v in values[1:]):
+            elif all(v == values[0] for v in values[1:]):
                 output_dict[prop] = values[0]
             else:
                 raise ValueError(f"There are inconsistent values {values} for {prop}")
         else:
             # Top level has this prop; subchart props must be either
             # Undefined or identical to proceed.
-            if all(c[prop] is Undefined or c[prop] is chart[prop] for c in subcharts):
+            if all(c[prop] is Undefined or c[prop] == chart[prop] for c in subcharts):
                 output_dict[prop] = chart[prop]
             else:
                 raise ValueError(f"There are inconsistent values {values} for {prop}")

--- a/tests/vegalite/v5/tests/test_layer_props.py
+++ b/tests/vegalite/v5/tests/test_layer_props.py
@@ -1,0 +1,23 @@
+import pytest
+
+import altair.vegalite.v5 as alt
+
+
+def test_layer_props():
+    """Beginning in Vega-Lite v5, the properties "height" and "width" were no longer allowed in a subchart within a LayerChart.  We check here that these are moved to the top level by Altair."""
+    base = alt.Chart().mark_point()
+
+    # Allowed
+    base.properties(width=100) + base
+    base.properties(width=100) + base.properties(height=200)
+    base.properties(width=100) + base.properties(height=200, width=100)
+
+    # Not allowed
+    with pytest.raises(ValueError, match="inconsistent"):
+        base.properties(width=100) + base.properties(width=200)
+
+    # Check that the resulting LayerChart has the correct properties.
+    c = base.properties(width=100) + base.properties(height=200, width=100)
+    assert isinstance(c, alt.LayerChart)
+    assert c.width == 100
+    assert c.height == 200


### PR DESCRIPTION
Reading through the old discussions, these properties in subcharts for a LayerChart were the cause of one of the biggest issues in updating to Vega-Lite version 5.