### PR TITLE
Docstring links class transform and mark methods

### DIFF
--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -546,12 +546,11 @@ def use_signature(Obj):
 
         # Supplement the docstring of f with information from Obj
         if Obj.__doc__:
-
             # Patch in a reference to the class this docstring is copied from,
-             # to generate a hyperlink
+            # to generate a hyperlink
             doclines = Obj.__doc__.splitlines()
             doclines[0] = f"Refer to :class:`{Obj.__name__}`"
-            
+
             if f.__doc__:
                 doc = f.__doc__ + "\n".join(doclines[1:])
             else:

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -546,7 +546,12 @@ def use_signature(Obj):
 
         # Supplement the docstring of f with information from Obj
         if Obj.__doc__:
+
+            # Patch in a reference to the class this docstring is copied from,
+             # to generate a hyperlink
             doclines = Obj.__doc__.splitlines()
+            doclines[0] = f"Refer to :class:`{Obj.__name__}`"
+            
             if f.__doc__:
                 doc = f.__doc__ + "\n".join(doclines[1:])
             else:

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -547,7 +547,7 @@ def use_signature(Obj):
         # Supplement the docstring of f with information from Obj
         if Obj.__doc__:
             # Patch in a reference to the class this docstring is copied from,
-            # to generate a hyperlink
+            # to generate a hyperlink.
             doclines = Obj.__doc__.splitlines()
             doclines[0] = f"Refer to :class:`{Obj.__name__}`"
 

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -901,7 +901,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         self: _TTopLevelMixin, aggregate=Undefined, groupby=Undefined, **kwds
     ) -> _TTopLevelMixin:
         """
-        Add an AggregateTransform to the schema.
+        Add an :class:`AggregateTransform` to the schema.
 
         Parameters
         ----------
@@ -977,7 +977,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         self: _TTopLevelMixin, as_=Undefined, field=Undefined, bin=True, **kwargs
     ) -> _TTopLevelMixin:
         """
-        Add a BinTransform to the schema.
+        Add a :class:`BinTransform` to the schema.
 
         Parameters
         ----------
@@ -1035,7 +1035,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         self: _TTopLevelMixin, as_=Undefined, calculate=Undefined, **kwargs
     ) -> _TTopLevelMixin:
         """
-        Add a CalculateTransform to the schema.
+        Add a :class:`CalculateTransform` to the schema.
 
         Parameters
         ----------
@@ -1108,7 +1108,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         minsteps=Undefined,
         steps=Undefined,
     ) -> _TTopLevelMixin:
-        """Add a DensityTransform to the spec.
+        """Add a :class:`DensityTransform` to the spec.
 
         Parameters
         ----------
@@ -1174,7 +1174,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         value=Undefined,
     ) -> _TTopLevelMixin:
         """
-        Add an ImputeTransform to the schema.
+        Add an :class:`ImputeTransform` to the schema.
 
         Parameters
         ----------
@@ -1237,7 +1237,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         self: _TTopLevelMixin, joinaggregate=Undefined, groupby=Undefined, **kwargs
     ) -> _TTopLevelMixin:
         """
-        Add a JoinAggregateTransform to the schema.
+        Add a :class:`JoinAggregateTransform` to the schema.
 
         Parameters
         ----------
@@ -1288,7 +1288,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
     # TODO: Update docstring
     def transform_filter(self: _TTopLevelMixin, filter, **kwargs) -> _TTopLevelMixin:
         """
-        Add a FilterTransform to the schema.
+        Add a :class:`FilterTransform` to the schema.
 
         Parameters
         ----------
@@ -1322,7 +1322,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
     def transform_flatten(
         self: _TTopLevelMixin, flatten, as_=Undefined
     ) -> _TTopLevelMixin:
-        """Add a FlattenTransform to the schema.
+        """Add a :class:`FlattenTransform` to the schema.
 
         Parameters
         ----------
@@ -1350,7 +1350,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         )
 
     def transform_fold(self: _TTopLevelMixin, fold, as_=Undefined) -> _TTopLevelMixin:
-        """Add a FoldTransform to the spec.
+        """Add a :class:`FoldTransform` to the spec.
 
         Parameters
         ----------
@@ -1380,7 +1380,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         bandwidth=Undefined,
         groupby=Undefined,
     ) -> _TTopLevelMixin:
-        """Add a LoessTransform to the spec.
+        """Add a :class:`LoessTransform` to the spec.
 
         Parameters
         ----------
@@ -1422,7 +1422,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         default=Undefined,
         **kwargs,
     ) -> _TTopLevelMixin:
-        """Add a DataLookupTransform or SelectionLookupTransform to the chart
+        """Add a :class:`DataLookupTransform` or :class:`SelectionLookupTransform` to the chart
 
         Parameters
         ----------
@@ -1477,7 +1477,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         limit=Undefined,
         op=Undefined,
     ) -> _TTopLevelMixin:
