### PR TITLE
Add announcement to docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,6 +155,7 @@ html_theme_options = {
         },
     ],
     "header_links_before_dropdown": 6,
+    "announcement": "This website is for Vega-Altair v5 (release candidate). Visit the <a href='https://altair-viz.github.io/altair-viz-v4/'>Vega-Altair v4 homepage</a> for previous release documentation.",
 }
 
 html_context = {"default_mode": "light"}


### PR DESCRIPTION
This PR adds an announcement to the documentation page mentioning:

> This website is for Vega-Altair v5 (release candidate). Visit the [Vega-Altair v4 homepage](https://altair-viz.github.io/altair-viz-v4/) for previous release documentation.

It looks as follow.
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/5186265/219494404-11b05c1c-8d93-40fd-abce-30a7891ffccc.png">

I think we will need this at least temporarily.