### PR TITLE
Add missing attribute descriptions

### DIFF
--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -94,8 +94,6 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
     """Angle schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -433,8 +431,6 @@ class AngleDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefnum
     """AngleDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -615,8 +611,6 @@ class Color(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
     """Color schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -954,8 +948,6 @@ class ColorDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefGra
     """ColorDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -1449,8 +1441,6 @@ class Description(FieldChannelMixin, core.StringFieldDefWithCondition):
     """Description schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -2376,8 +2366,6 @@ class Fill(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefG
     """Fill schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -2715,8 +2703,6 @@ class FillDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefGrad
     """FillDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -2897,8 +2883,6 @@ class FillOpacity(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFi
     """FillOpacity schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -3236,8 +3220,6 @@ class FillOpacityDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatum
     """FillOpacityDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -3418,8 +3400,6 @@ class Href(FieldChannelMixin, core.StringFieldDefWithCondition):
     """Href schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -5251,8 +5231,6 @@ class Opacity(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldD
     """Opacity schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -5590,8 +5568,6 @@ class OpacityDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefn
     """OpacityDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -7220,8 +7196,6 @@ class Shape(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
     """Shape schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -7559,8 +7533,6 @@ class ShapeDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefstr
     """ShapeDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -7741,8 +7713,6 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
     """Size schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -8080,8 +8050,6 @@ class SizeDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefnumb
     """SizeDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -8262,8 +8230,6 @@ class Stroke(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDe
     """Stroke schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -8601,8 +8567,6 @@ class StrokeDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefGr
     """StrokeDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -8783,8 +8747,6 @@ class StrokeDash(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFie
     """StrokeDash schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -9122,8 +9084,6 @@ class StrokeDashDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumD
     """StrokeDashDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -9304,8 +9264,6 @@ class StrokeOpacity(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkProp
     """StrokeOpacity schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -9643,8 +9601,6 @@ class StrokeOpacityDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDat
     """StrokeOpacityDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -9825,8 +9781,6 @@ class StrokeWidth(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFi
     """StrokeWidth schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -10164,8 +10118,6 @@ class StrokeWidthDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatum
     """StrokeWidthDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -10346,8 +10298,6 @@ class Text(FieldChannelMixin, core.FieldOrDatumDefWithConditionStringFieldDefTex
     """Text schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -10637,8 +10587,6 @@ class TextDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionStringDatumD
     """TextDatum schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -11729,8 +11677,6 @@ class Tooltip(FieldChannelMixin, core.StringFieldDefWithCondition):
     """Tooltip schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -12056,8 +12002,6 @@ class Url(FieldChannelMixin, core.StringFieldDefWithCondition):
     """Url schema wrapper
 
     Mapping(required=[shorthand])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -164,7 +164,7 @@ class AreaConfig(AnyMarkConfig):
         mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
         value can be used.
 
-        __Default value: ``"source-over"``
+        __Default value:__ ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 
@@ -1593,7 +1593,7 @@ class BarConfig(AnyMarkConfig):
         mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
         value can be used.
 
-        __Default value: ``"source-over"``
+        __Default value:__ ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 
@@ -8011,7 +8011,7 @@ class LineConfig(AnyMarkConfig):
         mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
         value can be used.
 
-        __Default value: ``"source-over"``
+        __Default value:__ ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 
@@ -8553,7 +8553,7 @@ class MarkConfig(AnyMarkConfig):
         mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
         value can be used.
 
-        __Default value: ``"source-over"``
+        __Default value:__ ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 
@@ -8980,7 +8980,7 @@ class MarkDef(AnyMark):
         mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
         value can be used.
 
-        __Default value: ``"source-over"``
+        __Default value:__ ``"source-over"``
     clip : boolean
         Whether a mark be clipped to the enclosing group’s width and height.
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
@@ -10988,7 +10988,7 @@ class OverlayMarkDef(VegaLiteSchema):
         mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
         value can be used.
 
-        __Default value: ``"source-over"``
+        __Default value:__ ``"source-over"``
     clip : boolean
         Whether a mark be clipped to the enclosing group’s width and height.
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
@@ -13393,7 +13393,7 @@ class RectConfig(AnyMarkConfig):
         mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
         value can be used.
 
-        __Default value: ``"source-over"``
+        __Default value:__ ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 
@@ -18068,7 +18068,7 @@ class TickConfig(AnyMarkConfig):
         mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
         value can be used.
 
-        __Default value: ``"source-over"``
+        __Default value:__ ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -5757,8 +5757,6 @@ class FieldOrDatumDefWithConditionStringFieldDefstring(VegaLiteSchema):
     """FieldOrDatumDefWithConditionStringFieldDefstring schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -9450,8 +9448,6 @@ class FieldOrDatumDefWithConditionDatumDefGradientstringnull(ColorDef, MarkPropD
     """FieldOrDatumDefWithConditionDatumDefGradientstringnull schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -9574,8 +9570,6 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull(ColorDef, M
     """FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -9974,8 +9968,6 @@ class FieldOrDatumDefWithConditionDatumDefnumberArray(MarkPropDefnumberArray, Nu
     """FieldOrDatumDefWithConditionDatumDefnumberArray schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -10097,8 +10089,6 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray(MarkPropDefnumberA
     """FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -10353,8 +10343,6 @@ class FieldOrDatumDefWithConditionDatumDefnumber(MarkPropDefnumber, NumericMarkP
     """FieldOrDatumDefWithConditionDatumDefnumber schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -10476,8 +10464,6 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumber(MarkPropDefnumber, Nume
     """FieldOrDatumDefWithConditionMarkPropFieldDefnumber schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -15509,8 +15495,6 @@ class FieldOrDatumDefWithConditionDatumDefstringnull(MarkPropDefstringnullTypeFo
     """FieldOrDatumDefWithConditionDatumDefstringnull schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -15632,8 +15616,6 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull(MarkPro
     """FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -17264,8 +17246,6 @@ class StringFieldDefWithCondition(VegaLiteSchema):
     """StringFieldDefWithCondition schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -17634,8 +17614,6 @@ class FieldOrDatumDefWithConditionStringDatumDefText(TextDef):
     """FieldOrDatumDefWithConditionStringDatumDefText schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------
@@ -17793,8 +17771,6 @@ class FieldOrDatumDefWithConditionStringFieldDefText(TextDef):
     """FieldOrDatumDefWithConditionStringFieldDefText schema wrapper
 
     Mapping(required=[])
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
 
     Attributes
     ----------

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -96,6 +96,7 @@ class AnyMark(VegaLiteSchema):
     """AnyMark schema wrapper
 
     anyOf(:class:`CompositeMark`, :class:`CompositeMarkDef`, :class:`Mark`, :class:`MarkDef`)
+    All types of primitive marks.
     """
     _schema = {'$ref': '#/definitions/AnyMark'}
 
@@ -129,15 +130,25 @@ class AreaConfig(AnyMarkConfig):
 
         **Note:** Expression reference is *not* supported for range marks.
     angle : anyOf(float, :class:`ExprRef`)
-
+        The rotation angle of the text, in degrees.
     aria : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG element, removing the mark item from the ARIA accessibility tree.
     ariaRole : anyOf(string, :class:`ExprRef`)
-
+        Sets the type of user interface element of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "role" attribute. Warning: this
+        property is experimental and may be changed in the future.
     ariaRoleDescription : anyOf(string, :class:`ExprRef`)
-
+        A human-readable, author-localized description for the role of the mark item for
+        `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "aria-roledescription" attribute.
+        Warning: this property is experimental and may be changed in the future.
     aspect : anyOf(boolean, :class:`ExprRef`)
-
+        Whether to keep aspect ratio of image marks.
     baseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
         For text marks, the vertical text baseline. One of ``"alphabetic"`` (default),
         ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, ``"line-bottom"``, or an
@@ -150,7 +161,11 @@ class AreaConfig(AnyMarkConfig):
 
         **Note:** Expression reference is *not* supported for range marks.
     blend : anyOf(:class:`Blend`, :class:`ExprRef`)
+        The color blend mode for drawing an item on its current background. Any valid `CSS
+        mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
+        value can be used.
 
+        __Default value: ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 
@@ -165,36 +180,61 @@ class AreaConfig(AnyMarkConfig):
         * The ``fill`` and ``stroke`` properties have higher precedence than ``color`` and
           will override ``color``.
     cornerRadius : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles or arcs' corners.
 
+        **Default value:** ``0``
     cornerRadiusBottomLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom left corner.
 
+        **Default value:** ``0``
     cornerRadiusBottomRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top left corner.
 
+        **Default value:** ``0``
     cursor : anyOf(:class:`Cursor`, :class:`ExprRef`)
-
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__.
     dir : anyOf(:class:`TextDirection`, :class:`ExprRef`)
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
 
+        **Default value:** ``"ltr"``
     dx : anyOf(float, :class:`ExprRef`)
-
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     dy : anyOf(float, :class:`ExprRef`)
-
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     ellipsis : anyOf(string, :class:`ExprRef`)
+        The ellipsis string for text truncated in response to the limit parameter.
 
+        **Default value:** ``"…"``
     endAngle : anyOf(float, :class:`ExprRef`)
-
+        The end angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     fill : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
         **Default value:** (None)
     fillOpacity : anyOf(float, :class:`ExprRef`)
+        The fill opacity (value between [0,1]).
 
+        **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
 
@@ -206,24 +246,48 @@ class AreaConfig(AnyMarkConfig):
         **Note:** This property cannot be used in a `style config
         <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
     font : anyOf(string, :class:`ExprRef`)
-
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : anyOf(float, :class:`ExprRef`)
+        The font size, in pixels.
 
+        **Default value:** ``11``
     fontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style (e.g., ``"italic"`` ).
     fontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     height : anyOf(float, :class:`ExprRef`)
-
+        Height of the marks.
     href : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     innerRadius : anyOf(float, :class:`ExprRef`)
         The inner radius in pixels of arc marks. ``innerRadius`` is an alias for
         ``radius2``.
 
         **Default value:** ``0``
     interpolate : anyOf(:class:`Interpolate`, :class:`ExprRef`)
+        The line interpolation method to use for line and area marks. One of the following:
 
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
     invalid : enum('filter', None)
         Defines how Vega-Lite should handle marks for invalid values ( ``null`` and ``NaN``
         ).
@@ -234,7 +298,10 @@ class AreaConfig(AnyMarkConfig):
         * If ``null``, all data items are included. In this case, invalid values will be
           interpreted as zeroes.
     limit : anyOf(float, :class:`ExprRef`)
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
 
+        **Default value:** ``0`` -- indicating no limit
     line : anyOf(boolean, :class:`OverlayMarkDef`)
         A flag for overlaying line on top of area marks, or an object defining the
         properties of the overlayed lines.
@@ -247,9 +314,11 @@ class AreaConfig(AnyMarkConfig):
 
         **Default value:** ``false``.
     lineBreak : anyOf(string, :class:`ExprRef`)
-
+        A delimiter, such as a newline character, upon which to break text strings into
+        multiple lines. This property is ignored if the text is array-valued.
     lineHeight : anyOf(float, :class:`ExprRef`)
-
+        The line height in pixels (the spacing between subsequent lines of text) for
+        multi-line text marks.
     opacity : anyOf(float, :class:`ExprRef`)
         The overall opacity (value between [0,1]).
 
@@ -275,7 +344,7 @@ class AreaConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     padAngle : anyOf(float, :class:`ExprRef`)
-
+        The angular padding applied to sides of the arc, in radians.
     point : anyOf(boolean, :class:`OverlayMarkDef`, string)
         A flag for overlaying points on top of line or area marks, or an object defining the
         properties of the overlayed points.
@@ -303,7 +372,20 @@ class AreaConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     shape : anyOf(anyOf(:class:`SymbolShape`, string), :class:`ExprRef`)
+        Shape of the point marks. Supported values include:
 
+
+        * plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
+          ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
+          ``"triangle-left"``.
+        * the line symbol ``"stroke"``
+        * centered directional shapes ``"arrow"``, ``"wedge"``, or ``"triangle"``
+        * a custom `SVG path string
+          <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ (For correct
+          sizing, custom shape paths should be defined within a square bounding box with
+          coordinates ranging from -1 to 1 along both the x and y dimensions.)
+
+        **Default value:** ``"circle"``
     size : anyOf(float, :class:`ExprRef`)
         Default size for marks.
 
@@ -322,34 +404,48 @@ class AreaConfig(AnyMarkConfig):
         * ``5`` for bar marks with continuous dimensions;
         * ``11`` for text marks.
     smooth : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag (default true) indicating if the image should be smoothed when
+        resized. If false, individual pixels should be scaled directly rather than
+        interpolated with smoothing. For SVG rendering, this option may not work in some
+        browsers due to lack of standardization.
     startAngle : anyOf(float, :class:`ExprRef`)
-
+        The start angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     stroke : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
         **Default value:** (None)
     strokeCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     strokeDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeJoin : anyOf(:class:`StrokeJoin`, :class:`ExprRef`)
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
 
+        **Default value:** ``"miter"``
     strokeMiterLimit : anyOf(float, :class:`ExprRef`)
-
+        The miter limit at which to bevel a line join.
     strokeOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset in pixels at which to draw the group stroke and fill. If unspecified, the
+        default behavior is to dynamically offset stroked groups such that 1 pixel stroke
+        widths align with the pixel grid.
     strokeOpacity : anyOf(float, :class:`ExprRef`)
+        The stroke opacity (value between [0,1]).
 
+        **Default value:** ``1``
     strokeWidth : anyOf(float, :class:`ExprRef`)
-
+        The stroke width, in pixels.
     tension : anyOf(float, :class:`ExprRef`)
-
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
     text : anyOf(:class:`Text`, :class:`ExprRef`)
-
+        Placeholder text if the ``text`` channel is not specified
     theta : anyOf(float, :class:`ExprRef`)
         For arc marks, the arc length in radians if theta2 is not specified, otherwise the
         start arc angle. (A value of 0 indicates up or “north”, increasing values proceed
@@ -383,9 +479,9 @@ class AreaConfig(AnyMarkConfig):
 
         **Default value:** ``null``
     url : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        The URL of the image file for image marks.
     width : anyOf(float, :class:`ExprRef`)
-
+        Width of the marks.
     x : anyOf(float, string, :class:`ExprRef`)
         X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"`` without
         specified ``x2`` or ``width``.
@@ -549,28 +645,49 @@ class Axis(VegaLiteSchema):
     ----------
 
     aria : anyOf(boolean, :class:`ExprRef`)
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG group, removing the axis from the ARIA accessibility tree.
 
+        **Default value:** ``true``
     bandPosition : anyOf(float, :class:`ExprRef`)
+        An interpolation fraction indicating where, for ``band`` scales, axis ticks should
+        be positioned. A value of ``0`` places ticks at the left edge of their bands. A
+        value of ``0.5`` places ticks in the middle of their bands.
 
+        **Default value:** ``0.5``
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of this axis for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If the ``aria`` property is true, for SVG output the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__
+        will be set to this description. If the description is unspecified it will be
+        automatically generated.
     domain : boolean
         A boolean flag indicating if the domain (the axis baseline) should be included as
         part of the axis.
 
         **Default value:** ``true``
     domainCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for the domain line's ending style. One of ``"butt"``, ``"round"`` or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     domainColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
+        Color of axis domain line.
 
+        **Default value:** ``"gray"``.
     domainDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating [stroke, space] lengths for dashed domain lines.
     domainDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The pixel offset at which to start drawing with the domain dash array.
     domainOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of the axis domain line.
     domainWidth : anyOf(float, :class:`ExprRef`)
+        Stroke width of axis domain line
 
+        **Default value:** ``1``
     format : anyOf(string, :class:`Dict`)
         When used with the default ``"number"`` and ``"time"`` format type, the text
         formatting pattern for labels of guides (axes, legends, headers) and text marks.
@@ -612,27 +729,49 @@ class Axis(VegaLiteSchema):
         <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__ that are not
         binned; otherwise, ``false``.
     gridCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for grid lines' ending style. One of ``"butt"``, ``"round"`` or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     gridColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`, :class:`ConditionalAxisColor`)
+        Color of gridlines.
 
+        **Default value:** ``"lightGray"``.
     gridDash : anyOf(List(float), :class:`ExprRef`, :class:`ConditionalAxisNumberArray`)
-
+        An array of alternating [stroke, space] lengths for dashed grid lines.
     gridDashOffset : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
-
+        The pixel offset at which to start drawing with the grid dash array.
     gridOpacity : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        The stroke opacity of grid (value between [0,1])
 
+        **Default value:** ``1``
     gridWidth : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        The grid width, in pixels.
 
+        **Default value:** ``1``
     labelAlign : anyOf(:class:`Align`, :class:`ExprRef`, :class:`ConditionalAxisLabelAlign`)
-
+        Horizontal text alignment of axis tick labels, overriding the default setting for
+        the current axis orientation.
     labelAngle : anyOf(float, :class:`ExprRef`)
+        The rotation angle of the axis labels.
 
+        **Default value:** ``-90`` for nominal and ordinal fields; ``0`` otherwise.
     labelBaseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`, :class:`ConditionalAxisLabelBaseline`)
-
+        Vertical text baseline of axis tick labels, overriding the default setting for the
+        current axis orientation. One of ``"alphabetic"`` (default), ``"top"``,
+        ``"middle"``, ``"bottom"``, ``"line-top"``, or ``"line-bottom"``. The ``"line-top"``
+        and ``"line-bottom"`` values operate similarly to ``"top"`` and ``"bottom"``, but
+        are calculated relative to the *lineHeight* rather than *fontSize* alone.
     labelBound : anyOf(anyOf(float, boolean), :class:`ExprRef`)
+        Indicates if labels should be hidden if they exceed the axis range. If ``false``
+        (the default) no bounds overlap analysis is performed. If ``true``, labels will be
+        hidden if they exceed the axis range by more than 1 pixel. If this property is a
+        number, it specifies the pixel tolerance: the maximum amount by which a label
+        bounding box may exceed the axis range.
 
+        **Default value:** ``false``.
     labelColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`, :class:`ConditionalAxisColor`)
-
+        The color of the tick label, can be in hex color code or regular color name.
     labelExpr : string
         `Vega expression <https://vega.github.io/vega/docs/expressions/>`__ for customizing
         labels.
@@ -651,23 +790,33 @@ class Axis(VegaLiteSchema):
 
         **Default value:** ``true`` for axis of a continuous x-scale. Otherwise, ``false``.
     labelFlushOffset : anyOf(float, :class:`ExprRef`)
+        Indicates the number of pixels by which to offset flush-adjusted labels. For
+        example, a value of ``2`` will push flush-adjusted labels 2 pixels outward from the
+        center of the axis. Offsets can help the labels better visually group with
+        corresponding axis ticks.
 
+        **Default value:** ``0``.
     labelFont : anyOf(string, :class:`ExprRef`, :class:`ConditionalAxisString`)
-
+        The font of the tick label.
     labelFontSize : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
-
+        The font size of the label, in pixels.
     labelFontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`, :class:`ConditionalAxisLabelFontStyle`)
-
+        Font style of the title.
     labelFontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`, :class:`ConditionalAxisLabelFontWeight`)
-
+        Font weight of axis tick labels.
     labelLimit : anyOf(float, :class:`ExprRef`)
+        Maximum allowed pixel width of axis tick labels.
 
+        **Default value:** ``180``
     labelLineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line label text or label text with ``"line-top"`` or
+        ``"line-bottom"`` baseline.
     labelOffset : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        Position offset in pixels to apply to labels, in addition to tickOffset.
 
+        **Default value:** ``0``
     labelOpacity : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
-
+        The opacity of the labels.
     labelOverlap : anyOf(:class:`LabelOverlap`, :class:`ExprRef`)
         The strategy to use for resolving overlap of axis labels. If ``false`` (the
         default), no overlap reduction is attempted. If set to ``true`` or ``"parity"``, a
@@ -679,17 +828,27 @@ class Axis(VegaLiteSchema):
         **Default value:** ``true`` for non-nominal fields with non-log scales; ``"greedy"``
         for log scales; otherwise ``false``.
     labelPadding : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        The padding in pixels between labels and ticks.
 
+        **Default value:** ``2``
     labelSeparation : anyOf(float, :class:`ExprRef`)
-
+        The minimum separation that must be between label bounding boxes for them to be
+        considered non-overlapping (default ``0`` ). This property is ignored if
+        *labelOverlap* resolution is not enabled.
     labels : boolean
         A boolean flag indicating if labels should be included as part of the axis.
 
         **Default value:** ``true``.
     maxExtent : anyOf(float, :class:`ExprRef`)
+        The maximum extent in pixels that axis ticks and labels should use. This determines
+        a maximum offset value for axis titles.
 
+        **Default value:** ``undefined``.
     minExtent : anyOf(float, :class:`ExprRef`)
+        The minimum extent in pixels that axis ticks and labels should use. This determines
+        a minimum offset value for axis titles.
 
+        **Default value:** ``30`` for y-axis; ``undefined`` for x-axis.
     offset : anyOf(float, :class:`ExprRef`)
         The offset, in pixels, by which to displace the axis from the edge of the enclosing
         group or data rectangle.
@@ -719,11 +878,17 @@ class Axis(VegaLiteSchema):
         style. For example, an x-axis mark with ``"style": "foo"`` will use ``config.axisX``
         and ``config.style.foo`` (the specified style ``"foo"`` has higher precedence).
     tickBand : anyOf(enum('center', 'extent'), :class:`ExprRef`)
-
+        For band scales, indicates if ticks and grid lines should be placed at the
+        ``"center"`` of a band (default) or at the band ``"extent"`` s to indicate intervals
     tickCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for the tick lines' ending style. One of ``"butt"``, ``"round"`` or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     tickColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`, :class:`ConditionalAxisColor`)
+        The color of the axis's tick.
 
+        **Default value:** ``"gray"``
     tickCount : anyOf(float, :class:`TimeInterval`, :class:`TimeIntervalStep`, :class:`ExprRef`)
         A desired number of ticks, for axes visualizing quantitative scales. The resulting
         number may be different so that values are "nice" (multiples of 2, 5, 10) and lie
@@ -739,9 +904,9 @@ class Axis(VegaLiteSchema):
         **Default value** : Determine using a formula ``ceil(width/40)`` for x and
         ``ceil(height/40)`` for y.
     tickDash : anyOf(List(float), :class:`ExprRef`, :class:`ConditionalAxisNumberArray`)
-
+        An array of alternating [stroke, space] lengths for dashed tick mark lines.
     tickDashOffset : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
-
+        The pixel offset at which to start drawing with the tick mark dash array.
     tickExtra : boolean
         Boolean flag indicating if an extra axis tick should be added for the initial
         position of the axis. This flag is useful for styling axes for ``band`` scales such
@@ -753,18 +918,22 @@ class Axis(VegaLiteSchema):
         If ``tickMinStep`` is specified, the ``tickCount`` value will be adjusted, if
         necessary, to enforce the minimum step value.
     tickOffset : anyOf(float, :class:`ExprRef`)
-
+        Position offset in pixels to apply to ticks, labels, and gridlines.
     tickOpacity : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
-
+        Opacity of the ticks.
     tickRound : boolean
         Boolean flag indicating if pixel position values should be rounded to the nearest
         integer.
 
         **Default value:** ``true``
     tickSize : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        The size in pixels of axis ticks.
 
+        **Default value:** ``5``
     tickWidth : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        The width, in pixels, of ticks.
 
+        **Default value:** ``1``
     ticks : boolean
         Boolean value that determines whether the axis should include ticks.
 
@@ -790,37 +959,50 @@ class Axis(VegaLiteSchema):
         2) If both field definition's ``title`` and axis, header, or legend ``title`` are
         defined, axis/header/legend title will be used.
     titleAlign : anyOf(:class:`Align`, :class:`ExprRef`)
-
+        Horizontal text alignment of axis titles.
     titleAnchor : anyOf(:class:`TitleAnchor`, :class:`ExprRef`)
-
+        Text anchor position for placing axis titles.
     titleAngle : anyOf(float, :class:`ExprRef`)
-
+        Angle in degrees of axis titles.
     titleBaseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
-
+        Vertical text baseline for axis titles. One of ``"alphabetic"`` (default),
+        ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, or ``"line-bottom"``. The
+        ``"line-top"`` and ``"line-bottom"`` values operate similarly to ``"top"`` and
+        ``"bottom"``, but are calculated relative to the *lineHeight* rather than *fontSize*
+        alone.
     titleColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Color of the title, can be in hex color code or regular color name.
     titleFont : anyOf(string, :class:`ExprRef`)
-
+        Font of the title. (e.g., ``"Helvetica Neue"`` ).
     titleFontSize : anyOf(float, :class:`ExprRef`)
-
+        Font size of the title.
     titleFontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        Font style of the title.
     titleFontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        Font weight of the title. This can be either a string (e.g ``"bold"``, ``"normal"``
+        ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400``
+        and ``"bold"`` = ``700`` ).
     titleLimit : anyOf(float, :class:`ExprRef`)
-
+        Maximum allowed pixel width of axis titles.
     titleLineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line title text or title text with ``"line-top"`` or
+        ``"line-bottom"`` baseline.
     titleOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of the axis title.
     titlePadding : anyOf(float, :class:`ExprRef`)
-
+        The padding, in pixels, between title and axis.
     titleX : anyOf(float, :class:`ExprRef`)
-
+        X-coordinate of the axis title relative to the axis group.
     titleY : anyOf(float, :class:`ExprRef`)
-
+        Y-coordinate of the axis title relative to the axis group.
     translate : anyOf(float, :class:`ExprRef`)
+        Coordinate space translation offset for axis layout. By default, axes are translated
+        by a 0.5 pixel offset for both the x and y coordinates in order to align stroked
+        lines with the pixel grid. However, for vector graphics output these pixel-specific
+        adjustments may be undesirable, in which case translate can be changed (for example,
+        to zero).
 
+        **Default value:** ``0.5``
     values : anyOf(List(float), List(string), List(boolean), List(:class:`DateTime`), :class:`ExprRef`)
         Explicitly set the visible axis tick values.
     zindex : float
@@ -898,11 +1080,25 @@ class AxisConfig(VegaLiteSchema):
     ----------
 
     aria : anyOf(boolean, :class:`ExprRef`)
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG group, removing the axis from the ARIA accessibility tree.
 
+        **Default value:** ``true``
     bandPosition : anyOf(float, :class:`ExprRef`)
+        An interpolation fraction indicating where, for ``band`` scales, axis ticks should
+        be positioned. A value of ``0`` places ticks at the left edge of their bands. A
+        value of ``0.5`` places ticks in the middle of their bands.
 
+        **Default value:** ``0.5``
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of this axis for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If the ``aria`` property is true, for SVG output the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__
+        will be set to this description. If the description is unspecified it will be
+        automatically generated.
     disable : boolean
         Disable axis by default.
     domain : boolean
@@ -911,17 +1107,24 @@ class AxisConfig(VegaLiteSchema):
 
         **Default value:** ``true``
     domainCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for the domain line's ending style. One of ``"butt"``, ``"round"`` or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     domainColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
+        Color of axis domain line.
 
+        **Default value:** ``"gray"``.
     domainDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating [stroke, space] lengths for dashed domain lines.
     domainDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The pixel offset at which to start drawing with the domain dash array.
     domainOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of the axis domain line.
     domainWidth : anyOf(float, :class:`ExprRef`)
+        Stroke width of axis domain line
 
+        **Default value:** ``1``
     format : anyOf(string, :class:`Dict`)
         When used with the default ``"number"`` and ``"time"`` format type, the text
         formatting pattern for labels of guides (axes, legends, headers) and text marks.
@@ -963,27 +1166,49 @@ class AxisConfig(VegaLiteSchema):
         <https://vega.github.io/vega-lite/docs/scale.html#continuous>`__ that are not
         binned; otherwise, ``false``.
     gridCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for grid lines' ending style. One of ``"butt"``, ``"round"`` or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     gridColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`, :class:`ConditionalAxisColor`)
+        Color of gridlines.
 
+        **Default value:** ``"lightGray"``.
     gridDash : anyOf(List(float), :class:`ExprRef`, :class:`ConditionalAxisNumberArray`)
-
+        An array of alternating [stroke, space] lengths for dashed grid lines.
     gridDashOffset : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
-
+        The pixel offset at which to start drawing with the grid dash array.
     gridOpacity : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        The stroke opacity of grid (value between [0,1])
 
+        **Default value:** ``1``
     gridWidth : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        The grid width, in pixels.
 
+        **Default value:** ``1``
     labelAlign : anyOf(:class:`Align`, :class:`ExprRef`, :class:`ConditionalAxisLabelAlign`)
-
+        Horizontal text alignment of axis tick labels, overriding the default setting for
+        the current axis orientation.
     labelAngle : anyOf(float, :class:`ExprRef`)
+        The rotation angle of the axis labels.
 
+        **Default value:** ``-90`` for nominal and ordinal fields; ``0`` otherwise.
     labelBaseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`, :class:`ConditionalAxisLabelBaseline`)
-
+        Vertical text baseline of axis tick labels, overriding the default setting for the
+        current axis orientation. One of ``"alphabetic"`` (default), ``"top"``,
+        ``"middle"``, ``"bottom"``, ``"line-top"``, or ``"line-bottom"``. The ``"line-top"``
+        and ``"line-bottom"`` values operate similarly to ``"top"`` and ``"bottom"``, but
+        are calculated relative to the *lineHeight* rather than *fontSize* alone.
     labelBound : anyOf(anyOf(float, boolean), :class:`ExprRef`)
+        Indicates if labels should be hidden if they exceed the axis range. If ``false``
+        (the default) no bounds overlap analysis is performed. If ``true``, labels will be
+        hidden if they exceed the axis range by more than 1 pixel. If this property is a
+        number, it specifies the pixel tolerance: the maximum amount by which a label
+        bounding box may exceed the axis range.
 
+        **Default value:** ``false``.
     labelColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`, :class:`ConditionalAxisColor`)
-
+        The color of the tick label, can be in hex color code or regular color name.
     labelExpr : string
         `Vega expression <https://vega.github.io/vega/docs/expressions/>`__ for customizing
         labels.
@@ -1002,23 +1227,33 @@ class AxisConfig(VegaLiteSchema):
 
         **Default value:** ``true`` for axis of a continuous x-scale. Otherwise, ``false``.
     labelFlushOffset : anyOf(float, :class:`ExprRef`)
+        Indicates the number of pixels by which to offset flush-adjusted labels. For
+        example, a value of ``2`` will push flush-adjusted labels 2 pixels outward from the
+        center of the axis. Offsets can help the labels better visually group with
+        corresponding axis ticks.
 
+        **Default value:** ``0``.
     labelFont : anyOf(string, :class:`ExprRef`, :class:`ConditionalAxisString`)
-
+        The font of the tick label.
     labelFontSize : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
-
+        The font size of the label, in pixels.
     labelFontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`, :class:`ConditionalAxisLabelFontStyle`)
-
+        Font style of the title.
     labelFontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`, :class:`ConditionalAxisLabelFontWeight`)
-
+        Font weight of axis tick labels.
     labelLimit : anyOf(float, :class:`ExprRef`)
+        Maximum allowed pixel width of axis tick labels.
 
+        **Default value:** ``180``
     labelLineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line label text or label text with ``"line-top"`` or
+        ``"line-bottom"`` baseline.
     labelOffset : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        Position offset in pixels to apply to labels, in addition to tickOffset.
 
+        **Default value:** ``0``
     labelOpacity : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
-
+        The opacity of the labels.
     labelOverlap : anyOf(:class:`LabelOverlap`, :class:`ExprRef`)
         The strategy to use for resolving overlap of axis labels. If ``false`` (the
         default), no overlap reduction is attempted. If set to ``true`` or ``"parity"``, a
@@ -1030,17 +1265,27 @@ class AxisConfig(VegaLiteSchema):
         **Default value:** ``true`` for non-nominal fields with non-log scales; ``"greedy"``
         for log scales; otherwise ``false``.
     labelPadding : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        The padding in pixels between labels and ticks.
 
+        **Default value:** ``2``
     labelSeparation : anyOf(float, :class:`ExprRef`)
-
+        The minimum separation that must be between label bounding boxes for them to be
+        considered non-overlapping (default ``0`` ). This property is ignored if
+        *labelOverlap* resolution is not enabled.
     labels : boolean
         A boolean flag indicating if labels should be included as part of the axis.
 
         **Default value:** ``true``.
     maxExtent : anyOf(float, :class:`ExprRef`)
+        The maximum extent in pixels that axis ticks and labels should use. This determines
+        a maximum offset value for axis titles.
 
+        **Default value:** ``undefined``.
     minExtent : anyOf(float, :class:`ExprRef`)
+        The minimum extent in pixels that axis ticks and labels should use. This determines
+        a minimum offset value for axis titles.
 
+        **Default value:** ``30`` for y-axis; ``undefined`` for x-axis.
     offset : anyOf(float, :class:`ExprRef`)
         The offset, in pixels, by which to displace the axis from the edge of the enclosing
         group or data rectangle.
@@ -1070,11 +1315,17 @@ class AxisConfig(VegaLiteSchema):
         style. For example, an x-axis mark with ``"style": "foo"`` will use ``config.axisX``
         and ``config.style.foo`` (the specified style ``"foo"`` has higher precedence).
     tickBand : anyOf(enum('center', 'extent'), :class:`ExprRef`)
-
+        For band scales, indicates if ticks and grid lines should be placed at the
+        ``"center"`` of a band (default) or at the band ``"extent"`` s to indicate intervals
     tickCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for the tick lines' ending style. One of ``"butt"``, ``"round"`` or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     tickColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`, :class:`ConditionalAxisColor`)
+        The color of the axis's tick.
 
+        **Default value:** ``"gray"``
     tickCount : anyOf(float, :class:`TimeInterval`, :class:`TimeIntervalStep`, :class:`ExprRef`)
         A desired number of ticks, for axes visualizing quantitative scales. The resulting
         number may be different so that values are "nice" (multiples of 2, 5, 10) and lie
@@ -1090,9 +1341,9 @@ class AxisConfig(VegaLiteSchema):
         **Default value** : Determine using a formula ``ceil(width/40)`` for x and
         ``ceil(height/40)`` for y.
     tickDash : anyOf(List(float), :class:`ExprRef`, :class:`ConditionalAxisNumberArray`)
-
+        An array of alternating [stroke, space] lengths for dashed tick mark lines.
     tickDashOffset : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
-
+        The pixel offset at which to start drawing with the tick mark dash array.
     tickExtra : boolean
         Boolean flag indicating if an extra axis tick should be added for the initial
         position of the axis. This flag is useful for styling axes for ``band`` scales such
@@ -1104,18 +1355,22 @@ class AxisConfig(VegaLiteSchema):
         If ``tickMinStep`` is specified, the ``tickCount`` value will be adjusted, if
         necessary, to enforce the minimum step value.
     tickOffset : anyOf(float, :class:`ExprRef`)
-
+        Position offset in pixels to apply to ticks, labels, and gridlines.
     tickOpacity : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
-
+        Opacity of the ticks.
     tickRound : boolean
         Boolean flag indicating if pixel position values should be rounded to the nearest
         integer.
 
         **Default value:** ``true``
     tickSize : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        The size in pixels of axis ticks.
 
+        **Default value:** ``5``
     tickWidth : anyOf(float, :class:`ExprRef`, :class:`ConditionalAxisNumber`)
+        The width, in pixels, of ticks.
 
+        **Default value:** ``1``
     ticks : boolean
         Boolean value that determines whether the axis should include ticks.
 
@@ -1141,37 +1396,50 @@ class AxisConfig(VegaLiteSchema):
         2) If both field definition's ``title`` and axis, header, or legend ``title`` are
         defined, axis/header/legend title will be used.
     titleAlign : anyOf(:class:`Align`, :class:`ExprRef`)
-
+        Horizontal text alignment of axis titles.
     titleAnchor : anyOf(:class:`TitleAnchor`, :class:`ExprRef`)
-
+        Text anchor position for placing axis titles.
     titleAngle : anyOf(float, :class:`ExprRef`)
-
+        Angle in degrees of axis titles.
     titleBaseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
-
+        Vertical text baseline for axis titles. One of ``"alphabetic"`` (default),
+        ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, or ``"line-bottom"``. The
+        ``"line-top"`` and ``"line-bottom"`` values operate similarly to ``"top"`` and
+        ``"bottom"``, but are calculated relative to the *lineHeight* rather than *fontSize*
+        alone.
     titleColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Color of the title, can be in hex color code or regular color name.
     titleFont : anyOf(string, :class:`ExprRef`)
-
+        Font of the title. (e.g., ``"Helvetica Neue"`` ).
     titleFontSize : anyOf(float, :class:`ExprRef`)
-
+        Font size of the title.
     titleFontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        Font style of the title.
     titleFontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        Font weight of the title. This can be either a string (e.g ``"bold"``, ``"normal"``
+        ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400``
+        and ``"bold"`` = ``700`` ).
     titleLimit : anyOf(float, :class:`ExprRef`)
-
+        Maximum allowed pixel width of axis titles.
     titleLineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line title text or title text with ``"line-top"`` or
+        ``"line-bottom"`` baseline.
     titleOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of the axis title.
     titlePadding : anyOf(float, :class:`ExprRef`)
-
+        The padding, in pixels, between title and axis.
     titleX : anyOf(float, :class:`ExprRef`)
-
+        X-coordinate of the axis title relative to the axis group.
     titleY : anyOf(float, :class:`ExprRef`)
-
+        Y-coordinate of the axis title relative to the axis group.
     translate : anyOf(float, :class:`ExprRef`)
+        Coordinate space translation offset for axis layout. By default, axes are translated
+        by a 0.5 pixel offset for both the x and y coordinates in order to align stroked
+        lines with the pixel grid. However, for vector graphics output these pixel-specific
+        adjustments may be undesirable, in which case translate can be changed (for example,
+        to zero).
 
+        **Default value:** ``0.5``
     values : anyOf(List(float), List(string), List(boolean), List(:class:`DateTime`), :class:`ExprRef`)
         Explicitly set the visible axis tick values.
     zindex : float
@@ -1286,15 +1554,25 @@ class BarConfig(AnyMarkConfig):
 
         **Note:** Expression reference is *not* supported for range marks.
     angle : anyOf(float, :class:`ExprRef`)
-
+        The rotation angle of the text, in degrees.
     aria : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG element, removing the mark item from the ARIA accessibility tree.
     ariaRole : anyOf(string, :class:`ExprRef`)
-
+        Sets the type of user interface element of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "role" attribute. Warning: this
+        property is experimental and may be changed in the future.
     ariaRoleDescription : anyOf(string, :class:`ExprRef`)
-
+        A human-readable, author-localized description for the role of the mark item for
+        `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "aria-roledescription" attribute.
+        Warning: this property is experimental and may be changed in the future.
     aspect : anyOf(boolean, :class:`ExprRef`)
-
+        Whether to keep aspect ratio of image marks.
     baseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
         For text marks, the vertical text baseline. One of ``"alphabetic"`` (default),
         ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, ``"line-bottom"``, or an
@@ -1312,7 +1590,11 @@ class BarConfig(AnyMarkConfig):
 
         **Default value:** ``1``
     blend : anyOf(:class:`Blend`, :class:`ExprRef`)
+        The color blend mode for drawing an item on its current background. Any valid `CSS
+        mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
+        value can be used.
 
+        __Default value: ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 
@@ -1331,43 +1613,68 @@ class BarConfig(AnyMarkConfig):
 
         **Default value:** ``5``
     cornerRadius : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles or arcs' corners.
 
+        **Default value:** ``0``
     cornerRadiusBottomLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom left corner.
 
+        **Default value:** ``0``
     cornerRadiusBottomRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom right corner.
 
+        **Default value:** ``0``
     cornerRadiusEnd : anyOf(float, :class:`ExprRef`)
         For vertical bars, top-left and top-right corner radius.
 
         For horizontal bars, top-right and bottom-right corner radius.
     cornerRadiusTopLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top left corner.
 
+        **Default value:** ``0``
     cursor : anyOf(:class:`Cursor`, :class:`ExprRef`)
-
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__.
     dir : anyOf(:class:`TextDirection`, :class:`ExprRef`)
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
 
+        **Default value:** ``"ltr"``
     discreteBandSize : anyOf(float, :class:`RelativeBandSize`)
         The default size of the bars with discrete dimensions. If unspecified, the default
         size is  ``step-2``, which provides 2 pixel offset between bars.
     dx : anyOf(float, :class:`ExprRef`)
-
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     dy : anyOf(float, :class:`ExprRef`)
-
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     ellipsis : anyOf(string, :class:`ExprRef`)
+        The ellipsis string for text truncated in response to the limit parameter.
 
+        **Default value:** ``"…"``
     endAngle : anyOf(float, :class:`ExprRef`)
-
+        The end angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     fill : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
         **Default value:** (None)
     fillOpacity : anyOf(float, :class:`ExprRef`)
+        The fill opacity (value between [0,1]).
 
+        **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
 
@@ -1379,24 +1686,48 @@ class BarConfig(AnyMarkConfig):
         **Note:** This property cannot be used in a `style config
         <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
     font : anyOf(string, :class:`ExprRef`)
-
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : anyOf(float, :class:`ExprRef`)
+        The font size, in pixels.
 
+        **Default value:** ``11``
     fontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style (e.g., ``"italic"`` ).
     fontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     height : anyOf(float, :class:`ExprRef`)
-
+        Height of the marks.
     href : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     innerRadius : anyOf(float, :class:`ExprRef`)
         The inner radius in pixels of arc marks. ``innerRadius`` is an alias for
         ``radius2``.
 
         **Default value:** ``0``
     interpolate : anyOf(:class:`Interpolate`, :class:`ExprRef`)
+        The line interpolation method to use for line and area marks. One of the following:
 
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
     invalid : enum('filter', None)
         Defines how Vega-Lite should handle marks for invalid values ( ``null`` and ``NaN``
         ).
@@ -1407,11 +1738,16 @@ class BarConfig(AnyMarkConfig):
         * If ``null``, all data items are included. In this case, invalid values will be
           interpreted as zeroes.
     limit : anyOf(float, :class:`ExprRef`)
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
 
+        **Default value:** ``0`` -- indicating no limit
     lineBreak : anyOf(string, :class:`ExprRef`)
-
+        A delimiter, such as a newline character, upon which to break text strings into
+        multiple lines. This property is ignored if the text is array-valued.
     lineHeight : anyOf(float, :class:`ExprRef`)
-
+        The line height in pixels (the spacing between subsequent lines of text) for
+        multi-line text marks.
     opacity : anyOf(float, :class:`ExprRef`)
         The overall opacity (value between [0,1]).
 
@@ -1437,7 +1773,7 @@ class BarConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     padAngle : anyOf(float, :class:`ExprRef`)
-
+        The angular padding applied to sides of the arc, in radians.
     radius : anyOf(float, :class:`ExprRef`)
         For arc mark, the primary (outer) radius in pixels.
 
@@ -1450,7 +1786,20 @@ class BarConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     shape : anyOf(anyOf(:class:`SymbolShape`, string), :class:`ExprRef`)
+        Shape of the point marks. Supported values include:
 
+
+        * plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
+          ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
+          ``"triangle-left"``.
+        * the line symbol ``"stroke"``
+        * centered directional shapes ``"arrow"``, ``"wedge"``, or ``"triangle"``
+        * a custom `SVG path string
+          <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ (For correct
+          sizing, custom shape paths should be defined within a square bounding box with
+          coordinates ranging from -1 to 1 along both the x and y dimensions.)
+
+        **Default value:** ``"circle"``
     size : anyOf(float, :class:`ExprRef`)
         Default size for marks.
 
@@ -1469,34 +1818,48 @@ class BarConfig(AnyMarkConfig):
         * ``5`` for bar marks with continuous dimensions;
         * ``11`` for text marks.
     smooth : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag (default true) indicating if the image should be smoothed when
+        resized. If false, individual pixels should be scaled directly rather than
+        interpolated with smoothing. For SVG rendering, this option may not work in some
+        browsers due to lack of standardization.
     startAngle : anyOf(float, :class:`ExprRef`)
-
+        The start angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     stroke : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
         **Default value:** (None)
     strokeCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     strokeDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeJoin : anyOf(:class:`StrokeJoin`, :class:`ExprRef`)
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
 
+        **Default value:** ``"miter"``
     strokeMiterLimit : anyOf(float, :class:`ExprRef`)
-
+        The miter limit at which to bevel a line join.
     strokeOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset in pixels at which to draw the group stroke and fill. If unspecified, the
+        default behavior is to dynamically offset stroked groups such that 1 pixel stroke
+        widths align with the pixel grid.
     strokeOpacity : anyOf(float, :class:`ExprRef`)
+        The stroke opacity (value between [0,1]).
 
+        **Default value:** ``1``
     strokeWidth : anyOf(float, :class:`ExprRef`)
-
+        The stroke width, in pixels.
     tension : anyOf(float, :class:`ExprRef`)
-
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
     text : anyOf(:class:`Text`, :class:`ExprRef`)
-
+        Placeholder text if the ``text`` channel is not specified
     theta : anyOf(float, :class:`ExprRef`)
         For arc marks, the arc length in radians if theta2 is not specified, otherwise the
         start arc angle. (A value of 0 indicates up or “north”, increasing values proceed
@@ -1530,9 +1893,9 @@ class BarConfig(AnyMarkConfig):
 
         **Default value:** ``null``
     url : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        The URL of the image file for image marks.
     width : anyOf(float, :class:`ExprRef`)
-
+        Width of the marks.
     x : anyOf(float, string, :class:`ExprRef`)
         X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"`` without
         specified ``x2`` or ``width``.
@@ -1622,11 +1985,18 @@ class BaseTitleNoValueRefs(VegaLiteSchema):
         Horizontal text alignment for title text. One of ``"left"``, ``"center"``, or
         ``"right"``.
     anchor : anyOf(:class:`TitleAnchor`, :class:`ExprRef`)
-
+        The anchor position for placing the title and subtitle text. One of ``"start"``,
+        ``"middle"``, or ``"end"``. For example, with an orientation of top these anchor
+        positions map to a left-, center-, or right-aligned title.
     angle : anyOf(float, :class:`ExprRef`)
-
+        Angle in degrees of title and subtitle text.
     aria : anyOf(boolean, :class:`ExprRef`)
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG group, removing the title from the ARIA accessibility tree.
 
+        **Default value:** ``true``
     baseline : :class:`TextBaseline`
         Vertical text baseline for title and subtitle text. One of ``"alphabetic"``
         (default), ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, or
@@ -1634,45 +2004,56 @@ class BaseTitleNoValueRefs(VegaLiteSchema):
         to ``"top"`` and ``"bottom"``, but are calculated relative to the *lineHeight*
         rather than *fontSize* alone.
     color : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Text color for title text.
     dx : anyOf(float, :class:`ExprRef`)
-
+        Delta offset for title and subtitle text x-coordinate.
     dy : anyOf(float, :class:`ExprRef`)
-
+        Delta offset for title and subtitle text y-coordinate.
     font : anyOf(string, :class:`ExprRef`)
-
+        Font name for title text.
     fontSize : anyOf(float, :class:`ExprRef`)
-
+        Font size in pixels for title text.
     fontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        Font style for title text.
     fontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        Font weight for title text. This can be either a string (e.g ``"bold"``,
+        ``"normal"`` ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where
+        ``"normal"`` = ``400`` and ``"bold"`` = ``700`` ).
     frame : anyOf(anyOf(:class:`TitleFrame`, string), :class:`ExprRef`)
-
+        The reference frame for the anchor position, one of ``"bounds"`` (to anchor relative
+        to the full bounding box) or ``"group"`` (to anchor relative to the group width or
+        height).
     limit : anyOf(float, :class:`ExprRef`)
-
+        The maximum allowed length in pixels of title and subtitle text.
     lineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line title text or title text with ``"line-top"`` or
+        ``"line-bottom"`` baseline.
     offset : anyOf(float, :class:`ExprRef`)
-
+        The orthogonal offset in pixels by which to displace the title group from its
+        position along the edge of the chart.
     orient : anyOf(:class:`TitleOrient`, :class:`ExprRef`)
-
+        Default title orientation ( ``"top"``, ``"bottom"``, ``"left"``, or ``"right"`` )
     subtitleColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Text color for subtitle text.
     subtitleFont : anyOf(string, :class:`ExprRef`)
-
+        Font name for subtitle text.
     subtitleFontSize : anyOf(float, :class:`ExprRef`)
-
+        Font size in pixels for subtitle text.
     subtitleFontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        Font style for subtitle text.
     subtitleFontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        Font weight for subtitle text. This can be either a string (e.g ``"bold"``,
+        ``"normal"`` ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where
+        ``"normal"`` = ``400`` and ``"bold"`` = ``700`` ).
     subtitleLineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line subtitle text.
     subtitlePadding : anyOf(float, :class:`ExprRef`)
-
+        The padding in pixels between title and subtitle text.
     zindex : anyOf(float, :class:`ExprRef`)
+        The integer z-index indicating the layering of the title group relative to other
+        axis, mark, and legend groups.
 
+        **Default value:** ``0``.
     """
     _schema = {'$ref': '#/definitions/BaseTitleNoValueRefs'}
 
@@ -2060,6 +2441,8 @@ class ColorDef(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull`,
     :class:`FieldOrDatumDefWithConditionDatumDefGradientstringnull`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefGradientstringnull`)
+    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
+    ... }
     """
     _schema = {'$ref': '#/definitions/ColorDef'}
 
@@ -5190,6 +5573,7 @@ class Field(VegaLiteSchema):
     """Field schema wrapper
 
     anyOf(:class:`FieldName`, :class:`RepeatRef`)
+    Reference to a repeated value.
     """
     _schema = {'$ref': '#/definitions/Field'}
 
@@ -6802,17 +7186,30 @@ class Legend(VegaLiteSchema):
     ----------
 
     aria : anyOf(boolean, :class:`ExprRef`)
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG group, removing the legend from the ARIA accessibility tree.
 
+        **Default value:** ``true``
     clipHeight : anyOf(float, :class:`ExprRef`)
-
+        The height in pixels to clip symbol legend entries and limit their size.
     columnPadding : anyOf(float, :class:`ExprRef`)
+        The horizontal padding in pixels between symbol legend entries.
 
+        **Default value:** ``10``.
     columns : anyOf(float, :class:`ExprRef`)
-
+        The number of columns in which to arrange symbol legend entries. A value of ``0`` or
+        lower indicates a single row with one column per entry.
     cornerRadius : anyOf(float, :class:`ExprRef`)
-
+        Corner radius for the full legend.
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of this legend for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If the ``aria`` property is true, for SVG output the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__
+        will be set to this description. If the description is unspecified it will be
+        automatically generated.
     direction : :class:`Orientation`
         The direction of the legend, one of ``"vertical"`` or ``"horizontal"``.
 
@@ -6824,7 +7221,7 @@ class Legend(VegaLiteSchema):
         * For top/bottom-left/right- ``orient`` ed legends, ``"horizontal"`` for gradient
           legends and ``"vertical"`` for symbol legends.
     fillColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Background fill color for the full legend.
     format : anyOf(string, :class:`Dict`)
         When used with the default ``"number"`` and ``"time"`` format type, the text
         formatting pattern for labels of guides (axes, legends, headers) and text marks.
@@ -6860,23 +7257,40 @@ class Legend(VegaLiteSchema):
         * ``"number"`` for quantitative fields as well as ordinal and nominal fields without
           ``timeUnit``.
     gradientLength : anyOf(float, :class:`ExprRef`)
+        The length in pixels of the primary axis of a color gradient. This value corresponds
+        to the height of a vertical gradient or the width of a horizontal gradient.
 
+        **Default value:** ``200``.
     gradientOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of the color gradient.
     gradientStrokeColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
+        The color of the gradient stroke, can be in hex color code or regular color name.
 
+        **Default value:** ``"lightGray"``.
     gradientStrokeWidth : anyOf(float, :class:`ExprRef`)
+        The width of the gradient stroke, in pixels.
 
+        **Default value:** ``0``.
     gradientThickness : anyOf(float, :class:`ExprRef`)
+        The thickness in pixels of the color gradient. This value corresponds to the width
+        of a vertical gradient or the height of a horizontal gradient.
 
+        **Default value:** ``16``.
     gridAlign : anyOf(:class:`LayoutAlign`, :class:`ExprRef`)
+        The alignment to apply to symbol legends rows and columns. The supported string
+        values are ``"all"``, ``"each"`` (the default), and ``none``. For more information,
+        see the `grid layout documentation <https://vega.github.io/vega/docs/layout>`__.
 
+        **Default value:** ``"each"``.
     labelAlign : anyOf(:class:`Align`, :class:`ExprRef`)
-
+        The alignment of the legend label, can be left, center, or right.
     labelBaseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
+        The position of the baseline of legend label, can be ``"top"``, ``"middle"``,
+        ``"bottom"``, or ``"alphabetic"``.
 
+        **Default value:** ``"middle"``.
     labelColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        The color of the legend label, can be in hex color code or regular color name.
     labelExpr : string
         `Vega expression <https://vega.github.io/vega/docs/expressions/>`__ for customizing
         labels.
@@ -6884,31 +7298,48 @@ class Legend(VegaLiteSchema):
         **Note:** The label text and value can be assessed via the ``label`` and ``value``
         properties of the legend's backing ``datum`` object.
     labelFont : anyOf(string, :class:`ExprRef`)
-
+        The font of the legend label.
     labelFontSize : anyOf(float, :class:`ExprRef`)
+        The font size of legend label.
 
+        **Default value:** ``10``.
     labelFontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style of legend label.
     labelFontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight of legend label.
     labelLimit : anyOf(float, :class:`ExprRef`)
+        Maximum allowed pixel width of legend tick labels.
 
+        **Default value:** ``160``.
     labelOffset : anyOf(float, :class:`ExprRef`)
+        The offset of the legend label.
 
+        **Default value:** ``4``.
     labelOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of labels.
     labelOverlap : anyOf(:class:`LabelOverlap`, :class:`ExprRef`)
+        The strategy to use for resolving overlap of labels in gradient legends. If
+        ``false``, no overlap reduction is attempted. If set to ``true`` (default) or
+        ``"parity"``, a strategy of removing every other label is used. If set to
+        ``"greedy"``, a linear scan of the labels is performed, removing any label that
+        overlaps with the last visible label (this often works better for log-scaled axes).
 
+        **Default value:** ``true``.
     labelPadding : anyOf(float, :class:`ExprRef`)
-
+        Padding in pixels between the legend and legend labels.
     labelSeparation : anyOf(float, :class:`ExprRef`)
-
+        The minimum separation that must be between label bounding boxes for them to be
+        considered non-overlapping (default ``0`` ). This property is ignored if
+        *labelOverlap* resolution is not enabled.
     legendX : anyOf(float, :class:`ExprRef`)
-
+        Custom x-position for legend with orient "none".
     legendY : anyOf(float, :class:`ExprRef`)
-
+        Custom y-position for legend with orient "none".
     offset : anyOf(float, :class:`ExprRef`)
+        The offset in pixels by which to displace the legend from the data rectangle and
+        axes.
 
+        **Default value:** ``18``.
     orient : :class:`LegendOrient`
         The orientation of the legend, which determines how the legend is positioned within
         the scene. One of ``"left"``, ``"right"``, ``"top"``, ``"bottom"``, ``"top-left"``,
@@ -6916,33 +7347,53 @@ class Legend(VegaLiteSchema):
 
         **Default value:** ``"right"``
     padding : anyOf(float, :class:`ExprRef`)
+        The padding between the border and content of the legend group.
 
+        **Default value:** ``0``.
     rowPadding : anyOf(float, :class:`ExprRef`)
+        The vertical padding in pixels between symbol legend entries.
 
+        **Default value:** ``2``.
     strokeColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Border stroke color for the full legend.
     symbolDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating [stroke, space] lengths for dashed symbol strokes.
     symbolDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The pixel offset at which to start drawing with the symbol stroke dash array.
     symbolFillColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        The color of the legend symbol,
     symbolLimit : anyOf(float, :class:`ExprRef`)
-
+        The maximum number of allowed entries for a symbol legend. Additional entries will
+        be dropped.
     symbolOffset : anyOf(float, :class:`ExprRef`)
+        Horizontal pixel offset for legend symbols.
 
+        **Default value:** ``0``.
     symbolOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of the legend symbols.
     symbolSize : anyOf(float, :class:`ExprRef`)
+        The size of the legend symbol, in pixels.
 
+        **Default value:** ``100``.
     symbolStrokeColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Stroke color for legend symbols.
     symbolStrokeWidth : anyOf(float, :class:`ExprRef`)
+        The width of the symbol's stroke.
 
+        **Default value:** ``1.5``.
     symbolType : anyOf(:class:`SymbolShape`, :class:`ExprRef`)
+        The symbol shape. One of the plotting shapes ``circle`` (default), ``square``,
+        ``cross``, ``diamond``, ``triangle-up``, ``triangle-down``, ``triangle-right``, or
+        ``triangle-left``, the line symbol ``stroke``, or one of the centered directional
+        shapes ``arrow``, ``wedge``, or ``triangle``. Alternatively, a custom `SVG path
+        string <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ can be
+        provided. For correct sizing, custom shape paths should be defined within a square
+        bounding box with coordinates ranging from -1 to 1 along both the x and y
+        dimensions.
 
+        **Default value:** ``"circle"``.
     tickCount : anyOf(:class:`TickCount`, :class:`ExprRef`)
-
+        The desired number of tick values for quantitative legends.
     tickMinStep : anyOf(float, :class:`ExprRef`)
         The minimum desired step between legend ticks, in terms of scale domain values. For
         example, a value of ``1`` indicates that ticks should not be less than 1 unit apart.
@@ -6971,31 +7422,46 @@ class Legend(VegaLiteSchema):
         2) If both field definition's ``title`` and axis, header, or legend ``title`` are
         defined, axis/header/legend title will be used.
     titleAlign : anyOf(:class:`Align`, :class:`ExprRef`)
+        Horizontal text alignment for legend titles.
 
+        **Default value:** ``"left"``.
     titleAnchor : anyOf(:class:`TitleAnchor`, :class:`ExprRef`)
-
+        Text anchor position for placing legend titles.
     titleBaseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
+        Vertical text baseline for legend titles.  One of ``"alphabetic"`` (default),
+        ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, or ``"line-bottom"``. The
+        ``"line-top"`` and ``"line-bottom"`` values operate similarly to ``"top"`` and
+        ``"bottom"``, but are calculated relative to the *lineHeight* rather than *fontSize*
+        alone.
 
+        **Default value:** ``"top"``.
     titleColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        The color of the legend title, can be in hex color code or regular color name.
     titleFont : anyOf(string, :class:`ExprRef`)
-
+        The font of the legend title.
     titleFontSize : anyOf(float, :class:`ExprRef`)
-
+        The font size of the legend title.
     titleFontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style of the legend title.
     titleFontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight of the legend title. This can be either a string (e.g ``"bold"``,
+        ``"normal"`` ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where
+        ``"normal"`` = ``400`` and ``"bold"`` = ``700`` ).
     titleLimit : anyOf(float, :class:`ExprRef`)
+        Maximum allowed pixel width of legend titles.
 
+        **Default value:** ``180``.
     titleLineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line title text or title text with ``"line-top"`` or
+        ``"line-bottom"`` baseline.
     titleOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of the legend title.
     titleOrient : anyOf(:class:`Orient`, :class:`ExprRef`)
-
+        Orientation of the legend title.
     titlePadding : anyOf(float, :class:`ExprRef`)
+        The padding, in pixels, between title and legend.
 
+        **Default value:** ``5``.
     type : enum('symbol', 'gradient')
         The type of the legend. Use ``"symbol"`` to create a discrete legend and
         ``"gradient"`` for a continuous color gradient.
@@ -7084,17 +7550,30 @@ class LegendConfig(VegaLiteSchema):
     ----------
 
     aria : anyOf(boolean, :class:`ExprRef`)
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG group, removing the legend from the ARIA accessibility tree.
 
+        **Default value:** ``true``
     clipHeight : anyOf(float, :class:`ExprRef`)
-
+        The height in pixels to clip symbol legend entries and limit their size.
     columnPadding : anyOf(float, :class:`ExprRef`)
+        The horizontal padding in pixels between symbol legend entries.
 
+        **Default value:** ``10``.
     columns : anyOf(float, :class:`ExprRef`)
-
+        The number of columns in which to arrange symbol legend entries. A value of ``0`` or
+        lower indicates a single row with one column per entry.
     cornerRadius : anyOf(float, :class:`ExprRef`)
-
+        Corner radius for the full legend.
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of this legend for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If the ``aria`` property is true, for SVG output the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__
+        will be set to this description. If the description is unspecified it will be
+        automatically generated.
     direction : :class:`Orientation`
         The direction of the legend, one of ``"vertical"`` or ``"horizontal"``.
 
@@ -7108,9 +7587,11 @@ class LegendConfig(VegaLiteSchema):
     disable : boolean
         Disable legend by default
     fillColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Background fill color for the full legend.
     gradientDirection : anyOf(:class:`Orientation`, :class:`ExprRef`)
+        The default direction ( ``"horizontal"`` or ``"vertical"`` ) for gradient legends.
 
+        **Default value:** ``"vertical"``.
     gradientHorizontalMaxLength : float
         Max legend length for a horizontal gradient when ``config.legend.gradientLength`` is
         undefined.
@@ -7122,19 +7603,31 @@ class LegendConfig(VegaLiteSchema):
 
         **Default value:** ``100``
     gradientLabelLimit : anyOf(float, :class:`ExprRef`)
-
+        The maximum allowed length in pixels of color ramp gradient labels.
     gradientLabelOffset : anyOf(float, :class:`ExprRef`)
+        Vertical offset in pixels for color ramp gradient labels.
 
+        **Default value:** ``2``.
     gradientLength : anyOf(float, :class:`ExprRef`)
+        The length in pixels of the primary axis of a color gradient. This value corresponds
+        to the height of a vertical gradient or the width of a horizontal gradient.
 
+        **Default value:** ``200``.
     gradientOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of the color gradient.
     gradientStrokeColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
+        The color of the gradient stroke, can be in hex color code or regular color name.
 
+        **Default value:** ``"lightGray"``.
     gradientStrokeWidth : anyOf(float, :class:`ExprRef`)
+        The width of the gradient stroke, in pixels.
 
+        **Default value:** ``0``.
     gradientThickness : anyOf(float, :class:`ExprRef`)
+        The thickness in pixels of the color gradient. This value corresponds to the width
+        of a vertical gradient or the height of a horizontal gradient.
 
+        **Default value:** ``16``.
     gradientVerticalMaxLength : float
         Max legend length for a vertical gradient when ``config.legend.gradientLength`` is
         undefined.
@@ -7146,27 +7639,40 @@ class LegendConfig(VegaLiteSchema):
 
         **Default value:** ``100``
     gridAlign : anyOf(:class:`LayoutAlign`, :class:`ExprRef`)
+        The alignment to apply to symbol legends rows and columns. The supported string
+        values are ``"all"``, ``"each"`` (the default), and ``none``. For more information,
+        see the `grid layout documentation <https://vega.github.io/vega/docs/layout>`__.
 
+        **Default value:** ``"each"``.
     labelAlign : anyOf(:class:`Align`, :class:`ExprRef`)
-
+        The alignment of the legend label, can be left, center, or right.
     labelBaseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
+        The position of the baseline of legend label, can be ``"top"``, ``"middle"``,
+        ``"bottom"``, or ``"alphabetic"``.
 
+        **Default value:** ``"middle"``.
     labelColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        The color of the legend label, can be in hex color code or regular color name.
     labelFont : anyOf(string, :class:`ExprRef`)
-
+        The font of the legend label.
     labelFontSize : anyOf(float, :class:`ExprRef`)
+        The font size of legend label.
 
+        **Default value:** ``10``.
     labelFontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style of legend label.
     labelFontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight of legend label.
     labelLimit : anyOf(float, :class:`ExprRef`)
+        Maximum allowed pixel width of legend tick labels.
 
+        **Default value:** ``160``.
     labelOffset : anyOf(float, :class:`ExprRef`)
+        The offset of the legend label.
 
+        **Default value:** ``4``.
     labelOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of labels.
     labelOverlap : anyOf(:class:`LabelOverlap`, :class:`ExprRef`)
         The strategy to use for resolving overlap of labels in gradient legends. If
         ``false``, no overlap reduction is attempted. If set to ``true`` or ``"parity"``, a
@@ -7176,17 +7682,22 @@ class LegendConfig(VegaLiteSchema):
 
         **Default value:** ``"greedy"`` for ``log scales otherwise`` true`.
     labelPadding : anyOf(float, :class:`ExprRef`)
-
+        Padding in pixels between the legend and legend labels.
     labelSeparation : anyOf(float, :class:`ExprRef`)
-
+        The minimum separation that must be between label bounding boxes for them to be
+        considered non-overlapping (default ``0`` ). This property is ignored if
+        *labelOverlap* resolution is not enabled.
     layout : :class:`ExprRef`
 
     legendX : anyOf(float, :class:`ExprRef`)
-
+        Custom x-position for legend with orient "none".
     legendY : anyOf(float, :class:`ExprRef`)
-
+        Custom y-position for legend with orient "none".
     offset : anyOf(float, :class:`ExprRef`)
+        The offset in pixels by which to displace the legend from the data rectangle and
+        axes.
 
+        **Default value:** ``18``.
     orient : :class:`LegendOrient`
         The orientation of the legend, which determines how the legend is positioned within
         the scene. One of ``"left"``, ``"right"``, ``"top"``, ``"bottom"``, ``"top-left"``,
@@ -7194,77 +7705,121 @@ class LegendConfig(VegaLiteSchema):
 
         **Default value:** ``"right"``
     padding : anyOf(float, :class:`ExprRef`)
+        The padding between the border and content of the legend group.
 
+        **Default value:** ``0``.
     rowPadding : anyOf(float, :class:`ExprRef`)
+        The vertical padding in pixels between symbol legend entries.
 
+        **Default value:** ``2``.
     strokeColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Border stroke color for the full legend.
     strokeDash : anyOf(List(float), :class:`ExprRef`)
-
+        Border stroke dash pattern for the full legend.
     strokeWidth : anyOf(float, :class:`ExprRef`)
-
+        Border stroke width for the full legend.
     symbolBaseFillColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
+        Default fill color for legend symbols. Only applied if there is no ``"fill"`` scale
+        color encoding for the legend.
 
+        **Default value:** ``"transparent"``.
     symbolBaseStrokeColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
+        Default stroke color for legend symbols. Only applied if there is no ``"fill"``
+        scale color encoding for the legend.
 
+        **Default value:** ``"gray"``.
     symbolDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating [stroke, space] lengths for dashed symbol strokes.
     symbolDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The pixel offset at which to start drawing with the symbol stroke dash array.
     symbolDirection : anyOf(:class:`Orientation`, :class:`ExprRef`)
+        The default direction ( ``"horizontal"`` or ``"vertical"`` ) for symbol legends.
 
+        **Default value:** ``"vertical"``.
     symbolFillColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        The color of the legend symbol,
     symbolLimit : anyOf(float, :class:`ExprRef`)
-
+        The maximum number of allowed entries for a symbol legend. Additional entries will
+        be dropped.
     symbolOffset : anyOf(float, :class:`ExprRef`)
+        Horizontal pixel offset for legend symbols.
 
+        **Default value:** ``0``.
     symbolOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of the legend symbols.
     symbolSize : anyOf(float, :class:`ExprRef`)
+        The size of the legend symbol, in pixels.
 
+        **Default value:** ``100``.
     symbolStrokeColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Stroke color for legend symbols.
     symbolStrokeWidth : anyOf(float, :class:`ExprRef`)
+        The width of the symbol's stroke.
 
+        **Default value:** ``1.5``.
     symbolType : anyOf(:class:`SymbolShape`, :class:`ExprRef`)
+        The symbol shape. One of the plotting shapes ``circle`` (default), ``square``,
+        ``cross``, ``diamond``, ``triangle-up``, ``triangle-down``, ``triangle-right``, or
+        ``triangle-left``, the line symbol ``stroke``, or one of the centered directional
+        shapes ``arrow``, ``wedge``, or ``triangle``. Alternatively, a custom `SVG path
+        string <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ can be
+        provided. For correct sizing, custom shape paths should be defined within a square
+        bounding box with coordinates ranging from -1 to 1 along both the x and y
+        dimensions.
 
+        **Default value:** ``"circle"``.
     tickCount : anyOf(:class:`TickCount`, :class:`ExprRef`)
-
+        The desired number of tick values for quantitative legends.
     title : None
         Set to null to disable title for the axis, legend, or header.
     titleAlign : anyOf(:class:`Align`, :class:`ExprRef`)
+        Horizontal text alignment for legend titles.
 
+        **Default value:** ``"left"``.
     titleAnchor : anyOf(:class:`TitleAnchor`, :class:`ExprRef`)
-
+        Text anchor position for placing legend titles.
     titleBaseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
+        Vertical text baseline for legend titles.  One of ``"alphabetic"`` (default),
+        ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, or ``"line-bottom"``. The
+        ``"line-top"`` and ``"line-bottom"`` values operate similarly to ``"top"`` and
+        ``"bottom"``, but are calculated relative to the *lineHeight* rather than *fontSize*
+        alone.
 
+        **Default value:** ``"top"``.
     titleColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        The color of the legend title, can be in hex color code or regular color name.
     titleFont : anyOf(string, :class:`ExprRef`)
-
+        The font of the legend title.
     titleFontSize : anyOf(float, :class:`ExprRef`)
-
+        The font size of the legend title.
     titleFontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style of the legend title.
     titleFontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight of the legend title. This can be either a string (e.g ``"bold"``,
+        ``"normal"`` ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where
+        ``"normal"`` = ``400`` and ``"bold"`` = ``700`` ).
     titleLimit : anyOf(float, :class:`ExprRef`)
+        Maximum allowed pixel width of legend titles.
 
+        **Default value:** ``180``.
     titleLineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line title text or title text with ``"line-top"`` or
+        ``"line-bottom"`` baseline.
     titleOpacity : anyOf(float, :class:`ExprRef`)
-
+        Opacity of the legend title.
     titleOrient : anyOf(:class:`Orient`, :class:`ExprRef`)
-
+        Orientation of the legend title.
     titlePadding : anyOf(float, :class:`ExprRef`)
+        The padding, in pixels, between title and legend.
 
+        **Default value:** ``5``.
     unselectedOpacity : float
         The opacity of unselected legend entries.
 
         **Default value:** 0.35.
     zindex : anyOf(float, :class:`ExprRef`)
-
+        The integer z-index indicating the layering of the legend group relative to other
+        axis, mark, and legend groups.
     """
     _schema = {'$ref': '#/definitions/LegendConfig'}
 
@@ -7425,15 +7980,25 @@ class LineConfig(AnyMarkConfig):
 
         **Note:** Expression reference is *not* supported for range marks.
     angle : anyOf(float, :class:`ExprRef`)
-
+        The rotation angle of the text, in degrees.
     aria : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG element, removing the mark item from the ARIA accessibility tree.
     ariaRole : anyOf(string, :class:`ExprRef`)
-
+        Sets the type of user interface element of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "role" attribute. Warning: this
+        property is experimental and may be changed in the future.
     ariaRoleDescription : anyOf(string, :class:`ExprRef`)
-
+        A human-readable, author-localized description for the role of the mark item for
+        `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "aria-roledescription" attribute.
+        Warning: this property is experimental and may be changed in the future.
     aspect : anyOf(boolean, :class:`ExprRef`)
-
+        Whether to keep aspect ratio of image marks.
     baseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
         For text marks, the vertical text baseline. One of ``"alphabetic"`` (default),
         ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, ``"line-bottom"``, or an
@@ -7446,7 +8011,11 @@ class LineConfig(AnyMarkConfig):
 
         **Note:** Expression reference is *not* supported for range marks.
     blend : anyOf(:class:`Blend`, :class:`ExprRef`)
+        The color blend mode for drawing an item on its current background. Any valid `CSS
+        mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
+        value can be used.
 
+        __Default value: ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 
@@ -7461,36 +8030,61 @@ class LineConfig(AnyMarkConfig):
         * The ``fill`` and ``stroke`` properties have higher precedence than ``color`` and
           will override ``color``.
     cornerRadius : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles or arcs' corners.
 
+        **Default value:** ``0``
     cornerRadiusBottomLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom left corner.
 
+        **Default value:** ``0``
     cornerRadiusBottomRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top left corner.
 
+        **Default value:** ``0``
     cursor : anyOf(:class:`Cursor`, :class:`ExprRef`)
-
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__.
     dir : anyOf(:class:`TextDirection`, :class:`ExprRef`)
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
 
+        **Default value:** ``"ltr"``
     dx : anyOf(float, :class:`ExprRef`)
-
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     dy : anyOf(float, :class:`ExprRef`)
-
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     ellipsis : anyOf(string, :class:`ExprRef`)
+        The ellipsis string for text truncated in response to the limit parameter.
 
+        **Default value:** ``"…"``
     endAngle : anyOf(float, :class:`ExprRef`)
-
+        The end angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     fill : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
         **Default value:** (None)
     fillOpacity : anyOf(float, :class:`ExprRef`)
+        The fill opacity (value between [0,1]).
 
+        **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
 
@@ -7502,24 +8096,48 @@ class LineConfig(AnyMarkConfig):
         **Note:** This property cannot be used in a `style config
         <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
     font : anyOf(string, :class:`ExprRef`)
-
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : anyOf(float, :class:`ExprRef`)
+        The font size, in pixels.
 
+        **Default value:** ``11``
     fontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style (e.g., ``"italic"`` ).
     fontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     height : anyOf(float, :class:`ExprRef`)
-
+        Height of the marks.
     href : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     innerRadius : anyOf(float, :class:`ExprRef`)
         The inner radius in pixels of arc marks. ``innerRadius`` is an alias for
         ``radius2``.
 
         **Default value:** ``0``
     interpolate : anyOf(:class:`Interpolate`, :class:`ExprRef`)
+        The line interpolation method to use for line and area marks. One of the following:
 
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
     invalid : enum('filter', None)
         Defines how Vega-Lite should handle marks for invalid values ( ``null`` and ``NaN``
         ).
@@ -7530,11 +8148,16 @@ class LineConfig(AnyMarkConfig):
         * If ``null``, all data items are included. In this case, invalid values will be
           interpreted as zeroes.
     limit : anyOf(float, :class:`ExprRef`)
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
 
+        **Default value:** ``0`` -- indicating no limit
     lineBreak : anyOf(string, :class:`ExprRef`)
-
+        A delimiter, such as a newline character, upon which to break text strings into
+        multiple lines. This property is ignored if the text is array-valued.
     lineHeight : anyOf(float, :class:`ExprRef`)
-
+        The line height in pixels (the spacing between subsequent lines of text) for
+        multi-line text marks.
     opacity : anyOf(float, :class:`ExprRef`)
         The overall opacity (value between [0,1]).
 
@@ -7560,7 +8183,7 @@ class LineConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     padAngle : anyOf(float, :class:`ExprRef`)
-
+        The angular padding applied to sides of the arc, in radians.
     point : anyOf(boolean, :class:`OverlayMarkDef`, string)
         A flag for overlaying points on top of line or area marks, or an object defining the
         properties of the overlayed points.
@@ -7588,7 +8211,20 @@ class LineConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     shape : anyOf(anyOf(:class:`SymbolShape`, string), :class:`ExprRef`)
+        Shape of the point marks. Supported values include:
 
+
+        * plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
+          ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
+          ``"triangle-left"``.
+        * the line symbol ``"stroke"``
+        * centered directional shapes ``"arrow"``, ``"wedge"``, or ``"triangle"``
+        * a custom `SVG path string
+          <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ (For correct
+          sizing, custom shape paths should be defined within a square bounding box with
+          coordinates ranging from -1 to 1 along both the x and y dimensions.)
+
+        **Default value:** ``"circle"``
     size : anyOf(float, :class:`ExprRef`)
         Default size for marks.
 
@@ -7607,34 +8243,48 @@ class LineConfig(AnyMarkConfig):
         * ``5`` for bar marks with continuous dimensions;
         * ``11`` for text marks.
     smooth : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag (default true) indicating if the image should be smoothed when
+        resized. If false, individual pixels should be scaled directly rather than
+        interpolated with smoothing. For SVG rendering, this option may not work in some
+        browsers due to lack of standardization.
     startAngle : anyOf(float, :class:`ExprRef`)
-
+        The start angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     stroke : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
         **Default value:** (None)
     strokeCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     strokeDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeJoin : anyOf(:class:`StrokeJoin`, :class:`ExprRef`)
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
 
+        **Default value:** ``"miter"``
     strokeMiterLimit : anyOf(float, :class:`ExprRef`)
-
+        The miter limit at which to bevel a line join.
     strokeOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset in pixels at which to draw the group stroke and fill. If unspecified, the
+        default behavior is to dynamically offset stroked groups such that 1 pixel stroke
+        widths align with the pixel grid.
     strokeOpacity : anyOf(float, :class:`ExprRef`)
+        The stroke opacity (value between [0,1]).
 
+        **Default value:** ``1``
     strokeWidth : anyOf(float, :class:`ExprRef`)
-
+        The stroke width, in pixels.
     tension : anyOf(float, :class:`ExprRef`)
-
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
     text : anyOf(:class:`Text`, :class:`ExprRef`)
-
+        Placeholder text if the ``text`` channel is not specified
     theta : anyOf(float, :class:`ExprRef`)
         For arc marks, the arc length in radians if theta2 is not specified, otherwise the
         start arc angle. (A value of 0 indicates up or “north”, increasing values proceed
@@ -7668,9 +8318,9 @@ class LineConfig(AnyMarkConfig):
 
         **Default value:** ``null``
     url : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        The URL of the image file for image marks.
     width : anyOf(float, :class:`ExprRef`)
-
+        Width of the marks.
     x : anyOf(float, string, :class:`ExprRef`)
         X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"`` without
         specified ``x2`` or ``width``.
@@ -7872,15 +8522,25 @@ class MarkConfig(AnyMarkConfig):
 
         **Note:** Expression reference is *not* supported for range marks.
     angle : anyOf(float, :class:`ExprRef`)
-
+        The rotation angle of the text, in degrees.
     aria : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG element, removing the mark item from the ARIA accessibility tree.
     ariaRole : anyOf(string, :class:`ExprRef`)
-
+        Sets the type of user interface element of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "role" attribute. Warning: this
+        property is experimental and may be changed in the future.
     ariaRoleDescription : anyOf(string, :class:`ExprRef`)
-
+        A human-readable, author-localized description for the role of the mark item for
+        `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "aria-roledescription" attribute.
+        Warning: this property is experimental and may be changed in the future.
     aspect : anyOf(boolean, :class:`ExprRef`)
-
+        Whether to keep aspect ratio of image marks.
     baseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
         For text marks, the vertical text baseline. One of ``"alphabetic"`` (default),
         ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, ``"line-bottom"``, or an
@@ -7893,7 +8553,11 @@ class MarkConfig(AnyMarkConfig):
 
         **Note:** Expression reference is *not* supported for range marks.
     blend : anyOf(:class:`Blend`, :class:`ExprRef`)
+        The color blend mode for drawing an item on its current background. Any valid `CSS
+        mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
+        value can be used.
 
+        __Default value: ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 
@@ -7908,36 +8572,61 @@ class MarkConfig(AnyMarkConfig):
         * The ``fill`` and ``stroke`` properties have higher precedence than ``color`` and
           will override ``color``.
     cornerRadius : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles or arcs' corners.
 
+        **Default value:** ``0``
     cornerRadiusBottomLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom left corner.
 
+        **Default value:** ``0``
     cornerRadiusBottomRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top left corner.
 
+        **Default value:** ``0``
     cursor : anyOf(:class:`Cursor`, :class:`ExprRef`)
-
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__.
     dir : anyOf(:class:`TextDirection`, :class:`ExprRef`)
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
 
+        **Default value:** ``"ltr"``
     dx : anyOf(float, :class:`ExprRef`)
-
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     dy : anyOf(float, :class:`ExprRef`)
-
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     ellipsis : anyOf(string, :class:`ExprRef`)
+        The ellipsis string for text truncated in response to the limit parameter.
 
+        **Default value:** ``"…"``
     endAngle : anyOf(float, :class:`ExprRef`)
-
+        The end angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     fill : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
         **Default value:** (None)
     fillOpacity : anyOf(float, :class:`ExprRef`)
+        The fill opacity (value between [0,1]).
 
+        **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
 
@@ -7949,24 +8638,48 @@ class MarkConfig(AnyMarkConfig):
         **Note:** This property cannot be used in a `style config
         <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
     font : anyOf(string, :class:`ExprRef`)
-
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : anyOf(float, :class:`ExprRef`)
+        The font size, in pixels.
 
+        **Default value:** ``11``
     fontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style (e.g., ``"italic"`` ).
     fontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     height : anyOf(float, :class:`ExprRef`)
-
+        Height of the marks.
     href : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     innerRadius : anyOf(float, :class:`ExprRef`)
         The inner radius in pixels of arc marks. ``innerRadius`` is an alias for
         ``radius2``.
 
         **Default value:** ``0``
     interpolate : anyOf(:class:`Interpolate`, :class:`ExprRef`)
+        The line interpolation method to use for line and area marks. One of the following:
 
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
     invalid : enum('filter', None)
         Defines how Vega-Lite should handle marks for invalid values ( ``null`` and ``NaN``
         ).
@@ -7977,11 +8690,16 @@ class MarkConfig(AnyMarkConfig):
         * If ``null``, all data items are included. In this case, invalid values will be
           interpreted as zeroes.
     limit : anyOf(float, :class:`ExprRef`)
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
 
+        **Default value:** ``0`` -- indicating no limit
     lineBreak : anyOf(string, :class:`ExprRef`)
-
+        A delimiter, such as a newline character, upon which to break text strings into
+        multiple lines. This property is ignored if the text is array-valued.
     lineHeight : anyOf(float, :class:`ExprRef`)
-
+        The line height in pixels (the spacing between subsequent lines of text) for
+        multi-line text marks.
     opacity : anyOf(float, :class:`ExprRef`)
         The overall opacity (value between [0,1]).
 
@@ -8007,7 +8725,7 @@ class MarkConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     padAngle : anyOf(float, :class:`ExprRef`)
-
+        The angular padding applied to sides of the arc, in radians.
     radius : anyOf(float, :class:`ExprRef`)
         For arc mark, the primary (outer) radius in pixels.
 
@@ -8020,7 +8738,20 @@ class MarkConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     shape : anyOf(anyOf(:class:`SymbolShape`, string), :class:`ExprRef`)
+        Shape of the point marks. Supported values include:
 
+
+        * plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
+          ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
+          ``"triangle-left"``.
+        * the line symbol ``"stroke"``
+        * centered directional shapes ``"arrow"``, ``"wedge"``, or ``"triangle"``
+        * a custom `SVG path string
+          <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ (For correct
+          sizing, custom shape paths should be defined within a square bounding box with
+          coordinates ranging from -1 to 1 along both the x and y dimensions.)
+
+        **Default value:** ``"circle"``
     size : anyOf(float, :class:`ExprRef`)
         Default size for marks.
 
@@ -8039,34 +8770,48 @@ class MarkConfig(AnyMarkConfig):
         * ``5`` for bar marks with continuous dimensions;
         * ``11`` for text marks.
     smooth : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag (default true) indicating if the image should be smoothed when
+        resized. If false, individual pixels should be scaled directly rather than
+        interpolated with smoothing. For SVG rendering, this option may not work in some
+        browsers due to lack of standardization.
     startAngle : anyOf(float, :class:`ExprRef`)
-
+        The start angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     stroke : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
         **Default value:** (None)
     strokeCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     strokeDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeJoin : anyOf(:class:`StrokeJoin`, :class:`ExprRef`)
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
 
+        **Default value:** ``"miter"``
     strokeMiterLimit : anyOf(float, :class:`ExprRef`)
-
+        The miter limit at which to bevel a line join.
     strokeOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset in pixels at which to draw the group stroke and fill. If unspecified, the
+        default behavior is to dynamically offset stroked groups such that 1 pixel stroke
+        widths align with the pixel grid.
     strokeOpacity : anyOf(float, :class:`ExprRef`)
+        The stroke opacity (value between [0,1]).
 
+        **Default value:** ``1``
     strokeWidth : anyOf(float, :class:`ExprRef`)
-
+        The stroke width, in pixels.
     tension : anyOf(float, :class:`ExprRef`)
-
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
     text : anyOf(:class:`Text`, :class:`ExprRef`)
-
+        Placeholder text if the ``text`` channel is not specified
     theta : anyOf(float, :class:`ExprRef`)
         For arc marks, the arc length in radians if theta2 is not specified, otherwise the
         start arc angle. (A value of 0 indicates up or “north”, increasing values proceed
@@ -8100,9 +8845,9 @@ class MarkConfig(AnyMarkConfig):
 
         **Default value:** ``null``
     url : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        The URL of the image file for image marks.
     width : anyOf(float, :class:`ExprRef`)
-
+        Width of the marks.
     x : anyOf(float, string, :class:`ExprRef`)
         X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"`` without
         specified ``x2`` or ``width``.
@@ -8194,15 +8939,25 @@ class MarkDef(AnyMark):
 
         **Note:** Expression reference is *not* supported for range marks.
     angle : anyOf(float, :class:`ExprRef`)
-
+        The rotation angle of the text, in degrees.
     aria : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG element, removing the mark item from the ARIA accessibility tree.
     ariaRole : anyOf(string, :class:`ExprRef`)
-
+        Sets the type of user interface element of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "role" attribute. Warning: this
+        property is experimental and may be changed in the future.
     ariaRoleDescription : anyOf(string, :class:`ExprRef`)
-
+        A human-readable, author-localized description for the role of the mark item for
+        `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "aria-roledescription" attribute.
+        Warning: this property is experimental and may be changed in the future.
     aspect : anyOf(boolean, :class:`ExprRef`)
-
+        Whether to keep aspect ratio of image marks.
     bandSize : float
         The width of the ticks.
 
@@ -8225,7 +8980,11 @@ class MarkDef(AnyMark):
 
         **Default value:** ``1``
     blend : anyOf(:class:`Blend`, :class:`ExprRef`)
+        The color blend mode for drawing an item on its current background. Any valid `CSS
+        mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
+        value can be used.
 
+        __Default value: ``"source-over"``
     clip : boolean
         Whether a mark be clipped to the enclosing group’s width and height.
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
@@ -8246,41 +9005,65 @@ class MarkDef(AnyMark):
 
         **Default value:** ``5``
     cornerRadius : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles or arcs' corners.
 
+        **Default value:** ``0``
     cornerRadiusBottomLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom left corner.
 
+        **Default value:** ``0``
     cornerRadiusBottomRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom right corner.
 
+        **Default value:** ``0``
     cornerRadiusEnd : anyOf(float, :class:`ExprRef`)
         For vertical bars, top-left and top-right corner radius.
 
         For horizontal bars, top-right and bottom-right corner radius.
     cornerRadiusTopLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top left corner.
 
+        **Default value:** ``0``
     cursor : anyOf(:class:`Cursor`, :class:`ExprRef`)
-
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__.
     dir : anyOf(:class:`TextDirection`, :class:`ExprRef`)
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
 
+        **Default value:** ``"ltr"``
     discreteBandSize : anyOf(float, :class:`RelativeBandSize`)
         The default size of the bars with discrete dimensions. If unspecified, the default
         size is  ``step-2``, which provides 2 pixel offset between bars.
     dx : anyOf(float, :class:`ExprRef`)
-
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     dy : anyOf(float, :class:`ExprRef`)
-
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     ellipsis : anyOf(string, :class:`ExprRef`)
+        The ellipsis string for text truncated in response to the limit parameter.
 
+        **Default value:** ``"…"``
     fill : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
         **Default value:** (None)
     fillOpacity : anyOf(float, :class:`ExprRef`)
+        The fill opacity (value between [0,1]).
 
+        **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
 
@@ -8292,13 +9075,17 @@ class MarkDef(AnyMark):
         **Note:** This property cannot be used in a `style config
         <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
     font : anyOf(string, :class:`ExprRef`)
-
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : anyOf(float, :class:`ExprRef`)
+        The font size, in pixels.
 
+        **Default value:** ``11``
     fontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style (e.g., ``"italic"`` ).
     fontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     height : anyOf(float, :class:`ExprRef`, :class:`RelativeBandSize`)
         Height of the marks.  One of:
 
@@ -8308,14 +9095,34 @@ class MarkDef(AnyMark):
         A relative band size definition.  For example, ``{band: 0.5}`` represents half of
         the band
     href : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     innerRadius : anyOf(float, :class:`ExprRef`)
         The inner radius in pixels of arc marks. ``innerRadius`` is an alias for
         ``radius2``.
 
         **Default value:** ``0``
     interpolate : anyOf(:class:`Interpolate`, :class:`ExprRef`)
+        The line interpolation method to use for line and area marks. One of the following:
 
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
     invalid : enum('filter', None)
         Defines how Vega-Lite should handle marks for invalid values ( ``null`` and ``NaN``
         ).
@@ -8326,7 +9133,10 @@ class MarkDef(AnyMark):
         * If ``null``, all data items are included. In this case, invalid values will be
           interpreted as zeroes.
     limit : anyOf(float, :class:`ExprRef`)
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
 
+        **Default value:** ``0`` -- indicating no limit
     line : anyOf(boolean, :class:`OverlayMarkDef`)
         A flag for overlaying line on top of area marks, or an object defining the
         properties of the overlayed lines.
@@ -8339,9 +9149,11 @@ class MarkDef(AnyMark):
 
         **Default value:** ``false``.
     lineBreak : anyOf(string, :class:`ExprRef`)
-
+        A delimiter, such as a newline character, upon which to break text strings into
+        multiple lines. This property is ignored if the text is array-valued.
     lineHeight : anyOf(float, :class:`ExprRef`)
-
+        The line height in pixels (the spacing between subsequent lines of text) for
+        multi-line text marks.
     opacity : anyOf(float, :class:`ExprRef`)
         The overall opacity (value between [0,1]).
 
@@ -8367,7 +9179,7 @@ class MarkDef(AnyMark):
 
         **Default value:** ``0``
     padAngle : anyOf(float, :class:`ExprRef`)
-
+        The angular padding applied to sides of the arc, in radians.
     point : anyOf(boolean, :class:`OverlayMarkDef`, string)
         A flag for overlaying points on top of line or area marks, or an object defining the
         properties of the overlayed points.
@@ -8399,7 +9211,20 @@ class MarkDef(AnyMark):
     radiusOffset : anyOf(float, :class:`ExprRef`)
         Offset for radius.
     shape : anyOf(anyOf(:class:`SymbolShape`, string), :class:`ExprRef`)
+        Shape of the point marks. Supported values include:
 
+
+        * plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
+          ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
+          ``"triangle-left"``.
+        * the line symbol ``"stroke"``
+        * centered directional shapes ``"arrow"``, ``"wedge"``, or ``"triangle"``
+        * a custom `SVG path string
+          <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ (For correct
+          sizing, custom shape paths should be defined within a square bounding box with
+          coordinates ranging from -1 to 1 along both the x and y dimensions.)
+
+        **Default value:** ``"circle"``
     size : anyOf(float, :class:`ExprRef`)
         Default size for marks.
 
@@ -8418,28 +9243,40 @@ class MarkDef(AnyMark):
         * ``5`` for bar marks with continuous dimensions;
         * ``11`` for text marks.
     smooth : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag (default true) indicating if the image should be smoothed when
+        resized. If false, individual pixels should be scaled directly rather than
+        interpolated with smoothing. For SVG rendering, this option may not work in some
+        browsers due to lack of standardization.
     stroke : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
         **Default value:** (None)
     strokeCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     strokeDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeJoin : anyOf(:class:`StrokeJoin`, :class:`ExprRef`)
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
 
+        **Default value:** ``"miter"``
     strokeMiterLimit : anyOf(float, :class:`ExprRef`)
-
+        The miter limit at which to bevel a line join.
     strokeOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset in pixels at which to draw the group stroke and fill. If unspecified, the
+        default behavior is to dynamically offset stroked groups such that 1 pixel stroke
+        widths align with the pixel grid.
     strokeOpacity : anyOf(float, :class:`ExprRef`)
+        The stroke opacity (value between [0,1]).
 
+        **Default value:** ``1``
     strokeWidth : anyOf(float, :class:`ExprRef`)
-
+        The stroke width, in pixels.
     style : anyOf(string, List(string))
         A string or array of strings indicating the name of custom styles to apply to the
         mark. A style is a named collection of mark property defaults defined within the
@@ -8455,9 +9292,10 @@ class MarkDef(AnyMark):
         ``config.style.bar`` and ``config.style.foo`` (the specified style ``"foo"`` has
         higher precedence).
     tension : anyOf(float, :class:`ExprRef`)
-
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
     text : anyOf(:class:`Text`, :class:`ExprRef`)
-
+        Placeholder text if the ``text`` channel is not specified
     theta : anyOf(float, :class:`ExprRef`)
         For arc marks, the arc length in radians if theta2 is not specified, otherwise the
         start arc angle. (A value of 0 indicates up or “north”, increasing values proceed
@@ -8499,7 +9337,7 @@ class MarkDef(AnyMark):
 
         **Default value:** ``null``
     url : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        The URL of the image file for image marks.
     width : anyOf(float, :class:`ExprRef`, :class:`RelativeBandSize`)
         Width of the marks.  One of:
 
@@ -8605,6 +9443,8 @@ class MarkPropDefGradientstringnull(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull`,
     :class:`FieldOrDatumDefWithConditionDatumDefGradientstringnull`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefGradientstringnull`)
+    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
+    ... }
     """
     _schema = {'$ref': '#/definitions/MarkPropDef<(Gradient|string|null)>'}
 
@@ -8986,6 +9826,8 @@ class MarkPropDefnumber(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefnumber`,
     :class:`FieldOrDatumDefWithConditionDatumDefnumber`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefnumber`)
+    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
+    ... }
     """
     _schema = {'$ref': '#/definitions/MarkPropDef<number>'}
 
@@ -8999,6 +9841,8 @@ class MarkPropDefnumberArray(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray`,
     :class:`FieldOrDatumDefWithConditionDatumDefnumberArray`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefnumberArray`)
+    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
+    ... }
     """
     _schema = {'$ref': '#/definitions/MarkPropDef<number[]>'}
 
@@ -9012,6 +9856,8 @@ class MarkPropDefstringnullTypeForShape(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull`,
     :class:`FieldOrDatumDefWithConditionDatumDefstringnull`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefTypeForShapestringnull`)
+    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
+    ... }
     """
     _schema = {'$ref': '#/definitions/MarkPropDef<(string|null),TypeForShape>'}
 
@@ -9129,6 +9975,8 @@ class NumericArrayMarkPropDef(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray`,
     :class:`FieldOrDatumDefWithConditionDatumDefnumberArray`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefnumberArray`)
+    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
+    ... }
     """
     _schema = {'$ref': '#/definitions/NumericArrayMarkPropDef'}
 
@@ -9508,6 +10356,8 @@ class NumericMarkPropDef(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefnumber`,
     :class:`FieldOrDatumDefWithConditionDatumDefnumber`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefnumber`)
+    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
+    ... }
     """
     _schema = {'$ref': '#/definitions/NumericMarkPropDef'}
 
@@ -9884,6 +10734,8 @@ class OffsetDef(VegaLiteSchema):
     """OffsetDef schema wrapper
 
     anyOf(:class:`ScaleFieldDef`, :class:`ScaleDatumDef`, :class:`ValueDefnumber`)
+    Definition object for a constant value (primitive value or gradient definition) of an
+    encoding channel.
     """
     _schema = {'$ref': '#/definitions/OffsetDef'}
 
@@ -10119,15 +10971,25 @@ class OverlayMarkDef(VegaLiteSchema):
 
         **Note:** Expression reference is *not* supported for range marks.
     angle : anyOf(float, :class:`ExprRef`)
-
+        The rotation angle of the text, in degrees.
     aria : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG element, removing the mark item from the ARIA accessibility tree.
     ariaRole : anyOf(string, :class:`ExprRef`)
-
+        Sets the type of user interface element of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "role" attribute. Warning: this
+        property is experimental and may be changed in the future.
     ariaRoleDescription : anyOf(string, :class:`ExprRef`)
-
+        A human-readable, author-localized description for the role of the mark item for
+        `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "aria-roledescription" attribute.
+        Warning: this property is experimental and may be changed in the future.
     aspect : anyOf(boolean, :class:`ExprRef`)
-
+        Whether to keep aspect ratio of image marks.
     baseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
         For text marks, the vertical text baseline. One of ``"alphabetic"`` (default),
         ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, ``"line-bottom"``, or an
@@ -10140,7 +11002,11 @@ class OverlayMarkDef(VegaLiteSchema):
 
         **Note:** Expression reference is *not* supported for range marks.
     blend : anyOf(:class:`Blend`, :class:`ExprRef`)
+        The color blend mode for drawing an item on its current background. Any valid `CSS
+        mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
+        value can be used.
 
+        __Default value: ``"source-over"``
     clip : boolean
         Whether a mark be clipped to the enclosing group’s width and height.
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
@@ -10157,36 +11023,61 @@ class OverlayMarkDef(VegaLiteSchema):
         * The ``fill`` and ``stroke`` properties have higher precedence than ``color`` and
           will override ``color``.
     cornerRadius : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles or arcs' corners.
 
+        **Default value:** ``0``
     cornerRadiusBottomLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom left corner.
 
+        **Default value:** ``0``
     cornerRadiusBottomRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top left corner.
 
+        **Default value:** ``0``
     cursor : anyOf(:class:`Cursor`, :class:`ExprRef`)
-
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__.
     dir : anyOf(:class:`TextDirection`, :class:`ExprRef`)
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
 
+        **Default value:** ``"ltr"``
     dx : anyOf(float, :class:`ExprRef`)
-
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     dy : anyOf(float, :class:`ExprRef`)
-
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     ellipsis : anyOf(string, :class:`ExprRef`)
+        The ellipsis string for text truncated in response to the limit parameter.
 
+        **Default value:** ``"…"``
     endAngle : anyOf(float, :class:`ExprRef`)
-
+        The end angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     fill : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
         **Default value:** (None)
     fillOpacity : anyOf(float, :class:`ExprRef`)
+        The fill opacity (value between [0,1]).
 
+        **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
 
@@ -10198,24 +11089,48 @@ class OverlayMarkDef(VegaLiteSchema):
         **Note:** This property cannot be used in a `style config
         <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
     font : anyOf(string, :class:`ExprRef`)
-
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : anyOf(float, :class:`ExprRef`)
+        The font size, in pixels.
 
+        **Default value:** ``11``
     fontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style (e.g., ``"italic"`` ).
     fontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     height : anyOf(float, :class:`ExprRef`)
-
+        Height of the marks.
     href : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     innerRadius : anyOf(float, :class:`ExprRef`)
         The inner radius in pixels of arc marks. ``innerRadius`` is an alias for
         ``radius2``.
 
         **Default value:** ``0``
     interpolate : anyOf(:class:`Interpolate`, :class:`ExprRef`)
+        The line interpolation method to use for line and area marks. One of the following:
 
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
     invalid : enum('filter', None)
         Defines how Vega-Lite should handle marks for invalid values ( ``null`` and ``NaN``
         ).
@@ -10226,11 +11141,16 @@ class OverlayMarkDef(VegaLiteSchema):
         * If ``null``, all data items are included. In this case, invalid values will be
           interpreted as zeroes.
     limit : anyOf(float, :class:`ExprRef`)
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
 
+        **Default value:** ``0`` -- indicating no limit
     lineBreak : anyOf(string, :class:`ExprRef`)
-
+        A delimiter, such as a newline character, upon which to break text strings into
+        multiple lines. This property is ignored if the text is array-valued.
     lineHeight : anyOf(float, :class:`ExprRef`)
-
+        The line height in pixels (the spacing between subsequent lines of text) for
+        multi-line text marks.
     opacity : anyOf(float, :class:`ExprRef`)
         The overall opacity (value between [0,1]).
 
@@ -10256,7 +11176,7 @@ class OverlayMarkDef(VegaLiteSchema):
 
         **Default value:** ``0``
     padAngle : anyOf(float, :class:`ExprRef`)
-
+        The angular padding applied to sides of the arc, in radians.
     radius : anyOf(float, :class:`ExprRef`)
         For arc mark, the primary (outer) radius in pixels.
 
@@ -10273,7 +11193,20 @@ class OverlayMarkDef(VegaLiteSchema):
     radiusOffset : anyOf(float, :class:`ExprRef`)
         Offset for radius.
     shape : anyOf(anyOf(:class:`SymbolShape`, string), :class:`ExprRef`)
+        Shape of the point marks. Supported values include:
 
+
+        * plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
+          ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
+          ``"triangle-left"``.
+        * the line symbol ``"stroke"``
+        * centered directional shapes ``"arrow"``, ``"wedge"``, or ``"triangle"``
+        * a custom `SVG path string
+          <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ (For correct
+          sizing, custom shape paths should be defined within a square bounding box with
+          coordinates ranging from -1 to 1 along both the x and y dimensions.)
+
+        **Default value:** ``"circle"``
     size : anyOf(float, :class:`ExprRef`)
         Default size for marks.
 
@@ -10292,30 +11225,43 @@ class OverlayMarkDef(VegaLiteSchema):
         * ``5`` for bar marks with continuous dimensions;
         * ``11`` for text marks.
     smooth : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag (default true) indicating if the image should be smoothed when
+        resized. If false, individual pixels should be scaled directly rather than
+        interpolated with smoothing. For SVG rendering, this option may not work in some
+        browsers due to lack of standardization.
     startAngle : anyOf(float, :class:`ExprRef`)
-
+        The start angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     stroke : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
         **Default value:** (None)
     strokeCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     strokeDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeJoin : anyOf(:class:`StrokeJoin`, :class:`ExprRef`)
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
 
+        **Default value:** ``"miter"``
     strokeMiterLimit : anyOf(float, :class:`ExprRef`)
-
+        The miter limit at which to bevel a line join.
     strokeOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset in pixels at which to draw the group stroke and fill. If unspecified, the
+        default behavior is to dynamically offset stroked groups such that 1 pixel stroke
+        widths align with the pixel grid.
     strokeOpacity : anyOf(float, :class:`ExprRef`)
+        The stroke opacity (value between [0,1]).
 
+        **Default value:** ``1``
     strokeWidth : anyOf(float, :class:`ExprRef`)
-
+        The stroke width, in pixels.
     style : anyOf(string, List(string))
         A string or array of strings indicating the name of custom styles to apply to the
         mark. A style is a named collection of mark property defaults defined within the
@@ -10331,9 +11277,10 @@ class OverlayMarkDef(VegaLiteSchema):
         ``config.style.bar`` and ``config.style.foo`` (the specified style ``"foo"`` has
         higher precedence).
     tension : anyOf(float, :class:`ExprRef`)
-
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
     text : anyOf(:class:`Text`, :class:`ExprRef`)
-
+        Placeholder text if the ``text`` channel is not specified
     theta : anyOf(float, :class:`ExprRef`)
         For arc marks, the arc length in radians if theta2 is not specified, otherwise the
         start arc angle. (A value of 0 indicates up or “north”, increasing values proceed
@@ -10371,9 +11318,9 @@ class OverlayMarkDef(VegaLiteSchema):
 
         **Default value:** ``null``
     url : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        The URL of the image file for image marks.
     width : anyOf(float, :class:`ExprRef`)
-
+        Width of the marks.
     x : anyOf(float, string, :class:`ExprRef`)
         X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"`` without
         specified ``x2`` or ``width``.
@@ -10736,6 +11683,8 @@ class PolarDef(VegaLiteSchema):
 
     anyOf(:class:`PositionFieldDefBase`, :class:`PositionDatumDefBase`,
     :class:`PositionValueDef`)
+    Definition object for a constant value (primitive value or gradient definition) of an
+    encoding channel.
     """
     _schema = {'$ref': '#/definitions/PolarDef'}
 
@@ -10747,6 +11696,8 @@ class Position2Def(VegaLiteSchema):
     """Position2Def schema wrapper
 
     anyOf(:class:`SecondaryFieldDef`, :class:`DatumDef`, :class:`PositionValueDef`)
+    A field definition of a secondary channel that shares a scale with another primary channel.
+    For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
     """
     _schema = {'$ref': '#/definitions/Position2Def'}
 
@@ -11024,6 +11975,8 @@ class PositionDef(VegaLiteSchema):
     """PositionDef schema wrapper
 
     anyOf(:class:`PositionFieldDef`, :class:`PositionDatumDef`, :class:`PositionValueDef`)
+    Definition object for a constant value (primitive value or gradient definition) of an
+    encoding channel.
     """
     _schema = {'$ref': '#/definitions/PositionDef'}
 
@@ -12016,52 +12969,96 @@ class Projection(VegaLiteSchema):
     ----------
 
     center : anyOf(:class:`Vector2number`, :class:`ExprRef`)
+        The projection's center, a two-element array of longitude and latitude in degrees.
 
+        **Default value:** ``[0, 0]``
     clipAngle : anyOf(float, :class:`ExprRef`)
-
+        The projection's clipping circle radius to the specified angle in degrees. If
+        ``null``, switches to `antimeridian <http://bl.ocks.org/mbostock/3788999>`__ cutting
+        rather than small-circle clipping.
     clipExtent : anyOf(:class:`Vector2Vector2number`, :class:`ExprRef`)
-
+        The projection's viewport clip extent to the specified bounds in pixels. The extent
+        bounds are specified as an array ``[[x0, y0], [x1, y1]]``, where ``x0`` is the
+        left-side of the viewport, ``y0`` is the top, ``x1`` is the right and ``y1`` is the
+        bottom. If ``null``, no viewport clipping is performed.
     coefficient : anyOf(float, :class:`ExprRef`)
+        The coefficient parameter for the ``hammer`` projection.
 
+        **Default value:** ``2``
     distance : anyOf(float, :class:`ExprRef`)
+        For the ``satellite`` projection, the distance from the center of the sphere to the
+        point of view, as a proportion of the sphere’s radius. The recommended maximum clip
+        angle for a given ``distance`` is acos(1 / distance) converted to degrees. If tilt
+        is also applied, then more conservative clipping may be necessary.
 
+        **Default value:** ``2.0``
     extent : anyOf(:class:`Vector2Vector2number`, :class:`ExprRef`)
 
     fit : anyOf(List(:class:`GeoJsonFeature`), List(:class:`Fit`), :class:`ExprRef`)
 
     fraction : anyOf(float, :class:`ExprRef`)
+        The fraction parameter for the ``bottomley`` projection.
 
+        **Default value:** ``0.5``, corresponding to a sin(ψ) where ψ = π/6.
     lobes : anyOf(float, :class:`ExprRef`)
-
+        The number of lobes in projections that support multi-lobe views: ``berghaus``,
+        ``gingery``, or ``healpix``. The default value varies based on the projection type.
     parallel : anyOf(float, :class:`ExprRef`)
-
+        The parallel parameter for projections that support it: ``armadillo``, ``bonne``,
+        ``craig``, ``cylindricalEqualArea``, ``cylindricalStereographic``,
+        ``hammerRetroazimuthal``, ``loximuthal``, or ``rectangularPolyconic``. The default
+        value varies based on the projection type.
     parallels : anyOf(List(float), :class:`ExprRef`)
-
+        For conic projections, the `two standard parallels
+        <https://en.wikipedia.org/wiki/Map_projection#Conic>`__ that define the map layout.
+        The default depends on the specific conic projection used.
     pointRadius : anyOf(float, :class:`ExprRef`)
+        The default radius (in pixels) to use when drawing GeoJSON ``Point`` and
+        ``MultiPoint`` geometries. This parameter sets a constant default value. To modify
+        the point radius in response to data, see the corresponding parameter of the GeoPath
+        and GeoShape transforms.
 
+        **Default value:** ``4.5``
     precision : anyOf(float, :class:`ExprRef`)
-
+        The threshold for the projection's `adaptive resampling
+        <http://bl.ocks.org/mbostock/3795544>`__ to the specified value in pixels. This
+        value corresponds to the `Douglas–Peucker distance
+        <http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm>`__.
+        If precision is not specified, returns the projection's current resampling precision
+        which defaults to ``√0.5 ≅ 0.70710…``.
     radius : anyOf(float, :class:`ExprRef`)
-
+        The radius parameter for the ``airy`` or ``gingery`` projection. The default value
+        varies based on the projection type.
     ratio : anyOf(float, :class:`ExprRef`)
-
+        The ratio parameter for the ``hill``, ``hufnagel``, or ``wagner`` projections. The
+        default value varies based on the projection type.
     reflectX : anyOf(boolean, :class:`ExprRef`)
-
+        Sets whether or not the x-dimension is reflected (negated) in the output.
     reflectY : anyOf(boolean, :class:`ExprRef`)
-
+        Sets whether or not the y-dimension is reflected (negated) in the output.
     rotate : anyOf(anyOf(:class:`Vector2number`, :class:`Vector3number`), :class:`ExprRef`)
+        The projection's three-axis rotation to the specified angles, which must be a two-
+        or three-element array of numbers [ ``lambda``, ``phi``, ``gamma`` ] specifying the
+        rotation angles in degrees about each spherical axis. (These correspond to yaw,
+        pitch and roll.)
 
+        **Default value:** ``[0, 0, 0]``
     scale : anyOf(float, :class:`ExprRef`)
         The projection’s scale (zoom) factor, overriding automatic fitting. The default
         scale is projection-specific. The scale factor corresponds linearly to the distance
         between projected points; however, scale factor values are not equivalent across
         projections.
     size : anyOf(:class:`Vector2number`, :class:`ExprRef`)
-
+        Used in conjunction with fit, provides the width and height in pixels of the area to
+        which the projection should be automatically fit.
     spacing : anyOf(float, :class:`ExprRef`)
+        The spacing parameter for the ``lagrange`` projection.
 
+        **Default value:** ``0.5``
     tilt : anyOf(float, :class:`ExprRef`)
+        The tilt angle (in degrees) for the ``satellite`` projection.
 
+        **Default value:** ``0``.
     translate : anyOf(:class:`Vector2number`, :class:`ExprRef`)
         The projection’s translation offset as a two-element array ``[tx, ty]``.
     type : anyOf(:class:`ProjectionType`, :class:`ExprRef`)
@@ -12100,52 +13097,96 @@ class ProjectionConfig(VegaLiteSchema):
     ----------
 
     center : anyOf(:class:`Vector2number`, :class:`ExprRef`)
+        The projection's center, a two-element array of longitude and latitude in degrees.
 
+        **Default value:** ``[0, 0]``
     clipAngle : anyOf(float, :class:`ExprRef`)
-
+        The projection's clipping circle radius to the specified angle in degrees. If
+        ``null``, switches to `antimeridian <http://bl.ocks.org/mbostock/3788999>`__ cutting
+        rather than small-circle clipping.
     clipExtent : anyOf(:class:`Vector2Vector2number`, :class:`ExprRef`)
-
+        The projection's viewport clip extent to the specified bounds in pixels. The extent
+        bounds are specified as an array ``[[x0, y0], [x1, y1]]``, where ``x0`` is the
+        left-side of the viewport, ``y0`` is the top, ``x1`` is the right and ``y1`` is the
+        bottom. If ``null``, no viewport clipping is performed.
     coefficient : anyOf(float, :class:`ExprRef`)
+        The coefficient parameter for the ``hammer`` projection.
 
+        **Default value:** ``2``
     distance : anyOf(float, :class:`ExprRef`)
+        For the ``satellite`` projection, the distance from the center of the sphere to the
+        point of view, as a proportion of the sphere’s radius. The recommended maximum clip
+        angle for a given ``distance`` is acos(1 / distance) converted to degrees. If tilt
+        is also applied, then more conservative clipping may be necessary.
 
+        **Default value:** ``2.0``
     extent : anyOf(:class:`Vector2Vector2number`, :class:`ExprRef`)
 
     fit : anyOf(List(:class:`GeoJsonFeature`), List(:class:`Fit`), :class:`ExprRef`)
 
     fraction : anyOf(float, :class:`ExprRef`)
+        The fraction parameter for the ``bottomley`` projection.
 
+        **Default value:** ``0.5``, corresponding to a sin(ψ) where ψ = π/6.
     lobes : anyOf(float, :class:`ExprRef`)
-
+        The number of lobes in projections that support multi-lobe views: ``berghaus``,
+        ``gingery``, or ``healpix``. The default value varies based on the projection type.
     parallel : anyOf(float, :class:`ExprRef`)
-
+        The parallel parameter for projections that support it: ``armadillo``, ``bonne``,
+        ``craig``, ``cylindricalEqualArea``, ``cylindricalStereographic``,
+        ``hammerRetroazimuthal``, ``loximuthal``, or ``rectangularPolyconic``. The default
+        value varies based on the projection type.
     parallels : anyOf(List(float), :class:`ExprRef`)
-
+        For conic projections, the `two standard parallels
+        <https://en.wikipedia.org/wiki/Map_projection#Conic>`__ that define the map layout.
+        The default depends on the specific conic projection used.
     pointRadius : anyOf(float, :class:`ExprRef`)
+        The default radius (in pixels) to use when drawing GeoJSON ``Point`` and
+        ``MultiPoint`` geometries. This parameter sets a constant default value. To modify
+        the point radius in response to data, see the corresponding parameter of the GeoPath
+        and GeoShape transforms.
 
+        **Default value:** ``4.5``
     precision : anyOf(float, :class:`ExprRef`)
-
+        The threshold for the projection's `adaptive resampling
+        <http://bl.ocks.org/mbostock/3795544>`__ to the specified value in pixels. This
+        value corresponds to the `Douglas–Peucker distance
+        <http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm>`__.
+        If precision is not specified, returns the projection's current resampling precision
+        which defaults to ``√0.5 ≅ 0.70710…``.
     radius : anyOf(float, :class:`ExprRef`)
-
+        The radius parameter for the ``airy`` or ``gingery`` projection. The default value
+        varies based on the projection type.
     ratio : anyOf(float, :class:`ExprRef`)
-
+        The ratio parameter for the ``hill``, ``hufnagel``, or ``wagner`` projections. The
+        default value varies based on the projection type.
     reflectX : anyOf(boolean, :class:`ExprRef`)
-
+        Sets whether or not the x-dimension is reflected (negated) in the output.
     reflectY : anyOf(boolean, :class:`ExprRef`)
-
+        Sets whether or not the y-dimension is reflected (negated) in the output.
     rotate : anyOf(anyOf(:class:`Vector2number`, :class:`Vector3number`), :class:`ExprRef`)
+        The projection's three-axis rotation to the specified angles, which must be a two-
+        or three-element array of numbers [ ``lambda``, ``phi``, ``gamma`` ] specifying the
+        rotation angles in degrees about each spherical axis. (These correspond to yaw,
+        pitch and roll.)
 
+        **Default value:** ``[0, 0, 0]``
     scale : anyOf(float, :class:`ExprRef`)
         The projection’s scale (zoom) factor, overriding automatic fitting. The default
         scale is projection-specific. The scale factor corresponds linearly to the distance
         between projected points; however, scale factor values are not equivalent across
         projections.
     size : anyOf(:class:`Vector2number`, :class:`ExprRef`)
-
+        Used in conjunction with fit, provides the width and height in pixels of the area to
+        which the projection should be automatically fit.
     spacing : anyOf(float, :class:`ExprRef`)
+        The spacing parameter for the ``lagrange`` projection.
 
+        **Default value:** ``0.5``
     tilt : anyOf(float, :class:`ExprRef`)
+        The tilt angle (in degrees) for the ``satellite`` projection.
 
+        **Default value:** ``0``.
     translate : anyOf(:class:`Vector2number`, :class:`ExprRef`)
         The projection’s translation offset as a two-element array ``[tx, ty]``.
     type : anyOf(:class:`ProjectionType`, :class:`ExprRef`)
@@ -12336,15 +13377,25 @@ class RectConfig(AnyMarkConfig):
 
         **Note:** Expression reference is *not* supported for range marks.
     angle : anyOf(float, :class:`ExprRef`)
-
+        The rotation angle of the text, in degrees.
     aria : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG element, removing the mark item from the ARIA accessibility tree.
     ariaRole : anyOf(string, :class:`ExprRef`)
-
+        Sets the type of user interface element of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "role" attribute. Warning: this
+        property is experimental and may be changed in the future.
     ariaRoleDescription : anyOf(string, :class:`ExprRef`)
-
+        A human-readable, author-localized description for the role of the mark item for
+        `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "aria-roledescription" attribute.
+        Warning: this property is experimental and may be changed in the future.
     aspect : anyOf(boolean, :class:`ExprRef`)
-
+        Whether to keep aspect ratio of image marks.
     baseline : anyOf(:class:`TextBaseline`, :class:`ExprRef`)
         For text marks, the vertical text baseline. One of ``"alphabetic"`` (default),
         ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, ``"line-bottom"``, or an
@@ -12362,7 +13413,11 @@ class RectConfig(AnyMarkConfig):
 
         **Default value:** ``1``
     blend : anyOf(:class:`Blend`, :class:`ExprRef`)
+        The color blend mode for drawing an item on its current background. Any valid `CSS
+        mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
+        value can be used.
 
+        __Default value: ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 
@@ -12381,39 +13436,64 @@ class RectConfig(AnyMarkConfig):
 
         **Default value:** ``5``
     cornerRadius : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles or arcs' corners.
 
+        **Default value:** ``0``
     cornerRadiusBottomLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom left corner.
 
+        **Default value:** ``0``
     cornerRadiusBottomRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top left corner.
 
+        **Default value:** ``0``
     cursor : anyOf(:class:`Cursor`, :class:`ExprRef`)
-
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__.
     dir : anyOf(:class:`TextDirection`, :class:`ExprRef`)
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
 
+        **Default value:** ``"ltr"``
     discreteBandSize : anyOf(float, :class:`RelativeBandSize`)
         The default size of the bars with discrete dimensions. If unspecified, the default
         size is  ``step-2``, which provides 2 pixel offset between bars.
     dx : anyOf(float, :class:`ExprRef`)
-
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     dy : anyOf(float, :class:`ExprRef`)
-
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     ellipsis : anyOf(string, :class:`ExprRef`)
+        The ellipsis string for text truncated in response to the limit parameter.
 
+        **Default value:** ``"…"``
     endAngle : anyOf(float, :class:`ExprRef`)
-
+        The end angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     fill : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
         **Default value:** (None)
     fillOpacity : anyOf(float, :class:`ExprRef`)
+        The fill opacity (value between [0,1]).
 
+        **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
 
@@ -12425,24 +13505,48 @@ class RectConfig(AnyMarkConfig):
         **Note:** This property cannot be used in a `style config
         <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
     font : anyOf(string, :class:`ExprRef`)
-
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : anyOf(float, :class:`ExprRef`)
+        The font size, in pixels.
 
+        **Default value:** ``11``
     fontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style (e.g., ``"italic"`` ).
     fontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     height : anyOf(float, :class:`ExprRef`)
-
+        Height of the marks.
     href : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     innerRadius : anyOf(float, :class:`ExprRef`)
         The inner radius in pixels of arc marks. ``innerRadius`` is an alias for
         ``radius2``.
 
         **Default value:** ``0``
     interpolate : anyOf(:class:`Interpolate`, :class:`ExprRef`)
+        The line interpolation method to use for line and area marks. One of the following:
 
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
     invalid : enum('filter', None)
         Defines how Vega-Lite should handle marks for invalid values ( ``null`` and ``NaN``
         ).
@@ -12453,11 +13557,16 @@ class RectConfig(AnyMarkConfig):
         * If ``null``, all data items are included. In this case, invalid values will be
           interpreted as zeroes.
     limit : anyOf(float, :class:`ExprRef`)
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
 
+        **Default value:** ``0`` -- indicating no limit
     lineBreak : anyOf(string, :class:`ExprRef`)
-
+        A delimiter, such as a newline character, upon which to break text strings into
+        multiple lines. This property is ignored if the text is array-valued.
     lineHeight : anyOf(float, :class:`ExprRef`)
-
+        The line height in pixels (the spacing between subsequent lines of text) for
+        multi-line text marks.
     opacity : anyOf(float, :class:`ExprRef`)
         The overall opacity (value between [0,1]).
 
@@ -12483,7 +13592,7 @@ class RectConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     padAngle : anyOf(float, :class:`ExprRef`)
-
+        The angular padding applied to sides of the arc, in radians.
     radius : anyOf(float, :class:`ExprRef`)
         For arc mark, the primary (outer) radius in pixels.
 
@@ -12496,7 +13605,20 @@ class RectConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     shape : anyOf(anyOf(:class:`SymbolShape`, string), :class:`ExprRef`)
+        Shape of the point marks. Supported values include:
 
+
+        * plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
+          ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
+          ``"triangle-left"``.
+        * the line symbol ``"stroke"``
+        * centered directional shapes ``"arrow"``, ``"wedge"``, or ``"triangle"``
+        * a custom `SVG path string
+          <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ (For correct
+          sizing, custom shape paths should be defined within a square bounding box with
+          coordinates ranging from -1 to 1 along both the x and y dimensions.)
+
+        **Default value:** ``"circle"``
     size : anyOf(float, :class:`ExprRef`)
         Default size for marks.
 
@@ -12515,34 +13637,48 @@ class RectConfig(AnyMarkConfig):
         * ``5`` for bar marks with continuous dimensions;
         * ``11`` for text marks.
     smooth : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag (default true) indicating if the image should be smoothed when
+        resized. If false, individual pixels should be scaled directly rather than
+        interpolated with smoothing. For SVG rendering, this option may not work in some
+        browsers due to lack of standardization.
     startAngle : anyOf(float, :class:`ExprRef`)
-
+        The start angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     stroke : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
         **Default value:** (None)
     strokeCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     strokeDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeJoin : anyOf(:class:`StrokeJoin`, :class:`ExprRef`)
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
 
+        **Default value:** ``"miter"``
     strokeMiterLimit : anyOf(float, :class:`ExprRef`)
-
+        The miter limit at which to bevel a line join.
     strokeOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset in pixels at which to draw the group stroke and fill. If unspecified, the
+        default behavior is to dynamically offset stroked groups such that 1 pixel stroke
+        widths align with the pixel grid.
     strokeOpacity : anyOf(float, :class:`ExprRef`)
+        The stroke opacity (value between [0,1]).
 
+        **Default value:** ``1``
     strokeWidth : anyOf(float, :class:`ExprRef`)
-
+        The stroke width, in pixels.
     tension : anyOf(float, :class:`ExprRef`)
-
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
     text : anyOf(:class:`Text`, :class:`ExprRef`)
-
+        Placeholder text if the ``text`` channel is not specified
     theta : anyOf(float, :class:`ExprRef`)
         For arc marks, the arc length in radians if theta2 is not specified, otherwise the
         start arc angle. (A value of 0 indicates up or “north”, increasing values proceed
@@ -12576,9 +13712,9 @@ class RectConfig(AnyMarkConfig):
 
         **Default value:** ``null``
     url : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        The URL of the image file for image marks.
     width : anyOf(float, :class:`ExprRef`)
-
+        Width of the marks.
     x : anyOf(float, string, :class:`ExprRef`)
         X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"`` without
         specified ``x2`` or ``width``.
@@ -14097,6 +15233,9 @@ class SelectionInit(VegaLiteSchema):
     """SelectionInit schema wrapper
 
     anyOf(:class:`PrimitiveValue`, :class:`DateTime`)
+    Object for defining datetime in Vega-Lite Filter. If both month and quarter are provided,
+    month has higher precedence. ``day`` cannot be combined with other date. We accept string
+    for month and day names.
     """
     _schema = {'$ref': '#/definitions/SelectionInit'}
 
@@ -14386,6 +15525,8 @@ class ShapeDef(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull`,
     :class:`FieldOrDatumDefWithConditionDatumDefstringnull`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefTypeForShapestringnull`)
+    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
+    ... }
     """
     _schema = {'$ref': '#/definitions/ShapeDef'}
 
@@ -14906,6 +16047,7 @@ class Sort(VegaLiteSchema):
 
     anyOf(:class:`SortArray`, :class:`AllSortString`, :class:`EncodingSortField`,
     :class:`SortByEncoding`, None)
+    A sort definition for sorting a discrete scale in an encoding field definition.
     """
     _schema = {'$ref': '#/definitions/Sort'}
 
@@ -15564,6 +16706,7 @@ class RepeatSpec(Spec, NonNormalizedSpec):
     """RepeatSpec schema wrapper
 
     anyOf(:class:`NonLayerRepeatSpec`, :class:`LayerRepeatSpec`)
+    Base interface for a repeat specification.
     """
     _schema = {'$ref': '#/definitions/RepeatSpec'}
 
@@ -16511,6 +17654,8 @@ class TextDef(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionStringFieldDefText`,
     :class:`FieldOrDatumDefWithConditionStringDatumDefText`,
     :class:`ValueDefWithConditionStringFieldDefText`)
+    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
+    ... }
     """
     _schema = {'$ref': '#/definitions/TextDef'}
 
@@ -16916,15 +18061,25 @@ class TickConfig(AnyMarkConfig):
 
         **Note:** Expression reference is *not* supported for range marks.
     angle : anyOf(float, :class:`ExprRef`)
-
+        The rotation angle of the text, in degrees.
     aria : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG element, removing the mark item from the ARIA accessibility tree.
     ariaRole : anyOf(string, :class:`ExprRef`)
-
+        Sets the type of user interface element of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "role" attribute. Warning: this
+        property is experimental and may be changed in the future.
     ariaRoleDescription : anyOf(string, :class:`ExprRef`)
-
+        A human-readable, author-localized description for the role of the mark item for
+        `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the "aria-roledescription" attribute.
+        Warning: this property is experimental and may be changed in the future.
     aspect : anyOf(boolean, :class:`ExprRef`)
-
+        Whether to keep aspect ratio of image marks.
     bandSize : float
         The width of the ticks.
 
@@ -16942,7 +18097,11 @@ class TickConfig(AnyMarkConfig):
 
         **Note:** Expression reference is *not* supported for range marks.
     blend : anyOf(:class:`Blend`, :class:`ExprRef`)
+        The color blend mode for drawing an item on its current background. Any valid `CSS
+        mix-blend-mode <https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode>`__
+        value can be used.
 
+        __Default value: ``"source-over"``
     color : anyOf(:class:`Color`, :class:`Gradient`, :class:`ExprRef`)
         Default color.
 
@@ -16957,36 +18116,61 @@ class TickConfig(AnyMarkConfig):
         * The ``fill`` and ``stroke`` properties have higher precedence than ``color`` and
           will override ``color``.
     cornerRadius : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles or arcs' corners.
 
+        **Default value:** ``0``
     cornerRadiusBottomLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom left corner.
 
+        **Default value:** ``0``
     cornerRadiusBottomRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' bottom right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopLeft : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top right corner.
 
+        **Default value:** ``0``
     cornerRadiusTopRight : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles' top left corner.
 
+        **Default value:** ``0``
     cursor : anyOf(:class:`Cursor`, :class:`ExprRef`)
-
+        The mouse cursor used over the mark. Any valid `CSS cursor type
+        <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
     description : anyOf(string, :class:`ExprRef`)
-
+        A text description of the mark item for `ARIA accessibility
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ (SVG output
+        only). If specified, this property determines the `"aria-label" attribute
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute>`__.
     dir : anyOf(:class:`TextDirection`, :class:`ExprRef`)
+        The direction of the text. One of ``"ltr"`` (left-to-right) or ``"rtl"``
+        (right-to-left). This property determines on which side is truncated in response to
+        the limit parameter.
 
+        **Default value:** ``"ltr"``
     dx : anyOf(float, :class:`ExprRef`)
-
+        The horizontal offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     dy : anyOf(float, :class:`ExprRef`)
-
+        The vertical offset, in pixels, between the text label and its anchor point. The
+        offset is applied after rotation by the *angle* property.
     ellipsis : anyOf(string, :class:`ExprRef`)
+        The ellipsis string for text truncated in response to the limit parameter.
 
+        **Default value:** ``"…"``
     endAngle : anyOf(float, :class:`ExprRef`)
-
+        The end angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     fill : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default fill color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove fill.
 
         **Default value:** (None)
     fillOpacity : anyOf(float, :class:`ExprRef`)
+        The fill opacity (value between [0,1]).
 
+        **Default value:** ``1``
     filled : boolean
         Whether the mark's color should be used as fill color instead of stroke color.
 
@@ -16998,24 +18182,48 @@ class TickConfig(AnyMarkConfig):
         **Note:** This property cannot be used in a `style config
         <https://vega.github.io/vega-lite/docs/mark.html#style-config>`__.
     font : anyOf(string, :class:`ExprRef`)
-
+        The typeface to set the text in (e.g., ``"Helvetica Neue"`` ).
     fontSize : anyOf(float, :class:`ExprRef`)
+        The font size, in pixels.
 
+        **Default value:** ``11``
     fontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        The font style (e.g., ``"italic"`` ).
     fontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        The font weight. This can be either a string (e.g ``"bold"``, ``"normal"`` ) or a
+        number ( ``100``, ``200``, ``300``, ..., ``900`` where ``"normal"`` = ``400`` and
+        ``"bold"`` = ``700`` ).
     height : anyOf(float, :class:`ExprRef`)
-
+        Height of the marks.
     href : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
     innerRadius : anyOf(float, :class:`ExprRef`)
         The inner radius in pixels of arc marks. ``innerRadius`` is an alias for
         ``radius2``.
 
         **Default value:** ``0``
     interpolate : anyOf(:class:`Interpolate`, :class:`ExprRef`)
+        The line interpolation method to use for line and area marks. One of the following:
 
+
+        * ``"linear"`` : piecewise linear segments, as in a polyline.
+        * ``"linear-closed"`` : close the linear segments to form a polygon.
+        * ``"step"`` : alternate between horizontal and vertical segments, as in a step
+          function.
+        * ``"step-before"`` : alternate between vertical and horizontal segments, as in a
+          step function.
+        * ``"step-after"`` : alternate between horizontal and vertical segments, as in a
+          step function.
+        * ``"basis"`` : a B-spline, with control point duplication on the ends.
+        * ``"basis-open"`` : an open B-spline; may not intersect the start or end.
+        * ``"basis-closed"`` : a closed B-spline, as in a loop.
+        * ``"cardinal"`` : a Cardinal spline, with control point duplication on the ends.
+        * ``"cardinal-open"`` : an open Cardinal spline; may not intersect the start or end,
+          but will intersect other control points.
+        * ``"cardinal-closed"`` : a closed Cardinal spline, as in a loop.
+        * ``"bundle"`` : equivalent to basis, except the tension parameter is used to
+          straighten the spline.
+        * ``"monotone"`` : cubic interpolation that preserves monotonicity in y.
     invalid : enum('filter', None)
         Defines how Vega-Lite should handle marks for invalid values ( ``null`` and ``NaN``
         ).
@@ -17026,11 +18234,16 @@ class TickConfig(AnyMarkConfig):
         * If ``null``, all data items are included. In this case, invalid values will be
           interpreted as zeroes.
     limit : anyOf(float, :class:`ExprRef`)
+        The maximum length of the text mark in pixels. The text value will be automatically
+        truncated if the rendered size exceeds the limit.
 
+        **Default value:** ``0`` -- indicating no limit
     lineBreak : anyOf(string, :class:`ExprRef`)
-
+        A delimiter, such as a newline character, upon which to break text strings into
+        multiple lines. This property is ignored if the text is array-valued.
     lineHeight : anyOf(float, :class:`ExprRef`)
-
+        The line height in pixels (the spacing between subsequent lines of text) for
+        multi-line text marks.
     opacity : anyOf(float, :class:`ExprRef`)
         The overall opacity (value between [0,1]).
 
@@ -17056,7 +18269,7 @@ class TickConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     padAngle : anyOf(float, :class:`ExprRef`)
-
+        The angular padding applied to sides of the arc, in radians.
     radius : anyOf(float, :class:`ExprRef`)
         For arc mark, the primary (outer) radius in pixels.
 
@@ -17069,7 +18282,20 @@ class TickConfig(AnyMarkConfig):
 
         **Default value:** ``0``
     shape : anyOf(anyOf(:class:`SymbolShape`, string), :class:`ExprRef`)
+        Shape of the point marks. Supported values include:
 
+
+        * plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``,
+          ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or
+          ``"triangle-left"``.
+        * the line symbol ``"stroke"``
+        * centered directional shapes ``"arrow"``, ``"wedge"``, or ``"triangle"``
+        * a custom `SVG path string
+          <https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths>`__ (For correct
+          sizing, custom shape paths should be defined within a square bounding box with
+          coordinates ranging from -1 to 1 along both the x and y dimensions.)
+
+        **Default value:** ``"circle"``
     size : anyOf(float, :class:`ExprRef`)
         Default size for marks.
 
@@ -17088,34 +18314,48 @@ class TickConfig(AnyMarkConfig):
         * ``5`` for bar marks with continuous dimensions;
         * ``11`` for text marks.
     smooth : anyOf(boolean, :class:`ExprRef`)
-
+        A boolean flag (default true) indicating if the image should be smoothed when
+        resized. If false, individual pixels should be scaled directly rather than
+        interpolated with smoothing. For SVG rendering, this option may not work in some
+        browsers due to lack of standardization.
     startAngle : anyOf(float, :class:`ExprRef`)
-
+        The start angle in radians for arc marks. A value of ``0`` indicates up (north),
+        increasing values proceed clockwise.
     stroke : anyOf(:class:`Color`, :class:`Gradient`, None, :class:`ExprRef`)
         Default stroke color. This property has higher precedence than ``config.color``. Set
         to ``null`` to remove stroke.
 
         **Default value:** (None)
     strokeCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     strokeDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeJoin : anyOf(:class:`StrokeJoin`, :class:`ExprRef`)
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
 
+        **Default value:** ``"miter"``
     strokeMiterLimit : anyOf(float, :class:`ExprRef`)
-
+        The miter limit at which to bevel a line join.
     strokeOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset in pixels at which to draw the group stroke and fill. If unspecified, the
+        default behavior is to dynamically offset stroked groups such that 1 pixel stroke
+        widths align with the pixel grid.
     strokeOpacity : anyOf(float, :class:`ExprRef`)
+        The stroke opacity (value between [0,1]).
 
+        **Default value:** ``1``
     strokeWidth : anyOf(float, :class:`ExprRef`)
-
+        The stroke width, in pixels.
     tension : anyOf(float, :class:`ExprRef`)
-
+        Depending on the interpolation type, sets the tension parameter (for line and area
+        marks).
     text : anyOf(:class:`Text`, :class:`ExprRef`)
-
+        Placeholder text if the ``text`` channel is not specified
     theta : anyOf(float, :class:`ExprRef`)
         For arc marks, the arc length in radians if theta2 is not specified, otherwise the
         start arc angle. (A value of 0 indicates up or “north”, increasing values proceed
@@ -17153,9 +18393,9 @@ class TickConfig(AnyMarkConfig):
 
         **Default value:** ``null``
     url : anyOf(:class:`URI`, :class:`ExprRef`)
-
+        The URL of the image file for image marks.
     width : anyOf(float, :class:`ExprRef`)
-
+        Width of the marks.
     x : anyOf(float, string, :class:`ExprRef`)
         X coordinates of the marks, or width of horizontal ``"bar"`` and ``"area"`` without
         specified ``x2`` or ``width``.
@@ -17412,11 +18652,18 @@ class TitleConfig(VegaLiteSchema):
         Horizontal text alignment for title text. One of ``"left"``, ``"center"``, or
         ``"right"``.
     anchor : anyOf(:class:`TitleAnchor`, :class:`ExprRef`)
-
+        The anchor position for placing the title and subtitle text. One of ``"start"``,
+        ``"middle"``, or ``"end"``. For example, with an orientation of top these anchor
+        positions map to a left-, center-, or right-aligned title.
     angle : anyOf(float, :class:`ExprRef`)
-
+        Angle in degrees of title and subtitle text.
     aria : anyOf(boolean, :class:`ExprRef`)
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG group, removing the title from the ARIA accessibility tree.
 
+        **Default value:** ``true``
     baseline : :class:`TextBaseline`
         Vertical text baseline for title and subtitle text. One of ``"alphabetic"``
         (default), ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, or
@@ -17424,45 +18671,56 @@ class TitleConfig(VegaLiteSchema):
         to ``"top"`` and ``"bottom"``, but are calculated relative to the *lineHeight*
         rather than *fontSize* alone.
     color : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Text color for title text.
     dx : anyOf(float, :class:`ExprRef`)
-
+        Delta offset for title and subtitle text x-coordinate.
     dy : anyOf(float, :class:`ExprRef`)
-
+        Delta offset for title and subtitle text y-coordinate.
     font : anyOf(string, :class:`ExprRef`)
-
+        Font name for title text.
     fontSize : anyOf(float, :class:`ExprRef`)
-
+        Font size in pixels for title text.
     fontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        Font style for title text.
     fontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        Font weight for title text. This can be either a string (e.g ``"bold"``,
+        ``"normal"`` ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where
+        ``"normal"`` = ``400`` and ``"bold"`` = ``700`` ).
     frame : anyOf(anyOf(:class:`TitleFrame`, string), :class:`ExprRef`)
-
+        The reference frame for the anchor position, one of ``"bounds"`` (to anchor relative
+        to the full bounding box) or ``"group"`` (to anchor relative to the group width or
+        height).
     limit : anyOf(float, :class:`ExprRef`)
-
+        The maximum allowed length in pixels of title and subtitle text.
     lineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line title text or title text with ``"line-top"`` or
+        ``"line-bottom"`` baseline.
     offset : anyOf(float, :class:`ExprRef`)
-
+        The orthogonal offset in pixels by which to displace the title group from its
+        position along the edge of the chart.
     orient : anyOf(:class:`TitleOrient`, :class:`ExprRef`)
-
+        Default title orientation ( ``"top"``, ``"bottom"``, ``"left"``, or ``"right"`` )
     subtitleColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Text color for subtitle text.
     subtitleFont : anyOf(string, :class:`ExprRef`)
-
+        Font name for subtitle text.
     subtitleFontSize : anyOf(float, :class:`ExprRef`)
-
+        Font size in pixels for subtitle text.
     subtitleFontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        Font style for subtitle text.
     subtitleFontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        Font weight for subtitle text. This can be either a string (e.g ``"bold"``,
+        ``"normal"`` ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where
+        ``"normal"`` = ``400`` and ``"bold"`` = ``700`` ).
     subtitleLineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line subtitle text.
     subtitlePadding : anyOf(float, :class:`ExprRef`)
-
+        The padding in pixels between title and subtitle text.
     zindex : anyOf(float, :class:`ExprRef`)
+        The integer z-index indicating the layering of the title group relative to other
+        axis, mark, and legend groups.
 
+        **Default value:** ``0``.
     """
     _schema = {'$ref': '#/definitions/TitleConfig'}
 
@@ -17536,9 +18794,14 @@ class TitleParams(VegaLiteSchema):
         <https://vega.github.io/vega-lite/docs/layer.html>`__ views. For other composite
         views, ``anchor`` is always ``"start"``.
     angle : anyOf(float, :class:`ExprRef`)
-
+        Angle in degrees of title and subtitle text.
     aria : anyOf(boolean, :class:`ExprRef`)
+        A boolean flag indicating if `ARIA attributes
+        <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA>`__ should be
+        included (SVG output only). If ``false``, the "aria-hidden" attribute will be set on
+        the output SVG group, removing the title from the ARIA accessibility tree.
 
+        **Default value:** ``true``
     baseline : :class:`TextBaseline`
         Vertical text baseline for title and subtitle text. One of ``"alphabetic"``
         (default), ``"top"``, ``"middle"``, ``"bottom"``, ``"line-top"``, or
@@ -17546,29 +18809,35 @@ class TitleParams(VegaLiteSchema):
         to ``"top"`` and ``"bottom"``, but are calculated relative to the *lineHeight*
         rather than *fontSize* alone.
     color : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Text color for title text.
     dx : anyOf(float, :class:`ExprRef`)
-
+        Delta offset for title and subtitle text x-coordinate.
     dy : anyOf(float, :class:`ExprRef`)
-
+        Delta offset for title and subtitle text y-coordinate.
     font : anyOf(string, :class:`ExprRef`)
-
+        Font name for title text.
     fontSize : anyOf(float, :class:`ExprRef`)
-
+        Font size in pixels for title text.
     fontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        Font style for title text.
     fontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        Font weight for title text. This can be either a string (e.g ``"bold"``,
+        ``"normal"`` ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where
+        ``"normal"`` = ``400`` and ``"bold"`` = ``700`` ).
     frame : anyOf(anyOf(:class:`TitleFrame`, string), :class:`ExprRef`)
-
+        The reference frame for the anchor position, one of ``"bounds"`` (to anchor relative
+        to the full bounding box) or ``"group"`` (to anchor relative to the group width or
+        height).
     limit : anyOf(float, :class:`ExprRef`)
-
+        The maximum allowed length in pixels of title and subtitle text.
     lineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line title text or title text with ``"line-top"`` or
+        ``"line-bottom"`` baseline.
     offset : anyOf(float, :class:`ExprRef`)
-
+        The orthogonal offset in pixels by which to displace the title group from its
+        position along the edge of the chart.
     orient : anyOf(:class:`TitleOrient`, :class:`ExprRef`)
-
+        Default title orientation ( ``"top"``, ``"bottom"``, ``"left"``, or ``"right"`` )
     style : anyOf(string, List(string))
         A `mark style property <https://vega.github.io/vega-lite/docs/config.html#style>`__
         to apply to the title text mark.
@@ -17577,19 +18846,21 @@ class TitleParams(VegaLiteSchema):
     subtitle : :class:`Text`
         The subtitle Text.
     subtitleColor : anyOf(anyOf(None, :class:`Color`), :class:`ExprRef`)
-
+        Text color for subtitle text.
     subtitleFont : anyOf(string, :class:`ExprRef`)
-
+        Font name for subtitle text.
     subtitleFontSize : anyOf(float, :class:`ExprRef`)
-
+        Font size in pixels for subtitle text.
     subtitleFontStyle : anyOf(:class:`FontStyle`, :class:`ExprRef`)
-
+        Font style for subtitle text.
     subtitleFontWeight : anyOf(:class:`FontWeight`, :class:`ExprRef`)
-
+        Font weight for subtitle text. This can be either a string (e.g ``"bold"``,
+        ``"normal"`` ) or a number ( ``100``, ``200``, ``300``, ..., ``900`` where
+        ``"normal"`` = ``400`` and ``"bold"`` = ``700`` ).
     subtitleLineHeight : anyOf(float, :class:`ExprRef`)
-
+        Line height in pixels for multi-line subtitle text.
     subtitlePadding : anyOf(float, :class:`ExprRef`)
-
+        The padding in pixels between title and subtitle text.
     zindex : float
         The integer z-index indicating the layering of the title group relative to other
         axis, mark and legend groups.
@@ -19864,7 +21135,9 @@ class ViewBackground(VegaLiteSchema):
     ----------
 
     cornerRadius : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles or arcs' corners.
 
+        **Default value:** ``0``
     cursor : :class:`Cursor`
         The mouse cursor used over the view. Any valid `CSS cursor type
         <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
@@ -19873,7 +21146,9 @@ class ViewBackground(VegaLiteSchema):
 
         **Default value:** ``undefined``
     fillOpacity : anyOf(float, :class:`ExprRef`)
+        The fill opacity (value between [0,1]).
 
+        **Default value:** ``1``
     opacity : anyOf(float, :class:`ExprRef`)
         The overall opacity (value between [0,1]).
 
@@ -19884,19 +21159,26 @@ class ViewBackground(VegaLiteSchema):
 
         **Default value:** ``"#ddd"``
     strokeCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     strokeDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeJoin : anyOf(:class:`StrokeJoin`, :class:`ExprRef`)
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
 
+        **Default value:** ``"miter"``
     strokeMiterLimit : anyOf(float, :class:`ExprRef`)
-
+        The miter limit at which to bevel a line join.
     strokeOpacity : anyOf(float, :class:`ExprRef`)
+        The stroke opacity (value between [0,1]).
 
+        **Default value:** ``1``
     strokeWidth : anyOf(float, :class:`ExprRef`)
-
+        The stroke width, in pixels.
     style : anyOf(string, List(string))
         A string or array of strings indicating the name of custom styles to apply to the
         view background. A style is a named collection of mark property defaults defined
@@ -19943,7 +21225,9 @@ class ViewConfig(VegaLiteSchema):
 
         **Default value:** ``200``
     cornerRadius : anyOf(float, :class:`ExprRef`)
+        The radius in pixels of rounded rectangles or arcs' corners.
 
+        **Default value:** ``0``
     cursor : :class:`Cursor`
         The mouse cursor used over the view. Any valid `CSS cursor type
         <https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values>`__ can be used.
@@ -19964,7 +21248,9 @@ class ViewConfig(VegaLiteSchema):
 
         **Default value:** ``undefined``
     fillOpacity : anyOf(float, :class:`ExprRef`)
+        The fill opacity (value between [0,1]).
 
+        **Default value:** ``1``
     opacity : anyOf(float, :class:`ExprRef`)
         The overall opacity (value between [0,1]).
 
@@ -19977,19 +21263,26 @@ class ViewConfig(VegaLiteSchema):
 
         **Default value:** ``"#ddd"``
     strokeCap : anyOf(:class:`StrokeCap`, :class:`ExprRef`)
+        The stroke cap for line ending style. One of ``"butt"``, ``"round"``, or
+        ``"square"``.
 
+        **Default value:** ``"butt"``
     strokeDash : anyOf(List(float), :class:`ExprRef`)
-
+        An array of alternating stroke, space lengths for creating dashed or dotted lines.
     strokeDashOffset : anyOf(float, :class:`ExprRef`)
-
+        The offset (in pixels) into which to begin drawing with the stroke dash array.
     strokeJoin : anyOf(:class:`StrokeJoin`, :class:`ExprRef`)
+        The stroke line join method. One of ``"miter"``, ``"round"`` or ``"bevel"``.
 
+        **Default value:** ``"miter"``
     strokeMiterLimit : anyOf(float, :class:`ExprRef`)
-
+        The miter limit at which to bevel a line join.
     strokeOpacity : anyOf(float, :class:`ExprRef`)
+        The stroke opacity (value between [0,1]).
 
+        **Default value:** ``1``
     strokeWidth : anyOf(float, :class:`ExprRef`)
-
+        The stroke width, in pixels.
     """
     _schema = {'$ref': '#/definitions/ViewConfig'}
 

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -96,7 +96,6 @@ class AnyMark(VegaLiteSchema):
     """AnyMark schema wrapper
 
     anyOf(:class:`CompositeMark`, :class:`CompositeMarkDef`, :class:`Mark`, :class:`MarkDef`)
-    All types of primitive marks.
     """
     _schema = {'$ref': '#/definitions/AnyMark'}
 
@@ -2441,8 +2440,6 @@ class ColorDef(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull`,
     :class:`FieldOrDatumDefWithConditionDatumDefGradientstringnull`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefGradientstringnull`)
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
     """
     _schema = {'$ref': '#/definitions/ColorDef'}
 
@@ -5573,7 +5570,6 @@ class Field(VegaLiteSchema):
     """Field schema wrapper
 
     anyOf(:class:`FieldName`, :class:`RepeatRef`)
-    Reference to a repeated value.
     """
     _schema = {'$ref': '#/definitions/Field'}
 
@@ -9443,8 +9439,6 @@ class MarkPropDefGradientstringnull(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull`,
     :class:`FieldOrDatumDefWithConditionDatumDefGradientstringnull`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefGradientstringnull`)
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
     """
     _schema = {'$ref': '#/definitions/MarkPropDef<(Gradient|string|null)>'}
 
@@ -9826,8 +9820,6 @@ class MarkPropDefnumber(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefnumber`,
     :class:`FieldOrDatumDefWithConditionDatumDefnumber`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefnumber`)
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
     """
     _schema = {'$ref': '#/definitions/MarkPropDef<number>'}
 
@@ -9841,8 +9833,6 @@ class MarkPropDefnumberArray(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray`,
     :class:`FieldOrDatumDefWithConditionDatumDefnumberArray`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefnumberArray`)
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
     """
     _schema = {'$ref': '#/definitions/MarkPropDef<number[]>'}
 
@@ -9856,8 +9846,6 @@ class MarkPropDefstringnullTypeForShape(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull`,
     :class:`FieldOrDatumDefWithConditionDatumDefstringnull`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefTypeForShapestringnull`)
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
     """
     _schema = {'$ref': '#/definitions/MarkPropDef<(string|null),TypeForShape>'}
 
@@ -9975,8 +9963,6 @@ class NumericArrayMarkPropDef(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray`,
     :class:`FieldOrDatumDefWithConditionDatumDefnumberArray`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefnumberArray`)
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
     """
     _schema = {'$ref': '#/definitions/NumericArrayMarkPropDef'}
 
@@ -10356,8 +10342,6 @@ class NumericMarkPropDef(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefnumber`,
     :class:`FieldOrDatumDefWithConditionDatumDefnumber`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefnumber`)
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
     """
     _schema = {'$ref': '#/definitions/NumericMarkPropDef'}
 
@@ -10734,8 +10718,6 @@ class OffsetDef(VegaLiteSchema):
     """OffsetDef schema wrapper
 
     anyOf(:class:`ScaleFieldDef`, :class:`ScaleDatumDef`, :class:`ValueDefnumber`)
-    Definition object for a constant value (primitive value or gradient definition) of an
-    encoding channel.
     """
     _schema = {'$ref': '#/definitions/OffsetDef'}
 
@@ -11683,8 +11665,6 @@ class PolarDef(VegaLiteSchema):
 
     anyOf(:class:`PositionFieldDefBase`, :class:`PositionDatumDefBase`,
     :class:`PositionValueDef`)
-    Definition object for a constant value (primitive value or gradient definition) of an
-    encoding channel.
     """
     _schema = {'$ref': '#/definitions/PolarDef'}
 
@@ -11696,8 +11676,6 @@ class Position2Def(VegaLiteSchema):
     """Position2Def schema wrapper
 
     anyOf(:class:`SecondaryFieldDef`, :class:`DatumDef`, :class:`PositionValueDef`)
-    A field definition of a secondary channel that shares a scale with another primary channel.
-    For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
     """
     _schema = {'$ref': '#/definitions/Position2Def'}
 
@@ -11975,8 +11953,6 @@ class PositionDef(VegaLiteSchema):
     """PositionDef schema wrapper
 
     anyOf(:class:`PositionFieldDef`, :class:`PositionDatumDef`, :class:`PositionValueDef`)
-    Definition object for a constant value (primitive value or gradient definition) of an
-    encoding channel.
     """
     _schema = {'$ref': '#/definitions/PositionDef'}
 
@@ -15233,9 +15209,6 @@ class SelectionInit(VegaLiteSchema):
     """SelectionInit schema wrapper
 
     anyOf(:class:`PrimitiveValue`, :class:`DateTime`)
-    Object for defining datetime in Vega-Lite Filter. If both month and quarter are provided,
-    month has higher precedence. ``day`` cannot be combined with other date. We accept string
-    for month and day names.
     """
     _schema = {'$ref': '#/definitions/SelectionInit'}
 
@@ -15525,8 +15498,6 @@ class ShapeDef(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull`,
     :class:`FieldOrDatumDefWithConditionDatumDefstringnull`,
     :class:`ValueDefWithConditionMarkPropFieldOrDatumDefTypeForShapestringnull`)
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
     """
     _schema = {'$ref': '#/definitions/ShapeDef'}
 
@@ -16047,7 +16018,6 @@ class Sort(VegaLiteSchema):
 
     anyOf(:class:`SortArray`, :class:`AllSortString`, :class:`EncodingSortField`,
     :class:`SortByEncoding`, None)
-    A sort definition for sorting a discrete scale in an encoding field definition.
     """
     _schema = {'$ref': '#/definitions/Sort'}
 
@@ -16706,7 +16676,6 @@ class RepeatSpec(Spec, NonNormalizedSpec):
     """RepeatSpec schema wrapper
 
     anyOf(:class:`NonLayerRepeatSpec`, :class:`LayerRepeatSpec`)
-    Base interface for a repeat specification.
     """
     _schema = {'$ref': '#/definitions/RepeatSpec'}
 
@@ -17654,8 +17623,6 @@ class TextDef(VegaLiteSchema):
     anyOf(:class:`FieldOrDatumDefWithConditionStringFieldDefText`,
     :class:`FieldOrDatumDefWithConditionStringDatumDefText`,
     :class:`ValueDefWithConditionStringFieldDefText`)
-    A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
-    ... }
     """
     _schema = {'$ref': '#/definitions/TextDef'}
 

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -202,6 +202,8 @@ class SchemaGenerator(codegen.SchemaGenerator):
         description = description.replace(r"\ ", " ")
         # turn explicit references into anonymous references
         description = description.replace(">`_", ">`__")
+        # Some entries in the Vega-Lite schema miss the second occurence of '__'
+        description = description.replace("__Default value: ", "__Default value:__ ")
         description += "\n"
         return description.strip()
 

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -168,8 +168,8 @@ class SchemaGenerator(object):
         # Remove lines which contain the "raw-html" directive which cannot be processed
         # by Sphinx at this level of the docstring. It works for descriptions
         # of attributes which is why we do not do the same below. The removed
-        # lines are anyway non-descriptive for a user. 
-        doc = [l for l in doc if not ":raw-html:" in l]
+        # lines are anyway non-descriptive for a user.
+        doc = [line for line in doc if ":raw-html:" not in line]
 
         if info.properties:
             nonkeyword, required, kwds, invalid_kwds, additional = _get_args(info)

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -165,6 +165,11 @@ class SchemaGenerator(object):
             doc += self._process_description(  # remove condition description
                 re.sub(r"\n\{\n(\n|.)*\n\}", "", info.description)
             ).splitlines()
+        # Remove lines which contain the "raw-html" directive which cannot be processed
+        # by Sphinx at this level of the docstring. It works for descriptions
+        # of attributes which is why we do not do the same below. The removed
+        # lines are anyway non-descriptive for a user. 
+        doc = [l for l in doc if not ":raw-html:" in l]
 
         if info.properties:
             nonkeyword, required, kwds, invalid_kwds, additional = _get_args(info)

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -173,7 +173,9 @@ class SchemaGenerator(object):
                 propinfo = info.properties[prop]
                 doc += [
                     "{} : {}".format(prop, propinfo.short_description),
-                    "    {}".format(self._process_description(propinfo.description)),
+                    "    {}".format(
+                        self._process_description(propinfo.deep_description)
+                    ),
                 ]
         if len(doc) > 1:
             doc += [""]

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -300,7 +300,16 @@ class SchemaInfo(object):
 
     @property
     def description(self):
-        return self.raw_schema.get("description", self.schema.get("description", ""))
+        return self._get_description()
+
+    def _get_description(self, include_sublevels: bool = True):
+        desc = self.raw_schema.get("description", self.schema.get("description", ""))
+        if not desc and include_sublevels:
+            for item in self.anyOf:
+                desc = item._get_description(include_sublevels=False)
+                if desc:
+                    break
+        return desc
 
     def is_list(self):
         return isinstance(self.schema, list)

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -300,9 +300,13 @@ class SchemaInfo(object):
 
     @property
     def description(self):
-        return self._get_description()
+        return self._get_description(include_sublevels=False)
 
-    def _get_description(self, include_sublevels: bool = True):
+    @property
+    def deep_description(self):
+        return self._get_description(include_sublevels=True)
+
+    def _get_description(self, include_sublevels: bool = False):
         desc = self.raw_schema.get("description", self.schema.get("description", ""))
         if not desc and include_sublevels:
             for item in self.anyOf:

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -310,9 +310,16 @@ class SchemaInfo(object):
         desc = self.raw_schema.get("description", self.schema.get("description", ""))
         if not desc and include_sublevels:
             for item in self.anyOf:
-                desc = item._get_description(include_sublevels=False)
-                if desc:
-                    break
+                sub_desc = item._get_description(include_sublevels=False)
+                if desc and sub_desc:
+                    raise ValueError(
+                        "There are multiple potential descriptions which could"
+                        + " be used for the currently inspected schema. You'll need to"
+                        + " clarify which one is the correct one.\n"
+                        + str(self.schema)
+                    )
+                if sub_desc:
+                    desc = sub_desc
         return desc
 
     def is_list(self):


### PR DESCRIPTION
# Background
Some attributes on classes are missing descriptions in the docstrings, see for example [`columnPadding` for `alt.Legend`](https://github.com/altair-viz/altair/blob/master/altair/vegalite/v5/schema/core.py#L6808):

```python
...
    clipHeight : anyOf(float, :class:`ExprRef`)

    columnPadding : anyOf(float, :class:`ExprRef`)

    columns : anyOf(float, :class:`ExprRef`)
...
```
These descriptions are then also missing in the documentation as the API references are generated based on these docstrings, see [altair.Legend](https://binste.github.io/altair-docs/user_guide/generated/core/altair.Legend.html):

<img width="620" alt="image" src="https://user-images.githubusercontent.com/23366411/219849413-ff27825f-0cc8-4095-bc47-fb7ccce4585f.png">

Due to this, I find myself often having to go to the [vega-lite docs](https://vega.github.io/vega-lite/docs/legend.html#symbol-layout) to find out what an attribute means. However, the description shown there would also be available in the VL json schema so we just need to adapt the code and docs generation for Altair to properly include it. 

Currently, descriptions for attributes/properties are only parsed during code generation if `description` is defined on the top-level of the attribute, see [`Legend.description`](https://github.com/altair-viz/altair/blob/master/altair/vegalite/v5/schema/vega-lite-schema.json#L12681). For some attributes such as `Legend.columnPadding` the [description is nested in `anyOf`](https://github.com/altair-viz/altair/blob/master/altair/vegalite/v5/schema/vega-lite-schema.json#L12638) and is currently ignored. Still figuring out when it is useful to take this nested description and what are all the possible cases.

# Current status
<img width="776" alt="image" src="https://user-images.githubusercontent.com/23366411/219849911-f128e5b7-4d5a-4973-81fd-f01fec7b4043.png">
It already looks much better :) Next up is figuring out if this makes sense for all attributes and if there are still missing descriptions. I think some descriptions are also cut off in the docs but properly included in the Python docstrings. There are also some other formatting issues to take care of. I'm hoping to get this done for the release candidate.
