### PR TITLE
[Doc] Fix Chart and MarkDef language

### DIFF
--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2830,17 +2830,17 @@ class Chart(
     data : Data
         An object describing the data source
     mark : AnyMark
-        A ``MarkDef`` or ``CompositeMarkDef`` object, or a string describing the mark type
-        (one of ``"arc"``, ``"area"``, ``"bar"``, ``"circle"``, ``"geoshape"``, ``"image"``,
-        ``"line"``, ``"point"``, ``"rule"``, ``"rect"``, ``"square"``, ``"text"``, ``"tick"``,
-        ``"trail"``, ``"boxplot"``, ``"errorband"``, and ``"errorbar"``).
+        A `MarkDef` or `CompositeMarkDef` object, or a string describing the mark type
+        (one of `"arc"`, `"area"`, `"bar"`, `"circle"`, `"geoshape"`, `"image"`,
+        `"line"`, `"point"`, `"rule"`, `"rect"`, `"square"`, `"text"`, `"tick"`,
+        `"trail"`, `"boxplot"`, `"errorband"`, and `"errorbar"`).
     encoding : FacetedEncoding
         A key-value mapping between encoding channels and definition of fields.
     autosize : anyOf(AutosizeType, AutoSizeParams)
         Sets how the visualization size should be determined. If a string, should be one of
-        ``"pad"``, ``"fit"`` or ``"none"``. Object values can additionally specify parameters for
-        content sizing and automatic resizing. ``"fit"`` is only supported for single and
-        layered views that don't use ``rangeStep``.  Default value: ``pad``
+        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
+        content sizing and automatic resizing. `"fit"` is only supported for single and
+        layered views that don't use `rangeStep`.  Default value: `pad`
     background : string
         CSS color property to use as the background of visualization.
 
@@ -2857,13 +2857,13 @@ class Chart(
     padding : Padding
         The default visualization padding, in pixels, from the edge of the visualization
         canvas to the data rectangle.  If a number, specifies padding for all sides. If an
-        object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}`` to specify padding for each side of the visualization.  Default
-        value: ``5``
+        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}` to specify padding for each side of the visualization.  Default
+        value: `5`
     projection : Projection
-        An object defining properties of geographic projection.  Works with ``"geoshape"``
-        marks and ``"point"`` or ``"line"`` marks that have a channel (one or more of ``"X"``,
-        ``"X2"``, ``"Y"``, ``"Y2"``) with type ``"latitude"``, or ``"longitude"``.
+        An object defining properties of geographic projection.  Works with `"geoshape"`
+        marks and `"point"` or `"line"` marks that have a channel (one or more of `"X"`,
+        `"X2"`, `"Y"`, `"Y2"`) with type `"latitude"`, or `"longitude"`.
     selection : Mapping(required=[])
         A key-value mapping between selection names and definitions.
     title : anyOf(string, TitleParams)

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2831,7 +2831,9 @@ class Chart(
         An object describing the data source
     mark : AnyMark
         A string describing the mark type
-        (either one of `"bar"`, `"circle"`, `"square"`, `"tick"`,`"line"`, `"area"`, `"point"`, `"rule"`, `"geoshape"`, `"text"`, `"arc"`, `"image"`, `"rect"`, `"trail"`, `"boxplot"`, `"errorband"`, `"errorbar"`) or a MarkDef object or a CompositeMarkDef objest.
+        (either one of ``"bar"``, ``"circle"``, ``"square"``, ``"tick"``,``"line"``, ``"area"``, ``"point"``,
+        ``"rule"``, ``"geoshape"``, ``"text"``, ``"arc"``, ``"image"``, ``"rect"``, ``"trail"``, ``"boxplot"``,
+        ``"errorband"``, ``"errorbar"``) or a MarkDef object or a CompositeMarkDef object.
     encoding : FacetedEncoding
         A key-value mapping between encoding channels and definition of fields.
     autosize : anyOf(AutosizeType, AutoSizeParams)

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2830,17 +2830,17 @@ class Chart(
     data : Data
         An object describing the data source
     mark : AnyMark
-        A string describing the mark type
-        (either one of ``"bar"``, ``"circle"``, ``"square"``, ``"tick"``,``"line"``, ``"area"``, ``"point"``,
-        ``"rule"``, ``"geoshape"``, ``"text"``, ``"arc"``, ``"image"``, ``"rect"``, ``"trail"``, ``"boxplot"``,
-        ``"errorband"``, ``"errorbar"``) or a MarkDef object or a CompositeMarkDef object.
+        A ``MarkDef`` or ``CompositeMarkDef`` object, or a string describing the mark type
+        (one of ``"arc"``, ``"area"``, ``"bar"``, ``"circle"``, ``"geoshape"``, ``"image"``,
+        ``"line"``, ``"point"``, ``"rule"``, ``"rect"``, ``"square"``, ``"text"``, ``"tick"``,
+        ``"trail"``, ``"boxplot"``, ``"errorband"``, and ``"errorbar"``).
     encoding : FacetedEncoding
         A key-value mapping between encoding channels and definition of fields.
     autosize : anyOf(AutosizeType, AutoSizeParams)
         Sets how the visualization size should be determined. If a string, should be one of
-        `"pad"`, `"fit"` or `"none"`. Object values can additionally specify parameters for
-        content sizing and automatic resizing. `"fit"` is only supported for single and
-        layered views that don't use `rangeStep`.  Default value: `pad`
+        ``"pad"``, ``"fit"`` or ``"none"``. Object values can additionally specify parameters for
+        content sizing and automatic resizing. ``"fit"`` is only supported for single and
+        layered views that don't use ``rangeStep``.  Default value: ``pad``
     background : string
         CSS color property to use as the background of visualization.
 
@@ -2857,13 +2857,13 @@ class Chart(
     padding : Padding
         The default visualization padding, in pixels, from the edge of the visualization
         canvas to the data rectangle.  If a number, specifies padding for all sides. If an
-        object, the value should have the format `{"left": 5, "top": 5, "right": 5,
-        "bottom": 5}` to specify padding for each side of the visualization.  Default
-        value: `5`
+        object, the value should have the format ``{"left": 5, "top": 5, "right": 5,
+        "bottom": 5}`` to specify padding for each side of the visualization.  Default
+        value: ``5``
     projection : Projection
-        An object defining properties of geographic projection.  Works with `"geoshape"`
-        marks and `"point"` or `"line"` marks that have a channel (one or more of `"X"`,
-        `"X2"`, `"Y"`, `"Y2"`) with type `"latitude"`, or `"longitude"`.
+        An object defining properties of geographic projection.  Works with ``"geoshape"``
+        marks and ``"point"`` or ``"line"`` marks that have a channel (one or more of ``"X"``,
+        ``"X2"``, ``"Y"``, ``"Y2"``) with type ``"latitude"``, or ``"longitude"``.
     selection : Mapping(required=[])
         A key-value mapping between selection names and definitions.
     title : anyOf(string, TitleParams)

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -2830,9 +2830,8 @@ class Chart(
     data : Data
         An object describing the data source
     mark : AnyMark
-        A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
-         `"line"`, * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a
-         MarkDef object.
+        A string describing the mark type
+        (either one of `"bar"`, `"circle"`, `"square"`, `"tick"`,`"line"`, `"area"`, `"point"`, `"rule"`, `"geoshape"`, `"text"`, `"arc"`, `"image"`, `"rect"`, `"trail"`, `"boxplot"`, `"errorband"`, `"errorbar"`) or a MarkDef object or a CompositeMarkDef objest.
     encoding : FacetedEncoding
         A key-value mapping between encoding channels and definition of fields.
     autosize : anyOf(AutosizeType, AutoSizeParams)


### PR DESCRIPTION
This will close #2545, 
where the usage should be alt.Chart(df, mark=alt.CompositeMarkDef(type='boxplot'))
this PR update definition in https://altair-viz.github.io/user_guide/generated/toplevel/altair.Chart.html,
![image](https://github.com/altair-viz/altair/assets/75072960/ceb5eaf9-1961-4234-a528-b96cfffb97c4)

but for MarkDef in https://altair-viz.github.io/user_guide/generated/core/altair.MarkDef.html
```
The mark type. This could a primitive mark type (one of "bar", "circle", "square", "tick", "line", "area", "point", "geoshape", "rule", and "text" ) or a composite mark type ( "boxplot", "errorband", "errorbar" ).
```
Seems like it's generated from vega-lite-schema and I might need some instruction on where to start



