### PR TITLE
perf: Improve performance of `Chart.from_dict`

### DIFF
--- a/altair/utils/schemapi.py
+++ b/altair/utils/schemapi.py
@@ -71,6 +71,8 @@ _DEFAULT_JSON_SCHEMA_DRAFT_URL: Final = "http://json-schema.org/draft-07/schema#
 # class-level _class_is_valid_at_instantiation attribute to False
 DEBUG_MODE: bool = True
 
+jsonschema_version_str = importlib_version("jsonschema")
+
 
 def enable_debug_mode() -> None:
     global DEBUG_MODE
@@ -203,7 +205,6 @@ def _get_json_schema_draft_url(schema: dict) -> str:
 def _use_referencing_library() -> bool:
     """In version 4.18.0, the jsonschema package deprecated RefResolver in
     favor of the referencing library."""
-    jsonschema_version_str = importlib_version("jsonschema")
     return Version(jsonschema_version_str) >= Version("4.18")
 
 

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -71,6 +71,7 @@ DEBUG_MODE: bool = True
 
 jsonschema_version_str = importlib_version("jsonschema")
 
+
 def enable_debug_mode() -> None:
     global DEBUG_MODE
     DEBUG_MODE = True

--- a/tools/schemapi/schemapi.py
+++ b/tools/schemapi/schemapi.py
@@ -69,6 +69,7 @@ _DEFAULT_JSON_SCHEMA_DRAFT_URL: Final = "http://json-schema.org/draft-07/schema#
 # class-level _class_is_valid_at_instantiation attribute to False
 DEBUG_MODE: bool = True
 
+jsonschema_version_str = importlib_version("jsonschema")
 
 def enable_debug_mode() -> None:
     global DEBUG_MODE
@@ -201,7 +202,6 @@ def _get_json_schema_draft_url(schema: dict) -> str:
 def _use_referencing_library() -> bool:
     """In version 4.18.0, the jsonschema package deprecated RefResolver in
     favor of the referencing library."""
-    jsonschema_version_str = importlib_version("jsonschema")
     return Version(jsonschema_version_str) >= Version("4.18")
 
 


### PR DESCRIPTION
Closes #3382

This PR substantially improves performance of `alt.Chart.from_dict`.  See #3382 for a detailed description and reprex.

Grateful for any feedback on this PR, e.g. whether the team would prefer I leave the current function as is, or use `functools.lru_cache`, instead of the top-level `jsonschema_version_str = importlib_version("jsonschema")` statement.  Or some other solution.

WIP whilst I make sure the builds/tests pass