### PR TITLE
Docs: Fix formatting of 2 links

### DIFF
--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -33,7 +33,7 @@ with the above installation commands:
 - typing_extensions_ (python<3.11)
 
 To run Altair's full test suite and build Altair's documentation requires a few
-additional dependencies, see `CONTRIBUTING.md <https://github.com/altair-viz/altair/blob/master/CONTRIBUTING.md>`
+additional dependencies, see `CONTRIBUTING.md <https://github.com/altair-viz/altair/blob/master/CONTRIBUTING.md>`_
 for the details.
 
 Development Install

--- a/doc/getting_started/project_philosophy.rst
+++ b/doc/getting_started/project_philosophy.rst
@@ -64,7 +64,7 @@ choice we feel is needed to simplify the user experience of exploratory
 visualization.
 
 You can find a more detailed comparison between Plotly and Altair in
-`this StackOverflow answer <https://stackoverflow.com/a/66040502>`.
+`this StackOverflow answer <https://stackoverflow.com/a/66040502>`_.
 
 Whence Vega-Altair?
 -------------------


### PR DESCRIPTION
Fixes rendering of 2 links which are currently displayed as:

<img width="801" alt="image" src="https://user-images.githubusercontent.com/23366411/222898844-87b06748-3928-41e2-b177-1040df1067c3.png">
