### PR TITLE
Docs: Add section on displaying Altair charts in dashboards

### DIFF
--- a/doc/releases/changes.rst
+++ b/doc/releases/changes.rst
@@ -8,6 +8,8 @@ Version 5.3.0 (unreleased month day, year)
 
 Enhancements
 ~~~~~~~~~~~~
+- Docs: Add :ref:`section on dashboards <display_dashboards>` which have support for Altair (#3299)
+
 Bug Fixes
 ~~~~~~~~~
 Backward-Incompatible Changes

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -153,6 +153,9 @@ Package                                                                         
 `Streamlit <https://docs.streamlit.io/library/api-reference/charts/st.altair_chart>`_                                                ✔                                              
 ===================================================================================================================================  ===================================  =============================
 
+The above mentioned frameworks all require you to run a web application on a server if you want to share your work with others. A web application gives you a lot of flexibility, you can for example fetch data from a database based on the value of a dropdown menu in the dashboard. However, it comes with some complexity as well. 
+For use cases where the interactivity provided by Altair itself is enough, you can also use tools which generate HTML pages which do not require a web server such as `Quarto <https://quarto.org/>`_ or `Jupyter Book <https://jupyterbook.org/>`_.
+
 If you are using a dashboarding package that is not listed here, please `open an issue <https://github.com/altair-viz/altair/issues>`_ on GitHub so that we can add it.
 
 .. _display-general:

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -135,7 +135,7 @@ Optionally, for offline rendering, you can use the mimetype renderer::
     # Optional in VS Code
     alt.renderers.enable('mimetype')
 
-.. _display-general:
+.. _display_dashboards:
 
 Dashboards
 ----------
@@ -155,6 +155,7 @@ Package                                                                         
 
 If you are using a dashboarding package that is not listed here, please `open an issue <https://github.com/altair-viz/altair/issues>`_ on GitHub so that we can add it.
 
+.. _display-general:
 
 Working in environments without a JavaScript frontend
 -----------------------------------------------------   

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -139,7 +139,7 @@ Optionally, for offline rendering, you can use the mimetype renderer::
 
 Dashboards
 ----------
-Altair is compatible with common Python dashboarding packages. Some of them even provide support for reading out :ref:`parameters <user-guide-interactions>` from the chart.
+Altair is compatible with common Python dashboarding packages. Many of them even provide support for reading out :ref:`parameters <user-guide-interactions>` from the chart.
 This allows you to e.g. select data points and update another part of the dashboard such as a table based on that selection:
 
 ===================================================================================================================================  ===================================  =============================

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -157,7 +157,7 @@ If you are using a dashboarding package that is not listed here, please `open an
 
 
 Working in environments without a JavaScript frontend
------------------------------------------------------
+-----------------------------------------------------   
 The Vega-Lite specifications produced by Altair can be produced in any Python
 environment, but to render these specifications currently requires a javascript
 engine. For this reason, Altair works most seamlessly with the browser-based

--- a/doc/user_guide/display_frontends.rst
+++ b/doc/user_guide/display_frontends.rst
@@ -137,8 +137,27 @@ Optionally, for offline rendering, you can use the mimetype renderer::
 
 .. _display-general:
 
-Working in non-Notebook Environments
-------------------------------------
+Dashboards
+----------
+Altair is compatible with common Python dashboarding packages. Some of them even provide support for reading out :ref:`parameters <user-guide-interactions>` from the chart.
+This allows you to e.g. select data points and update another part of the dashboard such as a table based on that selection:
+
+===================================================================================================================================  ===================================  =============================
+Package                                                                                                                              Displays interactive Altair charts   Supports reading out parameters
+===================================================================================================================================  ===================================  =============================
+`Panel <https://panel.holoviz.org/reference/panes/Vega.html#altair>`_                                                                ✔                                    ✔
+`Plotly Dash <https://dash.plotly.com/>`_ using `dash_vega_components <https://github.com/altair-viz/dash-vega-components>`_         ✔                                    ✔
+`Jupyter Voila <https://voila.readthedocs.io/en/stable/>`_ using :ref:`JupyterChart <user-guide-jupyterchart>`                       ✔                                    ✔
+`Shiny <https://shiny.posit.co/py/docs/ipywidgets.html#quick-start>`_ using :ref:`JupyterChart <user-guide-jupyterchart>`            ✔                                    ✔
+`Solara <https://solara.dev/api/altair>`_                                                                                            ✔                                    ✔
+`Streamlit <https://docs.streamlit.io/library/api-reference/charts/st.altair_chart>`_                                                ✔                                              
+===================================================================================================================================  ===================================  =============================
+
+If you are using a dashboarding package that is not listed here, please `open an issue <https://github.com/altair-viz/altair/issues>`_ on GitHub so that we can add it.
+
+
+Working in environments without a JavaScript frontend
+-----------------------------------------------------
 The Vega-Lite specifications produced by Altair can be produced in any Python
 environment, but to render these specifications currently requires a javascript
 engine. For this reason, Altair works most seamlessly with the browser-based
@@ -149,16 +168,6 @@ have a built-in javascript engine, you'll need to somehow connect your charts
 to a second tool that can execute javascript.
 
 There are a few options available for this:
-
-Vega-enabled IDEs
-~~~~~~~~~~~~~~~~~
-Some IDEs have extensions that natively recognize and display Altair charts.
-Examples are:
-
-- The `VSCode-Python`_ extension, which supports native Altair and Vega-Lite
-  chart display as of November 2019.
-- The Hydrogen_ project, which is built on nteract_ and renders Altair charts
-  via the ``mimetype`` renderer.
 
 Altair Viewer
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Adds a very brief section on dashboards to give users a quick overview which frameworks have support for Altair. These are the ones I'm aware off but please let me know if I missed anything!

This was previously discussed in https://github.com/altair-viz/altair/pull/2762 and https://github.com/altair-viz/altair/pull/2415.

![image](https://github.com/altair-viz/altair/assets/23366411/83de11b4-d605-45aa-9413-0eebe3b95bfc)
