### PR TITLE
MAINT: Remove inheritance from object for classes

### DIFF
--- a/altair/expr/core.py
+++ b/altair/expr/core.py
@@ -1,7 +1,7 @@
 from ..utils import SchemaBase
 
 
-class DatumType(object):
+class DatumType:
     """An object to assist in building Vega-Lite Expressions"""
 
     def __repr__(self):
@@ -38,7 +38,7 @@ def _js_repr(val):
 
 
 # Designed to work with Expression and VariableParameter
-class OperatorMixin(object):
+class OperatorMixin:
     def _to_expr(self):
         return repr(self)
 

--- a/altair/expr/funcs.py
+++ b/altair/expr/funcs.py
@@ -144,7 +144,7 @@ FUNCTION_LISTING = {
 NAME_MAP = {"if": "if_"}
 
 
-class ExprFunc(object):
+class ExprFunc:
     def __init__(self, name, doc):
         self.name = name
         self.doc = doc

--- a/altair/utils/deprecation.py
+++ b/altair/utils/deprecation.py
@@ -40,7 +40,7 @@ def _deprecate(obj, name=None, message=None):
 
     Examples
     --------
-    >>> class Foo(object): pass
+    >>> class Foo: pass
     >>> OldFoo = _deprecate(Foo, "OldFoo")
     >>> f = OldFoo()  # doctest: +SKIP
     AltairDeprecationWarning: alt.OldFoo is deprecated. Use alt.Foo instead.

--- a/altair/utils/display.py
+++ b/altair/utils/display.py
@@ -97,7 +97,7 @@ class RendererRegistry(PluginRegistry[RendererType]):
 # ==============================================================================
 
 
-class Displayable(object):
+class Displayable:
     """A base display class for VegaLite v1/v2.
 
     This class takes a VegaLite v1/v2 spec and does the following:
@@ -165,7 +165,7 @@ def json_renderer_base(spec, str_repr, **options):
     )
 
 
-class HTMLRenderer(object):
+class HTMLRenderer:
     """Object to render charts as HTML, with a unique output div each time"""
 
     def __init__(self, output_div="altair-viz-{}", **kwargs):

--- a/altair/utils/execeval.py
+++ b/altair/utils/execeval.py
@@ -10,7 +10,7 @@ else:
         return ast.Module(nodelist)
 
 
-class _CatchDisplay(object):
+class _CatchDisplay:
     """Class to temporarily catch sys.displayhook"""
 
     def __init__(self):

--- a/altair/utils/plugin_registry.py
+++ b/altair/utils/plugin_registry.py
@@ -22,7 +22,7 @@ class NoSuchEntryPoint(Exception):
         return f"No {self.name!r} entry point found in group {self.group!r}"
 
 
-class PluginEnabler(object):
+class PluginEnabler:
     """Context manager for enabling plugins
 
     This object lets you use enable() as a context manager to

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -277,7 +277,7 @@ class SchemaValidationError(jsonschema.ValidationError):
             )
 
 
-class UndefinedType(object):
+class UndefinedType:
     """A singleton object for marking undefined parameters"""
 
     __instance = None
@@ -298,7 +298,7 @@ class UndefinedType(object):
 Undefined: Any = UndefinedType()
 
 
-class SchemaBase(object):
+class SchemaBase:
     """Base class for schema wrappers.
 
     Each derived class should set the _schema class attribute (and optionally
@@ -648,7 +648,7 @@ def _passthrough(*args, **kwds):
     return args[0] if args else kwds
 
 
-class _FromDict(object):
+class _FromDict:
     """Class used to construct SchemaBase class hierarchies from a dict
 
     The primary purpose of using this class is to be able to build a hash table
@@ -763,7 +763,7 @@ class _FromDict(object):
             return cls(dct)
 
 
-class _PropertySetter(object):
+class _PropertySetter:
     def __init__(self, prop, schema):
         self.prop = prop
         self.schema = schema

