### PR TITLE
Fix wrong json schema url in a test

### DIFF
--- a/tests/utils/tests/test_schemapi.py
+++ b/tests/utils/tests/test_schemapi.py
@@ -137,7 +137,7 @@ class Draft7Schema(_TestSchema):
 
 class Draft202012Schema(_TestSchema):
     _schema = {
-        "$schema": "http://json-schema.org/draft/2020-12/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
             "e": {"items": [{"type": "string"}, {"type": "string"}]},
         },

--- a/tools/schemapi/tests/test_schemapi.py
+++ b/tools/schemapi/tests/test_schemapi.py
@@ -135,7 +135,7 @@ class Draft7Schema(_TestSchema):
 
 class Draft202012Schema(_TestSchema):
     _schema = {
-        "$schema": "http://json-schema.org/draft/2020-12/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
             "e": {"items": [{"type": "string"}, {"type": "string"}]},
         },


### PR DESCRIPTION
Fixes #2894. They switched to `https` and removed the `#` for the `2020-12` schema