### PR TITLE
Reformat code base with black version 23 and restrict version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: "3.10"
     - name: Check formatting with black
       run: |
-        pip install black
+        pip install "black<24"
         black --diff --color .
         black --check .
     - name: Lint with flake8

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2869,7 +2869,6 @@ def _remove_duplicate_params(layer):
     found_params = []
 
     for subchart in subcharts:
-
         if (not hasattr(subchart, "params")) or (subchart.params is Undefined):
             continue
 
@@ -2897,7 +2896,6 @@ def _remove_duplicate_params(layer):
 
 
 def _combine_subchart_params(params, subcharts):
-
     if params is Undefined:
         params = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-black
+black<24
 ipython
 flake8
 pytest

--- a/tests/utils/tests/test_utils.py
+++ b/tests/utils/tests/test_utils.py
@@ -116,7 +116,6 @@ def test_sanitize_dataframe_infs():
     reason="Nullable integers not supported in pandas v{}".format(pd.__version__),
 )
 def test_sanitize_nullable_integers():
-
     df = pd.DataFrame(
         {
             "int_np": [1, 2, 3, 4, 5],

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -192,7 +192,6 @@ class SchemaInfo(object):
 
     @property
     def medium_description(self):
-
         if self.is_list():
             return "[{0}]".format(
                 ", ".join(self.child(s).short_description for s in self.schema)


### PR DESCRIPTION
The new release 23 of black also brings some slight changes to the code style, see [here](https://black.readthedocs.io/en/stable/change_log.html#id1). Currently, the black linting workflows on GitHub fail as it installs black 23 but the code base is not yet formatted according to the new rules. This blocks any new or recently changed PRs such as #2846.

This PR:
* Applies those minimal formatting changes so that the black check passes again
* Restricts black to <24 so that this does not happen again in a year (major releases happen beginning of a year)
* Adapt the black target versions to the Python versions which are supported by Altair (3.7-3.11). This is somewhat unrelated to the issue and does not have any effect on the formatting but I thought it's nice to keep this up-to-date.

@mattijn @joelostblom @ChristopherDavisUCI You'll need to update black in your dev environment with `pip install black --upgrade`. Furthermore, if you have any open PRs which are affected by this, you'll need to merge master into your PR branch once this PR is merged so that the black test passes again.