### PR TITLE
Add --check to black test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 	python setup.py install
 
 test :
-	black --diff --color .
+	black --diff --color --check .
 	flake8 . --statistics
 	python -m pytest --pyargs --doctest-modules tests
 


### PR DESCRIPTION
Prior to changing this command in #2774, it already had the `--check` argument. This argument makes sure that the status is returned and therefore that the command fails if files would be formatted. I think removing it was unintentional (the reasoning in https://github.com/altair-viz/altair/pull/2774#discussion_r1060521819 was around adding `--diff --color` and not removing `--check`). I prefer if the command fails, else you need to scroll through the console output of pytest to get to the output of black to see the outcome.