--- a/altair/utils/server.py
+++ b/altair/utils/server.py
@@ -23,7 +23,7 @@ You must interrupt the kernel to cancel this command.
 # Mock server used for testing
 
 
-class MockRequest(object):
+class MockRequest:
     def makefile(self, *args, **kwargs):
         return IO(b"GET /")
 
@@ -31,7 +31,7 @@ class MockRequest(object):
         pass
 
 
-class MockServer(object):
+class MockServer:
     def __init__(self, ip_port, Handler):
         Handler(MockRequest(), ip_port[0], self)
 

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2026,7 +2026,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
         return self._set_resolve(scale=core.ScaleResolveMap(*args, **kwargs))
 
 
-class _EncodingMixin(object):
+class _EncodingMixin:
     @utils.use_signature(core.FacetedEncoding)
     def encode(self: _TEncodingMixin, *args, **kwargs) -> _TEncodingMixin:
         # Convert args to kwargs based on their types.

--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -8,7 +8,7 @@ from altair.utils import parse_shorthand
 from typing import overload, Type
 
 
-class FieldChannelMixin(object):
+class FieldChannelMixin:
     def to_dict(self, validate=True, ignore=(), context=None):
         context = context or {}
         shorthand = self._get('shorthand')
@@ -62,7 +62,7 @@ class FieldChannelMixin(object):
         )
 
 
-class ValueChannelMixin(object):
+class ValueChannelMixin:
     def to_dict(self, validate=True, ignore=(), context=None):
         context = context or {}
         condition = self._get('condition', Undefined)
@@ -79,7 +79,7 @@ class ValueChannelMixin(object):
                                                       context=context)
 
 
-class DatumChannelMixin(object):
+class DatumChannelMixin:
     def to_dict(self, validate=True, ignore=(), context=None):
         context = context or {}
         datum = self._get('datum', Undefined)

--- a/altair/vegalite/v5/schema/mixins.py
+++ b/altair/vegalite/v5/schema/mixins.py
@@ -9,7 +9,7 @@ _TConfigMethodMixin = TypeVar("_TConfigMethodMixin", bound="ConfigMethodMixin")
 _TMarkMethodMixin = TypeVar("_TMarkMethodMixin", bound="MarkMethodMixin")
 
 
