### PR TITLE
Cut dependencies from installation page

### DIFF
--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -22,8 +22,8 @@ and execute any of the code from the :ref:`example-gallery`.
 For more information on how to display charts in various notebook environments
 and non-notebook IDEs, see :ref:`displaying-charts`.
 
-Install source code
-===================
+Development Installation
+========================
 
 The `Altair source repository`_ is available on GitHub. Once you have cloned the
 repository and installed all the above dependencies, run the following command

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -2,8 +2,8 @@
 
 .. _installation:
 
-Install package
-===============
+Installation
+============
 
 Altair can be installed, along with the example datasets in vega_datasets_, using::
 

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -46,6 +46,8 @@ development version directly from GitHub using:
 
     pip install -e git+https://github.com/altair-viz/altair.git
 
+Please see `CONTRIBUTING.md <https://github.com/altair-viz/altair/blob/master/CONTRIBUTING.md>`_
+for details on how to contribute to the Altair project.
 
 .. _conda: https://docs.conda.io/
 .. _Vega-Lite: http://vega.github.io/vega-lite

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -2,8 +2,9 @@
 
 .. _installation:
 
-Installation
-============
+Install package
+===============
+
 Altair can be installed, along with the example datasets in vega_datasets_, using::
 
 .. code-block:: bash
@@ -21,26 +22,7 @@ and execute any of the code from the :ref:`example-gallery`.
 For more information on how to display charts in various notebook environments
 and non-notebook IDEs, see :ref:`displaying-charts`.
 
-Dependencies
-============
-
-Altair has the following dependencies, all of which are installed automatically
-with the above installation commands:
-
-- python 3.6 or newer
-- jinja2
-- jsonschema_
-- NumPy_
-- Pandas_
-- Toolz_
-- importlib_metadata_ (python<3.8)
-- typing_extensions_ (python<3.11)
-
-To run Altair's full test suite and build Altair's documentation requires a few
-additional dependencies, see `CONTRIBUTING.md <https://github.com/altair-viz/altair/blob/master/CONTRIBUTING.md>`_
-for the details.
-
-Development Install
+Install source code
 ===================
 
 The `Altair source repository`_ is available on GitHub. Once you have cloned the
@@ -67,18 +49,7 @@ development version directly from GitHub using:
 
 .. _conda: https://docs.conda.io/
 .. _Vega-Lite: http://vega.github.io/vega-lite
+.. _vega_datasets: https://github.com/altair-viz/vega_datasets
 .. _JupyterLab: http://jupyterlab.readthedocs.io/
 .. _Jupyter Notebook: https://jupyter-notebook.readthedocs.io/
-.. _Zeppelin: https://zeppelin.apache.org/
-.. _IPython: https://github.com/ipython/ipython
-
-.. _importlib_metadata: https://github.com/python/importlib_metadata
-.. _typing_extensions: https://github.com/python/typing_extensions
-.. _jsonschema: https://github.com/Julian/jsonschema
-.. _NumPy: http://www.numpy.org/
-.. _Pandas: http://pandas.pydata.org
-.. _Toolz: https://github.com/pytoolz/toolz
-.. _vega_datasets: https://github.com/altair-viz/vega_datasets
 .. _Altair source repository: http://github.com/altair-viz/altair
-.. _nteract: https://nteract.io
-.. _vega: https://pypi.python.org/pypi/vega/


### PR DESCRIPTION
This is of course subjective but my take is that introducing the dependencies list at this point is too much to throw at a total n00b and not really what they're on the page to get. I propose cutting it.