### PR TITLE
Fix incompatibility with jsonschema < 4.5

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -50,9 +50,10 @@ def validate_jsonschema(spec, schema, resolver=None):
     # e.g. '#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef,
     # (Gradient|string|null)>' would be a valid $ref in a Vega-Lite schema but
     # it is not a valid URI reference due to the characters such as '<'.
-    validator = JSONSCHEMA_VALIDATOR(
-        schema, format_checker=JSONSCHEMA_VALIDATOR.FORMAT_CHECKER, resolver=resolver
-    )
+    validator_kwargs = {"resolver": resolver}
+    if hasattr(JSONSCHEMA_VALIDATOR, "FORMAT_CHECKER"):
+        validator_kwargs["format_checker"] = JSONSCHEMA_VALIDATOR.FORMAT_CHECKER
+    validator = JSONSCHEMA_VALIDATOR(schema, **validator_kwargs)
     error = jsonschema.exceptions.best_match(validator.iter_errors(spec))
     if error is not None:
         raise error

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -3,6 +3,13 @@
 Altair Change Log
 =================
 
+Version 4.2.2 (released XXX YY, 2023)
+-------------------------------------
+
+Bug Fixes
+~~~~~~~~~
+- Fix incompatibility with jsonschema < 4.17 which got introduced in Altair 4.2.1 (#2860).
+
 Version 4.2.1 (released Jan 26, 2023)
 -------------------------------------
 

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -8,7 +8,7 @@ Version 4.2.2 (released XXX YY, 2023)
 
 Bug Fixes
 ~~~~~~~~~
-- Fix incompatibility with jsonschema < 4.17 which got introduced in Altair 4.2.1 (#2860).
+- Fix incompatibility with jsonschema < 4.5 which got introduced in Altair 4.2.1 (#2860).
 
 Version 4.2.1 (released Jan 26, 2023)
 -------------------------------------

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -48,9 +48,10 @@ def validate_jsonschema(spec, schema, resolver=None):
     # e.g. '#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef,
     # (Gradient|string|null)>' would be a valid $ref in a Vega-Lite schema but
     # it is not a valid URI reference due to the characters such as '<'.
-    validator = JSONSCHEMA_VALIDATOR(
-        schema, format_checker=JSONSCHEMA_VALIDATOR.FORMAT_CHECKER, resolver=resolver
-    )
+    validator_kwargs = {"resolver": resolver}
+    if hasattr(JSONSCHEMA_VALIDATOR, "FORMAT_CHECKER"):
+        validator_kwargs["format_checker"] = JSONSCHEMA_VALIDATOR.FORMAT_CHECKER
+    validator = JSONSCHEMA_VALIDATOR(schema, **validator_kwargs)
     error = jsonschema.exceptions.best_match(validator.iter_errors(spec))
     if error is not None:
         raise error


### PR DESCRIPTION
Fixes #2857 for a 4.2.2 release. CC @mattijn. I already added a changelog entry but without release date. I think it makes sense to release this as soon as possible if you find the time.

Tests pass against the following jsonschema versions which cover the range which is relevant for Altair:
* 3.0 (minimum version required by Altair)
* 4.0
* 4.4
* 4.5
* 4.16.0
* 4.17.3 (newest version)
* 4.17.3 with all format checks installed (this caused the original issue which was already fixed in Altair v4.2.1)

The `FORMAT_CHECKER` attribute on jsonschema validators was introduced in [version 4.5 of jsonschema](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.5.0). Therefore, the compatibility looks as follows:
* Altair 4.2.0 works with jsonschema >=3,<4.17 (just tested this locally to make sure)
  * [jsonschema 4.17](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.17.0) introduced format validation on schemas which causes an issue which is fixed in Altair 4.2.1
* Altair 4.2.1 works with jsonschema >=4.5 (just tested this locally to make sure)
  * Altair 4.2.1 requires the `FORMAT_CHECKER` attribute on validator classes which was only introduced in [jsonschema 4.5](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.5.0)
* Altair 4.2.2 would work with jsonschema >= 3.0

This issue has already been fixed in the master branch in https://github.com/altair-viz/altair/pull/2812/commits/29ad5e95f6a90c4ad07d45bbdbb387eb28ee80b5.



