### PR TITLE
Fix deprecation warning for SelectableGroup in Python 3.7

### DIFF
--- a/altair/utils/plugin_registry.py
+++ b/altair/utils/plugin_registry.py
@@ -154,7 +154,7 @@ class PluginRegistry(Generic[PluginType]):
             try:
                 (ep,) = [
                     ep
-                    for ep in entry_points().get(self.entry_point_group, [])
+                    for ep in importlib_metadata_get(self.entry_point_group)
                     if ep.name == name
                 ]
             except ValueError:

--- a/altair/utils/plugin_registry.py
+++ b/altair/utils/plugin_registry.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Any, Dict, List, Optional, Generic, TypeVar, cast
 from types import TracebackType
 


### PR DESCRIPTION
Fixes deprecationwarning discussed in https://github.com/altair-viz/altair/discussions/2599#discussioncomment-5113306. I used the same approach as they use in SQLAlchemy https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/util/compat.py#L139 which should provide the broadest possible compatibility by relying on the new `select` interface if it is present and else fall back on the old `get`, independent of if the standard library or `importlib_metadata` is used. CC @mattijn. Don't see any deprecation warnings related to this anymore for any Python version we test against.