### PR TITLE
include underscore after view

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -3310,7 +3310,7 @@ def _extend_view_name(v, r):
     if v.endswith("child__" + r):
         return v
     else:
-        return v + "child__" + r
+        return f"{v}_child__{r}"
 
 
 def _repeat_names(params, repeat):


### PR DESCRIPTION
Fix for https://github.com/altair-viz/altair/issues/3024.

Now the following spec:
```python
import altair as alt
from vega_datasets import data
iris = data.iris.url

alt.Chart(iris).mark_point().encode(
    alt.X(alt.repeat("column"), type='quantitative'),
    alt.Y(alt.repeat("row"), type='quantitative'),
    color='species:N'
).properties(
    width=200,
    height=200
).repeat(
    row=['petalLength', 'petalWidth'],
    column=['sepalLength', 'sepalWidth']
).interactive().to_dict()
```
Returns
```python
{'config': {'view': {'continuousWidth': 300, 'continuousHeight': 300}},
 'repeat': {'column': ['sepalLength', 'sepalWidth'],
  'row': ['petalLength', 'petalWidth']},
 'spec': {'data': {'url': 'https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/iris.json'},
  'mark': {'type': 'point'},
  'encoding': {'color': {'field': 'species', 'type': 'nominal'},
   'x': {'field': {'repeat': 'column'}, 'type': 'quantitative'},
   'y': {'field': {'repeat': 'row'}, 'type': 'quantitative'}},
  'height': 200,
  'name': 'view_1',
  'width': 200},
 'params': [{'name': 'param_1',
   'select': {'type': 'interval', 'encodings': ['x', 'y']},
   'bind': 'scales',
   'views': ['view_1_child__row_petalLengthcolumn_sepalLength',
    'view_1_child__row_petalLengthcolumn_sepalWidth',
    'view_1_child__row_petalWidthcolumn_sepalLength',
    'view_1_child__row_petalWidthcolumn_sepalWidth']}],
 '$schema': 'https://vega.github.io/schema/vega-lite/v5.7.1.json'}
```
Focus on:
```
'view_1_child__row_petalWidthcolumn_sepalLength'
```