-class MarkMethodMixin(object):
+class MarkMethodMixin:
     """A mixin class that defines mark methods"""
 
     def mark_arc(self: _TMarkMethodMixin, align=Undefined, angle=Undefined, aria=Undefined,
@@ -856,7 +856,7 @@ class MarkMethodMixin(object):
         return copy
 
 
-class ConfigMethodMixin(object):
+class ConfigMethodMixin:
     """A mixin class that defines config methods"""
 
     @use_signature(core.Config)

--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -13,7 +13,7 @@ VEGA_THEMES = [
 ]
 
 
-class VegaTheme(object):
+class VegaTheme:
     """Implementation of a builtin vega theme."""
 
     def __init__(self, theme):

--- a/tests/utils/tests/test_core.py
+++ b/tests/utils/tests/test_core.py
@@ -14,13 +14,13 @@ FAKE_CHANNELS_MODULE = '''
 from altair.utils import schemapi
 
 
-class FieldChannel(object):
+class FieldChannel:
     def __init__(self, shorthand, **kwargs):
         kwargs['shorthand'] = shorthand
         return super(FieldChannel, self).__init__(**kwargs)
 
 
-class ValueChannel(object):
+class ValueChannel:
     def __init__(self, value, **kwargs):
         kwargs['value'] = value
         return super(ValueChannel, self).__init__(**kwargs)

--- a/tests/vegalite/v5/tests/test_geo_interface.py
+++ b/tests/vegalite/v5/tests/test_geo_interface.py
@@ -3,7 +3,7 @@ import altair.vegalite.v5 as alt
 
 
 def geom_obj(geom):
-    class Geom(object):
+    class Geom:
         pass
 
     geom_obj = Geom()

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -62,7 +62,7 @@ def load_schema():
 
 
 CHANNEL_MIXINS = """
-class FieldChannelMixin(object):
+class FieldChannelMixin:
     def to_dict(self, validate=True, ignore=(), context=None):
         context = context or {}
         shorthand = self._get('shorthand')
@@ -113,7 +113,7 @@ class FieldChannelMixin(object):
         )
 
 
-class ValueChannelMixin(object):
+class ValueChannelMixin:
     def to_dict(self, validate=True, ignore=(), context=None):
         context = context or {}
         condition = self._get('condition', Undefined)
@@ -130,7 +130,7 @@ class ValueChannelMixin(object):
                                                       context=context)
 
 
-class DatumChannelMixin(object):
+class DatumChannelMixin:
     def to_dict(self, validate=True, ignore=(), context=None):
         context = context or {}
         datum = self._get('datum', Undefined)
@@ -511,7 +511,7 @@ def generate_vegalite_mark_mixin(schemafile, markdefs):
     )
 
     code = [
-        f"class {class_name}(object):",
+        f"class {class_name}:",
         '    """A mixin class that defines mark methods"""',
     ]
 
@@ -560,7 +560,7 @@ def generate_vegalite_config_mixin(schemafile):
     )
 
     code = [
-        f"class {class_name}(object):",
+        f"class {class_name}:",
         '    """A mixin class that defines config methods"""',
     ]
     with open(schemafile, encoding="utf8") as f:

--- a/tools/schemapi/codegen.py
+++ b/tools/schemapi/codegen.py
@@ -5,7 +5,7 @@ import textwrap
 import re
 
 
-class CodeSnippet(object):
+class CodeSnippet:
     """Object whose repr() is a string of code"""
 
     def __init__(self, code):
@@ -56,7 +56,7 @@ def _get_args(info):
     return (nonkeyword, required, kwds, invalid_kwds, additional)
 
 
-class SchemaGenerator(object):
+class SchemaGenerator:
     """Class that defines methods for generating code from schemas
 
     Parameters

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -275,7 +275,7 @@ class SchemaValidationError(jsonschema.ValidationError):
             )
 
 
-class UndefinedType(object):
+class UndefinedType:
     """A singleton object for marking undefined parameters"""
 
     __instance = None
@@ -296,7 +296,7 @@ class UndefinedType(object):
 Undefined: Any = UndefinedType()
 
 
-class SchemaBase(object):
+class SchemaBase:
     """Base class for schema wrappers.
 
     Each derived class should set the _schema class attribute (and optionally
@@ -646,7 +646,7 @@ def _passthrough(*args, **kwds):
     return args[0] if args else kwds
 
 
-class _FromDict(object):
+class _FromDict:
     """Class used to construct SchemaBase class hierarchies from a dict
 
     The primary purpose of using this class is to be able to build a hash table
@@ -761,7 +761,7 @@ class _FromDict(object):
             return cls(dct)
 
 
-class _PropertySetter(object):
+class _PropertySetter:
     def __init__(self, prop, schema):
         self.prop = prop
         self.schema = schema

--- a/tools/schemapi/utils.py
+++ b/tools/schemapi/utils.py
@@ -94,7 +94,7 @@ def is_valid_identifier(var, allow_unicode=False):
     return is_valid and not keyword.iskeyword(var)
 
 
-class SchemaProperties(object):
+class SchemaProperties:
     """A wrapper for properties within a schema"""
 
     def __init__(self, properties, schema, rootschema=None):
@@ -133,7 +133,7 @@ class SchemaProperties(object):
         return (self[key] for key in self)
 
 
-class SchemaInfo(object):
+class SchemaInfo:
     """A wrapper for inspecting a JSON schema"""
 
     def __init__(self, schema, rootschema=None):


### PR DESCRIPTION
Small maintenance change. Only removes inheritance of `object` for all classes as this was only necessary to maintain compatibility with Python 2. In Python 3, it does not matter if `object` is specified or not and we can therefore remove it. See https://stackoverflow.com/a/45062077