### PR TITLE
Fix accidental requirement of Pandas 1.5. Bump minimum Pandas version to 0.25. Run tests with it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,14 @@ jobs:
         # accidentally introduced a hard dependency on these libraries.
         # Uninstalling for Python 3.9 is an arbitrary choice.
         # Also see https://github.com/altair-viz/altair/pull/3114
-        if: ${{ matrix.python-version }}=="3.9"
+        if: matrix.python-version == "3.9"
         run: |
           pip uninstall -y pyarrow vegafusion vegafusion-python-embed
       - name: Maybe install lowest supported Pandas version
         # We install the lowest supported Pandas version for one job to test that
         # it still works. We do this for Python 3.8 as that is the last Python version
         # to work with this Pandas version.
-        if: ${{ matrix.python-version }}=="3.8"
+        if: matrix.python-version == "3.8"
         run: |
           pip install pandas==0.18
       - name: Test that schema generation has no effect

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,13 @@ jobs:
         if: ${{ matrix.python-version }}=="3.9"
         run: |
           pip uninstall -y pyarrow vegafusion vegafusion-python-embed
+      - name: Maybe install lowest supported Pandas version
+        # We install the lowest supported Pandas version for one job to test that
+        # it still works. We do this for Python 3.8 as that is the last Python version
+        # to work with this Pandas version.
+        if: ${{ matrix.python-version }}=="3.8"
+        run: |
+          pip install pandas==0.18
       - name: Test that schema generation has no effect
         run: |
           python tools/generate_schema_wrapper.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,11 @@ jobs:
           pip uninstall -y pyarrow vegafusion vegafusion-python-embed
       - name: Maybe install lowest supported Pandas version
         # We install the lowest supported Pandas version for one job to test that
-        # it still works. We do this for Python 3.8 as that is the last Python version
-        # to work with this Pandas version.
+        # it still works. Downgrade to the oldest versions of pandas and numpy that include
+        # Python 3.8 wheels, so only run this job for Python 3.8
         if: ${{ matrix.python-version == '3.8' }}
         run: |
-          pip install pandas==0.25.3
+          pip install pandas==0.25.3 numpy == 1.17.5
       - name: Test that schema generation has no effect
         run: |
           python tools/generate_schema_wrapper.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         # to work with this Pandas version.
         if: ${{ matrix.python-version == '3.8' }}
         run: |
-          pip install pandas==0.18
+          pip install pandas==0.25.3
       - name: Test that schema generation has no effect
         run: |
           python tools/generate_schema_wrapper.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         # Python 3.8 wheels, so only run this job for Python 3.8
         if: ${{ matrix.python-version == '3.8' }}
         run: |
-          pip install pandas==0.25.3 numpy == 1.17.5
+          pip install pandas==0.25.3 numpy==1.17.5
       - name: Test that schema generation has no effect
         run: |
           python tools/generate_schema_wrapper.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.8", "3.9", "3.10", "3.11"]
         jsonschema-version: ["3.0", "4.17"]
-    name: py ${{ matrix.python-version }} js ${{ matrix.jsonschema-version }}
+    name: py ${{ matrix.python_version }} js ${{ matrix.jsonschema-version }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python_version: ${{ matrix.python_version }}
       # - name: Set Up Chromedriver
       #   run: |
       #     sudo apt-get update
@@ -33,14 +33,14 @@ jobs:
         # accidentally introduced a hard dependency on these libraries.
         # Uninstalling for Python 3.9 is an arbitrary choice.
         # Also see https://github.com/altair-viz/altair/pull/3114
-        if: matrix.python-version == "3.9"
+        if: matrix.python_version == "3.9"
         run: |
           pip uninstall -y pyarrow vegafusion vegafusion-python-embed
       - name: Maybe install lowest supported Pandas version
         # We install the lowest supported Pandas version for one job to test that
         # it still works. We do this for Python 3.8 as that is the last Python version
         # to work with this Pandas version.
-        if: matrix.python-version == "3.8"
+        if: matrix.python_version == "3.8"
         run: |
           pip install pandas==0.18
       - name: Test that schema generation has no effect

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,14 @@ jobs:
         # accidentally introduced a hard dependency on these libraries.
         # Uninstalling for Python 3.9 is an arbitrary choice.
         # Also see https://github.com/altair-viz/altair/pull/3114
-        if: matrix.python-version == "3.9"
+        if: ${{ matrix.python-version == '3.9' }}
         run: |
           pip uninstall -y pyarrow vegafusion vegafusion-python-embed
       - name: Maybe install lowest supported Pandas version
         # We install the lowest supported Pandas version for one job to test that
         # it still works. We do this for Python 3.8 as that is the last Python version
         # to work with this Pandas version.
-        if: matrix.python-version == "3.8"
+        if: ${{ matrix.python-version == '3.8' }}
         run: |
           pip install pandas==0.18
       - name: Test that schema generation has no effect

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Maybe uninstall optional dependencies
         # We uninstall pyarrow and vegafusion for one job to test that we have not
         # accidentally introduced a hard dependency on these libraries.
-        # Uninstalling for Python 3.9 is an arbitrary choice.
+        # Uninstalling for Python 3.8 is an arbitrary choice.
         # Also see https://github.com/altair-viz/altair/pull/3114
-        if: ${{ matrix.python-version == '3.9' }}
+        if: ${{ matrix.python-version == '3.8' }}
         run: |
           pip uninstall -y pyarrow vegafusion vegafusion-python-embed
       - name: Maybe install lowest supported Pandas version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         jsonschema-version: ["3.0", "4.17"]
-    name: py ${{ matrix.python_version }} js ${{ matrix.jsonschema-version }}
+    name: py ${{ matrix.python-version }} js ${{ matrix.jsonschema-version }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python_version }}
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python_version: ${{ matrix.python_version }}
+          python-version: ${{ matrix.python-version }}
       # - name: Set Up Chromedriver
       #   run: |
       #     sudo apt-get update
