### PR TITLE
Add missing object attributes to __dir__

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -515,7 +515,7 @@ class SchemaBase(object):
         )
 
     def __dir__(self):
-        return list(self._kwds.keys())
+        return sorted(super().__dir__() + list(self._kwds.keys()))
 
 
 def _passthrough(*args, **kwds):

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -513,7 +513,7 @@ class SchemaBase(object):
         )
 
     def __dir__(self):
-        return list(self._kwds.keys())
+        return sorted(super().__dir__() + list(self._kwds.keys()))
 
 
 def _passthrough(*args, **kwds):


### PR DESCRIPTION
Resolves #2819. 

`SchemaBase.__dir__` was introduced in this commit https://github.com/altair-viz/altair/commit/d450c9963fc0943fe871e11d6d387d3143eb6b98 to enable tab completion for the attributes stored in `_kwds`. This makes sense as `SchemaBase` overwrites `__getattr__` so that you can access an attribute `x` which is stored in `_kwds` with `obj.x`. However, I don't think it was intended for that commit to remove all other attributes, especially on top-level objects, from tab completion. This PR adds back the original attribute list from `__dir__` + the attributes stored in `_kwds`.

With this PR:

```python
import altair as alt
from vega_datasets import data


cars = data.cars.url

scatter = alt.Chart(cars).mark_point().encode(
    x='Weight_in_lbs:Q',
    y='Horsepower:Q',
    color='Origin:N')

dir(scatter)
```
```python
['__add__',
 '__and__',
 '__class__',
 '__delattr__',
 '__dict__',
 '__dir__',
 '__doc__',
 '__eq__',
 '__format__',
 '__ge__',
 '__getattr__',
 '__getattribute__',
 '__getitem__',
 '__getstate__',
 '__gt__',
 '__hash__',
 '__init__',
 '__init_subclass__',
 '__le__',
 '__lt__',
 '__module__',
 '__ne__',
 '__new__',
 '__or__',
 '__reduce__',
 '__reduce_ex__',
 '__repr__',
 '__setattr__',
 '__setitem__',
 '__sizeof__',
 '__str__',
 '__subclasshook__',
 '__weakref__',
 '_add_transform',
 '_args',
 '_class_is_valid_at_instantiation',
 '_counter',
 '_default_wrapper_classes',
 '_get',
 '_get_name',
 '_kwds',
 '_repr_mimebundle_',
 '_rootschema',
 '_schema',
 '_set_resolve',
 'add_params',
 'add_selection',
 'align',
 'autosize',
 'background',
 'bounds',
 'center',
 'config',
 'configure',
 'configure_arc',
 'configure_area',
 'configure_axis',
 'configure_axisBand',
 'configure_axisBottom',
 'configure_axisDiscrete',
 'configure_axisLeft',
 'configure_axisPoint',
 'configure_axisQuantitative',
 'configure_axisRight',
 'configure_axisTemporal',
 'configure_axisTop',
 'configure_axisX',
 'configure_axisXBand',
 'configure_axisXDiscrete',
 'configure_axisXPoint',
 'configure_axisXQuantitative',
 'configure_axisXTemporal',
 'configure_axisY',
 'configure_axisYBand',
 'configure_axisYDiscrete',
 'configure_axisYPoint',
 'configure_axisYQuantitative',
 'configure_axisYTemporal',
 'configure_bar',
 'configure_boxplot',
 'configure_circle',
 'configure_concat',
 'configure_errorband',
 'configure_errorbar',
 'configure_facet',
 'configure_geoshape',
 'configure_header',
 'configure_headerColumn',
 'configure_headerFacet',
 'configure_headerRow',
 'configure_image',
 'configure_legend',
 'configure_line',
 'configure_mark',
 'configure_point',
 'configure_projection',
 'configure_range',
 'configure_rect',
 'configure_rule',
 'configure_scale',
 'configure_selection',
 'configure_square',
 'configure_text',
 'configure_tick',
 'configure_title',
 'configure_trail',
 'configure_view',
 'copy',
 'data',
 'datasets',
 'description',
 'display',
 'encode',
 'encoding',
 'facet',
 'from_dict',
 'from_json',
 'height',
 'interactive',
 'mark',
 'mark_arc',
 'mark_area',
 'mark_bar',
 'mark_boxplot',
 'mark_circle',
 'mark_errorband',
 'mark_errorbar',
 'mark_geoshape',
 'mark_image',
 'mark_line',
 'mark_point',
 'mark_rect',
 'mark_rule',
 'mark_square',
 'mark_text',
 'mark_tick',
 'mark_trail',
 'name',
 'padding',
 'params',
 'project',
 'projection',
 'properties',
 'repeat',
 'resolve',
 'resolve_axis',
 'resolve_legend',
 'resolve_references',
 'resolve_scale',
 'save',
 'serve',
 'show',
 'spacing',
 'title',
 'to_dict',
 'to_html',
 'to_json',
 'transform',
 'transform_aggregate',
 'transform_bin',
 'transform_calculate',
 'transform_density',
 'transform_filter',
 'transform_flatten',
 'transform_fold',
 'transform_impute',
 'transform_joinaggregate',
 'transform_loess',
 'transform_lookup',
 'transform_pivot',
 'transform_quantile',
 'transform_regression',
 'transform_sample',
 'transform_stack',
 'transform_timeunit',
 'transform_window',
 'usermeta',
 'validate',
 'validate_property',
 'view',
 'width']
```
where you can see that both attributes from `_kwds` such as `width` but also `to_json` are present. I didn't find any regression due to this change. The only usage of the `dir()` function is in https://github.com/altair-viz/altair/blob/master/altair/utils/core.py#L636. However, it is always called on the module `channels` and not on an object inheriting from `SchemaBase`. It's also covered well by tests which all pass.