### PR TITLE
Clean up development and documentation requirements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[dev]
           pip install "selenium<4.3.0"
-          pip install altair_saver vl-convert-python
+          pip install altair_saver
       - name: Test with pytest
         run: |
           pytest --doctest-modules tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
           pip install .[dev]
           pip install "selenium<4.3.0"
           pip install altair_saver vl-convert-python
-          pip install git+https://github.com/altair-viz/altair_viewer.git
       - name: Test with pytest
         run: |
           pytest --doctest-modules tests

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -20,7 +20,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
         pip install -r doc/requirements.txt
-        pip install git+https://github.com/altair-viz/altair_viewer.git
     - name: Run docbuild
       run: |
         cd doc && make ${{ matrix.build-type }}

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -32,21 +32,8 @@ with the above installation commands:
 - Toolz_
 
 To run Altair's full test suite and build Altair's documentation requires a few
-additional dependencies:
-
-- black
-- flake8
-- pytest
-- sphinx
-- m2r
-- docutils
-- vega_datasets_
-- ipython
-- myst-parser
-- numpydoc
-- pillow
-- pydata-sphinx-theme
-- geopandas
+additional dependencies, see `CONTRIBUTING.md <https://github.com/altair-viz/altair/blob/master/CONTRIBUTING.md>`
+for the details.
 
 Development Install
 ===================

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,9 @@
 sphinx
+docutils
 jinja2
 numpydoc
 pillow
 pydata-sphinx-theme
 geopandas
 vl-convert-python
+myst-parser

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,6 @@ sphinx
 jinja2
 numpydoc
 pillow
-mistune<=0.8.4
 pydata-sphinx-theme
 geopandas
 vl-convert-python

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,5 +5,4 @@ numpydoc
 pillow
 pydata-sphinx-theme
 geopandas
-vl-convert-python
 myst-parser

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,3 +6,4 @@ pytest-cov
 m2r
 vega_datasets
 altair_viewer @ git+https://github.com/altair-viz/altair_viewer.git
+vl-convert-python

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,6 @@ flake8
 pytest
 pytest-cov
 sphinx
-mistune<2.0.0  # necessary for m2r v0.2
 m2r
 vega_datasets
 altair_viewer @ git+https://github.com/altair-viz/altair_viewer.git

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,4 +8,5 @@ sphinx
 mistune<2.0.0  # necessary for m2r v0.2
 m2r
 vega_datasets
+altair_viewer
 myst-parser

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,5 +8,5 @@ sphinx
 mistune<2.0.0  # necessary for m2r v0.2
 m2r
 vega_datasets
-altair_viewer
+altair_viewer @ git+https://github.com/altair-viz/altair_viewer.git
 myst-parser

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,8 @@
 black
-docutils
 ipython
 flake8
 pytest
 pytest-cov
-sphinx
 m2r
 vega_datasets
 altair_viewer @ git+https://github.com/altair-viz/altair_viewer.git
-myst-parser


### PR DESCRIPTION
Moving `altair_viewer` into `requirements_dev.txt` as starting with https://github.com/altair-viz/altair/pull/2807 it needs to be installed to run the tests. Usually, it is installed anyway if someone has `altair_saver` installed but as this is no longer the norm for developers due to the recommendation in `CONTRIBUTING.md` to use `vl-convert-python`.