### PR TITLE
Use most specific class possible in schema validation errors

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -159,15 +159,18 @@ class SchemaValidationError(jsonschema.ValidationError):
         self._additional_errors = getattr(err, "_additional_errors", [])
 
     def __str__(self):
-        try:
-            class_name_raw = self.absolute_path[-1]
-            class_name = class_name_raw[0].upper() + class_name_raw[1:]
-            cls = getattr(vegalite, class_name)
-        except (IndexError, AttributeError):
-            # IndexError if self.absolute_path has 0 length
-            # AttributeError if vegalite does not have attribute class_name
-            # Fall back on class of top-level object which created
-            # the SchemaValidationError. Often this is altair.Chart
+        # Try to get the lowest class possible in the chart hierarchy so
+        # it can be displayed in the error message. This should lead to more informative
+        # error messages pointing the user closer to the source of the issue.
+        for prop_name in reversed(self.absolute_path):
+            potential_class_name = prop_name[0].upper() + prop_name[1:]
+            cls = getattr(vegalite, potential_class_name, None)
+            if cls is not None:
+                break
+        else:
+            # Did not find a suitable class based on traversing the path so we fall
+            # back on the class of the top-level object which created
+            # the SchemaValidationError
             cls = self.obj.__class__
         schema_path = ["{}.{}".format(cls.__module__, cls.__name__)]
         schema_path.extend(self.schema_path)

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -174,7 +174,7 @@ class SchemaValidationError(jsonschema.ValidationError):
         schema_path = "->".join(
             str(val)
             for val in schema_path[:-1]
-            if val not in ("properties", "additionalProperties", "patternProperties")
+            if val not in (0, "properties", "additionalProperties", "patternProperties")
         )
         message = self.message
         if self._additional_errors:

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -163,10 +163,12 @@ class SchemaValidationError(jsonschema.ValidationError):
         # it can be displayed in the error message. This should lead to more informative
         # error messages pointing the user closer to the source of the issue.
         for prop_name in reversed(self.absolute_path):
-            potential_class_name = prop_name[0].upper() + prop_name[1:]
-            cls = getattr(vegalite, potential_class_name, None)
-            if cls is not None:
-                break
+            # Check if str as e.g. first item can be a 0
+            if isinstance(prop_name, str):
+                potential_class_name = prop_name[0].upper() + prop_name[1:]
+                cls = getattr(vegalite, potential_class_name, None)
+                if cls is not None:
+                    break
         else:
             # Did not find a suitable class based on traversing the path so we fall
             # back on the class of the top-level object which created

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -159,7 +159,16 @@ class SchemaValidationError(jsonschema.ValidationError):
         self._additional_errors = getattr(err, "_additional_errors", [])
 
     def __str__(self):
-        cls = self.obj.__class__
+        try:
+            class_name_raw = self.absolute_path[-1]
+            class_name = class_name_raw[0].upper() + class_name_raw[1:]
+            cls = getattr(vegalite, class_name)
+        except (IndexError, AttributeError):
+            # IndexError if self.absolute_path has 0 length
+            # AttributeError if vegalite does not have attribute class_name
+            # Fall back on class of top-level object which created
+            # the SchemaValidationError. Often this is altair.Chart
+            cls = self.obj.__class__
         schema_path = ["{}.{}".format(cls.__module__, cls.__name__)]
         schema_path.extend(self.schema_path)
         schema_path = "->".join(

--- a/tests/utils/tests/test_schemapi.py
+++ b/tests/utils/tests/test_schemapi.py
@@ -467,30 +467,36 @@ def chart_example_invalid_y_option_value_with_condition():
     [
         (
             chart_example_invalid_y_option,
-            r"Additional properties are not allowed \('unknown' was unexpected\)",
+            r"schema.channels.X.*"
+            + r"Additional properties are not allowed \('unknown' was unexpected\)",
         ),
         (
             chart_example_invalid_y_option_value,
-            r"'asdf' is not one of \['zero', 'center', 'normalize'\].*"
+            r"schema.channels.Y.*"
+            + r"'asdf' is not one of \['zero', 'center', 'normalize'\].*"
             + r"'asdf' is not of type 'null'.*'asdf' is not of type 'boolean'",
         ),
         (
             chart_example_layer,
-            r"Additional properties are not allowed \('width' was unexpected\)",
+            r"api.VConcatChart.*"
+            + r"Additional properties are not allowed \('width' was unexpected\)",
         ),
         (
             chart_example_invalid_y_option_value_with_condition,
-            r"'asdf' is not one of \['zero', 'center', 'normalize'\].*"
+            r"schema.channels.Y.*"
+            + r"'asdf' is not one of \['zero', 'center', 'normalize'\].*"
             + r"'asdf' is not of type 'null'.*'asdf' is not of type 'boolean'",
         ),
         (
             chart_example_hconcat,
-            r"\{'text': 'Horsepower', 'align': 'right'\} is not of type 'string'.*"
+            r"schema.core.TitleParams.*"
+            + r"\{'text': 'Horsepower', 'align': 'right'\} is not of type 'string'.*"
             + r"\{'text': 'Horsepower', 'align': 'right'\} is not of type 'array'",
         ),
         (
             chart_example_invalid_channel_and_condition,
-            r"Additional properties are not allowed \('invalidChannel' was unexpected\)",
+            r"schema.core.Encoding->encoding.*"
+            + r"Additional properties are not allowed \('invalidChannel' was unexpected\)",
         ),
     ],
 )

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -157,7 +157,16 @@ class SchemaValidationError(jsonschema.ValidationError):
         self._additional_errors = getattr(err, "_additional_errors", [])
 
     def __str__(self):
