### PR TITLE
Docs: Modifying scale of "multiple interactions" example and adding legend adjustments

### DIFF
--- a/tests/examples_methods_syntax/multiple_interactions.py
+++ b/tests/examples_methods_syntax/multiple_interactions.py
@@ -1,3 +1,16 @@
+"""
+Multiple Interactions
+=====================
+This example shows how multiple user inputs can be layered onto a chart. The four inputs have functionality as follows:
+
+* Dropdown: Filters the movies by genre
+* Radio Buttons: Highlights certain films by Worldwide Gross
+* Mouse Drag and Scroll: Zooms the x and y scales to allow for panning.
+
+
+
+"""
+
 import altair as alt
 from vega_datasets import data
 

--- a/tests/examples_methods_syntax/multiple_interactions.py
+++ b/tests/examples_methods_syntax/multiple_interactions.py
@@ -10,7 +10,7 @@ This example shows how multiple user inputs can be layered onto a chart. The fou
 
 
 """
-
+# category: interactive charts
 import altair as alt
 from vega_datasets import data
 

--- a/tests/examples_methods_syntax/multiple_interactions.py
+++ b/tests/examples_methods_syntax/multiple_interactions.py
@@ -1,16 +1,3 @@
-"""
-Multiple Interactions
-=====================
-This example shows how multiple user inputs can be layered onto a chart. The four inputs have functionality as follows:
-
-* Dropdown: Filters the movies by genre
-* Radio Buttons: Highlights certain films by Worldwide Gross
-* Mouse Drag and Scroll: Zooms the x and y scales to allow for panning.
-
-
-
-"""
-# category: interactive charts
 import altair as alt
 from vega_datasets import data
 
@@ -27,8 +14,8 @@ genres = [
 
 base = alt.Chart(movies, width=200, height=200).mark_point(filled=True).transform_calculate(
     Rounded_IMDB_Rating = "floor(datum.IMDB_Rating)",
-    Hundred_Million_Production =  "datum.Production_Budget > 100000000.0 ? 100 : 10",
-    Release_Year = "year(datum.Release_Date)"
+    Hundred_Million_Production =  "datum.Production_Budget > 100000000.0 ? 1 : 0", 
+    Release_Year = "year(datum.Release_Date)",
 ).transform_filter(
     alt.datum.IMDB_Rating > 0
 ).transform_filter(
@@ -79,9 +66,11 @@ highlight_ratings = base.add_params(
 input_checkbox = alt.binding_checkbox(name="Big Budget Films ")
 checkbox_selection = alt.param(bind=input_checkbox)
 
+legend_labels = ("datum.label == 0  ? 'Below $100 Mil.' : 'Above $100 Mil.'") # labels for both legend entries within alt.Size condition
+
 size_checkbox_condition = alt.condition(
     checkbox_selection,
-    alt.Size('Hundred_Million_Production:Q'),
+    alt.Size('Hundred_Million_Production:N', title='Big Budget Status').legend(labelExpr=legend_labels).scale(range=[25,150]), # scale can be used to manually adjust mark size difference between two levels of budget status
     alt.SizeValue(25)
 )
 

--- a/tests/examples_methods_syntax/multiple_interactions.py
+++ b/tests/examples_methods_syntax/multiple_interactions.py
@@ -5,9 +5,8 @@ This example shows how multiple user inputs can be layered onto a chart. The fou
 
 * Dropdown: Filters the movies by genre
 * Radio Buttons: Highlights certain films by Worldwide Gross
-* Mouse Drag and Scroll: Zooms the x and y scales to allow for panning.
-
-
+* Mouse Drag and Scroll: Zooms the x and y scales to allow for panning
+* Checkbox: Scales the marker size of big budget films
 
 """
 # category: interactive charts
