### PR TITLE
reintroduce support `jsonschema>=3.0`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-    name: Python ${{ matrix.python-version }}
+        jsonschema-version: ["3.0", "4.17"]
+    name: py ${{ matrix.python-version }} js ${{ matrix.jsonschema-version }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -23,6 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install jsonschema==${{ matrix.jsonschema-version }}
           pip install .[dev]
           # pip install "selenium<4.3.0"
           # pip install altair_saver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "importlib_metadata; python_version<\"3.8\"",
     "typing_extensions>=4.0.1; python_version<\"3.11\"",
     "jinja2",
-    "jsonschema>=4.0.1",
+    "jsonschema>=3.0",
     "numpy",
     "pandas>=0.18",
     "toolz"

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -127,6 +127,21 @@ def _get_errors_from_spec(
     return errors
 
 
+def _json_path(err: jsonschema.exceptions.ValidationError):
+    """Drop in replacement for the .json_path property of the jsonschema
+    ValidationError class, which is not available as property for
+    ValidationError with jsonschema=<4.0.1.
+    More info, see https://github.com/altair-viz/altair/issues/3038
+    """
+    path = "$"
+    for elem in err.absolute_path:
+        if isinstance(elem, int):
+            path += "[" + str(elem) + "]"
+        else:
+            path += "." + elem
+    return path
+
+
 def _group_errors_by_json_path(
     errors: ValidationErrorList,
 ) -> GroupedValidationErrors:
@@ -137,7 +152,8 @@ def _group_errors_by_json_path(
     """
     errors_by_json_path = collections.defaultdict(list)
     for err in errors:
-        errors_by_json_path[err.json_path].append(err)
+        err_key = err.json_path if hasattr(err, "json_path") else _json_path(err)
+        errors_by_json_path[err_key].append(err)
     return dict(errors_by_json_path)
 
 
@@ -346,7 +362,7 @@ class SchemaValidationError(jsonschema.ValidationError):
         super().__init__(**err._contents())
         self.obj = obj
         self._errors: GroupedValidationErrors = getattr(
-            err, "_all_errors", {err.json_path: [err]}
+            err, "_all_errors", {_json_path(err): [err]}
         )
         # This is the message from err
         self._original_message = self.message


### PR DESCRIPTION
Given the discussion in https://github.com/altair-viz/altair/issues/3038.

I attempted to reintroduce support from jsonschema>=3.0 onwards. 
I merely introduced the property function in `jsonschema` on the ValidationError as function in Altair that accepts a ValidationError type as drop-in replacement.

https://github.com/python-jsonschema/jsonschema/blob/16fef5b641e82a88f71f50657e29ae8a827969a5/jsonschema/exceptions.py#L139

I also updated the github action workflow for build.yml to test against both jsonschema 3.0 and 4.17 by including it as matrix option.

Can you do a review @binste?