-        cls = self.obj.__class__
+        try:
+            class_name_raw = self.absolute_path[-1]
+            class_name = class_name_raw[0].upper() + class_name_raw[1:]
+            cls = getattr(vegalite, class_name)
+        except (IndexError, AttributeError):
+            # IndexError if self.absolute_path has 0 length
+            # AttributeError if vegalite does not have attribute class_name
+            # Fall back on class of top-level object which created
+            # the SchemaValidationError. Often this is altair.Chart
+            cls = self.obj.__class__
         schema_path = ["{}.{}".format(cls.__module__, cls.__name__)]
         schema_path.extend(self.schema_path)
         schema_path = "->".join(

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -172,7 +172,7 @@ class SchemaValidationError(jsonschema.ValidationError):
         schema_path = "->".join(
             str(val)
             for val in schema_path[:-1]
-            if val not in ("properties", "additionalProperties", "patternProperties")
+            if val not in (0, "properties", "additionalProperties", "patternProperties")
         )
         message = self.message
         if self._additional_errors:

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -157,15 +157,18 @@ class SchemaValidationError(jsonschema.ValidationError):
         self._additional_errors = getattr(err, "_additional_errors", [])
 
     def __str__(self):
-        try:
-            class_name_raw = self.absolute_path[-1]
-            class_name = class_name_raw[0].upper() + class_name_raw[1:]
-            cls = getattr(vegalite, class_name)
-        except (IndexError, AttributeError):
-            # IndexError if self.absolute_path has 0 length
-            # AttributeError if vegalite does not have attribute class_name
-            # Fall back on class of top-level object which created
-            # the SchemaValidationError. Often this is altair.Chart
+        # Try to get the lowest class possible in the chart hierarchy so
+        # it can be displayed in the error message. This should lead to more informative
+        # error messages pointing the user closer to the source of the issue.
+        for prop_name in reversed(self.absolute_path):
+            potential_class_name = prop_name[0].upper() + prop_name[1:]
+            cls = getattr(vegalite, potential_class_name, None)
+            if cls is not None:
+                break
+        else:
+            # Did not find a suitable class based on traversing the path so we fall
+            # back on the class of the top-level object which created
+            # the SchemaValidationError
             cls = self.obj.__class__
         schema_path = ["{}.{}".format(cls.__module__, cls.__name__)]
         schema_path.extend(self.schema_path)

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -161,10 +161,12 @@ class SchemaValidationError(jsonschema.ValidationError):
         # it can be displayed in the error message. This should lead to more informative
         # error messages pointing the user closer to the source of the issue.
         for prop_name in reversed(self.absolute_path):
-            potential_class_name = prop_name[0].upper() + prop_name[1:]
-            cls = getattr(vegalite, potential_class_name, None)
-            if cls is not None:
-                break
+            # Check if str as e.g. first item can be a 0
+            if isinstance(prop_name, str):
+                potential_class_name = prop_name[0].upper() + prop_name[1:]
+                cls = getattr(vegalite, potential_class_name, None)
+                if cls is not None:
+                    break
         else:
             # Did not find a suitable class based on traversing the path so we fall
             # back on the class of the top-level object which created

--- a/tools/schemapi/tests/test_schemapi.py
+++ b/tools/schemapi/tests/test_schemapi.py
@@ -465,30 +465,36 @@ def chart_example_invalid_y_option_value_with_condition():
     [
         (
             chart_example_invalid_y_option,
-            r"Additional properties are not allowed \('unknown' was unexpected\)",
+            r"schema.channels.X.*"
+            + r"Additional properties are not allowed \('unknown' was unexpected\)",
         ),
         (
             chart_example_invalid_y_option_value,
-            r"'asdf' is not one of \['zero', 'center', 'normalize'\].*"
+            r"schema.channels.Y.*"
+            + r"'asdf' is not one of \['zero', 'center', 'normalize'\].*"
             + r"'asdf' is not of type 'null'.*'asdf' is not of type 'boolean'",
         ),
         (
             chart_example_layer,
-            r"Additional properties are not allowed \('width' was unexpected\)",
+            r"api.VConcatChart.*"
+            + r"Additional properties are not allowed \('width' was unexpected\)",
         ),
         (
             chart_example_invalid_y_option_value_with_condition,
-            r"'asdf' is not one of \['zero', 'center', 'normalize'\].*"
+            r"schema.channels.Y.*"
+            + r"'asdf' is not one of \['zero', 'center', 'normalize'\].*"
             + r"'asdf' is not of type 'null'.*'asdf' is not of type 'boolean'",
         ),
         (
             chart_example_hconcat,
-            r"\{'text': 'Horsepower', 'align': 'right'\} is not of type 'string'.*"
+            r"schema.core.TitleParams.*"
+            + r"\{'text': 'Horsepower', 'align': 'right'\} is not of type 'string'.*"
             + r"\{'text': 'Horsepower', 'align': 'right'\} is not of type 'array'",
         ),
         (
             chart_example_invalid_channel_and_condition,
-            r"Additional properties are not allowed \('invalidChannel' was unexpected\)",
+            r"schema.core.Encoding->encoding.*"
+            + r"Additional properties are not allowed \('invalidChannel' was unexpected\)",
         ),
     ],
 )


### PR DESCRIPTION
Addresses https://github.com/altair-viz/altair/pull/2568#discussion_r1096814378

Works already well but I'll still want to

- [x] Extend existing and add new tests to check if correct class name appears in error message
- [x] Test against multiple `jsonschema` versions (3, 4, 4.5, 4.16, 4.17)