@@ -27,7 +26,7 @@ genres = [
 
 base = alt.Chart(movies, width=200, height=200).mark_point(filled=True).transform_calculate(
     Rounded_IMDB_Rating = "floor(datum.IMDB_Rating)",
-    Hundred_Million_Production =  "datum.Production_Budget > 100000000.0 ? 1 : 0", 
+    Big_Budget_Film =  "datum.Production_Budget > 100000000 ? 'Yes' : 'No'", 
     Release_Year = "year(datum.Release_Date)",
 ).transform_filter(
     alt.datum.IMDB_Rating > 0
@@ -59,7 +58,7 @@ filter_genres = base.add_params(
     genre_select
 ).properties(title="Dropdown Filtering")
 
-#color changing marks
+# Color changing marks
 rating_radio = alt.binding_radio(options=ratings, name="Rating")
 rating_select = alt.selection_point(fields=['MPAA_Rating'], bind=rating_radio)
 
@@ -79,11 +78,9 @@ highlight_ratings = base.add_params(
 input_checkbox = alt.binding_checkbox(name="Big Budget Films ")
 checkbox_selection = alt.param(bind=input_checkbox)
 
-legend_labels = ("datum.label == 0  ? 'Below $100 Mil.' : 'Above $100 Mil.'") # labels for both legend entries within alt.Size condition
-
 size_checkbox_condition = alt.condition(
     checkbox_selection,
-    alt.Size('Hundred_Million_Production:N', title='Big Budget Status').legend(labelExpr=legend_labels).scale(range=[25,150]), # scale can be used to manually adjust mark size difference between two levels of budget status
+    alt.Size('Big_Budget_Film:N').scale(range=[25, 150]),
     alt.SizeValue(25)
 )
 
@@ -93,4 +90,4 @@ budget_sizing = base.add_params(
     size=size_checkbox_condition
 ).properties(title="Checkbox Formatting")
 
-(filter_year | filter_genres) & (highlight_ratings | budget_sizing)
+(filter_year | budget_sizing) & (highlight_ratings | filter_genres)


### PR DESCRIPTION
This is an attempt to modify the original "multiple interaction" example from the Altair-Vega documentation website in regard to the scale created with the checkbox condition for big budget films within the movies dataset. I had experimented with the example on my own to see how the Altair-Vega syntax worked when I realized that the quantitative scale for the alt.Size argument regarding a film's big budget designation wasn't fully accurate considering how the variable is entered. From what I read, the initial transformation in the chart creation creates a nominal scale between two categories of films, which can be labelled as "above $100 mil (big budget)" and "below $100 mil (not big budget)." However, the default scale being set to ':Q' for this variable means that the scale incorrectly assumes that the values of "100" and "10" (for big budget and non big-budget films respectively) are within a quantitative scale which then suggests to the viewer that it is displaying a continuous scale of films (via dot size) relative to production budget between $20 mil to $100 mil when the "Big Budget Films" box is checked.

I'm not sure if this is intentional to showcase how ':Q' automatically creates legend intervals when given any potential range of data, but if it is not I think it would be best to modify the scale and legend of this to be nominal in nature to clarify the purpose of the Big Budget Film checkbox. This modified version assigns '1' to films above $100 mil in budget and '0' for films vice versa so that, with a 0 -> 1 scale, alt.Scale will give a smaller mark size for lower-budget films before scaling up for big-budget films. I also include an example of how legends can be manually adjusted by adding a title and a defined range for mark size increase (from 25 to 150) between films below and above $100 mil.

Edit: As a small note, I forgot to re-add the intro text and comment for it being an interactive chart for the multiple interactions webpage so I re-added it via a 2nd and 3rd commit to this request. Hopefully that should be enough to correct that, this is my first pull request here so apologies for any errors I might have made doing so.

<img width="617" alt="Screen Shot 2024-03-02 at 10 58 45 PM" src="https://github.com/altair-viz/altair/assets/153132523/dee65ed3-4e30-4ea6-a888-017933d6aa47">