### PR TITLE
Apply minor code formatting change in tools script

### DIFF
--- a/tools/schemapi/tests/test_schemapi.py
+++ b/tools/schemapi/tests/test_schemapi.py
@@ -461,7 +461,7 @@ def chart_example_invalid_y_option_value_with_condition():
 
 
 @pytest.mark.parametrize(
-    "chart_func,expected_error_message",
+    "chart_func, expected_error_message",
     [
         (
             chart_example_invalid_y_option,


### PR DESCRIPTION
In #2842 I applied this change in `tests/utils/tests/test_schemapi.py` instead of `tools/schemapi/tests/test_schemapi.py`. This fixes it so that `python tools/generate_schema_wrapper.py` again runs through without any changes.