### PR TITLE
Fix bug in reconstructing layered charts with from_json/from_dict

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -3395,9 +3395,12 @@ def _remove_layer_props(chart, subcharts, layer_props):
             else:
                 raise ValueError(f"There are inconsistent values {values} for {prop}")
         else:
-            # Top level has this prop; subchart props must be either
-            # Undefined or identical to proceed.
-            if all(c[prop] is Undefined or c[prop] == chart[prop] for c in subcharts):
+            # Top level has this prop; subchart must either not have the prop
+            # or it must be Undefined or identical to proceed.
+            if all(
+                getattr(c, prop, Undefined) is Undefined or c[prop] == chart[prop]
+                for c in subcharts
+            ):
                 output_dict[prop] = chart[prop]
             else:
                 raise ValueError(f"There are inconsistent values {values} for {prop}")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,6 +3,7 @@ import pkgutil
 
 import pytest
 
+import altair as alt
 from altair.utils.execeval import eval_block
 from tests import examples_arguments_syntax
 from tests import examples_methods_syntax
@@ -45,6 +46,39 @@ def test_render_examples_to_chart(syntax_module):
             raise AssertionError(
                 f"Example file {filename} raised an exception when "
                 f"converting to a dict: {err}"
+            ) from err
+
+
+@pytest.mark.parametrize(
+    "syntax_module", [examples_arguments_syntax, examples_methods_syntax]
+)
+def test_from_and_to_json_roundtrip(syntax_module):
+    """Tests if the to_json and from_json (and by extension to_dict and from_dict)
+    work for all examples in the Example Gallery.
+    """
+    for filename in iter_examples_filenames(syntax_module):
+        source = pkgutil.get_data(syntax_module.__name__, filename)
+        chart = eval_block(source)
+
+        if chart is None:
+            raise ValueError(
+                f"Example file {filename} should define chart in its final "
+                "statement."
+            )
+
+        try:
+            first_json = chart.to_json()
+            reconstructed_chart = alt.Chart.from_json(first_json)
+            # As the chart objects are not
+            # necessarily the same - they could use different objects to encode the same
+            # information - we do not test for equality of the chart objects, but rather
+            # for equality of the json strings.
+            second_json = reconstructed_chart.to_json()
+            assert first_json == second_json
+        except Exception as err:
+            raise AssertionError(
+                f"Example file {filename} raised an exception when "
+                f"doing a json conversion roundtrip: {err}"
             ) from err
 
 


### PR DESCRIPTION
Fixes #3067. When reconstructing a layered chart which has `height`or `width` defined on the top-level with `from_dict`, the code so far checked that the layers have that property set to `Undefined` or to the same value as the layered chart itself. However, it's often the case that the layers don't have the property set at all -> This fix handles those cases.

I also added a test to run a to_json and from_json roundtrip for all examples in the gallery so that we can hopefully catch future regressions to this functionality. I checked that these tests would have caught the bug reported in #3067.

@mattijn Would be great if this fix can still make it into 5.0.1 in case you or someone else has the time to review it.