### PR TITLE
Fixed Wheat and Wages case study

### DIFF
--- a/tests/examples_arguments_syntax/wheat_wages.py
+++ b/tests/examples_arguments_syntax/wheat_wages.py
@@ -21,7 +21,7 @@ base_monarchs = alt.Chart(data.monarchs.url).transform_calculate(
     x="+datum.start + (+datum.end - +datum.start)/2",
 )
 
-bars = base_wheat.mark_bar(**{"fill": "#aaa", "stroke": "#999"}).encode(
+bars = base_wheat.mark_bar(fill="#aaa", stroke="#999").encode(
     x=alt.X("year:Q", bin="binned", axis=alt.Axis(format="d", tickCount=5)).scale(
         zero=False
     ),
@@ -41,16 +41,16 @@ section_data = pd.DataFrame(
 
 section_line = (
     alt.Chart(section_data)
-    .mark_rule(**{"stroke": "#000", "strokeWidth": 0.6, "opacity": 0.7})
+    .mark_rule(stroke="#000", strokeWidth=0.6, opacity=0.7)
     .encode(x=alt.X("year"))
 )
 
-area = base_wheat.mark_area(**{"color": "#a4cedb", "opacity": 0.7}).encode(
+area = base_wheat.mark_area(color="#a4cedb", opacity=0.7).encode(
     x=alt.X("year:Q"), y=alt.Y("wages:Q")
 )
 
-area_line_1 = area.mark_line(**{"color": "#000", "opacity": 0.7})
-area_line_2 = area.mark_line(**{"yOffset": -2, "color": "#EE8182"})
+area_line_1 = area.mark_line(color="#000", opacity=0.7)
+area_line_2 = area.mark_line(yOffset=-2, color="#EE8182")
 
 top_bars = base_monarchs.mark_bar(stroke="#000").encode(
     x=alt.X("start:Q"),
@@ -62,9 +62,9 @@ top_bars = base_monarchs.mark_bar(stroke="#000").encode(
     ),
 )
 
-top_text = base_monarchs.mark_text(
-    **{"yOffset": 14, "fontSize": 9, "fontStyle": "italic"}
-).encode(x=alt.X("x:Q"), y=alt.Y("off2:Q"), text=alt.Text("name:N"))
+top_text = base_monarchs.mark_text(yOffset=14, fontSize=9, fontStyle="italic").encode(
+    x=alt.X("x:Q"), y=alt.Y("off2:Q"), text=alt.Text("name:N")
+)
 
 (
     (bars + section_line + area + area_line_1 + area_line_2 + top_bars + top_text)

--- a/tests/examples_arguments_syntax/wheat_wages.py
+++ b/tests/examples_arguments_syntax/wheat_wages.py
@@ -8,28 +8,45 @@ This is a more polished version of the simpler chart in :ref:`gallery_bar_and_li
 """
 # category: case studies
 import altair as alt
+import pandas as pd
 from vega_datasets import data
 
 
-base_wheat = alt.Chart(data.wheat.url).transform_calculate(
-    year_end="+datum.year + 5")
+base_wheat = alt.Chart(data.wheat.url).transform_calculate(year_end="+datum.year + 5")
 
 base_monarchs = alt.Chart(data.monarchs.url).transform_calculate(
     offset="((!datum.commonwealth && datum.index % 2) ? -1: 1) * 2 + 95",
     off2="((!datum.commonwealth && datum.index % 2) ? -1: 1) + 95",
     y="95",
-    x="+datum.start + (+datum.end - +datum.start)/2"
+    x="+datum.start + (+datum.end - +datum.start)/2",
 )
 
 bars = base_wheat.mark_bar(**{"fill": "#aaa", "stroke": "#999"}).encode(
-    x=alt.X("year:Q", axis=alt.Axis(format='d', tickCount=5)),
+    x=alt.X("year:Q", bin="binned", axis=alt.Axis(format="d", tickCount=5)).scale(
+        zero=False
+    ),
     y=alt.Y("wheat:Q", axis=alt.Axis(zindex=1)),
-    x2=alt.X2("year_end")
+    x2=alt.X2("year_end"),
+)
+
+section_data = pd.DataFrame(
+    [
+        {"year": 1600},
+        {"year": 1650},
+        {"year": 1700},
+        {"year": 1750},
+        {"year": 1800},
+    ]
+)
+
+section_line = (
+    alt.Chart(section_data)
+    .mark_rule(**{"stroke": "#000", "strokeWidth": 0.6, "opacity": 0.7})
+    .encode(x=alt.X("year"))
 )
 
 area = base_wheat.mark_area(**{"color": "#a4cedb", "opacity": 0.7}).encode(
-    x=alt.X("year:Q"),
-    y=alt.Y("wages:Q")
+    x=alt.X("year:Q"), y=alt.Y("wages:Q")
 )
 
 area_line_1 = area.mark_line(**{"color": "#000", "opacity": 0.7})
@@ -40,19 +57,18 @@ top_bars = base_monarchs.mark_bar(stroke="#000").encode(
     x2=alt.X2("end"),
     y=alt.Y("y:Q"),
     y2=alt.Y2("offset"),
-    fill=alt.Fill("commonwealth:N", legend=None, scale=alt.Scale(range=["black", "white"]))
+    fill=alt.Fill(
+        "commonwealth:N", legend=None, scale=alt.Scale(range=["black", "white"])
+    ),
 )
 
-top_text = base_monarchs.mark_text(**{"yOffset": 14, "fontSize": 9, "fontStyle": "italic"}).encode(
-    x=alt.X("x:Q"),
-    y=alt.Y("off2:Q"),
-    text=alt.Text("name:N")
-)
+top_text = base_monarchs.mark_text(
+    **{"yOffset": 14, "fontSize": 9, "fontStyle": "italic"}
+).encode(x=alt.X("x:Q"), y=alt.Y("off2:Q"), text=alt.Text("name:N"))
 
-(bars + area + area_line_1 + area_line_2 + top_bars + top_text).properties(
-    width=900, height=400
-).configure_axis(
-    title=None, gridColor="white", gridOpacity=0.25, domain=False
-).configure_view(
-    stroke="transparent"
+(
+    (bars + section_line + area + area_line_1 + area_line_2 + top_bars + top_text)
+    .properties(width=900, height=400)
+    .configure_axis(title=None, gridColor="white", gridOpacity=0.25, domain=False)
+    .configure_view(stroke="transparent")
 )

--- a/tests/examples_methods_syntax/wheat_wages.py
+++ b/tests/examples_methods_syntax/wheat_wages.py
@@ -8,28 +8,43 @@ This is a more polished version of the simpler chart in :ref:`gallery_bar_and_li
 """
 # category: case studies
 import altair as alt
+import pandas as pd
 from vega_datasets import data
 
 
-base_wheat = alt.Chart(data.wheat.url).transform_calculate(
-    year_end="+datum.year + 5")
+base_wheat = alt.Chart(data.wheat.url).transform_calculate(year_end="+datum.year + 5")
 
 base_monarchs = alt.Chart(data.monarchs.url).transform_calculate(
     offset="((!datum.commonwealth && datum.index % 2) ? -1: 1) * 2 + 95",
     off2="((!datum.commonwealth && datum.index % 2) ? -1: 1) + 95",
     y="95",
-    x="+datum.start + (+datum.end - +datum.start)/2"
+    x="+datum.start + (+datum.end - +datum.start)/2",
 )
 
 bars = base_wheat.mark_bar(**{"fill": "#aaa", "stroke": "#999"}).encode(
-    alt.X("year:Q").axis(format='d', tickCount=5),
+    alt.X("year:Q", bin="binned").axis(format="d", tickCount=5).scale(zero=False),
     alt.Y("wheat:Q").axis(zindex=1),
-    alt.X2("year_end")
+    alt.X2("year_end"),
+)
+
+section_data = pd.DataFrame(
+    [
+        {"year": 1600},
+        {"year": 1650},
+        {"year": 1700},
+        {"year": 1750},
+        {"year": 1800},
+    ]
+)
+
+section_line = (
+    alt.Chart(section_data)
+    .mark_rule(**{"stroke": "#000", "strokeWidth": 0.6, "opacity": 0.7})
+    .encode(alt.X("year"))
 )
 
 area = base_wheat.mark_area(**{"color": "#a4cedb", "opacity": 0.7}).encode(
-    alt.X("year:Q"),
-    alt.Y("wages:Q")
+    alt.X("year:Q"), alt.Y("wages:Q")
 )
 
 area_line_1 = area.mark_line(**{"color": "#000", "opacity": 0.7})
@@ -40,16 +55,14 @@ top_bars = base_monarchs.mark_bar(stroke="#000").encode(
     alt.X2("end"),
     alt.Y("y:Q"),
     alt.Y2("offset"),
-    alt.Fill("commonwealth:N").legend(None).scale(range=["black", "white"])
+    alt.Fill("commonwealth:N").legend(None).scale(range=["black", "white"]),
 )
 
-top_text = base_monarchs.mark_text(**{"yOffset": 14, "fontSize": 9, "fontStyle": "italic"}).encode(
-    alt.X("x:Q"),
-    alt.Y("off2:Q"),
-    alt.Text("name:N")
-)
+top_text = base_monarchs.mark_text(
+    **{"yOffset": 14, "fontSize": 9, "fontStyle": "italic"}
+).encode(alt.X("x:Q"), alt.Y("off2:Q"), alt.Text("name:N"))
 
-(bars + area + area_line_1 + area_line_2 + top_bars + top_text).properties(
+(bars + section_line + area + area_line_1 + area_line_2 + top_bars + top_text).properties(
     width=900, height=400
 ).configure_axis(
     title=None, gridColor="white", gridOpacity=0.25, domain=False

--- a/tests/examples_methods_syntax/wheat_wages.py
+++ b/tests/examples_methods_syntax/wheat_wages.py
@@ -21,7 +21,7 @@ base_monarchs = alt.Chart(data.monarchs.url).transform_calculate(
     x="+datum.start + (+datum.end - +datum.start)/2",
 )
 
-bars = base_wheat.mark_bar(**{"fill": "#aaa", "stroke": "#999"}).encode(
+bars = base_wheat.mark_bar(fill="#aaa", stroke="#999").encode(
     alt.X("year:Q", bin="binned").axis(format="d", tickCount=5).scale(zero=False),
     alt.Y("wheat:Q").axis(zindex=1),
     alt.X2("year_end"),
@@ -39,16 +39,16 @@ section_data = pd.DataFrame(
 
 section_line = (
     alt.Chart(section_data)
-    .mark_rule(**{"stroke": "#000", "strokeWidth": 0.6, "opacity": 0.7})
+    .mark_rule(stroke="#000", strokeWidth=0.6, opacity=0.7)
     .encode(alt.X("year"))
 )
 
-area = base_wheat.mark_area(**{"color": "#a4cedb", "opacity": 0.7}).encode(
+area = base_wheat.mark_area(color="#a4cedb", opacity=0.7).encode(
     alt.X("year:Q"), alt.Y("wages:Q")
 )
 
-area_line_1 = area.mark_line(**{"color": "#000", "opacity": 0.7})
-area_line_2 = area.mark_line(**{"yOffset": -2, "color": "#EE8182"})
+area_line_1 = area.mark_line(color="#000", opacity=0.7)
+area_line_2 = area.mark_line(yOffset=-2, color="#EE8182")
 
 top_bars = base_monarchs.mark_bar(stroke="#000").encode(
     alt.X("start:Q"),
@@ -58,9 +58,9 @@ top_bars = base_monarchs.mark_bar(stroke="#000").encode(
     alt.Fill("commonwealth:N").legend(None).scale(range=["black", "white"]),
 )
 
-top_text = base_monarchs.mark_text(
-    **{"yOffset": 14, "fontSize": 9, "fontStyle": "italic"}
-).encode(alt.X("x:Q"), alt.Y("off2:Q"), alt.Text("name:N"))
+top_text = base_monarchs.mark_text(yOffset=14, fontSize=9, fontStyle="italic").encode(
+    alt.X("x:Q"), alt.Y("off2:Q"), alt.Text("name:N")
+)
 
 (
     (bars + section_line + area + area_line_1 + area_line_2 + top_bars + top_text)

--- a/tests/examples_methods_syntax/wheat_wages.py
+++ b/tests/examples_methods_syntax/wheat_wages.py
@@ -22,7 +22,7 @@ base_monarchs = alt.Chart(data.monarchs.url).transform_calculate(
 )
 
 bars = base_wheat.mark_bar(fill="#aaa", stroke="#999").encode(
-    alt.X("year:Q", bin="binned").axis(format="d", tickCount=5).scale(zero=False),
+    alt.X("year:Q").bin("binned").axis(format="d", tickCount=5).scale(zero=False),
     alt.Y("wheat:Q").axis(zindex=1),
     alt.X2("year_end"),
 )

--- a/tests/examples_methods_syntax/wheat_wages.py
+++ b/tests/examples_methods_syntax/wheat_wages.py
@@ -62,10 +62,9 @@ top_text = base_monarchs.mark_text(
     **{"yOffset": 14, "fontSize": 9, "fontStyle": "italic"}
 ).encode(alt.X("x:Q"), alt.Y("off2:Q"), alt.Text("name:N"))
 
-(bars + section_line + area + area_line_1 + area_line_2 + top_bars + top_text).properties(
-    width=900, height=400
-).configure_axis(
-    title=None, gridColor="white", gridOpacity=0.25, domain=False
-).configure_view(
-    stroke="transparent"
+(
+    (bars + section_line + area + area_line_1 + area_line_2 + top_bars + top_text)
+    .properties(width=900, height=400)
+    .configure_axis(title=None, gridColor="white", gridOpacity=0.25, domain=False)
+    .configure_view(stroke="transparent")
 )


### PR DESCRIPTION
Fixed appearance of the Wheat and Wages case study (see Chart below):

![image](https://github.com/altair-viz/altair/assets/36770664/607ba0ea-fd6c-4b93-a533-00fbc1d586d5)

As mentioned in #2966 by @joelostblom I oriented myself at the [Vega-Lite example](https://vega.github.io/vega-lite/examples/wheat_wages.html).

Additionally there are some minor code formatting changes introduced (in line with pep8) caused by black's autoformatting.

