### PR TITLE
Fix Altair import in tools scripts

### DIFF
--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -12,8 +12,13 @@ from urllib import request
 
 import m2r
 
-# import schemapi from here
-sys.path.insert(0, abspath(dirname(__file__)))
+
+# Add path so that schemapi can be imported from the tools folder
+current_dir = dirname(__file__)
+sys.path.insert(0, abspath(current_dir))
+# And another path so that Altair can be imported from head. This is relevant when
+# generate_api_docs is imported in the main function
+sys.path.insert(0, abspath(join(current_dir, "..")))
 from schemapi import codegen  # noqa: E402
 from schemapi.codegen import CodeSnippet  # noqa: E402
 from schemapi.utils import (  # noqa: E402

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -634,6 +634,7 @@ def main():
     # Altair is imported after the generation of the new schema files so that
     # the API docs reflect the newest changes
     import generate_api_docs  # noqa: E402
+
     generate_api_docs.write_api_file()
 
 

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -22,7 +22,6 @@ from schemapi.utils import (  # noqa: E402
     indent_arglist,
     resolve_references,
 )
-import generate_api_docs  # noqa: E402
 
 # Map of version name to github branch name.
 SCHEMA_VERSION = {
@@ -627,6 +626,9 @@ def main():
     copy_schemapi_util()
     vegalite_main(args.skip_download)
 
+    # Altair is imported after the generation of the new schema files so that
+    # the API docs reflect the newest changes
+    import generate_api_docs  # noqa: E402
     generate_api_docs.write_api_file()
 
 


### PR DESCRIPTION
The current importing behaviour in the `tools` scripts has some inconsistencies which this PR tries to address. These issues were partially discovered in #2814.

## Issue 1: Altair is imported for `generate_api_docs` before the vegalite files are updated
The statement `import generate_api_docs` was previously at the top of `generate_schema_wrapper.py`. In `generate_api_docs.py`, one of the first statements is the import of Altair -> Altair got imported before `generate_schema_wrapper` can update the vegalite files. This was presumably not a big issue so far as this script is usually run multiple times anyway and so the api docs were updated eventually.

This PR solves this by moving the `import generate_api_docs` statement at the end of the `main` function in `generate_schema_wrapper.py`.

## Issue 2: If Altair is installed as a site-package, it might be imported instead of the currently checked out version
If you execute `python tools/generate_api_docs.py` then Python correctly uses Altair from the root folder due to the modification of `sys.path` in [the beginning of the script](https://github.com/altair-viz/altair/blob/master/tools/generate_api_docs.py#L11). However, if `generate_api_docs` is improted from `generate_schema_wrapper`, Python seems to use `sys.path` as it's defined in `generate_schema_wrapper` for the whole import procedure, i.e. `sys.path` needs to be modified to be able to import Altair before `generate_api_docs` is imported.

You can check this by installing Altair in `site-packages` with pip and then adding the following lines in `generate_api_docs.py` right after the Altair import:

```python
print("--------")
print(alt.__file__)
print("--------")
```

On the current `master` branch, when I execute `python tools/generate_schema_wrapper.py` I get the path to my `site-packages` Altair:
```
--------
/home/vscode/.local/lib/python3.11/site-packages/altair/__init__.py
--------
``` 
When I execute  `python tools/generate_api_docs.py` I get the path to the correct local version in the current folder (`/workspaces/altair`):
```
--------
/workspaces/altair/altair/__init__.py
--------
```

This PR solves this by adding the root folder to sys.path already in `generate_schema_wrapper.py` so it doesn't matter anymore if you call `python tools/generate_schema_wrapper.py` or `python tools/generate_api_docs.py`. Both now import the correct local version of Altair.

