### PR TITLE
Drop support for Python 3.7 which is end-of-life

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         jsonschema-version: ["3.0", "4.17"]
     name: py ${{ matrix.python-version }} js ${{ matrix.jsonschema-version }}
     steps:

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -5,10 +5,7 @@ from weakref import WeakValueDictionary
 
 from typing import Union, Dict, Set, MutableMapping
 
-if sys.version_info >= (3, 8):
-    from typing import TypedDict, Final
-else:
-    from typing_extensions import TypedDict, Final
+from typing import TypedDict, Final
 
 from altair.utils.core import _DataFrameLike
 from altair.utils.data import _DataType, _ToValuesReturnType, MaxRowsError

--- a/altair/utils/_vegafusion_data.py
+++ b/altair/utils/_vegafusion_data.py
@@ -1,4 +1,3 @@
-import sys
 from toolz import curried
 import uuid
 from weakref import WeakValueDictionary

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -23,10 +23,7 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import ParamSpec
 
-if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol
-else:
-    from typing_extensions import Literal, Protocol
+from typing import Literal, Protocol
 
 try:
     from pandas.api.types import infer_dtype as _infer_dtype

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -17,10 +17,7 @@ from .deprecation import AltairDeprecationWarning
 from .plugin_registry import PluginRegistry
 
 
-if sys.version_info >= (3, 8):
-    from typing import Protocol, TypedDict, Literal
-else:
-    from typing_extensions import Protocol, TypedDict, Literal
+from typing import Protocol, TypedDict, Literal
 
 
 if TYPE_CHECKING:

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -2,7 +2,6 @@ import json
 import os
 import random
 import hashlib
-import sys
 import warnings
 from typing import Union, MutableMapping, Optional, Dict, Sequence, TYPE_CHECKING, List
 from types import ModuleType

--- a/altair/utils/execeval.py
+++ b/altair/utils/execeval.py
@@ -2,7 +2,7 @@ import ast
 import sys
 
 
-if sys.version_info > (3, 8):
+if sys.version_info >= (3, 9):
     Module = ast.Module
 else:
     # Mock the Python >= 3.8 API

--- a/altair/utils/execeval.py
+++ b/altair/utils/execeval.py
@@ -2,14 +2,6 @@ import ast
 import sys
 
 
-if sys.version_info >= (3, 9):
-    Module = ast.Module
-else:
-    # Mock the Python >= 3.8 API
-    def Module(nodelist, type_ignores):
-        return ast.Module(nodelist)
-
-
 class _CatchDisplay:
     """Class to temporarily catch sys.displayhook"""
 
@@ -48,7 +40,7 @@ def eval_block(code, namespace=None, filename="<string>"):
         to_exec, to_eval = tree.body, []
 
     for node in to_exec:
-        compiled = compile(Module([node], []), filename=filename, mode="exec")
+        compiled = compile(ast.Module([node], []), filename=filename, mode="exec")
         exec(compiled, namespace)
 
     with catch_display:

--- a/altair/utils/plugin_registry.py
+++ b/altair/utils/plugin_registry.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Any, Dict, List, Optional, Generic, TypeVar, cast
 from types import TracebackType
 

--- a/altair/utils/plugin_registry.py
+++ b/altair/utils/plugin_registry.py
@@ -2,10 +2,7 @@ import sys
 from typing import Any, Dict, List, Optional, Generic, TypeVar, cast
 from types import TracebackType
 
-if sys.version_info >= (3, 8):
-    from importlib.metadata import entry_points
-else:
-    from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 from toolz import curry
 

--- a/altair/vegalite/v5/compiler.py
+++ b/altair/vegalite/v5/compiler.py
@@ -1,4 +1,3 @@
-
 from ...utils.compiler import VegaLiteCompilerRegistry
 
 from typing import Final

--- a/altair/vegalite/v5/compiler.py
+++ b/altair/vegalite/v5/compiler.py
@@ -2,10 +2,7 @@ import sys
 
 from ...utils.compiler import VegaLiteCompilerRegistry
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
+from typing import Final
 
 
 ENTRY_POINT_GROUP: Final = "altair.vegalite.v5.vegalite_compiler"

--- a/altair/vegalite/v5/compiler.py
+++ b/altair/vegalite/v5/compiler.py
@@ -1,4 +1,3 @@
-import sys
 
 from ...utils.compiler import VegaLiteCompilerRegistry
 