@@ -33,14 +33,14 @@ jobs:
         # accidentally introduced a hard dependency on these libraries.
         # Uninstalling for Python 3.9 is an arbitrary choice.
         # Also see https://github.com/altair-viz/altair/pull/3114
-        if: matrix.python_version == "3.9"
+        if: matrix.python-version == "3.9"
         run: |
           pip uninstall -y pyarrow vegafusion vegafusion-python-embed
       - name: Maybe install lowest supported Pandas version
         # We install the lowest supported Pandas version for one job to test that
         # it still works. We do this for Python 3.8 as that is the last Python version
         # to work with this Pandas version.
-        if: matrix.python_version == "3.8"
+        if: matrix.python-version == "3.8"
         run: |
           pip install pandas==0.18
       - name: Test that schema generation has no effect

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -324,7 +324,13 @@ def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:  # noqa: C901
 
     for col_name, dtype in df.dtypes.items():
         dtype_name = str(dtype)
-        if dtype_name == "string":
+        if dtype_name == "category":
+            # Work around bug in to_json for categorical types in older versions of pandas
+            # https://github.com/pydata/pandas/issues/10778
+            # https://github.com/altair-viz/altair/pull/2170
+            col = df[col_name].astype(object)
+            df[col_name] = col.where(col.notnull(), None)
+        elif dtype_name == "string":
             # dedicated string datatype (since 1.0)
             # https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html#dedicated-string-data-type
             col = df[col_name].astype(object)

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -15,7 +15,6 @@ from types import ModuleType
 import jsonschema
 import pandas as pd
 import numpy as np
-from pandas.core.interchange.dataframe_protocol import Column as PandasColumn
 
 from altair.utils.schemapi import SchemaBase
 from altair.utils._dfi_types import Column, DtypeKind, DataFrame as DfiDataFrame
@@ -25,13 +24,16 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import ParamSpec
 
-from typing import Literal, Protocol
+from typing import Literal, Protocol, TYPE_CHECKING
 
 try:
     from pandas.api.types import infer_dtype as _infer_dtype
 except ImportError:
     # Import for pandas < 0.20.0
     from pandas.lib import infer_dtype as _infer_dtype  # type: ignore[no-redef]
