### PR TITLE
Fail build workflow if generate_schema_wrapper produces changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,28 @@ jobs:
           pip install .[dev]
           # pip install "selenium<4.3.0"
           # pip install altair_saver
+      - name: Test that schema generation has no effect
+        run: |
+          python tools/generate_schema_wrapper.py
+          # This gets the paths of all files which were either deleted, modified
+          # or are not yet tracked by Git
+          files=`git ls-files --deleted --modified --others --exclude-standard`
+          # Depending on the shell it can happen that 'files' contains empty
+          # lines which are filtered out in the for loop below
+          files_cleaned=()
+          for i in "${files[@]}"; do
+            # Skip empty items
+            if [ -z "$i" ]; then
+              continue
+            fi
+            # Add the rest of the elements to a new array
+            files_cleaned+=("${i}")
+          done
+          if [ ${#files_cleaned[@]} -gt 0 ]; then
+              echo "The code generation modified the following files:"
+              echo $files
+              exit 1
+          fi
       - name: Test with pytest
         run: |
           pytest --doctest-modules tests


### PR DESCRIPTION
Closes #2906. Tested that it works on another branch in my forked repo, see the failed workflow [here](https://github.com/binste/altair/actions/runs/4330777174/jobs/7562209179):

<img width="641" alt="image" src="https://user-images.githubusercontent.com/23366411/222897765-835d641d-edc9-4228-865e-6b2a9ecb81de.png">

Tests for this PR fail right now because test_schemapi.py is not "clean" as I added some modifications in the wrong place. Will fix this in another PR.