### PR TITLE
Update save.py to use utf-8 instead of None per default

### DIFF
--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -142,7 +142,12 @@ def save(
 
         if format == "json":
             json_spec = json.dumps(spec, **json_kwds)
-            write_file_or_filename(fp, json_spec, mode="w", encoding=kwargs.get("encoding", "utf-8"))
+            write_file_or_filename(
+                fp,
+                json_spec,
+                mode="w",
+                encoding=kwargs.get("encoding", "utf-8")
+            )
         elif format == "html":
             if inline:
                 kwargs["template"] = "inline"

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -142,7 +142,7 @@ def save(
 
         if format == "json":
             json_spec = json.dumps(spec, **json_kwds)
-            write_file_or_filename(fp, json_spec, mode="w", encoding="utf-8")
+            write_file_or_filename(fp, json_spec, mode="w", kwargs.get("encoding", "utf-8"))
         elif format == "html":
             if inline:
                 kwargs["template"] = "inline"

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -158,7 +158,7 @@ def save(
                 **kwargs,
             )
             write_file_or_filename(
-                fp, mimebundle["text/html"], mode="w", encoding="utf-8"
+                fp, mimebundle["text/html"], mode="w", encoding=kwargs.get("encoding", "utf-8")
             )
         elif format in ["png", "svg", "pdf", "vega"]:
             mimebundle = spec_to_mimebundle(

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -142,7 +142,7 @@ def save(
 
         if format == "json":
             json_spec = json.dumps(spec, **json_kwds)
-            write_file_or_filename(fp, json_spec, mode="w", kwargs.get("encoding", "utf-8"))
+            write_file_or_filename(fp, json_spec, mode="w", encoding=kwargs.get("encoding", "utf-8"))
         elif format == "html":
             if inline:
                 kwargs["template"] = "inline"

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -12,7 +12,7 @@ def write_file_or_filename(
     fp: Union[str, pathlib.PurePath, IO],
     content: Union[str, bytes],
     mode: str = "w",
-    encoding: Optional[str] = None,
+    encoding: Optional[str] = "utf-8",
 ) -> None:
     """Write content to fp, whether fp is a string, a pathlib Path or a
     file-like object"""

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -163,7 +163,7 @@ def save(
                 fp,
                 mimebundle["text/html"],
                 mode="w",
-                encoding=kwargs.get("encoding", "utf-8")
+                encoding=kwargs.get("encoding", "utf-8"),
             )
         elif format in ["png", "svg", "pdf", "vega"]:
             mimebundle = spec_to_mimebundle(

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -143,10 +143,7 @@ def save(
         if format == "json":
             json_spec = json.dumps(spec, **json_kwds)
             write_file_or_filename(
-                fp,
-                json_spec,
-                mode="w",
-                encoding=kwargs.get("encoding", "utf-8")
+                fp, json_spec, mode="w", encoding=kwargs.get("encoding", "utf-8")
             )
         elif format == "html":
             if inline:
@@ -163,7 +160,10 @@ def save(
                 **kwargs,
             )
             write_file_or_filename(
-                fp, mimebundle["text/html"], mode="w", encoding=kwargs.get("encoding", "utf-8")
+                fp,
+                mimebundle["text/html"],
+                mode="w",
+                encoding=kwargs.get("encoding", "utf-8")
             )
         elif format in ["png", "svg", "pdf", "vega"]:
             mimebundle = spec_to_mimebundle(

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -157,7 +157,9 @@ def save(
                 json_kwds=json_kwds,
                 **kwargs,
             )
-            write_file_or_filename(fp, mimebundle["text/html"], mode="w", encoding="utf-8")
+            write_file_or_filename(
+                fp, mimebundle["text/html"], mode="w", encoding="utf-8"
+            )
         elif format in ["png", "svg", "pdf", "vega"]:
             mimebundle = spec_to_mimebundle(
                 spec=spec,

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -20,7 +20,7 @@ def write_file_or_filename(
         with open(file=fp, mode=mode, encoding=encoding) as f:
             f.write(content)
     else:
-        fp.write(content) 
+        fp.write(content)
 
 
 def set_inspect_format_argument(

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -20,7 +20,7 @@ def write_file_or_filename(
         with open(file=fp, mode=mode, encoding=encoding) as f:
             f.write(content)
     else:
-        fp.write(content)
+        fp.write(content) 
 
 
 def set_inspect_format_argument(

--- a/altair/utils/save.py
+++ b/altair/utils/save.py
@@ -12,7 +12,7 @@ def write_file_or_filename(
     fp: Union[str, pathlib.PurePath, IO],
     content: Union[str, bytes],
     mode: str = "w",
-    encoding: Optional[str] = "utf-8",
+    encoding: Optional[str] = None,
 ) -> None:
     """Write content to fp, whether fp is a string, a pathlib Path or a
     file-like object"""
@@ -142,7 +142,7 @@ def save(
 
         if format == "json":
             json_spec = json.dumps(spec, **json_kwds)
-            write_file_or_filename(fp, json_spec, mode="w")
+            write_file_or_filename(fp, json_spec, mode="w", encoding="utf-8")
         elif format == "html":
             if inline:
                 kwargs["template"] = "inline"
@@ -157,7 +157,7 @@ def save(
                 json_kwds=json_kwds,
                 **kwargs,
             )
-            write_file_or_filename(fp, mimebundle["text/html"], mode="w")
+            write_file_or_filename(fp, mimebundle["text/html"], mode="w", encoding="utf-8")
         elif format in ["png", "svg", "pdf", "vega"]:
             mimebundle = spec_to_mimebundle(
                 spec=spec,

--- a/altair/vegalite/v5/api.py
+++ b/altair/vegalite/v5/api.py
@@ -3247,7 +3247,7 @@ class RepeatChart(TopLevelMixin, core.TopLevelRepeatSpec):
 
 
 def repeat(
-    repeater: Literal["row", "column", "repeat", "layer"] = "repeat"
+    repeater: Literal["row", "column", "repeat", "layer"] = "repeat",
 ) -> core.RepeatRef:
     """Tie a channel to the row or column within a repeated chart
 


### PR DESCRIPTION
I experience issues with the Null on windows. It appears as if when saving HTML, the template is already utf-8 and when writing the files with the system default code page, there are encoding issues.

Alternatively I see another options to solve my problem.: 

set it only in the

`elif format == "html":`

branch...