### PR TITLE
 copied  percentage calculation in example

### DIFF
--- a/tests/examples_arguments_syntax/diverging_stacked_bar_chart.py
+++ b/tests/examples_arguments_syntax/diverging_stacked_bar_chart.py
@@ -5,336 +5,248 @@ This example shows a diverging stacked bar chart for sentiments towards a set of
 """
 # category: bar charts
 import altair as alt
+import pandas as pd
 
-source = alt.pd.DataFrame([
-      {
-        "question": "Question 1",
-        "type": "Strongly disagree",
-        "value": 24,
-        "percentage": 0.7,
-        "percentage_start": -19.1,
-        "percentage_end": -18.4
-      },
-      {
-        "question": "Question 1",
-        "type": "Disagree",
-        "value": 294,
-        "percentage": 9.1,
-        "percentage_start": -18.4,
-        "percentage_end": -9.2
-      },
-      {
-        "question": "Question 1",
-        "type": "Neither agree nor disagree",
-        "value": 594,
-        "percentage": 18.5,
-        "percentage_start": -9.2,
-        "percentage_end": 9.2
-      },
-      {
-        "question": "Question 1",
-        "type": "Agree",
-        "value": 1927,
-        "percentage": 59.9,
-        "percentage_start": 9.2,
-        "percentage_end": 69.2
-      },
-      {
-        "question": "Question 1",
-        "type": "Strongly agree",
-        "value": 376,
-        "percentage": 11.7,
-        "percentage_start": 69.2,
-        "percentage_end": 80.9
-      },
 
-      {
-        "question": "Question 2",
-        "type": "Strongly disagree",
-        "value": 2,
-        "percentage": 18.2,
-        "percentage_start": -36.4,
-        "percentage_end": -18.2
-      },
-      {
-        "question": "Question 2",
-        "type": "Disagree",
-        "value": 2,
-        "percentage": 18.2,
-        "percentage_start": -18.2,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 2",
-        "type": "Neither agree nor disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 0,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 2",
-        "type": "Agree",
-        "value": 7,
-        "percentage": 63.6,
-        "percentage_start": 0,
-        "percentage_end": 63.6
-      },
-      {
-        "question": "Question 2",
-        "type": "Strongly agree",
-        "value": 11,
-        "percentage": 0,
-        "percentage_start": 63.6,
-        "percentage_end": 63.6
-      },
+source = pd.DataFrame(
+    [
+        {
+            "question": "Question 1",
+            "type": "Strongly disagree",
+            "value": 24,
+        },
+        {
+            "question": "Question 1",
+            "type": "Disagree",
+            "value": 294,
+        },
+        {
+            "question": "Question 1",
+            "type": "Neither agree nor disagree",
+            "value": 594,
+        },
+        {
+            "question": "Question 1",
+            "type": "Agree",
+            "value": 1927,
+        },
+        {
+            "question": "Question 1",
+            "type": "Strongly agree",
+            "value": 376,
+        },
+        {
+            "question": "Question 2",
+            "type": "Strongly disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 2",
+            "type": "Disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 2",
+            "type": "Neither agree nor disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 2",
+            "type": "Agree",
+            "value": 7,
+        },
+        {
+            "question": "Question 2",
+            "type": "Strongly agree",
+            "value": 11,
+        },
+        {
+            "question": "Question 3",
+            "type": "Strongly disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 3",
+            "type": "Disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 3",
+            "type": "Neither agree nor disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 3",
+            "type": "Agree",
+            "value": 4,
+        },
+        {
+            "question": "Question 3",
+            "type": "Strongly agree",
+            "value": 2,
+        },
+        {
+            "question": "Question 4",
+            "type": "Strongly disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 4",
+            "type": "Disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 4",
+            "type": "Neither agree nor disagree",
+            "value": 1,
+        },
+        {
+            "question": "Question 4",
+            "type": "Agree",
+            "value": 7,
+        },
+        {
+            "question": "Question 4",
+            "type": "Strongly agree",
+            "value": 6,
+        },
+        {
+            "question": "Question 5",
+            "type": "Strongly disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 5",
+            "type": "Disagree",
+            "value": 1,
+        },
+        {
+            "question": "Question 5",
+            "type": "Neither agree nor disagree",
+            "value": 3,
+        },
+        {
+            "question": "Question 5",
+            "type": "Agree",
+            "value": 16,
+        },
+        {
+            "question": "Question 5",
+            "type": "Strongly agree",
+            "value": 4,
+        },
+        {
+            "question": "Question 6",
+            "type": "Strongly disagree",
+            "value": 1,
+        },
+        {
+            "question": "Question 6",
+            "type": "Disagree",
+            "value": 1,
+        },
+        {
+            "question": "Question 6",
+            "type": "Neither agree nor disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 6",
+            "type": "Agree",
+            "value": 9,
+        },
+        {
+            "question": "Question 6",
+            "type": "Strongly agree",
+            "value": 3,
+        },
+        {
+            "question": "Question 7",
+            "type": "Strongly disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 7",
+            "type": "Disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 7",
+            "type": "Neither agree nor disagree",
+            "value": 1,
+        },
+        {
+            "question": "Question 7",
+            "type": "Agree",
+            "value": 4,
+        },
+        {
+            "question": "Question 7",
+            "type": "Strongly agree",
+            "value": 0,
+        },
+        {
+            "question": "Question 8",
+            "type": "Strongly disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 8",
+            "type": "Disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 8",
+            "type": "Neither agree nor disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 8",
+            "type": "Agree",
+            "value": 0,
+        },
+        {
+            "question": "Question 8",
+            "type": "Strongly agree",
+            "value": 2,
+        },
+    ]
+)
 
-      {
-        "question": "Question 3",
-        "type": "Strongly disagree",
-        "value": 2,
-        "percentage": 20,
-        "percentage_start": -30,
-        "percentage_end": -10
-      },
-      {
-        "question": "Question 3",
-        "type": "Disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": -10,
-        "percentage_end": -10
-      },
-      {
-        "question": "Question 3",
-        "type": "Neither agree nor disagree",
-        "value": 2,
-        "percentage": 20,
-        "percentage_start": -10,
-        "percentage_end": 10
-      },
-      {
-        "question": "Question 3",
-        "type": "Agree",
-        "value": 4,
-        "percentage": 40,
-        "percentage_start": 10,
-        "percentage_end": 50
-      },
-      {
-        "question": "Question 3",
-        "type": "Strongly agree",
-        "value": 2,
-        "percentage": 20,
-        "percentage_start": 50,
-        "percentage_end": 70
-      },
 
-      {
-        "question": "Question 4",
-        "type": "Strongly disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": -15.6,
-        "percentage_end": -15.6
-      },
-      {
-        "question": "Question 4",
-        "type": "Disagree",
-        "value": 2,
-        "percentage": 12.5,
-        "percentage_start": -15.6,
-        "percentage_end": -3.1
-      },
-      {
-        "question": "Question 4",
-        "type": "Neither agree nor disagree",
-        "value": 1,
-        "percentage": 6.3,
-        "percentage_start": -3.1,
-        "percentage_end": 3.1
-      },
-      {
-        "question": "Question 4",
-        "type": "Agree",
-        "value": 7,
-        "percentage": 43.8,
-        "percentage_start": 3.1,
-        "percentage_end": 46.9
-      },
-      {
-        "question": "Question 4",
-        "type": "Strongly agree",
-        "value": 6,
-        "percentage": 37.5,
-        "percentage_start": 46.9,
-        "percentage_end": 84.4
-      },
+# Add type_code that we can sort by
+source["type_code"] = source["type"].map(
+    {
+        "Strongly disagree": -2,
+        "Disagree": -1,
+        "Neither agree nor disagree": 0,
+        "Agree": 1,
+        "Strongly agree": 2,
+    }
+)
 
-      {
-        "question": "Question 5",
-        "type": "Strongly disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": -10.4,
-        "percentage_end": -10.4
-      },
-      {
-        "question": "Question 5",
-        "type": "Disagree",
-        "value": 1,
-        "percentage": 4.2,
-        "percentage_start": -10.4,
-        "percentage_end": -6.3
-      },
-      {
-        "question": "Question 5",
-        "type": "Neither agree nor disagree",
-        "value": 3,
-        "percentage": 12.5,
-        "percentage_start": -6.3,
-        "percentage_end": 6.3
-      },
-      {
-        "question": "Question 5",
-        "type": "Agree",
-        "value": 16,
-        "percentage": 66.7,
-        "percentage_start": 6.3,
-        "percentage_end": 72.9
-      },
-      {
-        "question": "Question 5",
-        "type": "Strongly agree",
-        "value": 4,
-        "percentage": 16.7,
-        "percentage_start": 72.9,
-        "percentage_end": 89.6
-      },
 
-      {
-        "question": "Question 6",
-        "type": "Strongly disagree",
-        "value": 1,
-        "percentage": 6.3,
-        "percentage_start": -18.8,
-        "percentage_end": -12.5
-      },
-      {
-        "question": "Question 6",
-        "type": "Disagree",
-        "value": 1,
-        "percentage": 6.3,
-        "percentage_start": -12.5,
-        "percentage_end": -6.3
-      },
-      {
-        "question": "Question 6",
-        "type": "Neither agree nor disagree",
-        "value": 2,
-        "percentage": 12.5,
-        "percentage_start": -6.3,
-        "percentage_end": 6.3
-      },
-      {
-        "question": "Question 6",
-        "type": "Agree",
-        "value": 9,
-        "percentage": 56.3,
-        "percentage_start": 6.3,
-        "percentage_end": 62.5
-      },
-      {
-        "question": "Question 6",
-        "type": "Strongly agree",
-        "value": 3,
-        "percentage": 18.8,
-        "percentage_start": 62.5,
-        "percentage_end": 81.3
-      },
+def compute_percentages(
+    group,
+):
+    # Set type_code as index and sort
+    group = group.set_index("type_code").sort_index()
 
-      {
-        "question": "Question 7",
-        "type": "Strongly disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": -10,
-        "percentage_end": -10
-      },
-      {
-        "question": "Question 7",
-        "type": "Disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": -10,
-        "percentage_end": -10
-      },
-      {
-        "question": "Question 7",
-        "type": "Neither agree nor disagree",
-        "value": 1,
-        "percentage": 20,
-        "percentage_start": -10,
-        "percentage_end": 10
-      },
-      {
-        "question": "Question 7",
-        "type": "Agree",
-        "value": 4,
-        "percentage": 80,
-        "percentage_start": 10,
-        "percentage_end": 90
-      },
-      {
-        "question": "Question 7",
-        "type": "Strongly agree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 90,
-        "percentage_end": 90
-      },
+    # Compute percentage of value with question group
+    perc = (group["value"] / group["value"].sum()) * 100
+    group["percentage"] = perc
 
-      {
-        "question": "Question 8",
-        "type": "Strongly disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 0,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 8",
-        "type": "Disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 0,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 8",
-        "type": "Neither agree nor disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 0,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 8",
-        "type": "Agree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 0,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 8",
-        "type": "Strongly agree",
-        "value": 2,
-        "percentage": 100,
-        "percentage_start": 0,
-        "percentage_end": 100
-      }
-])
+    # Compute percentage end, centered on "Neither agree nor disagree" (type_code 0)
+    # Note that we access the perc series via index which is based on 'type_code'.
+    group["percentage_end"] = perc.cumsum() - (perc[-2] + perc[-1] + perc[0] / 2)
+
+    # Compute percentage start by subtracting percent
+    group["percentage_start"] = group["percentage_end"] - perc
+
+    return group
+
+
+source = source.groupby("question").apply(compute_percentages).reset_index(drop=True)
 
 color_scale = alt.Scale(
     domain=[
@@ -342,26 +254,20 @@ color_scale = alt.Scale(
         "Disagree",
         "Neither agree nor disagree",
         "Agree",
-        "Strongly agree"
+        "Strongly agree",
     ],
-    range=["#c30d24", "#f3a583", "#cccccc", "#94c6da", "#1770ab"]
+    range=["#c30d24", "#f3a583", "#cccccc", "#94c6da", "#1770ab"],
 )
 
-y_axis = alt.Axis(
-    title='Question',
-    offset=5,
-    ticks=False,
-    minExtent=60,
-    domain=False
-)
+y_axis = alt.Axis(title="Question", offset=5, ticks=False, minExtent=60, domain=False)
 
 alt.Chart(source).mark_bar().encode(
-    x='percentage_start:Q',
-    x2='percentage_end:Q',
-    y=alt.Y('question:N', axis=y_axis),
+    x="percentage_start:Q",
+    x2="percentage_end:Q",
+    y=alt.Y("question:N", axis=y_axis),
     color=alt.Color(
-        'type:N',
-        legend=alt.Legend( title='Response'),
+        "type:N",
+        legend=alt.Legend(title="Response"),
         scale=color_scale,
-    )
+    ),
 )

--- a/tests/examples_methods_syntax/diverging_stacked_bar_chart.py
+++ b/tests/examples_methods_syntax/diverging_stacked_bar_chart.py
@@ -5,336 +5,249 @@ This example shows a diverging stacked bar chart for sentiments towards a set of
 """
 # category: bar charts
 import altair as alt
