### PR TITLE
Increase minimum required jsonschema (`>=4.0.01`) 

### DIFF
--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -52,6 +52,7 @@ Backward-Incompatible Changes
 - Removed the Vega-Lite 3 and 4 wrappers (#2847).
 - Removed the deprecated datasets.py (#3010).
 - In regards to the grammar changes listed above, the old terminology will still work in many basic cases.  On the other hand, if that old terminology gets used at a lower level, then it most likely will not work.  For example, in the current version of :ref:`gallery_scatter_with_minimap`, two instances of the key ``param`` are used in dictionaries to specify axis domains.  Those used to be ``selection``, but that usage is not compatible with the current Vega-Lite schema.
+- Minimum requirement of ``jsonschema`` is ``4.0.1`` or higher (#).
 
 Maintenance
 ~~~~~~~~~~~

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -52,7 +52,7 @@ Backward-Incompatible Changes
 - Removed the Vega-Lite 3 and 4 wrappers (#2847).
 - Removed the deprecated datasets.py (#3010).
 - In regards to the grammar changes listed above, the old terminology will still work in many basic cases.  On the other hand, if that old terminology gets used at a lower level, then it most likely will not work.  For example, in the current version of :ref:`gallery_scatter_with_minimap`, two instances of the key ``param`` are used in dictionaries to specify axis domains.  Those used to be ``selection``, but that usage is not compatible with the current Vega-Lite schema.
-- Minimum requirement of ``jsonschema`` is ``4.0.1`` or higher (#).
+- Minimum requirement of ``jsonschema`` is ``4.0.1`` or higher (#3039).
 
 Maintenance
 ~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "importlib_metadata; python_version<\"3.8\"",
     "typing_extensions>=4.0.1; python_version<\"3.11\"",
     "jinja2",
-    "jsonschema>=3.0",
+    "jsonschema>=4.0.1",
     "numpy",
     "pandas>=0.18",
     "toolz"
@@ -65,7 +65,7 @@ dev = [
     "m2r",
     "vega_datasets",
     # following is rejected by PyPI
-    "altair_viewer @ git+https://github.com/altair-viz/altair_viewer.git",
+    "altair_viewer @ git+https://github.com/mattijn/altair_viewer.git@vl5.8",
     "vl-convert-python",
     "mypy",
     "pandas-stubs",


### PR DESCRIPTION
Fix #3038.

This PR increases the minimum required version of jsonschema to be `4.0.1` or higher.
