### PR TITLE
MAINT: Use importlib.metadata and packaging instead of deprecated pkg_resources

### DIFF
--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -3,8 +3,7 @@ import os
 import random
 import hashlib
 import warnings
-from importlib.metadata import version as importlib_version
-from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as importlib_version, PackageNotFoundError
 from typing import Union, MutableMapping, Optional, Dict, Sequence, TYPE_CHECKING, List
 from types import ModuleType
 

--- a/altair/utils/data.py
+++ b/altair/utils/data.py
@@ -3,12 +3,15 @@ import os
 import random
 import hashlib
 import warnings
+from importlib.metadata import version as importlib_version
+from importlib.metadata import PackageNotFoundError
 from typing import Union, MutableMapping, Optional, Dict, Sequence, TYPE_CHECKING, List
 from types import ModuleType
 
 import pandas as pd
 from toolz import curried
 from typing import TypeVar
+from packaging.version import Version
 
 from .core import sanitize_dataframe, sanitize_arrow_table, _DataFrameLike
 from .core import sanitize_geo_interface
@@ -349,25 +352,23 @@ def curry(*args, **kwargs):
 
 
 def import_pyarrow_interchange() -> ModuleType:
-    import pkg_resources
-
     try:
-        pkg_resources.require("pyarrow>=11.0.0")
-        # The package is installed and meets the minimum version requirement
-        import pyarrow.interchange as pi
+        pyarrow_version_str = importlib_version("pyarrow")
+    except PackageNotFoundError as err:
+        raise ImportError(
+            "Usage of the DataFrame Interchange Protocol requires the package"
+            + " 'pyarrow', but it is not installed."
+        ) from err
+    else:
+        if Version(pyarrow_version_str) < Version("11.0.0"):
+            raise ImportError(
+                "The installed version of 'pyarrow' does not meet the minimum requirement of version 11.0.0. "
+                "Please update 'pyarrow' to use the DataFrame Interchange Protocol."
+            )
+        else:
+            import pyarrow.interchange as pi
 
-        return pi
-    except pkg_resources.DistributionNotFound as err:
-        # The package is not installed
-        raise ImportError(
-            "Usage of the DataFrame Interchange Protocol requires the package 'pyarrow', but it is not installed."
-        ) from err
-    except pkg_resources.VersionConflict as err:
-        # The package is installed but does not meet the minimum version requirement
-        raise ImportError(
-            "The installed version of 'pyarrow' does not meet the minimum requirement of version 11.0.0. "
-            "Please update 'pyarrow' to use the DataFrame Interchange Protocol."
-        ) from err
+            return pi
 
 
 def pyarrow_available() -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     "jsonschema>=3.0",
     "numpy",
     "pandas>=0.18",
-    "toolz"
+    "toolz",
+    "packaging"
 ]
 description = "Vega-Altair: A declarative statistical visualization library for Python."
 readme = "README.md"


### PR DESCRIPTION
Closes #3132