### PR TITLE
Remove extra files in site-packages from wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ include = [
     "pyproject.toml"
 ]
 
+[tool.hatch.build.targets.wheel]
+only-include = ["/altair"]
+
 [tool.hatch.envs.default]
 features = ["dev"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,15 +93,7 @@ path = "altair/__init__.py"
 allow-direct-references = true
 
 [tool.hatch.build]
-include = [
-    "/altair",
-    "README.md",
-    "LICENSE",
-    "pyproject.toml"
-]
-
-[tool.hatch.build.targets.wheel]
-only-include = ["/altair"]
+include = ["/altair"]
 
 [tool.hatch.envs.default]
 features = ["dev"]


### PR DESCRIPTION
Currently, when I install altair, I get a couple of extra files in my site-packages directory:

```
python -m env .env
pip install altair
cat .env/lib/python3.11/site-packages/README.md
cat .env/lib/python3.11/site-packages/LICENSE
cat .env/lib/python3.11/site-packages/pyproject.toml
```
These are all altair files. I think these files shouldn't be there 😉 

This PR removes them.

Note: I'm no hatch expert, so I don't fully understand what the benefit of adding these files in `tool.hatch.build` is.