-        """Add a pivot transform to the chart.
+        """Add a :class:`PivotTransform` to the chart.
 
         Parameters
         ----------
@@ -1523,7 +1523,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         probs=Undefined,
         step=Undefined,
     ) -> _TTopLevelMixin:
-        """Add a quantile transform to the chart
+        """Add a :class:`QuantileTransform` to the chart
 
         Parameters
         ----------
@@ -1572,7 +1572,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         order=Undefined,
         params=Undefined,
     ) -> _TTopLevelMixin:
-        """Add a RegressionTransform to the chart.
+        """Add a :class:`RegressionTransform` to the chart.
 
         Parameters
         ----------
@@ -1628,7 +1628,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
     def transform_sample(self: _TTopLevelMixin, sample=1000) -> _TTopLevelMixin:
         """
-        Add a SampleTransform to the schema.
+        Add a :class:`SampleTransform` to the schema.
 
         Parameters
         ----------
@@ -1650,7 +1650,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         self: _TTopLevelMixin, as_, stack, groupby, offset=Undefined, sort=Undefined
     ) -> _TTopLevelMixin:
         """
-        Add a StackTransform to the schema.
+        Add a :class:`StackTransform` to the schema.
 
         Parameters
         ----------
@@ -1691,7 +1691,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         **kwargs,
     ) -> _TTopLevelMixin:
         """
-        Add a TimeUnitTransform to the schema.
+        Add a :class:`TimeUnitTransform` to the schema.
 
         Parameters
         ----------
@@ -1776,7 +1776,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         sort=Undefined,
         **kwargs,
     ) -> _TTopLevelMixin:
-        """Add a WindowTransform to the schema
+        """Add a :class:`WindowTransform` to the schema
 
         Parameters
         ----------

--- a/altair/vegalite/v5/schema/mixins.py
+++ b/altair/vegalite/v5/schema/mixins.py
@@ -36,9 +36,7 @@ class MarkMethodMixin(object):
                  url=Undefined, width=Undefined, x=Undefined, x2=Undefined, x2Offset=Undefined,
                  xOffset=Undefined, y=Undefined, y2=Undefined, y2Offset=Undefined, yOffset=Undefined,
                  **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'arc'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'arc' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -95,9 +93,7 @@ class MarkMethodMixin(object):
                   tooltip=Undefined, url=Undefined, width=Undefined, x=Undefined, x2=Undefined,
                   x2Offset=Undefined, xOffset=Undefined, y=Undefined, y2=Undefined, y2Offset=Undefined,
                   yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'area'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'area' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -154,9 +150,7 @@ class MarkMethodMixin(object):
                  url=Undefined, width=Undefined, x=Undefined, x2=Undefined, x2Offset=Undefined,
                  xOffset=Undefined, y=Undefined, y2=Undefined, y2Offset=Undefined, yOffset=Undefined,
                  **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'bar'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'bar' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -213,9 +207,7 @@ class MarkMethodMixin(object):
                    timeUnitBandSize=Undefined, tooltip=Undefined, url=Undefined, width=Undefined,
                    x=Undefined, x2=Undefined, x2Offset=Undefined, xOffset=Undefined, y=Undefined,
                    y2=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'image'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'image' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -272,9 +264,7 @@ class MarkMethodMixin(object):
                   tooltip=Undefined, url=Undefined, width=Undefined, x=Undefined, x2=Undefined,
                   x2Offset=Undefined, xOffset=Undefined, y=Undefined, y2=Undefined, y2Offset=Undefined,
                   yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'line'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'line' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -331,9 +321,7 @@ class MarkMethodMixin(object):
                    timeUnitBandSize=Undefined, tooltip=Undefined, url=Undefined, width=Undefined,
                    x=Undefined, x2=Undefined, x2Offset=Undefined, xOffset=Undefined, y=Undefined,
                    y2=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'point'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'point' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -390,9 +378,7 @@ class MarkMethodMixin(object):
                   tooltip=Undefined, url=Undefined, width=Undefined, x=Undefined, x2=Undefined,
                   x2Offset=Undefined, xOffset=Undefined, y=Undefined, y2=Undefined, y2Offset=Undefined,
                   yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'rect'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'rect' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -449,9 +435,7 @@ class MarkMethodMixin(object):
                   tooltip=Undefined, url=Undefined, width=Undefined, x=Undefined, x2=Undefined,
                   x2Offset=Undefined, xOffset=Undefined, y=Undefined, y2=Undefined, y2Offset=Undefined,
                   yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'rule'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'rule' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -508,9 +492,7 @@ class MarkMethodMixin(object):
                   tooltip=Undefined, url=Undefined, width=Undefined, x=Undefined, x2=Undefined,
                   x2Offset=Undefined, xOffset=Undefined, y=Undefined, y2=Undefined, y2Offset=Undefined,
                   yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'text'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'text' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -567,9 +549,7 @@ class MarkMethodMixin(object):
                   tooltip=Undefined, url=Undefined, width=Undefined, x=Undefined, x2=Undefined,
                   x2Offset=Undefined, xOffset=Undefined, y=Undefined, y2=Undefined, y2Offset=Undefined,
                   yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'tick'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'tick' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -626,9 +606,7 @@ class MarkMethodMixin(object):
                    timeUnitBandSize=Undefined, tooltip=Undefined, url=Undefined, width=Undefined,
                    x=Undefined, x2=Undefined, x2Offset=Undefined, xOffset=Undefined, y=Undefined,
                    y2=Undefined, y2Offset=Undefined, yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'trail'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'trail' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -686,9 +664,7 @@ class MarkMethodMixin(object):
                     tooltip=Undefined, url=Undefined, width=Undefined, x=Undefined, x2=Undefined,
                     x2Offset=Undefined, xOffset=Undefined, y=Undefined, y2=Undefined,
                     y2Offset=Undefined, yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'circle'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'circle' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -746,9 +722,7 @@ class MarkMethodMixin(object):
                     tooltip=Undefined, url=Undefined, width=Undefined, x=Undefined, x2=Undefined,
                     x2Offset=Undefined, xOffset=Undefined, y=Undefined, y2=Undefined,
                     y2Offset=Undefined, yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'square'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'square' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -806,9 +780,7 @@ class MarkMethodMixin(object):
                       tooltip=Undefined, url=Undefined, width=Undefined, x=Undefined, x2=Undefined,
                       x2Offset=Undefined, xOffset=Undefined, y=Undefined, y2=Undefined,
                       y2Offset=Undefined, yOffset=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'geoshape'
-    
-        For information on additional arguments, see :class:`MarkDef`
+        """Set the chart's mark to 'geoshape' (see :class:`MarkDef`)
         """
         kwds = dict(align=align, angle=angle, aria=aria, ariaRole=ariaRole,
                     ariaRoleDescription=ariaRoleDescription, aspect=aspect, bandSize=bandSize,
@@ -844,9 +816,7 @@ class MarkMethodMixin(object):
     def mark_boxplot(self: _TMarkMethodMixin, box=Undefined, clip=Undefined, color=Undefined,
                      extent=Undefined, median=Undefined, opacity=Undefined, orient=Undefined,
                      outliers=Undefined, rule=Undefined, size=Undefined, ticks=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'boxplot'
-    
-        For information on additional arguments, see :class:`BoxPlotDef`
+        """Set the chart's mark to 'boxplot' (see :class:`BoxPlotDef`)
         """
         kwds = dict(box=box, clip=clip, color=color, extent=extent, median=median, opacity=opacity,
                     orient=orient, outliers=outliers, rule=rule, size=size, ticks=ticks, **kwds)
@@ -860,9 +830,7 @@ class MarkMethodMixin(object):
     def mark_errorbar(self: _TMarkMethodMixin, clip=Undefined, color=Undefined, extent=Undefined,
                       opacity=Undefined, orient=Undefined, rule=Undefined, size=Undefined,
                       thickness=Undefined, ticks=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'errorbar'
-    
-        For information on additional arguments, see :class:`ErrorBarDef`
+        """Set the chart's mark to 'errorbar' (see :class:`ErrorBarDef`)
         """
         kwds = dict(clip=clip, color=color, extent=extent, opacity=opacity, orient=orient, rule=rule,
                     size=size, thickness=thickness, ticks=ticks, **kwds)
@@ -876,9 +844,7 @@ class MarkMethodMixin(object):
     def mark_errorband(self: _TMarkMethodMixin, band=Undefined, borders=Undefined, clip=Undefined,
                        color=Undefined, extent=Undefined, interpolate=Undefined, opacity=Undefined,
                        orient=Undefined, tension=Undefined, **kwds) -> _TMarkMethodMixin:
-        """Set the chart's mark to 'errorband'
-    
-        For information on additional arguments, see :class:`ErrorBandDef`
+        """Set the chart's mark to 'errorband' (see :class:`ErrorBandDef`)
         """
         kwds = dict(band=band, borders=borders, clip=clip, color=color, extent=extent,
                     interpolate=interpolate, opacity=opacity, orient=orient, tension=tension, **kwds)

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -145,9 +145,7 @@ class DatumChannelMixin(object):
 
 MARK_METHOD = '''
 def mark_{mark}({def_arglist}) -> {self_type}:
-    """Set the chart's mark to '{mark}'
-
-    For information on additional arguments, see :class:`{mark_def}`
+    """Set the chart's mark to '{mark}' (see :class:`{mark_def}`)
     """
     kwds = dict({dict_arglist})
     copy = self.copy(deep=False)


### PR DESCRIPTION
replaces: https://github.com/altair-viz/altair/pull/2610
fix: https://github.com/altair-viz/altair/issues/2608

@binste, I build the docs, but I could not find the tables of the screenshots in #2610, not sure where I should be able to see changes.