--- a/altair/vegalite/v5/data.py
+++ b/altair/vegalite/v5/data.py
@@ -1,4 +1,3 @@
-
 from ..data import (
     MaxRowsError,
     curry,

--- a/altair/vegalite/v5/data.py
+++ b/altair/vegalite/v5/data.py
@@ -15,10 +15,7 @@ from ..data import (
 
 from ...utils._vegafusion_data import vegafusion_data_transformer
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
+from typing import Final
 
 
 # ==============================================================================

--- a/altair/vegalite/v5/data.py
+++ b/altair/vegalite/v5/data.py
@@ -1,4 +1,3 @@
-import sys
 
 from ..data import (
     MaxRowsError,

--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from typing import Dict
 
 from ...utils.mimebundle import spec_to_mimebundle

--- a/altair/vegalite/v5/display.py
+++ b/altair/vegalite/v5/display.py
@@ -14,10 +14,7 @@ from ..display import (
 
 from .schema import SCHEMA_VERSION
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
+from typing import Final
 
 VEGALITE_VERSION: Final = SCHEMA_VERSION.lstrip("v")
 VEGA_VERSION: Final = "5"

--- a/altair/vegalite/v5/schema/channels.py
+++ b/altair/vegalite/v5/schema/channels.py
@@ -8,10 +8,7 @@ from altair.utils.schemapi import Undefined, with_property_setters
 from altair.utils import parse_shorthand
 from typing import overload, List
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import Literal
 
 
 class FieldChannelMixin:

--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -17,10 +17,7 @@ VEGA_THEMES = [
     "powerbi",
 ]
 
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final
+from typing import Final
 
 
 class VegaTheme:

--- a/altair/vegalite/v5/theme.py
+++ b/altair/vegalite/v5/theme.py
@@ -1,6 +1,5 @@
 """Tools for enabling and registering chart themes"""
-import sys
-from typing import Dict, Union
+from typing import Dict, Union, Final
 
 from ...utils.theme import ThemeRegistry
 
@@ -16,8 +15,6 @@ VEGA_THEMES = [
     "googlecharts",
     "powerbi",
 ]
-
-from typing import Final
 
 
 class VegaTheme:

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -14,6 +14,7 @@ Bug Fixes
 
 Backward-Incompatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Drop support for Python 3.7 which is end-of-life
 
 Version 5.0.1 (released May 26, 2023)
 -------------------------------------

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -14,7 +14,7 @@ Bug Fixes
 
 Backward-Incompatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- Drop support for Python 3.7 which is end-of-life
+- Drop support for Python 3.7 which is end-of-life (#3100).
 
 Version 5.0.1 (released May 26, 2023)
 -------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ build-backend = "hatchling.build"
 name = "altair"
 authors = [ {name = "Vega-Altair Contributors"} ]
 dependencies = [
-    "importlib_metadata; python_version<\"3.8\"",
     "typing_extensions>=4.0.1; python_version<\"3.11\"",
     "jinja2",
     "jsonschema>=3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
     "json",
     "vega-lite",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dynamic = ["version"]
 license-files = { paths = ["LICENSE"] }
 classifiers= [
@@ -43,7 +43,6 @@ classifiers= [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -153,7 +152,7 @@ publish-clean-build = [
 
 [tool.black]
 line-length = 88
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311"]
 include = '\.pyi?$'
 extend-exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ extend-exclude = '''
 '''
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py38"
 line-length = 88
 select = [
     # flake8-bugbear

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -424,10 +424,7 @@ def generate_vegalite_channel_wrappers(schemafile, version, imports=None):
             "from altair.utils import parse_shorthand",
             "from typing import overload, List",
             "",
-            "if sys.version_info >= (3, 8):",
-            "    from typing import Literal",
-            "else:",
-            "    from typing_extensions import Literal",
+            "from typing import Literal",
         ]
     contents = [HEADER]
     contents.extend(imports)

--- a/tools/update_init_file.py
+++ b/tools/update_init_file.py
@@ -15,10 +15,7 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import Literal
 
 # Import Altair from head
 ROOT_DIR = abspath(join(dirname(__file__), ".."))


### PR DESCRIPTION
Python 3.7 is [end-of-life as of 27.06.2023](https://devguide.python.org/versions/). Many other packages (e.g. [Streamlit](https://docs.streamlit.io/library/changelog), [python-jsonschema](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.18.0), ...) have already dropped support for it in minor releases and I'd recommend to do the same to simplify maintenance. Users with 3.7 can still install Altair 5.0.1 which has been a rather stable release so far.