### PR TITLE
Add instructions on how to install release candidate

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,7 +155,7 @@ html_theme_options = {
         },
     ],
     "header_links_before_dropdown": 6,
-    "announcement": "This website is for Vega-Altair v5 (release candidate). Visit the <a href='https://altair-viz.github.io/altair-viz-v4/'>Vega-Altair v4 homepage</a> for previous release documentation.",
+    "announcement": """This website is for the release candidate of version 5 <code class="docutils literal notranslate"><span class="pre">pip install altair==5.0.0rc1</span></code>. You can find the documentation for version 4 <a href='https://altair-viz.github.io/altair-viz-v4/'>here</a>.""",
 }
 
 html_context = {"default_mode": "light"}


### PR DESCRIPTION
I think we need some instructions in the docs on how to install the release candidate as `pip install altair` will still install version 4, see https://jugmac00.github.io/til/how-to-install-release-candidates/. CC @mattijn What do you think of this? Had to shorten the existing text to make room for the pip install command.

<img width="1467" alt="image" src="https://user-images.githubusercontent.com/23366411/219957332-dc571801-c605-4fbf-b7ff-85d7ec8922a4.png">

I did not modify the pip install command on the Installation page as I maybe the announcement is enough and easy to spot and remove once version 5 is out but not sure.