### PR TITLE
MAINT: Gitignore venv folders and use gitignore for black

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv
+.venv
 build/
 develop-eggs/
 dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ publish-clean-build = [
 line-length = 88
 target-version = ["py37", "py38", "py39", "py310", "py311"]
 include = '\.pyi?$'
-exclude = '''
+extend-exclude = '''
 /(
     \.eggs
   | \.git


### PR DESCRIPTION
By switching to `extend-exclude`, black respects gitignore, see https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html#gitignore