### PR TITLE
Reduce line-height in the gallery thumbnail headlines

### DIFF
--- a/doc/_static/altair-gallery.css
+++ b/doc/_static/altair-gallery.css
@@ -132,4 +132,6 @@ div.bottomnav {
 
 .gallery .image-title {
   font-size: .95em;
+  display: block;
+  line-height: 22px;
 }


### PR DESCRIPTION
This is what we have now:

<img width="850" alt="Screen Shot 2023-03-15 at 3 36 31 PM" src="https://user-images.githubusercontent.com/9993/225458914-871d70a2-cc75-4ba0-aa8b-427044aa32ee.png">

Here's how this change should turn out:

<img width="850" alt="Screen Shot 2023-03-15 at 3 36 20 PM" src="https://user-images.githubusercontent.com/9993/225458937-811c0299-6fc6-4772-ac48-67dfc7975015.png">
