### PR TITLE
feat(widget): prefer lodash-es/debounce to reduce import size

### DIFF
--- a/altair/jupyter/js/index.js
+++ b/altair/jupyter/js/index.js
@@ -1,5 +1,5 @@
 import embed from "https://cdn.jsdelivr.net/npm/vega-embed@6/+esm";
-import { debounce } from "https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/lodash.js"
+import debounce from "https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/debounce/+esm";
 
 export async function render({ model, el }) {
     let finalize;


### PR DESCRIPTION
Follow up from https://github.com/altair-viz/altair/pull/3119#pullrequestreview-1558483029.

The `https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/lodash.js` entrypoint points to:

```js
/**
 * @license
 * Lodash (Custom Build) <https://lodash.com/>
 * Build: `lodash modularize exports="es" -o ./`
 * Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
 * Released under MIT license <https://lodash.com/license>
 * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
 * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 */
export { default as add } from './add.js';
export { default as after } from './after.js';
export { default as ary } from './ary.js';
export { default as assign } from './assign.js';
export { default as assignIn } from './assignIn.js';
export { default as assignInWith } from './assignInWith.js';
export { default as assignWith } from './assignWith.js';
export { default as at } from './at.js';
export { default as attempt } from './attempt.js';
export { default as before } from './before.js';
export { default as bind } from './bind.js';
export { default as bindAll } from './bindAll.js';
export { default as bindKey } from './bindKey.js';
export { default as camelCase } from './camelCase.js';
export { default as capitalize } from './capitalize.js';
export { default as castArray } from './castArray.js';
export { default as ceil } from './ceil.js';
export { default as chain } from './chain.js';
export { default as chunk } from './chunk.js';
export { default as clamp } from './clamp.js';
export { default as clone } from './clone.js';
export { default as cloneDeep } from './cloneDeep.js';
export { default as cloneDeepWith } from './cloneDeepWith.js';
export { default as cloneWith } from './cloneWith.js';
export { default as commit } from './commit.js';
export { default as compact } from './compact.js';
export { default as concat } from './concat.js';
export { default as cond } from './cond.js';
export { default as conforms } from './conforms.js';
export { default as conformsTo } from './conformsTo.js';
export { default as constant } from './constant.js';
export { default as countBy } from './countBy.js';
export { default as create } from './create.js';
export { default as curry } from './curry.js';
export { default as curryRight } from './curryRight.js';
export { default as debounce } from './debounce.js';
export { default as deburr } from './deburr.js';
export { default as defaultTo } from './defaultTo.js';
export { default as defaults } from './defaults.js';
export { default as defaultsDeep } from './defaultsDeep.js';
export { default as defer } from './defer.js';
export { default as delay } from './delay.js';
export { default as difference } from './difference.js';
export { default as differenceBy } from './differenceBy.js';
export { default as differenceWith } from './differenceWith.js';
export { default as divide } from './divide.js';
export { default as drop } from './drop.js';
export { default as dropRight } from './dropRight.js';
export { default as dropRightWhile } from './dropRightWhile.js';
export { default as dropWhile } from './dropWhile.js';
export { default as each } from './each.js';
export { default as eachRight } from './eachRight.js';
export { default as endsWith } from './endsWith.js';
export { default as entries } from './entries.js';
export { default as entriesIn } from './entriesIn.js';
export { default as eq } from './eq.js';
export { default as escape } from './escape.js';
export { default as escapeRegExp } from './escapeRegExp.js';
export { default as every } from './every.js';
export { default as extend } from './extend.js';
export { default as extendWith } from './extendWith.js';
export { default as fill } from './fill.js';
export { default as filter } from './filter.js';
export { default as find } from './find.js';
export { default as findIndex } from './findIndex.js';
export { default as findKey } from './findKey.js';
export { default as findLast } from './findLast.js';
export { default as findLastIndex } from './findLastIndex.js';
export { default as findLastKey } from './findLastKey.js';
export { default as first } from './first.js';
export { default as flatMap } from './flatMap.js';
export { default as flatMapDeep } from './flatMapDeep.js';
export { default as flatMapDepth } from './flatMapDepth.js';
export { default as flatten } from './flatten.js';
export { default as flattenDeep } from './flattenDeep.js';
export { default as flattenDepth } from './flattenDepth.js';
export { default as flip } from './flip.js';
export { default as floor } from './floor.js';
export { default as flow } from './flow.js';
export { default as flowRight } from './flowRight.js';
export { default as forEach } from './forEach.js';
export { default as forEachRight } from './forEachRight.js';
export { default as forIn } from './forIn.js';
export { default as forInRight } from './forInRight.js';
export { default as forOwn } from './forOwn.js';
export { default as forOwnRight } from './forOwnRight.js';
export { default as fromPairs } from './fromPairs.js';
export { default as functions } from './functions.js';
export { default as functionsIn } from './functionsIn.js';
export { default as get } from './get.js';
export { default as groupBy } from './groupBy.js';
export { default as gt } from './gt.js';
export { default as gte } from './gte.js';
export { default as has } from './has.js';
export { default as hasIn } from './hasIn.js';
export { default as head } from './head.js';
export { default as identity } from './identity.js';
export { default as inRange } from './inRange.js';
export { default as includes } from './includes.js';
export { default as indexOf } from './indexOf.js';
export { default as initial } from './initial.js';
export { default as intersection } from './intersection.js';
export { default as intersectionBy } from './intersectionBy.js';
export { default as intersectionWith } from './intersectionWith.js';
export { default as invert } from './invert.js';
export { default as invertBy } from './invertBy.js';
export { default as invoke } from './invoke.js';
export { default as invokeMap } from './invokeMap.js';
export { default as isArguments } from './isArguments.js';
export { default as isArray } from './isArray.js';
export { default as isArrayBuffer } from './isArrayBuffer.js';
export { default as isArrayLike } from './isArrayLike.js';
export { default as isArrayLikeObject } from './isArrayLikeObject.js';
export { default as isBoolean } from './isBoolean.js';
export { default as isBuffer } from './isBuffer.js';
export { default as isDate } from './isDate.js';
export { default as isElement } from './isElement.js';
export { default as isEmpty } from './isEmpty.js';
export { default as isEqual } from './isEqual.js';
export { default as isEqualWith } from './isEqualWith.js';
export { default as isError } from './isError.js';
export { default as isFinite } from './isFinite.js';
export { default as isFunction } from './isFunction.js';
export { default as isInteger } from './isInteger.js';
export { default as isLength } from './isLength.js';
export { default as isMap } from './isMap.js';
export { default as isMatch } from './isMatch.js';
export { default as isMatchWith } from './isMatchWith.js';
export { default as isNaN } from './isNaN.js';
export { default as isNative } from './isNative.js';
export { default as isNil } from './isNil.js';
export { default as isNull } from './isNull.js';
export { default as isNumber } from './isNumber.js';
export { default as isObject } from './isObject.js';
export { default as isObjectLike } from './isObjectLike.js';
export { default as isPlainObject } from './isPlainObject.js';
export { default as isRegExp } from './isRegExp.js';
export { default as isSafeInteger } from './isSafeInteger.js';
export { default as isSet } from './isSet.js';
export { default as isString } from './isString.js';
export { default as isSymbol } from './isSymbol.js';
export { default as isTypedArray } from './isTypedArray.js';
export { default as isUndefined } from './isUndefined.js';
export { default as isWeakMap } from './isWeakMap.js';
export { default as isWeakSet } from './isWeakSet.js';
export { default as iteratee } from './iteratee.js';
export { default as join } from './join.js';
export { default as kebabCase } from './kebabCase.js';
export { default as keyBy } from './keyBy.js';
export { default as keys } from './keys.js';
export { default as keysIn } from './keysIn.js';
export { default as last } from './last.js';
export { default as lastIndexOf } from './lastIndexOf.js';
export { default as lodash } from './wrapperLodash.js';
export { default as lowerCase } from './lowerCase.js';
export { default as lowerFirst } from './lowerFirst.js';
export { default as lt } from './lt.js';
export { default as lte } from './lte.js';
export { default as map } from './map.js';
export { default as mapKeys } from './mapKeys.js';
export { default as mapValues } from './mapValues.js';
export { default as matches } from './matches.js';
export { default as matchesProperty } from './matchesProperty.js';
export { default as max } from './max.js';
export { default as maxBy } from './maxBy.js';
export { default as mean } from './mean.js';
export { default as meanBy } from './meanBy.js';
export { default as memoize } from './memoize.js';
export { default as merge } from './merge.js';
export { default as mergeWith } from './mergeWith.js';
export { default as method } from './method.js';
export { default as methodOf } from './methodOf.js';
export { default as min } from './min.js';
export { default as minBy } from './minBy.js';
export { default as mixin } from './mixin.js';
export { default as multiply } from './multiply.js';
export { default as negate } from './negate.js';
export { default as next } from './next.js';
export { default as noop } from './noop.js';
export { default as now } from './now.js';
export { default as nth } from './nth.js';
export { default as nthArg } from './nthArg.js';
export { default as omit } from './omit.js';
export { default as omitBy } from './omitBy.js';
export { default as once } from './once.js';
export { default as orderBy } from './orderBy.js';
export { default as over } from './over.js';
export { default as overArgs } from './overArgs.js';
export { default as overEvery } from './overEvery.js';
export { default as overSome } from './overSome.js';
export { default as pad } from './pad.js';
export { default as padEnd } from './padEnd.js';
export { default as padStart } from './padStart.js';
export { default as parseInt } from './parseInt.js';
export { default as partial } from './partial.js';
export { default as partialRight } from './partialRight.js';
export { default as partition } from './partition.js';
export { default as pick } from './pick.js';
export { default as pickBy } from './pickBy.js';
export { default as plant } from './plant.js';
export { default as property } from './property.js';
export { default as propertyOf } from './propertyOf.js';
export { default as pull } from './pull.js';
export { default as pullAll } from './pullAll.js';
export { default as pullAllBy } from './pullAllBy.js';
export { default as pullAllWith } from './pullAllWith.js';
export { default as pullAt } from './pullAt.js';
export { default as random } from './random.js';
export { default as range } from './range.js';
export { default as rangeRight } from './rangeRight.js';
export { default as rearg } from './rearg.js';
export { default as reduce } from './reduce.js';
export { default as reduceRight } from './reduceRight.js';
export { default as reject } from './reject.js';
export { default as remove } from './remove.js';
export { default as repeat } from './repeat.js';
export { default as replace } from './replace.js';
export { default as rest } from './rest.js';
export { default as result } from './result.js';
export { default as reverse } from './reverse.js';
export { default as round } from './round.js';
export { default as sample } from './sample.js';
export { default as sampleSize } from './sampleSize.js';
export { default as set } from './set.js';
export { default as setWith } from './setWith.js';
export { default as shuffle } from './shuffle.js';
export { default as size } from './size.js';
export { default as slice } from './slice.js';
export { default as snakeCase } from './snakeCase.js';
export { default as some } from './some.js';
export { default as sortBy } from './sortBy.js';
export { default as sortedIndex } from './sortedIndex.js';
export { default as sortedIndexBy } from './sortedIndexBy.js';
export { default as sortedIndexOf } from './sortedIndexOf.js';
export { default as sortedLastIndex } from './sortedLastIndex.js';
export { default as sortedLastIndexBy } from './sortedLastIndexBy.js';
export { default as sortedLastIndexOf } from './sortedLastIndexOf.js';
export { default as sortedUniq } from './sortedUniq.js';
export { default as sortedUniqBy } from './sortedUniqBy.js';
export { default as split } from './split.js';
export { default as spread } from './spread.js';
export { default as startCase } from './startCase.js';
export { default as startsWith } from './startsWith.js';
export { default as stubArray } from './stubArray.js';
export { default as stubFalse } from './stubFalse.js';
export { default as stubObject } from './stubObject.js';
export { default as stubString } from './stubString.js';
export { default as stubTrue } from './stubTrue.js';
export { default as subtract } from './subtract.js';
export { default as sum } from './sum.js';
export { default as sumBy } from './sumBy.js';
export { default as tail } from './tail.js';
export { default as take } from './take.js';
export { default as takeRight } from './takeRight.js';
export { default as takeRightWhile } from './takeRightWhile.js';
export { default as takeWhile } from './takeWhile.js';
export { default as tap } from './tap.js';
export { default as template } from './template.js';
export { default as templateSettings } from './templateSettings.js';
export { default as throttle } from './throttle.js';
export { default as thru } from './thru.js';
export { default as times } from './times.js';
export { default as toArray } from './toArray.js';
export { default as toFinite } from './toFinite.js';
export { default as toInteger } from './toInteger.js';
export { default as toIterator } from './toIterator.js';
export { default as toJSON } from './toJSON.js';
export { default as toLength } from './toLength.js';
export { default as toLower } from './toLower.js';
export { default as toNumber } from './toNumber.js';
export { default as toPairs } from './toPairs.js';
export { default as toPairsIn } from './toPairsIn.js';
export { default as toPath } from './toPath.js';
export { default as toPlainObject } from './toPlainObject.js';
export { default as toSafeInteger } from './toSafeInteger.js';
export { default as toString } from './toString.js';
export { default as toUpper } from './toUpper.js';
export { default as transform } from './transform.js';
export { default as trim } from './trim.js';
export { default as trimEnd } from './trimEnd.js';
export { default as trimStart } from './trimStart.js';
export { default as truncate } from './truncate.js';
export { default as unary } from './unary.js';
export { default as unescape } from './unescape.js';
export { default as union } from './union.js';
export { default as unionBy } from './unionBy.js';
export { default as unionWith } from './unionWith.js';
export { default as uniq } from './uniq.js';
export { default as uniqBy } from './uniqBy.js';
export { default as uniqWith } from './uniqWith.js';
export { default as uniqueId } from './uniqueId.js';
export { default as unset } from './unset.js';
export { default as unzip } from './unzip.js';
export { default as unzipWith } from './unzipWith.js';
export { default as update } from './update.js';
export { default as updateWith } from './updateWith.js';
export { default as upperCase } from './upperCase.js';
export { default as upperFirst } from './upperFirst.js';
export { default as value } from './value.js';
export { default as valueOf } from './valueOf.js';
export { default as values } from './values.js';
export { default as valuesIn } from './valuesIn.js';
export { default as without } from './without.js';
export { default as words } from './words.js';
export { default as wrap } from './wrap.js';
export { default as wrapperAt } from './wrapperAt.js';
export { default as wrapperChain } from './wrapperChain.js';
export { default as wrapperCommit } from './commit.js';
export { default as wrapperLodash } from './wrapperLodash.js';
export { default as wrapperNext } from './next.js';
export { default as wrapperPlant } from './plant.js';
export { default as wrapperReverse } from './wrapperReverse.js';
export { default as wrapperToIterator } from './toIterator.js';
export { default as wrapperValue } from './wrapperValue.js';
export { default as xor } from './xor.js';
export { default as xorBy } from './xorBy.js';
export { default as xorWith } from './xorWith.js';
export { default as zip } from './zip.js';
export { default as zipObject } from './zipObject.js';
export { default as zipObjectDeep } from './zipObjectDeep.js';
export { default as zipWith } from './zipWith.js';
export { default } from './lodash.default.js';
```

Which triggers a large import waterfall.

The replacement here `https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/debounce/+esm` just imports the `./debounce.js` directly:

```js
/**
 * Bundled by jsDelivr using Rollup v2.79.1 and Terser v5.19.0.
 * Original file: /npm/lodash-es@4.17.21/debounce.js
 *
 * Do NOT use SRI with dynamically generated files! More information: https://www.jsdelivr.com/using-sri-with-dynamic-files
 */
function t(t){var n=typeof t;return null!=t&&("object"==n||"function"==n)}var n="undefined"!=typeof global?global:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{},e="object"==typeof n&&n&&n.Object===Object&&n,r="object"==typeof self&&self&&self.Object===Object&&self,o=e||r||Function("return this")(),i=function(){return o.Date.now()},u=/\s/;var f=/^\s+/;function a(t){return t?t.slice(0,function(t){for(var n=t.length;n--&&u.test(t.charAt(n)););return n}(t)+1).replace(f,""):t}var c=o.Symbol,l=Object.prototype,v=l.hasOwnProperty,d=l.toString,s=c?c.toStringTag:void 0;var p=Object.prototype.toString;var b="[object Null]",y="[object Undefined]",j=c?c.toStringTag:void 0;function m(t){return null==t?void 0===t?y:b:j&&j in Object(t)?function(t){var n=v.call(t,s),e=t[s];try{t[s]=void 0;var r=!0}catch(t){}var o=d.call(t);return r&&(n?t[s]=e:delete t[s]),o}(t):function(t){return p.call(t)}(t)}var g="[object Symbol]";var h=NaN,O=/^[-+]0x[0-9a-f]+$/i,T=/^0b[01]+$/i,w=/^0o[0-7]+$/i,x=parseInt;function S(n){if("number"==typeof n)return n;if(function(t){return"symbol"==typeof t||function(t){return null!=t&&"object"==typeof t}(t)&&m(t)==g}(n))return h;if(t(n)){var e="function"==typeof n.valueOf?n.valueOf():n;n=t(e)?e+"":e}if("string"!=typeof n)return 0===n?n:+n;n=a(n);var r=T.test(n);return r||w.test(n)?x(n.slice(2),r?2:8):O.test(n)?h:+n}var N=Math.max,$=Math.min;function E(n,e,r){var o,u,f,a,c,l,v=0,d=!1,s=!1,p=!0;if("function"!=typeof n)throw new TypeError("Expected a function");function b(t){var e=o,r=u;return o=u=void 0,v=t,a=n.apply(r,e)}function y(t){var n=t-l;return void 0===l||n>=e||n<0||s&&t-v>=f}function j(){var t=i();if(y(t))return m(t);c=setTimeout(j,function(t){var n=e-(t-l);return s?$(n,f-(t-v)):n}(t))}function m(t){return c=void 0,p&&o?b(t):(o=u=void 0,a)}function g(){var t=i(),n=y(t);if(o=arguments,u=this,l=t,n){if(void 0===c)return function(t){return v=t,c=setTimeout(j,e),d?b(t):a}(l);if(s)return clearTimeout(c),c=setTimeout(j,e),b(l)}return void 0===c&&(c=setTimeout(j,e)),a}return e=S(e)||0,t(r)&&(d=!!r.leading,f=(s="maxWait"in r)?N(S(r.maxWait)||0,e):f,p="trailing"in r?!!r.trailing:p),g.cancel=function(){void 0!==c&&clearTimeout(c),v=0,o=l=u=c=void 0},g.flush=function(){return void 0===c?a:m(i())},g}export{E as default};
//# sourceMappingURL=/sm/5eff9372c11fcee2b1055d9a016184ecc70e6763673732f56e1bc851fdb31698.map
```
