### PR TITLE
Rename 'Attributes' to 'Parameters' to fix documentation formatting

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -197,7 +197,7 @@ class SchemaValidationError(jsonschema.ValidationError):
 
 
 class UndefinedType(object):
-    """A singleton object for marking undefined attributes"""
+    """A singleton object for marking undefined parameters"""
 
     __instance = None
 
@@ -699,13 +699,13 @@ class _PropertySetter(object):
             # Add the docstring from the helper class (e.g. `BinParams`) so
             # that all the parameter names of the helper class are included in
             # the final docstring
-            attribute_index = altair_prop.__doc__.find("Attributes\n")
-            if attribute_index > -1:
+            parameter_index = altair_prop.__doc__.find("Parameters\n")
+            if parameter_index > -1:
                 self.__doc__ = (
-                    altair_prop.__doc__[:attribute_index].replace("    ", "")
+                    altair_prop.__doc__[:parameter_index].replace("    ", "")
                     + self.__doc__
                     + textwrap.dedent(
-                        f"\n\n    {altair_prop.__doc__[attribute_index:]}"
+                        f"\n\n    {altair_prop.__doc__[parameter_index:]}"
                     )
                 )
             # For short docstrings such as Aggregate, Stack, et

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -799,7 +799,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         'conicConformal', 'conicEqualArea', 'conicEquidistant', 'equalEarth', 'equirectangular',
         'gnomonic', 'identity', 'mercator', 'orthographic', 'stereographic', 'transverseMercator']
 
-        Attributes
+        Parameters
         ----------
         type : ProjectionType
             The cartographic projection to use. This value is case-insensitive, for example
@@ -1110,7 +1110,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
     ) -> _TTopLevelMixin:
         """Add a DensityTransform to the spec.
 
-        Attributes
+        Parameters
         ----------
         density : str
             The data field for which to perform density estimation.
@@ -1424,7 +1424,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
     ) -> _TTopLevelMixin:
         """Add a DataLookupTransform or SelectionLookupTransform to the chart
 
-        Attributes
+        Parameters
         ----------
         lookup : string
             Key in primary data source.
