### PR TITLE
Don't error when hashing data that can't be serialised to JSON

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -52,7 +52,7 @@ def _dataset_name(values):
         values = values.to_dict()
     if values == [{}]:
         return "empty"
-    values_json = json.dumps(values, sort_keys=True)
+    values_json = json.dumps(values, sort_keys=True, default=str)
     hsh = hashlib.md5(values_json.encode()).hexdigest()
     return "data-" + hsh
 


### PR DESCRIPTION
This is a suggestion that would help a particular issue I've got but it might be a bit niche. Thanks for looking!

Converting non-serialisable data to a string instead of erroring seems fine when it's just for generating a hash. This allows `to_dict` to be called when there's data that `json.dumps` can't serialise.

In my case I've got `datetime.time` instances in the dataframe I'm plotting a chart from and am using Pydantic (which can convert `datetime.time` to JSON) to serialise the chart dictionary.