### PR TITLE
Add missing arguments to Parameter and add type hints

### DIFF
--- a/altair/__init__.py
+++ b/altair/__init__.py
@@ -489,6 +489,7 @@ __all__ = [
     "TypedFieldDef",
     "URI",
     "Undefined",
+    "UndefinedType",
     "UnitSpec",
     "UnitSpecWithFrame",
     "Url",

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -8,7 +8,7 @@ import pandas as pd
 from toolz.curried import pipe as _pipe
 import itertools
 import sys
-from typing import cast, List, Optional, Any, Iterable, Union, Literal, Dict
+from typing import cast, List, Optional, Any, Iterable, Union, Literal
 
 # Have to rename it here as else it overlaps with schema.core.Type
 from typing import Type as TypingType
@@ -219,7 +219,7 @@ class Parameter(expr.core.OperatorMixin, object):
         "'ref' is deprecated. No need to call '.ref()' anymore."
         return self.to_dict()
 
-    def to_dict(self) -> Dict[str, Union[str, dict]]:
+    def to_dict(self) -> TypingDict[str, Union[str, dict]]:
         if self.param_type == "variable":
             return {"expr": self.name}
         elif self.param_type == "selection":
@@ -1744,7 +1744,7 @@ class TopLevelMixin(mixins.ConfigMethodMixin):
 
         """
         if isinstance(filter, Parameter):
-            new_filter = {"param": filter.name}
+            new_filter: TypingDict[str, Union[bool, str]] = {"param": filter.name}
             if "empty" in kwargs:
                 new_filter["empty"] = kwargs.pop("empty")
             elif isinstance(filter.empty, bool):

--- a/altair/vegalite/v5/schema/core.py
+++ b/altair/vegalite/v5/schema/core.py
@@ -1,7 +1,7 @@
 # The contents of this file are automatically written by
 # tools/generate_schema_wrapper.py. Do not modify directly.
 
-from altair.utils.schemapi import SchemaBase, Undefined, _subclasses
+from altair.utils.schemapi import SchemaBase, Undefined, UndefinedType, _subclasses
 
 import pkgutil
 import json

--- a/tools/generate_schema_wrapper.py
+++ b/tools/generate_schema_wrapper.py
@@ -391,7 +391,7 @@ def generate_vegalite_schema_wrapper(schema_file):
 
     contents = [
         HEADER,
-        "from altair.utils.schemapi import SchemaBase, Undefined, _subclasses",
+        "from altair.utils.schemapi import SchemaBase, Undefined, UndefinedType, _subclasses",
         LOAD_SCHEMA.format(schemafile="vega-lite-schema.json"),
     ]
     contents.append(BASE_SCHEMA.format(basename=basename))

--- a/tools/update_init_file.py
+++ b/tools/update_init_file.py
@@ -6,7 +6,7 @@ import inspect
 import sys
 from pathlib import Path
 from os.path import abspath, dirname, join
-from typing import TypeVar, Type, cast, List, Any, Optional, Iterable
+from typing import TypeVar, Type, cast, List, Any, Optional, Iterable, Union
 
 import black
 
@@ -79,6 +79,7 @@ def _is_relevant_attribute(attr_name):
         or attr is Literal
         or attr is Optional
         or attr is Iterable
+        or attr is Union
         or attr_name == "TypingDict"
     ):
         return False


### PR DESCRIPTION
I noticed in #3143 that `alt.param` sets some attributes on `alt.Parameter` which do not exist on that class when its initialised. That's a problem for mypy as all attributes should exist from the beginning. This PR adds `empty`, `param`, and `param_type` and type hints for the whole class.

I tested with the [Interval examples](https://altair-viz.github.io/user_guide/interactions.html#interval-selections) from the docs to make sure that indeed `empty=Undefined` leads to `empty` not being present in the final chart dict which is the old behaviour when `empty` was not present on the parameter instance at all if it was not defined.