@@ -2115,7 +2115,7 @@ class Chart(
     ``transform_filter()``, ``properties()``, etc. See Altair's documentation
     for details and examples: http://altair-viz.github.io/.
 
-    Attributes
+    Parameters
     ----------
     data : Data
         An object describing the data source

--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -97,7 +97,7 @@ class Angle(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -436,7 +436,7 @@ class AngleDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefnum
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -580,7 +580,7 @@ class AngleValue(ValueChannelMixin, core.ValueDefWithConditionMarkPropFieldOrDat
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefnumberExprRef`, List(:class:`ConditionalValueDefnumberExprRef`))
@@ -618,7 +618,7 @@ class Color(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -957,7 +957,7 @@ class ColorDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefGra
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -1101,7 +1101,7 @@ class ColorValue(ValueChannelMixin, core.ValueDefWithConditionMarkPropFieldOrDat
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefGradientstringnullExprRef`, List(:class:`ConditionalValueDefGradientstringnullExprRef`))
@@ -1137,7 +1137,7 @@ class Column(FieldChannelMixin, core.RowColumnEncodingFieldDef):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -1452,7 +1452,7 @@ class Description(FieldChannelMixin, core.StringFieldDefWithCondition):
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -1741,7 +1741,7 @@ class DescriptionValue(ValueChannelMixin, core.StringValueDefWithCondition):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, List(:class:`ConditionalValueDefstringnullExprRef`))
@@ -1778,7 +1778,7 @@ class Detail(FieldChannelMixin, core.FieldDefWithoutScale):
     Mapping(required=[shorthand])
     Definition object for a data field, its type and transformation of an encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -2005,7 +2005,7 @@ class Facet(FieldChannelMixin, core.FacetEncodingFieldDef):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -2379,7 +2379,7 @@ class Fill(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefG
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -2718,7 +2718,7 @@ class FillDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefGrad
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -2862,7 +2862,7 @@ class FillValue(ValueChannelMixin, core.ValueDefWithConditionMarkPropFieldOrDatu
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefGradientstringnullExprRef`, List(:class:`ConditionalValueDefGradientstringnullExprRef`))
@@ -2900,7 +2900,7 @@ class FillOpacity(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFi
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -3239,7 +3239,7 @@ class FillOpacityDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatum
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -3383,7 +3383,7 @@ class FillOpacityValue(ValueChannelMixin, core.ValueDefWithConditionMarkPropFiel
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefnumberExprRef`, List(:class:`ConditionalValueDefnumberExprRef`))
@@ -3421,7 +3421,7 @@ class Href(FieldChannelMixin, core.StringFieldDefWithCondition):
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -3710,7 +3710,7 @@ class HrefValue(ValueChannelMixin, core.StringValueDefWithCondition):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, List(:class:`ConditionalValueDefstringnullExprRef`))
@@ -3747,7 +3747,7 @@ class Key(FieldChannelMixin, core.FieldDefWithoutScale):
     Mapping(required=[shorthand])
     Definition object for a data field, its type and transformation of an encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -3974,7 +3974,7 @@ class Latitude(FieldChannelMixin, core.LatLongFieldDef):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -4188,7 +4188,7 @@ class LatitudeDatum(DatumChannelMixin, core.DatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -4318,7 +4318,7 @@ class Latitude2(FieldChannelMixin, core.SecondaryFieldDef):
     A field definition of a secondary channel that shares a scale with another primary channel.
     For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -4460,7 +4460,7 @@ class Latitude2Datum(DatumChannelMixin, core.DatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -4590,7 +4590,7 @@ class Latitude2Value(ValueChannelMixin, core.PositionValueDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -4613,7 +4613,7 @@ class Longitude(FieldChannelMixin, core.LatLongFieldDef):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -4827,7 +4827,7 @@ class LongitudeDatum(DatumChannelMixin, core.DatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -4957,7 +4957,7 @@ class Longitude2(FieldChannelMixin, core.SecondaryFieldDef):
     A field definition of a secondary channel that shares a scale with another primary channel.
     For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -5099,7 +5099,7 @@ class Longitude2Datum(DatumChannelMixin, core.DatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -5229,7 +5229,7 @@ class Longitude2Value(ValueChannelMixin, core.PositionValueDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -5254,7 +5254,7 @@ class Opacity(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldD
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -5593,7 +5593,7 @@ class OpacityDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefn
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -5737,7 +5737,7 @@ class OpacityValue(ValueChannelMixin, core.ValueDefWithConditionMarkPropFieldOrD
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefnumberExprRef`, List(:class:`ConditionalValueDefnumberExprRef`))
@@ -5773,7 +5773,7 @@ class Order(FieldChannelMixin, core.OrderFieldDef):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -6006,7 +6006,7 @@ class OrderValue(ValueChannelMixin, core.OrderValueDef):
 
     Mapping(required=[value])
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, :class:`ExprRef`)
@@ -6043,7 +6043,7 @@ class Radius(FieldChannelMixin, core.PositionFieldDefBase):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -6394,7 +6394,7 @@ class RadiusDatum(DatumChannelMixin, core.PositionDatumDefBase):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -6588,7 +6588,7 @@ class RadiusValue(ValueChannelMixin, core.PositionValueDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -6613,7 +6613,7 @@ class Radius2(FieldChannelMixin, core.SecondaryFieldDef):
     A field definition of a secondary channel that shares a scale with another primary channel.
     For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -6755,7 +6755,7 @@ class Radius2Datum(DatumChannelMixin, core.DatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -6885,7 +6885,7 @@ class Radius2Value(ValueChannelMixin, core.PositionValueDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -6908,7 +6908,7 @@ class Row(FieldChannelMixin, core.RowColumnEncodingFieldDef):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -7223,7 +7223,7 @@ class Shape(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDef
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -7562,7 +7562,7 @@ class ShapeDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefstr
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -7706,7 +7706,7 @@ class ShapeValue(ValueChannelMixin, core.ValueDefWithConditionMarkPropFieldOrDat
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDefTypeForShape`, :class:`ConditionalValueDefstringnullExprRef`, List(:class:`ConditionalValueDefstringnullExprRef`))
@@ -7744,7 +7744,7 @@ class Size(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDefn
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -8083,7 +8083,7 @@ class SizeDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefnumb
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -8227,7 +8227,7 @@ class SizeValue(ValueChannelMixin, core.ValueDefWithConditionMarkPropFieldOrDatu
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefnumberExprRef`, List(:class:`ConditionalValueDefnumberExprRef`))
@@ -8265,7 +8265,7 @@ class Stroke(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFieldDe
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -8604,7 +8604,7 @@ class StrokeDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumDefGr
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -8748,7 +8748,7 @@ class StrokeValue(ValueChannelMixin, core.ValueDefWithConditionMarkPropFieldOrDa
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefGradientstringnullExprRef`, List(:class:`ConditionalValueDefGradientstringnullExprRef`))
@@ -8786,7 +8786,7 @@ class StrokeDash(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFie
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -9125,7 +9125,7 @@ class StrokeDashDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatumD
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -9269,7 +9269,7 @@ class StrokeDashValue(ValueChannelMixin, core.ValueDefWithConditionMarkPropField
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefnumberArrayExprRef`, List(:class:`ConditionalValueDefnumberArrayExprRef`))
@@ -9307,7 +9307,7 @@ class StrokeOpacity(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkProp
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -9646,7 +9646,7 @@ class StrokeOpacityDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDat
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -9790,7 +9790,7 @@ class StrokeOpacityValue(ValueChannelMixin, core.ValueDefWithConditionMarkPropFi
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefnumberExprRef`, List(:class:`ConditionalValueDefnumberExprRef`))
@@ -9828,7 +9828,7 @@ class StrokeWidth(FieldChannelMixin, core.FieldOrDatumDefWithConditionMarkPropFi
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -10167,7 +10167,7 @@ class StrokeWidthDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionDatum
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -10311,7 +10311,7 @@ class StrokeWidthValue(ValueChannelMixin, core.ValueDefWithConditionMarkPropFiel
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefnumberExprRef`, List(:class:`ConditionalValueDefnumberExprRef`))
@@ -10349,7 +10349,7 @@ class Text(FieldChannelMixin, core.FieldOrDatumDefWithConditionStringFieldDefTex
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -10640,7 +10640,7 @@ class TextDatum(DatumChannelMixin, core.FieldOrDatumDefWithConditionStringDatumD
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -10830,7 +10830,7 @@ class TextValue(ValueChannelMixin, core.ValueDefWithConditionStringFieldDefText)
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalStringFieldDef`, :class:`ConditionalValueDefTextExprRef`, List(:class:`ConditionalValueDefTextExprRef`))
@@ -10866,7 +10866,7 @@ class Theta(FieldChannelMixin, core.PositionFieldDefBase):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -11216,7 +11216,7 @@ class ThetaDatum(DatumChannelMixin, core.PositionDatumDefBase):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -11410,7 +11410,7 @@ class ThetaValue(ValueChannelMixin, core.PositionValueDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -11435,7 +11435,7 @@ class Theta2(FieldChannelMixin, core.SecondaryFieldDef):
     A field definition of a secondary channel that shares a scale with another primary channel.
     For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -11577,7 +11577,7 @@ class Theta2Datum(DatumChannelMixin, core.DatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -11707,7 +11707,7 @@ class Theta2Value(ValueChannelMixin, core.PositionValueDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -11732,7 +11732,7 @@ class Tooltip(FieldChannelMixin, core.StringFieldDefWithCondition):
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -12021,7 +12021,7 @@ class TooltipValue(ValueChannelMixin, core.StringValueDefWithCondition):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, List(:class:`ConditionalValueDefstringnullExprRef`))
@@ -12059,7 +12059,7 @@ class Url(FieldChannelMixin, core.StringFieldDefWithCondition):
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -12348,7 +12348,7 @@ class UrlValue(ValueChannelMixin, core.StringValueDefWithCondition):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, List(:class:`ConditionalValueDefstringnullExprRef`))
@@ -12384,7 +12384,7 @@ class X(FieldChannelMixin, core.PositionFieldDef):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -12768,7 +12768,7 @@ class XDatum(DatumChannelMixin, core.PositionDatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     axis : anyOf(:class:`Axis`, None)
@@ -12995,7 +12995,7 @@ class XValue(ValueChannelMixin, core.PositionValueDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -13020,7 +13020,7 @@ class X2(FieldChannelMixin, core.SecondaryFieldDef):
     A field definition of a secondary channel that shares a scale with another primary channel.
     For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -13161,7 +13161,7 @@ class X2Datum(DatumChannelMixin, core.DatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -13291,7 +13291,7 @@ class X2Value(ValueChannelMixin, core.PositionValueDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -13316,7 +13316,7 @@ class XError(FieldChannelMixin, core.SecondaryFieldDef):
     A field definition of a secondary channel that shares a scale with another primary channel.
     For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -13460,7 +13460,7 @@ class XErrorValue(ValueChannelMixin, core.ValueDefnumber):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : float
@@ -13485,7 +13485,7 @@ class XError2(FieldChannelMixin, core.SecondaryFieldDef):
     A field definition of a secondary channel that shares a scale with another primary channel.
     For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -13629,7 +13629,7 @@ class XError2Value(ValueChannelMixin, core.ValueDefnumber):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : float
@@ -13652,7 +13652,7 @@ class XOffset(FieldChannelMixin, core.ScaleFieldDef):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -13956,7 +13956,7 @@ class XOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -14108,7 +14108,7 @@ class XOffsetValue(ValueChannelMixin, core.ValueDefnumber):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : float
@@ -14131,7 +14131,7 @@ class Y(FieldChannelMixin, core.PositionFieldDef):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -14515,7 +14515,7 @@ class YDatum(DatumChannelMixin, core.PositionDatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     axis : anyOf(:class:`Axis`, None)
@@ -14742,7 +14742,7 @@ class YValue(ValueChannelMixin, core.PositionValueDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -14767,7 +14767,7 @@ class Y2(FieldChannelMixin, core.SecondaryFieldDef):
     A field definition of a secondary channel that shares a scale with another primary channel.
     For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -14908,7 +14908,7 @@ class Y2Datum(DatumChannelMixin, core.DatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -15038,7 +15038,7 @@ class Y2Value(ValueChannelMixin, core.PositionValueDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -15063,7 +15063,7 @@ class YError(FieldChannelMixin, core.SecondaryFieldDef):
     A field definition of a secondary channel that shares a scale with another primary channel.
     For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -15207,7 +15207,7 @@ class YErrorValue(ValueChannelMixin, core.ValueDefnumber):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : float
@@ -15232,7 +15232,7 @@ class YError2(FieldChannelMixin, core.SecondaryFieldDef):
     A field definition of a secondary channel that shares a scale with another primary channel.
     For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -15376,7 +15376,7 @@ class YError2Value(ValueChannelMixin, core.ValueDefnumber):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : float
@@ -15399,7 +15399,7 @@ class YOffset(FieldChannelMixin, core.ScaleFieldDef):
 
     Mapping(required=[shorthand])
 
-    Attributes
+    Parameters
     ----------
 
     shorthand : string
@@ -15703,7 +15703,7 @@ class YOffsetDatum(DatumChannelMixin, core.ScaleDatumDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -15855,7 +15855,7 @@ class YOffsetValue(ValueChannelMixin, core.ValueDefnumber):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : float

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -62,7 +62,7 @@ class AggregatedFieldDef(VegaLiteSchema):
 
     Mapping(required=[op, as])
 
-    Attributes
+    Parameters
     ----------
 
     op : :class:`AggregateOp`
@@ -120,7 +120,7 @@ class AreaConfig(AnyMarkConfig):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     align : anyOf(:class:`Align`, :class:`ExprRef`)
@@ -464,7 +464,7 @@ class ArgmaxDef(Aggregate):
 
     Mapping(required=[argmax])
 
-    Attributes
+    Parameters
     ----------
 
     argmax : :class:`FieldName`
@@ -481,7 +481,7 @@ class ArgminDef(Aggregate):
 
     Mapping(required=[argmin])
 
-    Attributes
+    Parameters
     ----------
 
     argmin : :class:`FieldName`
@@ -498,7 +498,7 @@ class AutoSizeParams(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     contains : enum('content', 'padding')
@@ -545,7 +545,7 @@ class Axis(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aria : anyOf(boolean, :class:`ExprRef`)
@@ -894,7 +894,7 @@ class AxisConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aria : anyOf(boolean, :class:`ExprRef`)
@@ -1258,7 +1258,7 @@ class AxisResolveMap(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     x : :class:`ResolveMode`
@@ -1277,7 +1277,7 @@ class BarConfig(AnyMarkConfig):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     align : anyOf(:class:`Align`, :class:`ExprRef`)
@@ -1615,7 +1615,7 @@ class BaseTitleNoValueRefs(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     align : :class:`Align`
@@ -1715,7 +1715,7 @@ class BinParams(VegaLiteSchema):
     Mapping(required=[])
     Binning properties or boolean flag for determining whether to bin data or not.
 
-    Attributes
+    Parameters
     ----------
 
     anchor : float
@@ -1785,7 +1785,7 @@ class BindCheckbox(Binding):
 
     Mapping(required=[input])
 
-    Attributes
+    Parameters
     ----------
 
     input : string
@@ -1813,7 +1813,7 @@ class BindDirect(Binding):
 
     Mapping(required=[element])
 
-    Attributes
+    Parameters
     ----------
 
     element : anyOf(:class:`Element`, Mapping(required=[]))
@@ -1841,7 +1841,7 @@ class BindInput(Binding):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     autocomplete : string
@@ -1878,7 +1878,7 @@ class BindRadioSelect(Binding):
 
     Mapping(required=[input, options])
 
-    Attributes
+    Parameters
     ----------
 
     input : enum('radio', 'select')
@@ -1912,7 +1912,7 @@ class BindRange(Binding):
 
     Mapping(required=[input])
 
-    Attributes
+    Parameters
     ----------
 
     input : string
@@ -1963,7 +1963,7 @@ class BoxPlotConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     box : anyOf(boolean, :class:`MarkConfig`)
@@ -2004,7 +2004,7 @@ class BrushConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     cursor : :class:`Cursor`
@@ -2162,7 +2162,7 @@ class BoxPlotDef(CompositeMarkDef):
 
     Mapping(required=[type])
 
-    Attributes
+    Parameters
     ----------
 
     type : :class:`BoxPlot`
@@ -2233,7 +2233,7 @@ class CompositionConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     columns : float
@@ -2603,7 +2603,7 @@ class ConditionalParameterStringFieldDef(ConditionalStringFieldDef):
 
     Mapping(required=[param])
 
-    Attributes
+    Parameters
     ----------
 
     param : :class:`ParameterName`
@@ -2810,7 +2810,7 @@ class ConditionalPredicateStringFieldDef(ConditionalStringFieldDef):
 
     Mapping(required=[test])
 
-    Attributes
+    Parameters
     ----------
 
     test : :class:`PredicateComposition`
@@ -3026,7 +3026,7 @@ class ConditionalParameterValueDefGradientstringnullExprRef(ConditionalValueDefG
 
     Mapping(required=[param, value])
 
-    Attributes
+    Parameters
     ----------
 
     param : :class:`ParameterName`
@@ -3052,7 +3052,7 @@ class ConditionalPredicateValueDefGradientstringnullExprRef(ConditionalValueDefG
 
     Mapping(required=[test, value])
 
-    Attributes
+    Parameters
     ----------
 
     test : :class:`PredicateComposition`
@@ -3086,7 +3086,7 @@ class ConditionalParameterValueDefTextExprRef(ConditionalValueDefTextExprRef):
 
     Mapping(required=[param, value])
 
-    Attributes
+    Parameters
     ----------
 
     param : :class:`ParameterName`
@@ -3111,7 +3111,7 @@ class ConditionalPredicateValueDefTextExprRef(ConditionalValueDefTextExprRef):
 
     Mapping(required=[test, value])
 
-    Attributes
+    Parameters
     ----------
 
     test : :class:`PredicateComposition`
@@ -3144,7 +3144,7 @@ class ConditionalParameterValueDefnumber(ConditionalValueDefnumber):
 
     Mapping(required=[param, value])
 
-    Attributes
+    Parameters
     ----------
 
     param : :class:`ParameterName`
@@ -3169,7 +3169,7 @@ class ConditionalPredicateValueDefnumber(ConditionalValueDefnumber):
 
     Mapping(required=[test, value])
 
-    Attributes
+    Parameters
     ----------
 
     test : :class:`PredicateComposition`
@@ -3202,7 +3202,7 @@ class ConditionalParameterValueDefnumberArrayExprRef(ConditionalValueDefnumberAr
 
     Mapping(required=[param, value])
 
-    Attributes
+    Parameters
     ----------
 
     param : :class:`ParameterName`
@@ -3227,7 +3227,7 @@ class ConditionalPredicateValueDefnumberArrayExprRef(ConditionalValueDefnumberAr
 
     Mapping(required=[test, value])
 
-    Attributes
+    Parameters
     ----------
 
     test : :class:`PredicateComposition`
@@ -3261,7 +3261,7 @@ class ConditionalParameterValueDefnumberExprRef(ConditionalValueDefnumberExprRef
 
     Mapping(required=[param, value])
 
-    Attributes
+    Parameters
     ----------
 
     param : :class:`ParameterName`
@@ -3286,7 +3286,7 @@ class ConditionalPredicateValueDefnumberExprRef(ConditionalValueDefnumberExprRef
 
     Mapping(required=[test, value])
 
-    Attributes
+    Parameters
     ----------
 
     test : :class:`PredicateComposition`
@@ -3319,7 +3319,7 @@ class ConditionalParameterValueDefstringExprRef(ConditionalValueDefstringExprRef
 
     Mapping(required=[param, value])
 
-    Attributes
+    Parameters
     ----------
 
     param : :class:`ParameterName`
@@ -3344,7 +3344,7 @@ class ConditionalPredicateValueDefstringExprRef(ConditionalValueDefstringExprRef
 
     Mapping(required=[test, value])
 
-    Attributes
+    Parameters
     ----------
 
     test : :class:`PredicateComposition`
@@ -3377,7 +3377,7 @@ class ConditionalParameterValueDefstringnullExprRef(ConditionalValueDefstringnul
 
     Mapping(required=[param, value])
 
-    Attributes
+    Parameters
     ----------
 
     param : :class:`ParameterName`
@@ -3402,7 +3402,7 @@ class ConditionalPredicateValueDefstringnullExprRef(ConditionalValueDefstringnul
 
     Mapping(required=[test, value])
 
-    Attributes
+    Parameters
     ----------
 
     test : :class:`PredicateComposition`
@@ -3424,7 +3424,7 @@ class Config(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     arc : :class:`RectConfig`
@@ -3746,7 +3746,7 @@ class CsvDataFormat(DataFormat):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     parse : anyOf(:class:`Parse`, None)
@@ -3890,7 +3890,7 @@ class DomainUnionWith(VegaLiteSchema):
 
     Mapping(required=[unionWith])
 
-    Attributes
+    Parameters
     ----------
 
     unionWith : anyOf(List(float), List(string), List(boolean), List(:class:`DateTime`))
@@ -3908,7 +3908,7 @@ class DsvDataFormat(DataFormat):
 
     Mapping(required=[delimiter])
 
-    Attributes
+    Parameters
     ----------
 
     delimiter : string
@@ -3959,7 +3959,7 @@ class Encoding(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     angle : :class:`NumericMarkPropDef`
@@ -4191,7 +4191,7 @@ class ErrorBandConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     band : anyOf(boolean, :class:`MarkConfig`)
@@ -4249,7 +4249,7 @@ class ErrorBandDef(CompositeMarkDef):
 
     Mapping(required=[type])
 
-    Attributes
+    Parameters
     ----------
 
     type : :class:`ErrorBand`
@@ -4345,7 +4345,7 @@ class ErrorBarConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     extent : :class:`ErrorBarExtent`
@@ -4382,7 +4382,7 @@ class ErrorBarDef(CompositeMarkDef):
 
     Mapping(required=[type])
 
-    Attributes
+    Parameters
     ----------
 
     type : :class:`ErrorBar`
@@ -4468,7 +4468,7 @@ class ExprRef(VegaLiteSchema):
 
     Mapping(required=[expr])
 
-    Attributes
+    Parameters
     ----------
 
     expr : string
@@ -4485,7 +4485,7 @@ class FacetEncodingFieldDef(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -4745,7 +4745,7 @@ class FacetFieldDef(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -4939,7 +4939,7 @@ class FacetMapping(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     column : :class:`FacetFieldDef`
@@ -4958,7 +4958,7 @@ class FacetedEncoding(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     angle : :class:`NumericMarkPropDef`
@@ -5203,7 +5203,7 @@ class FieldDefWithoutScale(VegaLiteSchema):
     Mapping(required=[])
     Definition object for a data field, its type and transformation of an encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -5380,7 +5380,7 @@ class FieldOrDatumDefWithConditionStringFieldDefstring(VegaLiteSchema):
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -5593,7 +5593,7 @@ class FieldRange(VegaLiteSchema):
 
     Mapping(required=[field])
 
-    Attributes
+    Parameters
     ----------
 
     field : string
@@ -5656,7 +5656,7 @@ class GenericUnitSpecEncodingAnyMark(VegaLiteSchema):
     Mapping(required=[mark])
     Base interface for a unit (single-view) specification.
 
-    Attributes
+    Parameters
     ----------
 
     mark : :class:`AnyMark`
@@ -5735,7 +5735,7 @@ class GradientStop(VegaLiteSchema):
 
     Mapping(required=[offset, color])
 
-    Attributes
+    Parameters
     ----------
 
     color : :class:`Color`
@@ -5754,7 +5754,7 @@ class GraticuleGenerator(Generator):
 
     Mapping(required=[graticule])
 
-    Attributes
+    Parameters
     ----------
 
     graticule : anyOf(boolean, :class:`GraticuleParams`)
@@ -5773,7 +5773,7 @@ class GraticuleParams(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     extent : :class:`Vector2Vector2number`
@@ -5812,7 +5812,7 @@ class Header(VegaLiteSchema):
     Mapping(required=[])
     Headers of row / column channels for faceted plots.
 
-    Attributes
+    Parameters
     ----------
 
     format : anyOf(string, :class:`Dict`)
@@ -6004,7 +6004,7 @@ class HeaderConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     format : anyOf(string, :class:`Dict`)
@@ -6200,7 +6200,7 @@ class ImputeParams(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     frame : List(anyOf(None, float))
@@ -6244,7 +6244,7 @@ class ImputeSequence(VegaLiteSchema):
 
     Mapping(required=[stop])
 
-    Attributes
+    Parameters
     ----------
 
     stop : float
@@ -6266,7 +6266,7 @@ class InlineData(DataSource):
 
     Mapping(required=[values])
 
-    Attributes
+    Parameters
     ----------
 
     values : :class:`InlineDataset`
@@ -6314,7 +6314,7 @@ class IntervalSelectionConfig(VegaLiteSchema):
 
     Mapping(required=[type])
 
-    Attributes
+    Parameters
     ----------
 
     type : string
@@ -6418,7 +6418,7 @@ class IntervalSelectionConfigWithoutType(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     clear : anyOf(:class:`Stream`, string, boolean)
@@ -6514,7 +6514,7 @@ class JoinAggregateFieldDef(VegaLiteSchema):
 
     Mapping(required=[op, as])
 
-    Attributes
+    Parameters
     ----------
 
     op : :class:`AggregateOp`
@@ -6538,7 +6538,7 @@ class JsonDataFormat(DataFormat):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     parse : anyOf(:class:`Parse`, None)
@@ -6601,7 +6601,7 @@ class LatLongFieldDef(LatLongDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -6765,7 +6765,7 @@ class LayerRepeatMapping(VegaLiteSchema):
 
     Mapping(required=[layer])
 
-    Attributes
+    Parameters
     ----------
 
     layer : List(string)
@@ -6798,7 +6798,7 @@ class Legend(VegaLiteSchema):
     Mapping(required=[])
     Properties of a legend or boolean flag for determining whether to show it.
 
-    Attributes
+    Parameters
     ----------
 
     aria : anyOf(boolean, :class:`ExprRef`)
@@ -7080,7 +7080,7 @@ class LegendConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aria : anyOf(boolean, :class:`ExprRef`)
@@ -7356,7 +7356,7 @@ class LegendResolveMap(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     angle : :class:`ResolveMode`
@@ -7399,7 +7399,7 @@ class LegendStreamBinding(LegendBinding):
 
     Mapping(required=[legend])
 
-    Attributes
+    Parameters
     ----------
 
     legend : anyOf(string, :class:`Stream`)
@@ -7416,7 +7416,7 @@ class LineConfig(AnyMarkConfig):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     align : anyOf(:class:`Align`, :class:`ExprRef`)
@@ -7748,7 +7748,7 @@ class LinearGradient(Gradient):
 
     Mapping(required=[gradient, stops])
 
-    Attributes
+    Parameters
     ----------
 
     gradient : string
@@ -7787,7 +7787,7 @@ class Locale(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     number : :class:`NumberLocale`
@@ -7806,7 +7806,7 @@ class LookupData(VegaLiteSchema):
 
     Mapping(required=[data, key])
 
-    Attributes
+    Parameters
     ----------
 
     data : :class:`Data`
@@ -7828,7 +7828,7 @@ class LookupSelection(VegaLiteSchema):
 
     Mapping(required=[key, param])
 
-    Attributes
+    Parameters
     ----------
 
     key : :class:`FieldName`
@@ -7863,7 +7863,7 @@ class MarkConfig(AnyMarkConfig):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     align : anyOf(:class:`Align`, :class:`ExprRef`)
@@ -8180,7 +8180,7 @@ class MarkDef(AnyMark):
 
     Mapping(required=[type])
 
-    Attributes
+    Parameters
     ----------
 
     type : :class:`Mark`
@@ -8619,7 +8619,7 @@ class FieldOrDatumDefWithConditionDatumDefGradientstringnull(ColorDef, MarkPropD
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -8743,7 +8743,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefGradientstringnull(ColorDef, M
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -9047,7 +9047,7 @@ class NamedData(DataSource):
 
     Mapping(required=[name])
 
-    Attributes
+    Parameters
     ----------
 
     name : string
@@ -9094,7 +9094,7 @@ class NumberLocale(VegaLiteSchema):
     Mapping(required=[decimal, thousands, grouping, currency])
     Locale definition for formatting numbers.
 
-    Attributes
+    Parameters
     ----------
 
     currency : :class:`Vector2string`
@@ -9143,7 +9143,7 @@ class FieldOrDatumDefWithConditionDatumDefnumberArray(MarkPropDefnumberArray, Nu
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -9266,7 +9266,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumberArray(MarkPropDefnumberA
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -9522,7 +9522,7 @@ class FieldOrDatumDefWithConditionDatumDefnumber(MarkPropDefnumber, NumericMarkP
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -9645,7 +9645,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefnumber(MarkPropDefnumber, Nume
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -9896,7 +9896,7 @@ class OrderFieldDef(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -10062,7 +10062,7 @@ class OrderValueDef(VegaLiteSchema):
 
     Mapping(required=[value])
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, :class:`ExprRef`)
@@ -10110,7 +10110,7 @@ class OverlayMarkDef(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     align : anyOf(:class:`Align`, :class:`ExprRef`)
@@ -10522,7 +10522,7 @@ class PointSelectionConfig(VegaLiteSchema):
 
     Mapping(required=[type])
 
-    Attributes
+    Parameters
     ----------
 
     type : string
@@ -10633,7 +10633,7 @@ class PointSelectionConfigWithoutType(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     clear : anyOf(:class:`Stream`, string, boolean)
@@ -10759,7 +10759,7 @@ class DatumDef(LatLongDef, Position2Def):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -10870,7 +10870,7 @@ class PositionDatumDefBase(PolarDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -11036,7 +11036,7 @@ class PositionDatumDef(PositionDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     axis : anyOf(:class:`Axis`, None)
@@ -11209,7 +11209,7 @@ class PositionFieldDef(PositionDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -11474,7 +11474,7 @@ class PositionFieldDefBase(PolarDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -11724,7 +11724,7 @@ class PositionValueDef(PolarDef, Position2Def, PositionDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -11755,7 +11755,7 @@ class LogicalAndPredicate(PredicateComposition):
 
     Mapping(required=[and])
 
-    Attributes
+    Parameters
     ----------
 
     and : List(:class:`PredicateComposition`)
@@ -11772,7 +11772,7 @@ class LogicalNotPredicate(PredicateComposition):
 
     Mapping(required=[not])
 
-    Attributes
+    Parameters
     ----------
 
     not : :class:`PredicateComposition`
@@ -11789,7 +11789,7 @@ class LogicalOrPredicate(PredicateComposition):
 
     Mapping(required=[or])
 
-    Attributes
+    Parameters
     ----------
 
     or : List(:class:`PredicateComposition`)
@@ -11820,7 +11820,7 @@ class FieldEqualPredicate(Predicate):
 
     Mapping(required=[equal, field])
 
-    Attributes
+    Parameters
     ----------
 
     equal : anyOf(string, float, boolean, :class:`DateTime`, :class:`ExprRef`)
@@ -11841,7 +11841,7 @@ class FieldGTEPredicate(Predicate):
 
     Mapping(required=[field, gte])
 
-    Attributes
+    Parameters
     ----------
 
     field : :class:`FieldName`
@@ -11862,7 +11862,7 @@ class FieldGTPredicate(Predicate):
 
     Mapping(required=[field, gt])
 
-    Attributes
+    Parameters
     ----------
 
     field : :class:`FieldName`
@@ -11883,7 +11883,7 @@ class FieldLTEPredicate(Predicate):
 
     Mapping(required=[field, lte])
 
-    Attributes
+    Parameters
     ----------
 
     field : :class:`FieldName`
@@ -11904,7 +11904,7 @@ class FieldLTPredicate(Predicate):
 
     Mapping(required=[field, lt])
 
-    Attributes
+    Parameters
     ----------
 
     field : :class:`FieldName`
@@ -11925,7 +11925,7 @@ class FieldOneOfPredicate(Predicate):
 
     Mapping(required=[field, oneOf])
 
-    Attributes
+    Parameters
     ----------
 
     field : :class:`FieldName`
@@ -11947,7 +11947,7 @@ class FieldRangePredicate(Predicate):
 
     Mapping(required=[field, range])
 
-    Attributes
+    Parameters
     ----------
 
     field : :class:`FieldName`
@@ -11969,7 +11969,7 @@ class FieldValidPredicate(Predicate):
 
     Mapping(required=[field, valid])
 
-    Attributes
+    Parameters
     ----------
 
     field : :class:`FieldName`
@@ -11992,7 +11992,7 @@ class ParameterPredicate(Predicate):
 
     Mapping(required=[param])
 
-    Attributes
+    Parameters
     ----------
 
     param : :class:`ParameterName`
@@ -12012,7 +12012,7 @@ class Projection(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     center : anyOf(:class:`Vector2number`, :class:`ExprRef`)
@@ -12096,7 +12096,7 @@ class ProjectionConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     center : anyOf(:class:`Vector2number`, :class:`ExprRef`)
@@ -12195,7 +12195,7 @@ class RadialGradient(Gradient):
 
     Mapping(required=[gradient, stops])
 
-    Attributes
+    Parameters
     ----------
 
     gradient : string
@@ -12248,7 +12248,7 @@ class RangeConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     category : anyOf(:class:`RangeScheme`, List(:class:`Color`))
@@ -12327,7 +12327,7 @@ class RectConfig(AnyMarkConfig):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     align : anyOf(:class:`Align`, :class:`ExprRef`)
@@ -12659,7 +12659,7 @@ class RelativeBandSize(VegaLiteSchema):
 
     Mapping(required=[band])
 
-    Attributes
+    Parameters
     ----------
 
     band : float
@@ -12677,7 +12677,7 @@ class RepeatMapping(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     column : List(string)
@@ -12697,7 +12697,7 @@ class RepeatRef(Field):
     Mapping(required=[repeat])
     Reference to a repeated value.
 
-    Attributes
+    Parameters
     ----------
 
     repeat : enum('row', 'column', 'repeat', 'layer')
@@ -12717,7 +12717,7 @@ class Resolve(VegaLiteSchema):
     mapping from ``scale``, ``axis``, and ``legend`` to a mapping from channels to resolutions.
     Scales and guides can be resolved to be ``"independent"`` or ``"shared"``.
 
-    Attributes
+    Parameters
     ----------
 
     axis : :class:`AxisResolveMap`
@@ -12749,7 +12749,7 @@ class RowColLayoutAlign(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     column : :class:`LayoutAlign`
@@ -12768,7 +12768,7 @@ class RowColboolean(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     column : boolean
@@ -12787,7 +12787,7 @@ class RowColnumber(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     column : float
@@ -12806,7 +12806,7 @@ class RowColumnEncodingFieldDef(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -13027,7 +13027,7 @@ class Scale(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     align : anyOf(float, :class:`ExprRef`)
@@ -13313,7 +13313,7 @@ class ScaleBinParams(ScaleBins):
 
     Mapping(required=[step])
 
-    Attributes
+    Parameters
     ----------
 
     step : float
@@ -13338,7 +13338,7 @@ class ScaleConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPaddingInner : anyOf(float, :class:`ExprRef`)
@@ -13502,7 +13502,7 @@ class ScaleDatumDef(OffsetDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -13627,7 +13627,7 @@ class ScaleFieldDef(OffsetDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -13855,7 +13855,7 @@ class ScaleInterpolateParams(VegaLiteSchema):
 
     Mapping(required=[type])
 
-    Attributes
+    Parameters
     ----------
 
     type : enum('rgb', 'cubehelix', 'cubehelix-long')
@@ -13874,7 +13874,7 @@ class ScaleResolveMap(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     angle : :class:`ResolveMode`
@@ -13943,7 +13943,7 @@ class SchemeParams(VegaLiteSchema):
 
     Mapping(required=[name])
 
-    Attributes
+    Parameters
     ----------
 
     name : string
@@ -13973,7 +13973,7 @@ class SecondaryFieldDef(Position2Def):
     A field definition of a secondary channel that shares a scale with another primary channel.
     For example, ``x2``, ``xError`` and ``xError2`` share the same scale with ``x``.
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -14067,7 +14067,7 @@ class SelectionConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     interval : :class:`IntervalSelectionConfigWithoutType`
@@ -14112,7 +14112,7 @@ class DateTime(SelectionInit):
     month has higher precedence. ``day`` cannot be combined with other date. We accept string
     for month and day names.
 
-    Attributes
+    Parameters
     ----------
 
     date : float
@@ -14204,7 +14204,7 @@ class SelectionParameter(VegaLiteSchema):
 
     Mapping(required=[name, select])
 
-    Attributes
+    Parameters
     ----------
 
     name : :class:`ParameterName`
@@ -14278,7 +14278,7 @@ class SequenceGenerator(Generator):
 
     Mapping(required=[sequence])
 
-    Attributes
+    Parameters
     ----------
 
     sequence : :class:`SequenceParams`
@@ -14297,7 +14297,7 @@ class SequenceParams(VegaLiteSchema):
 
     Mapping(required=[start, stop])
 
-    Attributes
+    Parameters
     ----------
 
     start : float
@@ -14400,7 +14400,7 @@ class FieldOrDatumDefWithConditionDatumDefstringnull(MarkPropDefstringnullTypeFo
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -14523,7 +14523,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapestringnull(MarkPro
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -14765,7 +14765,7 @@ class SharedEncoding(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     angle : Mapping(required=[])
@@ -14930,7 +14930,7 @@ class EncodingSortField(Sort):
     Mapping(required=[])
     A sort definition for sorting a discrete scale in an encoding field definition.
 
-    Attributes
+    Parameters
     ----------
 
     field : :class:`Field`
@@ -15000,7 +15000,7 @@ class SortByEncoding(Sort):
 
     Mapping(required=[encoding])
 
-    Attributes
+    Parameters
     ----------
 
     encoding : :class:`SortByChannel`
@@ -15023,7 +15023,7 @@ class SortField(VegaLiteSchema):
     Mapping(required=[field])
     A sort definition for transform
 
-    Attributes
+    Parameters
     ----------
 
     field : :class:`FieldName`
@@ -15069,7 +15069,7 @@ class ConcatSpecGenericSpec(Spec, NonNormalizedSpec):
     Mapping(required=[concat])
     Base interface for a generalized concatenation specification.
 
-    Attributes
+    Parameters
     ----------
 
     concat : List(:class:`Spec`)
@@ -15169,7 +15169,7 @@ class FacetSpec(Spec, NonNormalizedSpec):
     Mapping(required=[facet, spec])
     Base interface for a facet specification.
 
-    Attributes
+    Parameters
     ----------
 
     facet : anyOf(:class:`FacetFieldDef`, :class:`FacetMapping`)
@@ -15276,7 +15276,7 @@ class FacetedUnitSpec(Spec, NonNormalizedSpec):
     Unit spec that can have a composite mark and row or column channels (shorthand for a facet
     spec).
 
-    Attributes
+    Parameters
     ----------
 
     mark : :class:`AnyMark`
@@ -15417,7 +15417,7 @@ class HConcatSpecGenericSpec(Spec, NonNormalizedSpec):
     Mapping(required=[hconcat])
     Base interface for a horizontal concatenation specification.
 
-    Attributes
+    Parameters
     ----------
 
     hconcat : List(:class:`Spec`)
@@ -15475,7 +15475,7 @@ class LayerSpec(Spec, NonNormalizedSpec):
     A full layered plot specification, which may contains ``encoding`` and ``projection``
     properties that will be applied to underlying unit (single-view) specifications.
 
-    Attributes
+    Parameters
     ----------
 
     layer : List(anyOf(:class:`LayerSpec`, :class:`UnitSpec`))
@@ -15576,7 +15576,7 @@ class LayerRepeatSpec(RepeatSpec):
 
     Mapping(required=[repeat, spec])
 
-    Attributes
+    Parameters
     ----------
 
     repeat : :class:`LayerRepeatMapping`
@@ -15684,7 +15684,7 @@ class NonLayerRepeatSpec(RepeatSpec):
     Mapping(required=[repeat, spec])
     Base interface for a repeat specification.
 
-    Attributes
+    Parameters
     ----------
 
     repeat : anyOf(List(string), :class:`RepeatMapping`)
@@ -15792,7 +15792,7 @@ class SphereGenerator(Generator):
 
     Mapping(required=[sphere])
 
-    Attributes
+    Parameters
     ----------
 
     sphere : anyOf(boolean, Mapping(required=[]))
@@ -15833,7 +15833,7 @@ class Step(VegaLiteSchema):
 
     Mapping(required=[step])
 
-    Attributes
+    Parameters
     ----------
 
     step : float
@@ -15875,7 +15875,7 @@ class DerivedStream(Stream):
 
     Mapping(required=[stream])
 
-    Attributes
+    Parameters
     ----------
 
     stream : :class:`Stream`
@@ -15920,7 +15920,7 @@ class MergedStream(Stream):
 
     Mapping(required=[merge])
 
-    Attributes
+    Parameters
     ----------
 
     merge : List(:class:`Stream`)
@@ -15954,7 +15954,7 @@ class StringFieldDef(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -16155,7 +16155,7 @@ class StringFieldDefWithCondition(VegaLiteSchema):
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -16364,7 +16364,7 @@ class StringValueDefWithCondition(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, List(:class:`ConditionalValueDefstringnullExprRef`))
@@ -16407,7 +16407,7 @@ class StyleConfigIndex(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     arc : :class:`RectConfig`
@@ -16525,7 +16525,7 @@ class FieldOrDatumDefWithConditionStringDatumDefText(TextDef):
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     bandPosition : float
@@ -16684,7 +16684,7 @@ class FieldOrDatumDefWithConditionStringFieldDefText(TextDef):
     A FieldDef with Condition :raw-html:`<ValueDef>` {   condition: {value: ...},   field: ...,
     ... }
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -16907,7 +16907,7 @@ class TickConfig(AnyMarkConfig):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     align : anyOf(:class:`Align`, :class:`ExprRef`)
@@ -17255,7 +17255,7 @@ class TimeIntervalStep(TickCount):
 
     Mapping(required=[interval, step])
 
-    Attributes
+    Parameters
     ----------
 
     interval : :class:`TimeInterval`
@@ -17275,7 +17275,7 @@ class TimeLocale(VegaLiteSchema):
     Mapping(required=[dateTime, date, time, periods, days, shortDays, months, shortMonths])
     Locale definition for formatting dates and times.
 
-    Attributes
+    Parameters
     ----------
 
     date : string
@@ -17371,7 +17371,7 @@ class TimeUnitParams(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     maxbins : float
@@ -17405,7 +17405,7 @@ class TitleConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     align : :class:`Align`
@@ -17512,7 +17512,7 @@ class TitleParams(VegaLiteSchema):
 
     Mapping(required=[text])
 
-    Attributes
+    Parameters
     ----------
 
     text : anyOf(:class:`Text`, :class:`ExprRef`)
@@ -17624,7 +17624,7 @@ class TooltipContent(VegaLiteSchema):
 
     Mapping(required=[content])
 
-    Attributes
+    Parameters
     ----------
 
     content : enum('encoding', 'data')
@@ -17641,7 +17641,7 @@ class TopLevelSelectionParameter(VegaLiteSchema):
 
     Mapping(required=[name, select])
 
-    Attributes
+    Parameters
     ----------
 
     name : :class:`ParameterName`
@@ -17713,7 +17713,7 @@ class TopLevelConcatSpec(TopLevelSpec):
 
     Mapping(required=[concat])
 
-    Attributes
+    Parameters
     ----------
 
     concat : List(:class:`NonNormalizedSpec`)
@@ -17851,7 +17851,7 @@ class TopLevelFacetSpec(TopLevelSpec):
 
     Mapping(required=[data, facet, spec])
 
-    Attributes
+    Parameters
     ----------
 
     data : anyOf(:class:`Data`, None)
@@ -17995,7 +17995,7 @@ class TopLevelHConcatSpec(TopLevelSpec):
 
     Mapping(required=[hconcat])
 
-    Attributes
+    Parameters
     ----------
 
     hconcat : List(:class:`NonNormalizedSpec`)
@@ -18091,7 +18091,7 @@ class TopLevelLayerSpec(TopLevelSpec):
 
     Mapping(required=[layer])
 
-    Attributes
+    Parameters
     ----------
 
     layer : List(anyOf(:class:`LayerSpec`, :class:`UnitSpec`))
@@ -18232,7 +18232,7 @@ class TopLevelUnitSpec(TopLevelSpec):
 
     Mapping(required=[data, mark])
 
-    Attributes
+    Parameters
     ----------
 
     data : anyOf(:class:`Data`, None)
@@ -18408,7 +18408,7 @@ class TopLevelVConcatSpec(TopLevelSpec):
 
     Mapping(required=[vconcat])
 
-    Attributes
+    Parameters
     ----------
 
     vconcat : List(:class:`NonNormalizedSpec`)
@@ -18504,7 +18504,7 @@ class TopoDataFormat(DataFormat):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     feature : string
@@ -18568,7 +18568,7 @@ class AggregateTransform(Transform):
 
     Mapping(required=[aggregate])
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : List(:class:`AggregatedFieldDef`)
@@ -18588,7 +18588,7 @@ class BinTransform(Transform):
 
     Mapping(required=[bin, field, as])
 
-    Attributes
+    Parameters
     ----------
 
     bin : anyOf(boolean, :class:`BinParams`)
@@ -18613,7 +18613,7 @@ class CalculateTransform(Transform):
 
     Mapping(required=[calculate, as])
 
-    Attributes
+    Parameters
     ----------
 
     calculate : string
@@ -18633,7 +18633,7 @@ class DensityTransform(Transform):
 
     Mapping(required=[density])
 
-    Attributes
+    Parameters
     ----------
 
     density : :class:`FieldName`
@@ -18694,7 +18694,7 @@ class FilterTransform(Transform):
 
     Mapping(required=[filter])
 
-    Attributes
+    Parameters
     ----------
 
     filter : :class:`PredicateComposition`
@@ -18737,7 +18737,7 @@ class FlattenTransform(Transform):
 
     Mapping(required=[flatten])
 
-    Attributes
+    Parameters
     ----------
 
     flatten : List(:class:`FieldName`)
@@ -18761,7 +18761,7 @@ class FoldTransform(Transform):
 
     Mapping(required=[fold])
 
-    Attributes
+    Parameters
     ----------
 
     fold : List(:class:`FieldName`)
@@ -18781,7 +18781,7 @@ class ImputeTransform(Transform):
 
     Mapping(required=[impute, key])
 
-    Attributes
+    Parameters
     ----------
 
     impute : :class:`FieldName`
@@ -18834,7 +18834,7 @@ class JoinAggregateTransform(Transform):
 
     Mapping(required=[joinaggregate])
 
-    Attributes
+    Parameters
     ----------
 
     joinaggregate : List(:class:`JoinAggregateFieldDef`)
@@ -18855,7 +18855,7 @@ class LoessTransform(Transform):
 
     Mapping(required=[loess, on])
 
-    Attributes
+    Parameters
     ----------
 
     loess : :class:`FieldName`
@@ -18887,7 +18887,7 @@ class LookupTransform(Transform):
 
     Mapping(required=[lookup, from])
 
-    Attributes
+    Parameters
     ----------
 
     lookup : string
@@ -18920,7 +18920,7 @@ class PivotTransform(Transform):
 
     Mapping(required=[pivot, value])
 
-    Attributes
+    Parameters
     ----------
 
     pivot : :class:`FieldName`
@@ -18953,7 +18953,7 @@ class QuantileTransform(Transform):
 
     Mapping(required=[quantile])
 
-    Attributes
+    Parameters
     ----------
 
     quantile : :class:`FieldName`
@@ -18985,7 +18985,7 @@ class RegressionTransform(Transform):
 
     Mapping(required=[regression, on])
 
-    Attributes
+    Parameters
     ----------
 
     on : :class:`FieldName`
@@ -19035,7 +19035,7 @@ class SampleTransform(Transform):
 
     Mapping(required=[sample])
 
-    Attributes
+    Parameters
     ----------
 
     sample : float
@@ -19054,7 +19054,7 @@ class StackTransform(Transform):
 
     Mapping(required=[stack, groupby, as])
 
-    Attributes
+    Parameters
     ----------
 
     groupby : List(:class:`FieldName`)
@@ -19088,7 +19088,7 @@ class TimeUnitTransform(Transform):
 
     Mapping(required=[timeUnit, field, as])
 
-    Attributes
+    Parameters
     ----------
 
     field : :class:`FieldName`
@@ -19133,7 +19133,7 @@ class TypedFieldDef(VegaLiteSchema):
     Mapping(required=[])
     Definition object for a data field, its type and transformation of an encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     aggregate : :class:`Aggregate`
@@ -19309,7 +19309,7 @@ class UnitSpec(VegaLiteSchema):
     Mapping(required=[mark])
     Base interface for a unit (single-view) specification.
 
-    Attributes
+    Parameters
     ----------
 
     mark : :class:`AnyMark`
@@ -19353,7 +19353,7 @@ class UnitSpecWithFrame(VegaLiteSchema):
 
     Mapping(required=[mark])
 
-    Attributes
+    Parameters
     ----------
 
     mark : :class:`AnyMark`
@@ -19442,7 +19442,7 @@ class UrlData(DataSource):
 
     Mapping(required=[url])
 
-    Attributes
+    Parameters
     ----------
 
     url : string
@@ -19496,7 +19496,7 @@ class VConcatSpecGenericSpec(Spec, NonNormalizedSpec):
     Mapping(required=[vconcat])
     Base interface for a vertical concatenation specification.
 
-    Attributes
+    Parameters
     ----------
 
     vconcat : List(:class:`Spec`)
@@ -19552,7 +19552,7 @@ class ValueDefWithConditionMarkPropFieldOrDatumDefGradientstringnull(ColorDef, M
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefGradientstringnullExprRef`, List(:class:`ConditionalValueDefGradientstringnullExprRef`))
@@ -19575,7 +19575,7 @@ class ValueDefWithConditionMarkPropFieldOrDatumDefTypeForShapestringnull(MarkPro
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDefTypeForShape`, :class:`ConditionalValueDefstringnullExprRef`, List(:class:`ConditionalValueDefstringnullExprRef`))
@@ -19598,7 +19598,7 @@ class ValueDefWithConditionMarkPropFieldOrDatumDefnumber(MarkPropDefnumber, Nume
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefnumberExprRef`, List(:class:`ConditionalValueDefnumberExprRef`))
@@ -19620,7 +19620,7 @@ class ValueDefWithConditionMarkPropFieldOrDatumDefnumberArray(MarkPropDefnumberA
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefnumberArrayExprRef`, List(:class:`ConditionalValueDefnumberArrayExprRef`))
@@ -19643,7 +19643,7 @@ class ValueDefWithConditionMarkPropFieldOrDatumDefstringnull(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalMarkPropFieldOrDatumDef`, :class:`ConditionalValueDefstringnullExprRef`, List(:class:`ConditionalValueDefstringnullExprRef`))
@@ -19665,7 +19665,7 @@ class ValueDefWithConditionStringFieldDefText(TextDef):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     condition : anyOf(:class:`ConditionalStringFieldDef`, :class:`ConditionalValueDefTextExprRef`, List(:class:`ConditionalValueDefTextExprRef`))
@@ -19689,7 +19689,7 @@ class ValueDefnumber(OffsetDef):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : float
@@ -19710,7 +19710,7 @@ class ValueDefnumberwidthheightExprRef(VegaLiteSchema):
     Definition object for a constant value (primitive value or gradient definition) of an
     encoding channel.
 
-    Attributes
+    Parameters
     ----------
 
     value : anyOf(float, string, string, :class:`ExprRef`)
@@ -19729,7 +19729,7 @@ class VariableParameter(VegaLiteSchema):
 
     Mapping(required=[name])
 
-    Attributes
+    Parameters
     ----------
 
     name : :class:`ParameterName`
@@ -19860,7 +19860,7 @@ class ViewBackground(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     cornerRadius : anyOf(float, :class:`ExprRef`)
@@ -19927,7 +19927,7 @@ class ViewConfig(VegaLiteSchema):
 
     Mapping(required=[])
 
-    Attributes
+    Parameters
     ----------
 
     clip : boolean
@@ -20039,7 +20039,7 @@ class WindowFieldDef(VegaLiteSchema):
 
     Mapping(required=[op, as])
 
-    Attributes
+    Parameters
     ----------
 
     op : anyOf(:class:`AggregateOp`, :class:`WindowOnlyOp`)
@@ -20082,7 +20082,7 @@ class WindowTransform(Transform):
 
     Mapping(required=[window])
 
-    Attributes
+    Parameters
     ----------
 
     window : List(:class:`WindowFieldDef`)

--- a/doc/getting_started/starting.rst
+++ b/doc/getting_started/starting.rst
@@ -192,7 +192,7 @@ column as well:
     y = alt.Y('average(b):Q')
     print(y.to_json())
 
-This short-hand is equivalent to spelling-out the attributes by name:
+This short-hand is equivalent to spelling-out the parameters by name:
 
 .. altair-plot::
     :output: repr

--- a/doc/user_guide/configuration.rst
+++ b/doc/user_guide/configuration.rst
@@ -35,7 +35,7 @@ For more discussion of approaches to chart customization, see
 Chart Configuration
 -------------------
 The :meth:`Chart.configure` method adds a :class:`Config` instance to the chart,
-and accepts the following arguments:
+and accepts the following parameters:
 
 .. altair-object-table:: altair.Config
 

--- a/doc/user_guide/configuration.rst
+++ b/doc/user_guide/configuration.rst
@@ -35,7 +35,7 @@ For more discussion of approaches to chart customization, see
 Chart Configuration
 -------------------
 The :meth:`Chart.configure` method adds a :class:`Config` instance to the chart,
-and has the following attributes:
+and accepts the following arguments:
 
 .. altair-object-table:: altair.Config
 

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -168,7 +168,7 @@ class SchemaGenerator(object):
 
         if info.properties:
             nonkeyword, required, kwds, invalid_kwds, additional = _get_args(info)
-            doc += ["", "Attributes", "----------", ""]
+            doc += ["", "Parameters", "----------", ""]
             for prop in sorted(required) + sorted(kwds) + sorted(invalid_kwds):
                 propinfo = info.properties[prop]
                 doc += [

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -195,7 +195,7 @@ class SchemaValidationError(jsonschema.ValidationError):
 
 
 class UndefinedType(object):
-    """A singleton object for marking undefined attributes"""
+    """A singleton object for marking undefined parameters"""
 
     __instance = None
 
@@ -697,13 +697,13 @@ class _PropertySetter(object):
             # Add the docstring from the helper class (e.g. `BinParams`) so
             # that all the parameter names of the helper class are included in
             # the final docstring
-            attribute_index = altair_prop.__doc__.find("Attributes\n")
-            if attribute_index > -1:
+            parameter_index = altair_prop.__doc__.find("Parameters\n")
+            if parameter_index > -1:
                 self.__doc__ = (
-                    altair_prop.__doc__[:attribute_index].replace("    ", "")
+                    altair_prop.__doc__[:parameter_index].replace("    ", "")
                     + self.__doc__
                     + textwrap.dedent(
-                        f"\n\n    {altair_prop.__doc__[attribute_index:]}"
+                        f"\n\n    {altair_prop.__doc__[parameter_index:]}"
                     )
                 )
             # For short docstrings such as Aggregate, Stack, et


### PR DESCRIPTION
With the addition of method-based attribute setting in #2795, Sphinx started generate the documentation differently for the encoding channels. The documentation for attributes is now the first sentence of the documentation which is defined by `_PropertySetter`:

<img width="774" alt="image" src="https://user-images.githubusercontent.com/23366411/219955442-9e7fd253-5f4e-4a87-bf28-afb2966c10d4.png">

This is much less informative then what is in the docstring of `altair.X` and which would be shown otherwise:
```python
    Attributes
    ----------

    shorthand : string
        shorthand for field, aggregate, and type
    aggregate : :class:`Aggregate`
        Aggregation function for the field (e.g., ``"mean"``, ``"sum"``, ``"median"``,
        ``"min"``, ``"max"``, ``"count"`` ).

        **Default value:** ``undefined`` (None)

        **See also:** `aggregate <https://vega.github.io/vega-lite/docs/aggregate.html>`__
        documentation.
    axis : anyOf(:class:`Axis`, None)
        An object defining properties of axis's gridlines, ticks and labels. If ``null``,
        the axis for the encoding channel will be removed.

        **Default value:** If undefined, default `axis properties
        <https://vega.github.io/vega-lite/docs/axis.html>`__ are applied.

        **See also:** `axis <https://vega.github.io/vega-lite/docs/axis.html>`__
        documentation.
```
I tried to disable this behavior but didn't find a way. However, I'd suggest to tackle the root cause of this directly instead of trying to reconfigure Sphinx. Following [the numpydoc style for docstrings](https://numpydoc.readthedocs.io/en/latest/format.html#parameters) (see also [`ExampleError` on this page](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html)), what is called `Attributes` in the Altair class docstrings should, in my understanding, be called `Parameters` as we document what parameters can be passed to e.g. `altair.X` and not what attributes it has after instantiation. As all `Parameters` usually also appear as `Attributes` (with the exception of the ones which are now replaced by the property-based methods) this didn't matter much so far. I'd suggest to now introduce this distinction by replacing `Attributes` with `Parameters` in the docstrings:

```python
    Parameters
    ----------

    shorthand : string
        shorthand for field, aggregate, and type
```
After this change, the documentation renders again how it's supposed to:

<img width="783" alt="image" src="https://user-images.githubusercontent.com/23366411/219955717-47257210-6277-499d-aebe-aab6549c43ea.png">
