### PR TITLE
Explicitly specify arguments for to_dict and to_json methods for top-level chart objects

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -827,10 +827,10 @@ class SchemaBase:
     def to_json(
         self,
         validate: bool = True,
-        ignore: Optional[List[str]] = None,
-        context: Optional[Dict[str, Any]] = None,
         indent: int = 2,
         sort_keys: bool = True,
+        ignore: Optional[List[str]] = None,
+        context: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> str:
         """Emit the JSON representation for this object as a string.
@@ -840,16 +840,16 @@ class SchemaBase:
         validate : bool, optional
             If True (default), then validate the output dictionary
             against the schema.
+        indent : int, optional
+            The number of spaces of indentation to use. The default is 2.
+        sort_keys : bool, optional
+            If True (default), sort keys in the output.
         ignore : list[str], optional
             A list of keys to ignore. It is usually not needed
             to specify this argument as a user.
         context : dict[str, Any], optional
             A context dictionary. It is usually not needed
             to specify this argument as a user.
-        indent : int, optional
-            The number of spaces of indentation to use. The default is 2.
-        sort_keys : bool, optional
-            If True (default), sort keys in the output.
         **kwargs
             Additional keyword arguments are passed to ``json.dumps()``
 

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -750,7 +750,7 @@ class SchemaBase:
         ignore : list[str], optional
             A list of keys to ignore. It is usually not needed
             to specify this argument as a user.
-        context : dict[str, Any] (optional)
+        context : dict[str, Any], optional
             A context dictionary. It is usually not needed
             to specify this argument as a user.
 

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -744,7 +744,7 @@ class SchemaBase:
 
         Parameters
         ----------
-        validate : boolean, optional
+        validate : bool, optional
             If True (default), then validate the output dictionary
             against the schema.
         ignore : list[str], optional

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -734,29 +734,37 @@ class SchemaBase:
             and self._kwds == other._kwds
         )
 
-    def to_dict(self, validate=True, ignore=None, context=None):
+    def to_dict(
+        self,
+        validate: bool = True,
+        ignore: Optional[List[str]] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> dict:
         """Return a dictionary representation of the object
 
         Parameters
         ----------
-        validate : boolean
+        validate : boolean, optional
             If True (default), then validate the output dictionary
             against the schema.
-        ignore : list
-            A list of keys to ignore. This will *not* passed to child to_dict
-            function calls.
-        context : dict (optional)
-            A context dictionary that will be passed to all child to_dict
-            function calls
+        ignore : list[str], optional
+            A list of keys to ignore.
+        context : dict[str, Any] (optional)
+            A context dictionary.
+
+        Notes
+        -----
+        Technical: The ignore parameter will *not* be passed to child to_dict
+        function calls.
 
         Returns
         -------
-        dct : dictionary
+        dict
             The dictionary representation of this object
 
         Raises
         ------
-        jsonschema.ValidationError :
+        SchemaValidationError :
             if validate=True and the dict does not conform to the schema
         """
         if context is None:
@@ -816,36 +824,39 @@ class SchemaBase:
 
     def to_json(
         self,
-        validate=True,
-        ignore=None,
-        context=None,
-        indent=2,
-        sort_keys=True,
+        validate: bool = True,
+        ignore: Optional[List[str]] = None,
+        context: Optional[Dict[str, Any]] = None,
+        indent: int = 2,
+        sort_keys: bool = True,
         **kwargs,
-    ):
+    ) -> str:
         """Emit the JSON representation for this object as a string.
 
         Parameters
         ----------
-        validate : boolean
+        validate : bool, optional
             If True (default), then validate the output dictionary
             against the schema.
-        ignore : list (optional)
-            A list of keys to ignore. This will *not* passed to child to_dict
-            function calls.
-        context : dict (optional)
-            A context dictionary that will be passed to all child to_dict
-            function calls
-        indent : integer, default 2
-            the number of spaces of indentation to use
-        sort_keys : boolean, default True
-            if True, sort keys in the output
+        ignore : list[str], optional
+            A list of keys to ignore.
+        context : dict[str, Any], optional
+            A context dictionary.
+        indent : int, optional
+            The number of spaces of indentation to use. The default is 2.
+        sort_keys : bool, optional
+            If True (default), sort keys in the output.
         **kwargs
             Additional keyword arguments are passed to ``json.dumps()``
 
+        Notes
+        -----
+        Technical: The ignore parameter will *not* be passed to child to_dict
+        function calls.
+
         Returns
         -------
-        spec : string
+        str
             The JSON specification of the chart object.
         """
         if ignore is None:

--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -748,9 +748,11 @@ class SchemaBase:
             If True (default), then validate the output dictionary
             against the schema.
         ignore : list[str], optional
-            A list of keys to ignore.
+            A list of keys to ignore. It is usually not needed
+            to specify this argument as a user.
         context : dict[str, Any] (optional)
-            A context dictionary.
+            A context dictionary. It is usually not needed
+            to specify this argument as a user.
 
         Notes
         -----
@@ -839,9 +841,11 @@ class SchemaBase:
             If True (default), then validate the output dictionary
             against the schema.
         ignore : list[str], optional
-            A list of keys to ignore.
+            A list of keys to ignore. It is usually not needed
+            to specify this argument as a user.
         context : dict[str, Any], optional
-            A context dictionary.
+            A context dictionary. It is usually not needed
+            to specify this argument as a user.
         indent : int, optional
             The number of spaces of indentation to use. The default is 2.
         sort_keys : bool, optional

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -831,10 +831,10 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
             against the schema.
         ignore : list[str], optional
             A list of keys to ignore. It is usually not needed
-            to specify this argument.
+            to specify this argument as a user.
         context : dict[str, Any], optional
             A context dictionary. It is usually not needed
-            to specify this argument.
+            to specify this argument as a user.
 
         Notes
         -----
@@ -2558,10 +2558,10 @@ class Chart(
             against the schema.
         ignore : list[str], optional
             A list of keys to ignore. It is usually not needed
-            to specify this argument.
+            to specify this argument as a user.
         context : dict[str, Any], optional
             A context dictionary. It is usually not needed
-            to specify this argument.
+            to specify this argument as a user.
 
         Notes
         -----

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -746,9 +746,11 @@ class SchemaBase:
             If True (default), then validate the output dictionary
             against the schema.
         ignore : list[str], optional
-            A list of keys to ignore.
+            A list of keys to ignore. It is usually not needed
+            to specify this argument as a user.
         context : dict[str, Any] (optional)
-            A context dictionary.
+            A context dictionary. It is usually not needed
+            to specify this argument as a user.
 
         Notes
         -----
@@ -837,9 +839,11 @@ class SchemaBase:
             If True (default), then validate the output dictionary
             against the schema.
         ignore : list[str], optional
-            A list of keys to ignore.
+            A list of keys to ignore. It is usually not needed
+            to specify this argument as a user.
         context : dict[str, Any], optional
-            A context dictionary.
+            A context dictionary. It is usually not needed
+            to specify this argument as a user.
         indent : int, optional
             The number of spaces of indentation to use. The default is 2.
         sort_keys : bool, optional

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -748,7 +748,7 @@ class SchemaBase:
         ignore : list[str], optional
             A list of keys to ignore. It is usually not needed
             to specify this argument as a user.
-        context : dict[str, Any] (optional)
+        context : dict[str, Any], optional
             A context dictionary. It is usually not needed
             to specify this argument as a user.
 

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -732,29 +732,37 @@ class SchemaBase:
             and self._kwds == other._kwds
         )
 
-    def to_dict(self, validate=True, ignore=None, context=None):
+    def to_dict(
+        self,
+        validate: bool = True,
+        ignore: Optional[List[str]] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> dict:
         """Return a dictionary representation of the object
 
         Parameters
         ----------
-        validate : boolean
+        validate : boolean, optional
             If True (default), then validate the output dictionary
             against the schema.
-        ignore : list
-            A list of keys to ignore. This will *not* passed to child to_dict
-            function calls.
-        context : dict (optional)
-            A context dictionary that will be passed to all child to_dict
-            function calls
+        ignore : list[str], optional
+            A list of keys to ignore.
+        context : dict[str, Any] (optional)
+            A context dictionary.
+
+        Notes
+        -----
+        Technical: The ignore parameter will *not* be passed to child to_dict
+        function calls.
 
         Returns
         -------
-        dct : dictionary
+        dict
             The dictionary representation of this object
 
         Raises
         ------
-        jsonschema.ValidationError :
+        SchemaValidationError :
             if validate=True and the dict does not conform to the schema
         """
         if context is None:
@@ -814,36 +822,39 @@ class SchemaBase:
 
     def to_json(
         self,
-        validate=True,
-        ignore=None,
-        context=None,
-        indent=2,
-        sort_keys=True,
+        validate: bool = True,
+        ignore: Optional[List[str]] = None,
+        context: Optional[Dict[str, Any]] = None,
+        indent: int = 2,
+        sort_keys: bool = True,
         **kwargs,
-    ):
+    ) -> str:
         """Emit the JSON representation for this object as a string.
 
         Parameters
         ----------
-        validate : boolean
+        validate : bool, optional
             If True (default), then validate the output dictionary
             against the schema.
-        ignore : list (optional)
-            A list of keys to ignore. This will *not* passed to child to_dict
-            function calls.
-        context : dict (optional)
-            A context dictionary that will be passed to all child to_dict
-            function calls
-        indent : integer, default 2
-            the number of spaces of indentation to use
-        sort_keys : boolean, default True
-            if True, sort keys in the output
+        ignore : list[str], optional
+            A list of keys to ignore.
+        context : dict[str, Any], optional
+            A context dictionary.
+        indent : int, optional
+            The number of spaces of indentation to use. The default is 2.
+        sort_keys : bool, optional
+            If True (default), sort keys in the output.
         **kwargs
             Additional keyword arguments are passed to ``json.dumps()``
 
+        Notes
+        -----
+        Technical: The ignore parameter will *not* be passed to child to_dict
+        function calls.
+
         Returns
         -------
-        spec : string
+        str
             The JSON specification of the chart object.
         """
         if ignore is None:

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -742,7 +742,7 @@ class SchemaBase:
 
         Parameters
         ----------
-        validate : boolean, optional
+        validate : bool, optional
             If True (default), then validate the output dictionary
             against the schema.
         ignore : list[str], optional

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -825,10 +825,10 @@ class SchemaBase:
     def to_json(
         self,
         validate: bool = True,
-        ignore: Optional[List[str]] = None,
-        context: Optional[Dict[str, Any]] = None,
         indent: int = 2,
         sort_keys: bool = True,
+        ignore: Optional[List[str]] = None,
+        context: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> str:
         """Emit the JSON representation for this object as a string.
@@ -838,16 +838,16 @@ class SchemaBase:
         validate : bool, optional
             If True (default), then validate the output dictionary
             against the schema.
+        indent : int, optional
+            The number of spaces of indentation to use. The default is 2.
+        sort_keys : bool, optional
+            If True (default), sort keys in the output.
         ignore : list[str], optional
             A list of keys to ignore. It is usually not needed
             to specify this argument as a user.
         context : dict[str, Any], optional
             A context dictionary. It is usually not needed
             to specify this argument as a user.
-        indent : int, optional
-            The number of spaces of indentation to use. The default is 2.
-        sort_keys : bool, optional
-            If True (default), sort keys in the output.
         **kwargs
             Additional keyword arguments are passed to ``json.dumps()``
 

--- a/tools/update_init_file.py
+++ b/tools/update_init_file.py
@@ -6,7 +6,7 @@ import inspect
 import sys
 from pathlib import Path
 from os.path import abspath, dirname, join
-from typing import TypeVar, Type, cast, List, Any
+from typing import TypeVar, Type, cast, List, Any, Optional
 
 import black
 
@@ -80,6 +80,8 @@ def _is_relevant_attribute(attr_name):
         or attr is List
         or attr is Any
         or attr is Literal
+        or attr is Optional
+        or attr_name == "TypingDict"
     ):
         return False
     else:


### PR DESCRIPTION
This PR explicitly specifies and documents the accepted arguments for `to_dict` and `to_json` on top-level chart objects (e.g. `Chart`, `LayerChart`, ...). Previously, these methods used `args` and `kwargs`. This improves the documentation for users, allows us to type hint the arguments, and it unblocks https://github.com/altair-viz/altair/pull/3071#discussion_r1208617735 where it is currently unclear how to best add an additional documented keyword argument `format`.

This might break existing code in case a user passes an unused argument, e.g. `to_dict(this_argument_is_not_used=1`). However, that seems acceptable to me as I don't think it was the intended behavior to allow for arbitrary arguments.

cc @jonmmease. 
Maybe someone else could review it as well. Just in case I'm missing an actual use case for the `args`/`kwargs` notation