### PR TITLE
Support DataFrame Interchange Protocol (allow Polars DataFrames)

### DIFF
--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -156,9 +156,12 @@ def to_values(data):
             raise KeyError("values expected in data dict, but not present.")
         return data
     elif hasattr(data, "__dataframe__"):
-        # only support for polars dataframe
+        # here we like to provide agnostic dataframe support
+        # we start with experimental support for polars dataframe
         if "polars" in type(data).__module__:
-            # currently no sanization on the data
+            # currently the polars function .to_dicts() is used to retrieve the data
+            # but here we would like to explore options using the .__dataframe__()
+            # currently no sanitization on the data
             return {"values": data.to_dicts()}
 
 

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -235,6 +235,7 @@ def _data_to_csv_string(data):
         pi = import_pyarrow_interchange()
         import pyarrow as pa
         import pyarrow.csv as pa_csv
+
         pa_table = pi.from_dataframe(data)
         csv_buffer = pa.BufferOutputStream()
         pa_csv.write_csv(pa_table, csv_buffer)
@@ -271,17 +272,22 @@ def curry(*args, **kwargs):
     )
     return curried.curry(*args, **kwargs)
 
+
 def import_pyarrow_interchange():
     import pkg_resources
+
     try:
         pkg_resources.require("pyarrow>=11.0.0")
         # The package is installed and meets the minimum version requirement
         import pyarrow.interchange as pi
+
         return pi
     except pkg_resources.DistributionNotFound:
         # The package is not installed
         raise ImportError("The package 'pyarrow' is required, but not installed")
     except pkg_resources.VersionConflict:
         # The package is installed but does not meet the minimum version requirement
-        raise ImportError("The installed version of 'pyarrow' does not meet "
-                          "the minimum requirement of version 11.0.0.")
+        raise ImportError(
+            "The installed version of 'pyarrow' does not meet "
+            "the minimum requirement of version 11.0.0."
+        )

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -284,10 +284,12 @@ def import_pyarrow_interchange():
         return pi
     except pkg_resources.DistributionNotFound:
         # The package is not installed
-        raise ImportError("The package 'pyarrow' is required, but not installed")
+        raise ImportError(
+            "Usage of the DataFrame Interchange Protocol requires the package 'pyarrow', but it is not installed."
+        )
     except pkg_resources.VersionConflict:
         # The package is installed but does not meet the minimum version requirement
         raise ImportError(
-            "The installed version of 'pyarrow' does not meet "
-            "the minimum requirement of version 11.0.0."
+            "The installed version of 'pyarrow' does not meet the minimum requirement of version 11.0.0. "
+            "Please update 'pyarrow' to use the DataFrame Interchange Protocol."
         )

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -105,8 +105,7 @@ def _prepare_data(data, context=None):
         data = core.UrlData(data)
 
     elif hasattr(data, "__dataframe__"):
-        if "polars" in type(data).__module__:
-            data = _pipe(data, data_transformers.get())
+        data = _pipe(data, data_transformers.get())
 
     # consolidate inline data to top-level datasets
     if context is not None and data_transformers.consolidate_datasets:

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -8,6 +8,7 @@ import jsonschema
 import pandas as pd
 from toolz.curried import pipe as _pipe
 import itertools
+from importlib.util import find_spec
 
 from .schema import core, channels, mixins, Undefined, SCHEMA_URL
 
@@ -107,6 +108,11 @@ def _prepare_data(data, context=None):
     # consolidate inline data to top-level datasets
     if context is not None and data_transformers.consolidate_datasets:
         data = _consolidate_data(data, context)
+
+    if find_spec('polars'):
+        import polars as pl
+        if isinstance(data, pl.DataFrame):
+            data = core.Data({"values": data.write_json(row_oriented=True)})
 
     # if data is still not a recognized type, then return
     if not isinstance(data, (dict, core.Data)):

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -109,8 +109,9 @@ def _prepare_data(data, context=None):
     if context is not None and data_transformers.consolidate_datasets:
         data = _consolidate_data(data, context)
 
-    if find_spec('polars'):
+    if find_spec("polars"):
         import polars as pl
+
         if isinstance(data, pl.DataFrame):
             data = core.Data({"values": data.write_json(row_oriented=True)})
 

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -22,7 +22,7 @@ Enhancements
 - The documentation page has been revamped, both in terms of appearance and content.
 - More informative autocompletion by removing deprecated methods (#2814) and adding support for completion in method chains for editors that rely on type hints (e.g. VS Code) (#2846)
 - Improved error messages (#2842)
-- Include experimental support for the DataFrame Interchange Protocol (through `__dataframe__`. This is dependent on `pyarrow>=11.0.0` (#2888)
+- Include experimental support for the DataFrame Interchange Protocol (through `__dataframe__` attribute). This requires `pyarrow>=11.0.0` (#2888).
 
 Grammar Changes
 ~~~~~~~~~~~~~~~

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -22,6 +22,7 @@ Enhancements
 - The documentation page has been revamped, both in terms of appearance and content.
 - More informative autocompletion by removing deprecated methods (#2814) and adding support for completion in method chains for editors that rely on type hints (e.g. VS Code) (#2846)
 - Improved error messages (#2842)
+- Include experimental support for the DataFrame Interchange Protocol (through `__dataframe__`. This is dependent on `pyarrow>=11.0.0` (#2888)
 
 Grammar Changes
 ~~~~~~~~~~~~~~~

--- a/doc/user_guide/data.rst
+++ b/doc/user_guide/data.rst
@@ -21,6 +21,7 @@ there are many different ways of specifying a dataset:
 - as a url string pointing to a ``json`` or ``csv`` formatted text file
 - as a `geopandas GeoDataFrame <http://geopandas.org/data_structures.html#geodataframe>`_, `Shapely Geometries <https://shapely.readthedocs.io/en/latest/manual.html#geometric-objects>`_, `GeoJSON Objects <https://github.com/jazzband/geojson#geojson-objects>`_ or other objects that support the ``__geo_interface__``
 - as a generated dataset such as numerical sequences or geographic reference elements
+- as a DataFrame that supports the DataFrame Interchange Protocol (contains a `__dataframe__` attribute). This is experimental.
 
 When data is specified as a DataFrame, the encoding is quite simple, as Altair
 uses the data type information provided by pandas to automatically determine


### PR DESCRIPTION
Based on the discussion in https://github.com/altair-viz/altair/issues/2868, this is an attempt to provide modest support for specifying data as a Polars DataFrame.  We do not convert to a pandas DataFrame, so at this point, the encoding type (e.g., `"Q"`, `"N"`, ...) needs to be specified explicitly.  (My reasoning is that it would be easier to add type inference later than to take it away.)

Example:

```
import polars as pl
import altair as alt

df = pl.DataFrame(
    {
        "A": [1, 2, 3, 4, 5],
        "cars": ["beetle", "audi", "beetle", "beetle", "beetle"],
        "optional": [28, 300, None, 2, -30],
    }
)

alt.Chart(df).mark_bar().encode(
    x="A:O",
    y="optional:Q",
    color="cars:N"
)
```

<img width="196" alt="Screenshot 2023-02-14 at 4 12 47 PM" src="https://user-images.githubusercontent.com/82750240/218892279-8df97d12-aaaf-4f0c-a180-a8e87dfdbf5f.png">