+
+if TYPE_CHECKING:
+    from pandas.core.interchange.dataframe_protocol import Column as PandasColumn
 
 _V = TypeVar("_V")
 _P = ParamSpec("_P")

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -632,7 +632,7 @@ def parse_shorthand(
 
 
 def infer_vegalite_type_for_dfi_column(
-    column: Union[Column, PandasColumn],
+    column: Union[Column, "PandasColumn"],
 ) -> Union[_InferredVegaLiteType, Tuple[_InferredVegaLiteType, list]]:
     from pyarrow.interchange.from_dataframe import column_to_array
 

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -324,13 +324,7 @@ def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:  # noqa: C901
 
     for col_name, dtype in df.dtypes.items():
         dtype_name = str(dtype)
-        if dtype_name == "category":
-            # Work around bug in to_json for categorical types in older versions of pandas
-            # https://github.com/pydata/pandas/issues/10778
-            # https://github.com/altair-viz/altair/pull/2170
-            col = df[col_name].astype(object)
-            df[col_name] = col.where(col.notnull(), None)
-        elif dtype_name == "string":
+        if dtype_name == "string":
             # dedicated string datatype (since 1.0)
             # https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html#dedicated-string-data-type
             col = df[col_name].astype(object)

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -325,9 +325,9 @@ def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:  # noqa: C901
     for col_name, dtype in df.dtypes.items():
         dtype_name = str(dtype)
         if dtype_name == "category":
-            # Work around bug in to_json for categorical types in older versions of pandas
-            # https://github.com/pydata/pandas/issues/10778
-            # https://github.com/altair-viz/altair/pull/2170
+            # Work around bug in to_json for categorical types in older versions 
+            # of pandas as they do not properly convert NaN values to null in to_json.
+            # We can probably remove this part once we require Pandas >= 1.0
             col = df[col_name].astype(object)
             df[col_name] = col.where(col.notnull(), None)
         elif dtype_name == "string":

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -191,7 +191,7 @@ def infer_vegalite_type(
     ----------
     data: object
     """
-    typ = infer_dtype(data)
+    typ = infer_dtype(data, skipna=False)
 
     if typ in [
         "floating",

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -15,6 +15,7 @@ from types import ModuleType
 import jsonschema
 import pandas as pd
 import numpy as np
+from pandas.api.types import infer_dtype
 
 from altair.utils.schemapi import SchemaBase
 from altair.utils._dfi_types import Column, DtypeKind, DataFrame as DfiDataFrame
@@ -26,12 +27,6 @@ else:
 
 from typing import Literal, Protocol, TYPE_CHECKING
 
-try:
-    from pandas.api.types import infer_dtype as _infer_dtype
-except ImportError:
-    # Import for pandas < 0.20.0
-    from pandas.lib import infer_dtype as _infer_dtype  # type: ignore[no-redef]
-
 if TYPE_CHECKING:
     from pandas.core.interchange.dataframe_protocol import Column as PandasColumn
 
@@ -42,26 +37,6 @@ _P = ParamSpec("_P")
 class _DataFrameLike(Protocol):
     def __dataframe__(self, *args, **kwargs) -> DfiDataFrame:
         ...
-
-
-def infer_dtype(value: object) -> str:
-    """Infer the dtype of the value.
-
-    This is a compatibility function for pandas infer_dtype,
-    with skipna=False regardless of the pandas version.
-    """
-    if not hasattr(infer_dtype, "_supports_skipna"):
-        try:
-            _infer_dtype([1], skipna=False)
-        except TypeError:
-            # pandas < 0.21.0 don't support skipna keyword
-            infer_dtype._supports_skipna = False  # type: ignore[attr-defined]
-        else:
-            infer_dtype._supports_skipna = True  # type: ignore[attr-defined]
-    if infer_dtype._supports_skipna:  # type: ignore[attr-defined]
-        return _infer_dtype(value, skipna=False)
-    else:
-        return _infer_dtype(value)
 
 
 TYPECODE_MAP = {

--- a/altair/utils/core.py
+++ b/altair/utils/core.py
@@ -325,7 +325,7 @@ def sanitize_dataframe(df: pd.DataFrame) -> pd.DataFrame:  # noqa: C901
     for col_name, dtype in df.dtypes.items():
         dtype_name = str(dtype)
         if dtype_name == "category":
-            # Work around bug in to_json for categorical types in older versions 
+            # Work around bug in to_json for categorical types in older versions
             # of pandas as they do not properly convert NaN values to null in to_json.
             # We can probably remove this part once we require Pandas >= 1.0
             col = df[col_name].astype(object)

--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -18,7 +18,8 @@ Bug Fixes
 
 Backward-Incompatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- Drop support for Python 3.7 which is end-of-life (#3100).
+- Drop support for Python 3.7 which is end-of-life (#3100)
+- Increase minimum required Pandas version to 0.25 (#3130)
 
 Version 5.0.1 (released May 26, 2023)
 -------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "jsonschema>=3.0",
     "numpy",
     # If you update the minimum required pandas version, also update it in build.yml
-    "pandas>=0.18",
+    "pandas>=0.25",
     "toolz"
 ]
 description = "Vega-Altair: A declarative statistical visualization library for Python."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,10 @@ authors = [ {name = "Vega-Altair Contributors"} ]
 dependencies = [
     "typing_extensions>=4.0.1; python_version<\"3.11\"",
     "jinja2",
+    # If you update the minimum required jsonschema version, also update it in build.yml
     "jsonschema>=3.0",
     "numpy",
+    # If you update the minimum required pandas version, also update it in build.yml
     "pandas>=0.18",
     "toolz"
 ]

--- a/tests/utils/test_core.py
+++ b/tests/utils/test_core.py
@@ -74,7 +74,7 @@ class StrokeWidthValue(ValueChannel, schemapi.SchemaBase):
     ],
 )
 def test_infer_dtype(value, expected_type):
-    assert infer_dtype(value) == expected_type
+    assert infer_dtype(value, skipna=False) == expected_type
 
 
 def test_parse_shorthand():


### PR DESCRIPTION
[This import](https://github.com/altair-viz/altair/pull/3114/files#diff-d110e8643c6feff37c22c1a5c7d213b8384177718b8e26edd8e1b8f2ed027a0aR18) introduced in #3114 is not available in Pandas < 1.5 and Altair currently supports Pandas >= 0.18. This PR adds a test run with the lowest supported Pandas version.

@jonmmease Do you know of a good way to make that type check independent of the pandas import? Else, we could fall back on not type-hinting it if necessary. Feel free to push directly to this branch if you have an idea and want to try it out in the GitHub actions workflow.

Pandas 0.18 is from 2016 and we could for sure consider bumping it but I don't think we can go to Pandas 1.5 just yet. Especially not in a minor release of Altair.