### PR TITLE
doc: Add tooltip to Line example with custom order

### DIFF
--- a/doc/user_guide/marks/line.rst
+++ b/doc/user_guide/marks/line.rst
@@ -276,6 +276,7 @@ For example, to show a pattern of data change over time between gasoline price a
         alt.X("miles").scale(zero=False),
         alt.Y("gas").scale(zero=False),
         order="year",
+        tooltip=["miles", "gas", "year"],
     )
 
 Line interpolation


### PR DESCRIPTION
It wasn't obvious how the year was used to create the order. Now you can see that one endpoint is 1956, the other is 2010.

I considered adding mark_text(), but that seemed heavier weight and potentially distracting.

Now, the chart has this tooltip when I hover over the last point:
<img width="301" alt="image" src="https://github.com/altair-viz/altair/assets/10820686/65ab3a4b-3e08-4107-8c27-352920f0ee03">
