### PR TITLE
Adding missing interpolation methods to Line example

### DIFF
--- a/doc/user_guide/marks/line.rst
+++ b/doc/user_guide/marks/line.rst
@@ -20,14 +20,20 @@ Line Mark Properties
     interpolate_select = alt.binding_select(
         options=[
             "basis",
+            "basis-open",
+            "basis-closed",
+            "bundle",
             "cardinal",
+            "cardinal-open",
+            "cardinal-closed",
             "catmull-rom",
             "linear",
+            "linear-closed",
             "monotone",
             "natural",
             "step",
-            "step-after",
             "step-before",
+            "step-after",
         ],
         name="interpolate",
     )


### PR DESCRIPTION
 As discussed in [#3322](https://github.com/altair-viz/altair/issues/3322) 