### PR TITLE
Add vega themes 'excel', 'googlecharts', 'powerbi'

### DIFF
--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -10,6 +10,9 @@ VEGA_THEMES = [
     "dark",
     "latimes",
     "urbaninstitute",
+    "excel",
+    "googlecharts",
+    "powerbi",
 ]
 
 


### PR DESCRIPTION
Adds missing themes from https://github.com/vega/vega-themes to Altair. Tested all 3.