### PR TITLE
Fix disable_debug_mode

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -30,7 +30,7 @@ def enable_debug_mode():
 
 def disable_debug_mode():
     global DEBUG_MODE
-    DEBUG_MODE = True
+    DEBUG_MODE = False
 
 
 @contextlib.contextmanager

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -28,7 +28,7 @@ def enable_debug_mode():
 
 def disable_debug_mode():
     global DEBUG_MODE
-    DEBUG_MODE = True
+    DEBUG_MODE = False
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Fixes the bug reported in #2850. Both `enable_debug_mode` and `disable_debug_mode` previously set `DEBUG_MODE` to `True`.