### PR TITLE
Fix ridgeline example

### DIFF
--- a/tests/examples_arguments_syntax/ridgeline_plot.py
+++ b/tests/examples_arguments_syntax/ridgeline_plot.py
@@ -49,7 +49,7 @@ alt.Chart(source, height=step).transform_timeunit(
     row=alt.Row(
         'Month:T',
         title=None,
-        header=alt.Header(labelAngle=0, labelAlign='right', format='%B')
+        header=alt.Header(labelAngle=0, labelAlign='left', format='%B')
     )
 ).properties(
     title='Seattle Weather',

--- a/tests/examples_methods_syntax/ridgeline_plot.py
+++ b/tests/examples_methods_syntax/ridgeline_plot.py
@@ -46,7 +46,7 @@ alt.Chart(source, height=step).transform_timeunit(
 ).facet(
     row=alt.Row('Month:T')
         .title(None)
-        .header(labelAngle=0, labelAlign='right', format='%B')
+        .header(labelAngle=0, labelAlign='left', format='%B')
 ).properties(
     title='Seattle Weather',
     bounds='flush'

--- a/tests/examples_methods_syntax/ridgeline_plot.py
+++ b/tests/examples_methods_syntax/ridgeline_plot.py
@@ -35,7 +35,7 @@ alt.Chart(source, height=step).transform_timeunit(
     strokeWidth=0.5
 ).encode(
     alt.X('bin_min:Q')
-        .bin(True)
+        .bin('binned')
         .title('Maximum Daily Temperature (C)'),
     alt.Y('value:Q')
         .axis(None)
@@ -44,7 +44,7 @@ alt.Chart(source, height=step).transform_timeunit(
         .legend(None)
         .scale(domain=[30, 5], scheme='redyellowblue')
 ).facet(
-    alt.Row('Month:T')
+    row=alt.Row('Month:T')
         .title(None)
         .header(labelAngle=0, labelAlign='right', format='%B')
 ).properties(


### PR DESCRIPTION
The method-based example did not render properly. The first commit fixes these issues. Closes #3079

In the second commit, I changed the alignment of the months from:

<img width="449" alt="image" src="https://github.com/altair-viz/altair/assets/23366411/f3dd3795-d714-41c7-a806-b1c6c9eddbcc">


to:

<img width="371" alt="image" src="https://github.com/altair-viz/altair/assets/23366411/d2fd6128-b9a5-40a4-8087-7c3d7f54b582">