+import pandas as pd
 
-source = alt.pd.DataFrame([
-      {
-        "question": "Question 1",
-        "type": "Strongly disagree",
-        "value": 24,
-        "percentage": 0.7,
-        "percentage_start": -19.1,
-        "percentage_end": -18.4
-      },
-      {
-        "question": "Question 1",
-        "type": "Disagree",
-        "value": 294,
-        "percentage": 9.1,
-        "percentage_start": -18.4,
-        "percentage_end": -9.2
-      },
-      {
-        "question": "Question 1",
-        "type": "Neither agree nor disagree",
-        "value": 594,
-        "percentage": 18.5,
-        "percentage_start": -9.2,
-        "percentage_end": 9.2
-      },
-      {
-        "question": "Question 1",
-        "type": "Agree",
-        "value": 1927,
-        "percentage": 59.9,
-        "percentage_start": 9.2,
-        "percentage_end": 69.2
-      },
-      {
-        "question": "Question 1",
-        "type": "Strongly agree",
-        "value": 376,
-        "percentage": 11.7,
-        "percentage_start": 69.2,
-        "percentage_end": 80.9
-      },
 
-      {
-        "question": "Question 2",
-        "type": "Strongly disagree",
-        "value": 2,
-        "percentage": 18.2,
-        "percentage_start": -36.4,
-        "percentage_end": -18.2
-      },
-      {
-        "question": "Question 2",
-        "type": "Disagree",
-        "value": 2,
-        "percentage": 18.2,
-        "percentage_start": -18.2,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 2",
-        "type": "Neither agree nor disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 0,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 2",
-        "type": "Agree",
-        "value": 7,
-        "percentage": 63.6,
-        "percentage_start": 0,
-        "percentage_end": 63.6
-      },
-      {
-        "question": "Question 2",
-        "type": "Strongly agree",
-        "value": 11,
-        "percentage": 0,
-        "percentage_start": 63.6,
-        "percentage_end": 63.6
-      },
+source = pd.DataFrame(
+    [
+        {
+            "question": "Question 1",
+            "type": "Strongly disagree",
+            "value": 24,
+        },
+        {
+            "question": "Question 1",
+            "type": "Disagree",
+            "value": 294,
+        },
+        {
+            "question": "Question 1",
+            "type": "Neither agree nor disagree",
+            "value": 594,
+        },
+        {
+            "question": "Question 1",
+            "type": "Agree",
+            "value": 1927,
+        },
+        {
+            "question": "Question 1",
+            "type": "Strongly agree",
+            "value": 376,
+        },
+        {
+            "question": "Question 2",
+            "type": "Strongly disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 2",
+            "type": "Disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 2",
+            "type": "Neither agree nor disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 2",
+            "type": "Agree",
+            "value": 7,
+        },
+        {
+            "question": "Question 2",
+            "type": "Strongly agree",
+            "value": 11,
+        },
+        {
+            "question": "Question 3",
+            "type": "Strongly disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 3",
+            "type": "Disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 3",
+            "type": "Neither agree nor disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 3",
+            "type": "Agree",
+            "value": 4,
+        },
+        {
+            "question": "Question 3",
+            "type": "Strongly agree",
+            "value": 2,
+        },
+        {
+            "question": "Question 4",
+            "type": "Strongly disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 4",
+            "type": "Disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 4",
+            "type": "Neither agree nor disagree",
+            "value": 1,
+        },
+        {
+            "question": "Question 4",
+            "type": "Agree",
+            "value": 7,
+        },
+        {
+            "question": "Question 4",
+            "type": "Strongly agree",
+            "value": 6,
+        },
+        {
+            "question": "Question 5",
+            "type": "Strongly disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 5",
+            "type": "Disagree",
+            "value": 1,
+        },
+        {
+            "question": "Question 5",
+            "type": "Neither agree nor disagree",
+            "value": 3,
+        },
+        {
+            "question": "Question 5",
+            "type": "Agree",
+            "value": 16,
+        },
+        {
+            "question": "Question 5",
+            "type": "Strongly agree",
+            "value": 4,
+        },
+        {
+            "question": "Question 6",
+            "type": "Strongly disagree",
+            "value": 1,
+        },
+        {
+            "question": "Question 6",
+            "type": "Disagree",
+            "value": 1,
+        },
+        {
+            "question": "Question 6",
+            "type": "Neither agree nor disagree",
+            "value": 2,
+        },
+        {
+            "question": "Question 6",
+            "type": "Agree",
+            "value": 9,
+        },
+        {
+            "question": "Question 6",
+            "type": "Strongly agree",
+            "value": 3,
+        },
+        {
+            "question": "Question 7",
+            "type": "Strongly disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 7",
+            "type": "Disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 7",
+            "type": "Neither agree nor disagree",
+            "value": 1,
+        },
+        {
+            "question": "Question 7",
+            "type": "Agree",
+            "value": 4,
+        },
+        {
+            "question": "Question 7",
+            "type": "Strongly agree",
+            "value": 0,
+        },
+        {
+            "question": "Question 8",
+            "type": "Strongly disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 8",
+            "type": "Disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 8",
+            "type": "Neither agree nor disagree",
+            "value": 0,
+        },
+        {
+            "question": "Question 8",
+            "type": "Agree",
+            "value": 0,
+        },
+        {
+            "question": "Question 8",
+            "type": "Strongly agree",
+            "value": 2,
+        },
+    ]
+)
 
-      {
-        "question": "Question 3",
-        "type": "Strongly disagree",
-        "value": 2,
-        "percentage": 20,
-        "percentage_start": -30,
-        "percentage_end": -10
-      },
-      {
-        "question": "Question 3",
-        "type": "Disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": -10,
-        "percentage_end": -10
-      },
-      {
-        "question": "Question 3",
-        "type": "Neither agree nor disagree",
-        "value": 2,
-        "percentage": 20,
-        "percentage_start": -10,
-        "percentage_end": 10
-      },
-      {
-        "question": "Question 3",
-        "type": "Agree",
-        "value": 4,
-        "percentage": 40,
-        "percentage_start": 10,
-        "percentage_end": 50
-      },
-      {
-        "question": "Question 3",
-        "type": "Strongly agree",
-        "value": 2,
-        "percentage": 20,
-        "percentage_start": 50,
-        "percentage_end": 70
-      },
 
-      {
-        "question": "Question 4",
-        "type": "Strongly disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": -15.6,
-        "percentage_end": -15.6
-      },
-      {
-        "question": "Question 4",
-        "type": "Disagree",
-        "value": 2,
-        "percentage": 12.5,
-        "percentage_start": -15.6,
-        "percentage_end": -3.1
-      },
-      {
-        "question": "Question 4",
-        "type": "Neither agree nor disagree",
-        "value": 1,
-        "percentage": 6.3,
-        "percentage_start": -3.1,
-        "percentage_end": 3.1
-      },
-      {
-        "question": "Question 4",
-        "type": "Agree",
-        "value": 7,
-        "percentage": 43.8,
-        "percentage_start": 3.1,
-        "percentage_end": 46.9
-      },
-      {
-        "question": "Question 4",
-        "type": "Strongly agree",
-        "value": 6,
-        "percentage": 37.5,
-        "percentage_start": 46.9,
-        "percentage_end": 84.4
-      },
+# Add type_code that we can sort by
+source["type_code"] = source["type"].map(
+    {
+        "Strongly disagree": -2,
+        "Disagree": -1,
+        "Neither agree nor disagree": 0,
+        "Agree": 1,
+        "Strongly agree": 2,
+    }
+)
 
-      {
-        "question": "Question 5",
-        "type": "Strongly disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": -10.4,
-        "percentage_end": -10.4
-      },
-      {
-        "question": "Question 5",
-        "type": "Disagree",
-        "value": 1,
-        "percentage": 4.2,
-        "percentage_start": -10.4,
-        "percentage_end": -6.3
-      },
-      {
-        "question": "Question 5",
-        "type": "Neither agree nor disagree",
-        "value": 3,
-        "percentage": 12.5,
-        "percentage_start": -6.3,
-        "percentage_end": 6.3
-      },
-      {
-        "question": "Question 5",
-        "type": "Agree",
-        "value": 16,
-        "percentage": 66.7,
-        "percentage_start": 6.3,
-        "percentage_end": 72.9
-      },
-      {
-        "question": "Question 5",
-        "type": "Strongly agree",
-        "value": 4,
-        "percentage": 16.7,
-        "percentage_start": 72.9,
-        "percentage_end": 89.6
-      },
 
-      {
-        "question": "Question 6",
-        "type": "Strongly disagree",
-        "value": 1,
-        "percentage": 6.3,
-        "percentage_start": -18.8,
-        "percentage_end": -12.5
-      },
-      {
-        "question": "Question 6",
-        "type": "Disagree",
-        "value": 1,
-        "percentage": 6.3,
-        "percentage_start": -12.5,
-        "percentage_end": -6.3
-      },
-      {
-        "question": "Question 6",
-        "type": "Neither agree nor disagree",
-        "value": 2,
-        "percentage": 12.5,
-        "percentage_start": -6.3,
-        "percentage_end": 6.3
-      },
-      {
-        "question": "Question 6",
-        "type": "Agree",
-        "value": 9,
-        "percentage": 56.3,
-        "percentage_start": 6.3,
-        "percentage_end": 62.5
-      },
-      {
-        "question": "Question 6",
-        "type": "Strongly agree",
-        "value": 3,
-        "percentage": 18.8,
-        "percentage_start": 62.5,
-        "percentage_end": 81.3
-      },
+def compute_percentages(
+    group,
+):
+    # Set type_code as index and sort
+    group = group.set_index("type_code").sort_index()
 
-      {
-        "question": "Question 7",
-        "type": "Strongly disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": -10,
-        "percentage_end": -10
-      },
-      {
-        "question": "Question 7",
-        "type": "Disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": -10,
-        "percentage_end": -10
-      },
-      {
-        "question": "Question 7",
-        "type": "Neither agree nor disagree",
-        "value": 1,
-        "percentage": 20,
-        "percentage_start": -10,
-        "percentage_end": 10
-      },
-      {
-        "question": "Question 7",
-        "type": "Agree",
-        "value": 4,
-        "percentage": 80,
-        "percentage_start": 10,
-        "percentage_end": 90
-      },
-      {
-        "question": "Question 7",
-        "type": "Strongly agree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 90,
-        "percentage_end": 90
-      },
+    # Compute percentage of value with question group
+    perc = (group["value"] / group["value"].sum()) * 100
+    group["percentage"] = perc
 
-      {
-        "question": "Question 8",
-        "type": "Strongly disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 0,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 8",
-        "type": "Disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 0,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 8",
-        "type": "Neither agree nor disagree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 0,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 8",
-        "type": "Agree",
-        "value": 0,
-        "percentage": 0,
-        "percentage_start": 0,
-        "percentage_end": 0
-      },
-      {
-        "question": "Question 8",
-        "type": "Strongly agree",
-        "value": 2,
-        "percentage": 100,
-        "percentage_start": 0,
-        "percentage_end": 100
-      }
-])
+    # Compute percentage end, centered on "Neither agree nor disagree" (type_code 0)
+    # Note that we access the perc series via index which is based on 'type_code'.
+    group["percentage_end"] = perc.cumsum() - (perc[-2] + perc[-1] + perc[0] / 2)
+
+    # Compute percentage start by subtracting percent
+    group["percentage_start"] = group["percentage_end"] - perc
+
+    return group
+
+
+source = source.groupby("question").apply(compute_percentages).reset_index(drop=True)
+
 
 color_scale = alt.Scale(
     domain=[
@@ -342,22 +255,16 @@ color_scale = alt.Scale(
         "Disagree",
         "Neither agree nor disagree",
         "Agree",
-        "Strongly agree"
+        "Strongly agree",
     ],
-    range=["#c30d24", "#f3a583", "#cccccc", "#94c6da", "#1770ab"]
+    range=["#c30d24", "#f3a583", "#cccccc", "#94c6da", "#1770ab"],
 )
 
-y_axis = alt.Axis(
-    title='Question',
-    offset=5,
-    ticks=False,
-    minExtent=60,
-    domain=False
-)
+y_axis = alt.Axis(title="Question", offset=5, ticks=False, minExtent=60, domain=False)
 
 alt.Chart(source).mark_bar().encode(
-    x='percentage_start:Q',
-    x2='percentage_end:Q',
-    y=alt.Y('question:N').axis(y_axis),
-    color=alt.Color('type:N').title('Response').scale(color_scale),
+    x="percentage_start:Q",
+    x2="percentage_end:Q",
+    y=alt.Y("question:N").axis(y_axis),
+    color=alt.Color("type:N").title("Response").scale(color_scale),
 )


### PR DESCRIPTION
I added @jonmmease 's implementation of the percentage calculation (https://github.com/altair-viz/altair/issues/3101) to the [diverging stacked bar chart example](https://altair-viz.github.io/gallery/diverging_stacked_bar_chart.html).

It was mentioned in  (https://github.com/altair-viz/altair/discussions/3103) that this would be helpful.

The example now slightly differs from the [Vega-Lite example](https://vega.github.io/vega-lite-v2/examples/bar_diverging_stacked.html) since there is a small error in the hard-coded data provided in the Vega-Lite example (percentage should not be 0 when there are 11 answers): 
```
{
        "question": "Question 2",
        "type": "Strongly agree",
        "value": 11,
        "percentage": 0,
        "percentage_start": 63.6,
        "percentage_end": 63.6
      }
```
@binste would be great if you can again test run the documentation on your machine since it did not work properly on the github code-space. 


