### PR TITLE
Report filename of failing test

### DIFF
--- a/tests/tests/test_examples.py
+++ b/tests/tests/test_examples.py
@@ -35,9 +35,17 @@ def test_render_examples_to_chart(syntax_module):
 
         if chart is None:
             raise ValueError(
-                "Example file should define chart in its final " "statement."
+                f"Example file {filename} should define chart in its final "
+                "statement."
             )
-        assert isinstance(chart.to_dict(), dict)
+
+        try:
+            assert isinstance(chart.to_dict(), dict)
+        except Exception as e:
+            raise AssertionError(
+                f"Example file {filename} raised an exception when "
+                f"converting to a dict: {e}"
+            )
 
 
 # We do not apply the save_engine mark to this test. This mark is used in


### PR DESCRIPTION
In another PR, a change was causing the `test_render_examples_to_chart` test to fail, but I had a hard time locating which specific example was failing.  This PR is an attempt to report the filename.

I tested this PR by temporarily adding an error to one of the example files (I used `:ON` rather than `:O` for an encoding type shorthand).  This is what was reported to me by VS Code:

<img width="562" alt="Screenshot 2023-02-15 at 9 48 11 AM" src="https://user-images.githubusercontent.com/82750240/219112433-d69269e1-79ff-4e23-b41a-0eddf8646fed.png">